### PR TITLE
use https clone for node app

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -41,7 +41,7 @@ module ShopifyCli
       end
 
       def build(name)
-        ShopifyCli::Tasks::Clone.call('git@github.com:shopify/shopify-app-node.git', name)
+        ShopifyCli::Tasks::Clone.call('https://github.com/Shopify/shopify-app-node.git', name)
         ShopifyCli::Finalize.request_cd(name)
         ShopifyCli::Tasks::JsDeps.call(ctx.root)
 

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -18,7 +18,7 @@ module ShopifyCli
 
       def test_build_creates_app
         ShopifyCli::Tasks::Clone.stubs(:call).with(
-          'git@github.com:shopify/shopify-app-node.git',
+          'https://github.com/Shopify/shopify-app-node.git',
           'test-app',
         )
         ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
@@ -72,7 +72,7 @@ module ShopifyCli
 
       def test_build_does_not_error_on_missing_git_dir
         ShopifyCli::Tasks::Clone.stubs(:call).with(
-          'git@github.com:shopify/shopify-app-node.git',
+          'https://github.com/Shopify/shopify-app-node.git',
           'test-app',
         )
         ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)


### PR DESCRIPTION
If the user hasn't added their SSH public key to github they're met with a `fatal: Could not read from remote repository.`, like in #184. If we use https it should just work.