### PR TITLE
fix schema dumping/parsing

### DIFF
--- a/lib/shopify-cli/tasks/schema.rb
+++ b/lib/shopify-cli/tasks/schema.rb
@@ -14,7 +14,7 @@ module ShopifyCli
 
       def get
         _, resp = @api.post(@api.graphql_url, @api.query_body(introspection))
-        File.write(File.join(ShopifyCli::TEMP_DIR, 'shopify_schema.json'), resp)
+        File.write(File.join(ShopifyCli::TEMP_DIR, 'shopify_schema.json'), JSON.dump(resp))
       rescue Helpers::API::APIRequestUnauthorizedError
         ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)
         get

--- a/test/shopify-cli/task/schema_test.rb
+++ b/test/shopify-cli/task/schema_test.rb
@@ -27,8 +27,14 @@ module ShopifyCli
         stub_request(:post, "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")
           .with(body: JSON.dump(query: introspection, variables: {}),
             headers: { 'X-Shopify-Access-Token' => 'accesstoken123' })
-          .to_return(status: 200, body: "{}", headers: {})
-        ShopifyCli::Tasks::Schema.call(@context)
+          .to_return(status: 200, body: '{"foo":"baz"}', headers: {})
+        assert_equal({ "foo" => "baz" }, ShopifyCli::Tasks::Schema.call(@context))
+        assert_equal('{"foo":"baz"}', File.read(File.join(ShopifyCli::TEMP_DIR, 'shopify_schema.json')))
+      end
+
+      def test_gets_schema_if_already_downloaded
+        File.write(File.join(ShopifyCli::TEMP_DIR, 'shopify_schema.json'), '{"foo":"baz"}')
+        assert_equal({ "foo" => "baz" }, ShopifyCli::Tasks::Schema.call(@context))
       end
 
       def test_error_gets_access_token


### PR DESCRIPTION
Tim and I noticed the populate command was returning a big JSON.parse error. Turns out it was storing the schema as a ruby Hash, not JSON and we didn't have a test for this.