### PR TITLE
[Fix] Update install.sh to correctly reference `project` in create option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ postmsg() {
   echo -e "\x1b[36mshopify-app-cli\x1b[0m is installed!"
   echo -e "Run \x1b[36mshopify help\x1b[0m to see what you can do, or read \x1b[36mhttps://github.com/Shopify/shopify-app-cli\x1b[0m."
   echo -e "To start developing on shopify, for example:"
-  echo -e "  * run \x1b[36mshopify create app <appname>\x1b[0m"
+  echo -e "  * run \x1b[36mshopify create project <appname>\x1b[0m"
 }
 
 install_prerequisites() {


### PR DESCRIPTION
### WHY are these changes introduced?

Fairly certain the current wording in the install script is incorrect and definitely confused me:

<img width="348" alt="Screen Shot 2019-06-20 at 9 56 46 PM" src="https://user-images.githubusercontent.com/3484527/59892388-d2ae4000-93a6-11e9-9a43-5ef0870f08e7.png">

It says *"shopify create app <appname>"* when it should be *"... create project <appname>"*

### WHAT is this pull request doing?

Fixes wording error
