### PR TITLE
add messaging to load-dev and load-system

### DIFF
--- a/lib/shopify-cli/commands/load_dev.rb
+++ b/lib/shopify-cli/commands/load_dev.rb
@@ -5,6 +5,10 @@ module ShopifyCli
     class LoadDev < ShopifyCli::Command
       def call(args, _name)
         project_dir = File.expand_path(args.shift || Dir.pwd)
+        unless File.exist?(project_dir)
+          raise(ShopifyCli::AbortSilent, "#{project_dir} does not exist")
+        end
+        @ctx.done("Reloading #{TOOL_FULL_NAME} from #{project_dir}")
         ShopifyCli::Finalize.reload_shopify_from(project_dir)
       end
 

--- a/lib/shopify-cli/commands/load_system.rb
+++ b/lib/shopify-cli/commands/load_system.rb
@@ -4,6 +4,7 @@ module ShopifyCli
   module Commands
     class LoadSystem < ShopifyCli::Command
       def call(_args, _name)
+        @ctx.done("Reloading #{TOOL_FULL_NAME} from #{ShopifyCli::INSTALL_DIR}")
         ShopifyCli::Finalize.reload_shopify_from(ShopifyCli::INSTALL_DIR)
       end
 

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -46,6 +46,7 @@ module ShopifyCli
   extend CLI::Kit::Autocall
 
   TOOL_NAME        = 'shopify'
+  TOOL_FULL_NAME   = 'Shopify App CLI'
   VERSION          = 'beta'
   ROOT             = File.expand_path('../..', __FILE__)
   INSTALL_DIR      = File.expand_path('.shopify-app-cli', ENV.fetch('XDG_RUNTIME_DIR', ENV.fetch('HOME')))

--- a/test/shopify-cli/commands/load_dev_test.rb
+++ b/test/shopify-cli/commands/load_dev_test.rb
@@ -15,11 +15,19 @@ module ShopifyCli
       end
 
       def test_with_argument
-        ShopifyCli::Finalize.expects(:reload_shopify_from).with(
-          File.expand_path('~/shopify-cli')
-        )
+        dir = File.expand_path(Dir.pwd)
+        ShopifyCli::Finalize.expects(:reload_shopify_from).with(dir)
         capture_io do
-          @command.call(['~/shopify-cli'], nil)
+          @command.call([dir], nil)
+        end
+      end
+
+      def test_with_missing_dir
+        dir = File.join(Dir.mktmpdir, 'doesnotexist')
+        assert_raises ShopifyCli::AbortSilent do
+          capture_io do
+            @command.call([dir], nil)
+          end
         end
       end
     end


### PR DESCRIPTION
Currently these two commands don't display any output when you run them, so it's hard to tell if they worked or not.
