### PR TITLE
Fix for create project test.

### DIFF
--- a/test/shopify-cli/commands/create/project_test.rb
+++ b/test/shopify-cli/commands/create/project_test.rb
@@ -25,6 +25,7 @@ module ShopifyCli
           CLI::UI.expects(:ask).times(3)
             .returns('apikey', 'apisecret', 'test-shop.myshopify.com')
           CLI::UI::Prompt.expects(:ask).returns(:node)
+          ShopifyCli::AppTypes::Node.any_instance.stubs(:check_dependencies)
           ShopifyCli::AppTypes::Node.any_instance.stubs(:build)
           @command.call(['test-app'], nil)
           assert_equal 'apikey', @context.app_metadata[:api_key]


### PR DESCRIPTION
### WHY are these changes introduced?
I only have a local non-functional version of node installed so this
test was failing because my system did not have node installed which is
probably not what we want.

### WHAT is this pull request doing?
stubs the check deps call since the build call is also stubbed
