### PR TITLE
moves check for rails app

### DIFF
--- a/lib/shopify-cli/commands/generate.rb
+++ b/lib/shopify-cli/commands/generate.rb
@@ -55,9 +55,6 @@ module ShopifyCli
       end
 
       def self.run_generate(script, name, ctx)
-        if script.include?('NotImplementedError')
-          raise(ShopifyCli::Abort, 'This feature is not yet available for Rails apps')
-        end
         stat = ctx.system(script)
         unless stat.success?
           raise(ShopifyCli::Abort, response(stat.exitstatus, name))

--- a/lib/shopify-cli/commands/generate/billing.rb
+++ b/lib/shopify-cli/commands/generate/billing.rb
@@ -6,6 +6,11 @@ module ShopifyCli
       class Billing < ShopifyCli::Task
         def call(ctx, args)
           ctx.puts(self.class.help) if args.empty?
+          # temporary check until we build for rails
+          if ctx.project.app_type == ShopifyCli::AppTypes::Rails
+            raise(ShopifyCli::Abort, 'This feature is not yet available for Rails apps')
+          end
+
           project = ShopifyCli::Project.current
           type = CLI::UI::Prompt.ask('Which kind of billing?') do |handler|
             handler.option('recurring billing') { :billing_recurring }

--- a/lib/shopify-cli/commands/generate/page.rb
+++ b/lib/shopify-cli/commands/generate/page.rb
@@ -9,6 +9,10 @@ module ShopifyCli
             ctx.puts(self.class.help)
             return
           end
+          # temporary check until we build for rails
+          if ctx.project.app_type == ShopifyCli::AppTypes::Rails
+            raise(ShopifyCli::Abort, 'This feature is not yet available for Rails apps')
+          end
           name = args.first
           project = ShopifyCli::Project.current
           ShopifyCli::Commands::Generate.run_generate("#{project.app_type.generate[:page]} #{name}", name, ctx)

--- a/lib/shopify-cli/commands/generate/webhook.rb
+++ b/lib/shopify-cli/commands/generate/webhook.rb
@@ -5,13 +5,16 @@ module ShopifyCli
     class Generate
       class Webhook < ShopifyCli::Task
         def call(ctx, args)
+          # temporary check until we build for rails
+          if ctx.project.app_type == ShopifyCli::AppTypes::Rails
+            raise(ShopifyCli::Abort, 'This feature is not yet available for Rails apps')
+          end
           selected_type = args.first
           schema = ShopifyCli::Helpers::SchemaParser.new(
             schema: ShopifyCli::Tasks::Schema.call(ctx)
           )
           enum = schema['WebhookSubscriptionTopic']
           webhooks = schema.get_names_from_enum(enum)
-
           unless selected_type
             selected_type = CLI::UI::Prompt.ask('What type of webhook would you like to create?') do |handler|
               webhooks.each do |type|

--- a/test/shopify-cli/commands/generate/webhook_test.rb
+++ b/test/shopify-cli/commands/generate/webhook_test.rb
@@ -5,15 +5,13 @@ module ShopifyCli
     class Generate
       class WebhookTest < MiniTest::Test
         include TestHelpers::Context
+        include TestHelpers::AppType
         def setup
           super
           @command = ShopifyCli::Commands::Generate.new(@context)
         end
 
         def test_with_param
-          ShopifyCli::Tasks::Schema.expects(:call).returns(
-            JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
-          )
           ShopifyCli::Project.expects(:current).returns(
             TestHelpers::FakeProject.new(
               directory: @context.root,
@@ -22,15 +20,15 @@ module ShopifyCli
               }
             )
           ).at_least_once
+          ShopifyCli::Tasks::Schema.expects(:call).returns(
+            JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
+          )
           @context.expects(:system).with('npm run-script generate-webhook --silent PRODUCT_CREATE')
             .returns(mock(success?: true))
           @command.call(['webhook', 'PRODUCT_CREATE'], nil)
         end
 
         def test_with_selection
-          ShopifyCli::Tasks::Schema.expects(:call).returns(
-            JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json"))),
-          )
           ShopifyCli::Project.expects(:current).returns(
             TestHelpers::FakeProject.new(
               directory: @context.root,
@@ -39,6 +37,9 @@ module ShopifyCli
               }
             )
           ).at_least_once
+          ShopifyCli::Tasks::Schema.expects(:call).returns(
+            JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json"))),
+          )
           CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
           @context.expects(:system).with('npm run-script generate-webhook --silent PRODUCT_CREATE')
             .returns(mock(success?: true))


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #176  <!-- link to issue if one exists -->

The check to ensure generate commands didn't run for Rails apps was happening too late. It was giving the user the idea that they were available, throwing errors.

### WHAT is this pull request doing?

Checking early in call to make sure it raises before it moves on. This is not an elegant approach, but I'm going to be working on a refactor of generate tomorrow.
