### PR TITLE
Cleanup how we test in a Project context

### DIFF
--- a/test/commands/open_test.rb
+++ b/test/commands/open_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class OpenTest < MiniTest::Test
-      include TestHelpers::AppType
+      include TestHelpers::Project
 
       def setup
         super

--- a/test/fixtures/app_types/rails/.env
+++ b/test/fixtures/app_types/rails/.env
@@ -1,4 +1,5 @@
-SHOPIFY_API_KEY=mykey
-SHOPIFY_API_SECRET_KEY=mysecretkey
+SHOPIFY_API_KEY=api_key
+SHOPIFY_API_SECRET_KEY=secret
+SCOPES=write_products,write_customers,write_orders
 HOST=https://example.com
 SHOP=my-test-shop.myshopify.com

--- a/test/fixtures/project/.env
+++ b/test/fixtures/project/.env
@@ -1,0 +1,4 @@
+API_KEY=apikey
+SECRET=secret
+HOST=https://example.com
+SHOP=my-test-shop.myshopify.com

--- a/test/fixtures/project/.shopify-cli.yml
+++ b/test/fixtures/project/.shopify-cli.yml
@@ -1,0 +1,2 @@
+---
+app_type: fake

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 module ShopifyCli
   module AppTypes
     class NodeTest < MiniTest::Test
-      include TestHelpers::Context
+      include TestHelpers::Project
       include TestHelpers::Constants
 
       def setup
-        super
+        project_context('app_types', 'node')
         @app = ShopifyCli::AppTypes::Node.new(ctx: @context)
         @context.app_metadata = {
           host: 'host',
@@ -81,9 +81,6 @@ module ShopifyCli
       end
 
       def test_server_command
-        @context.stubs(:project).returns(
-          Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-        ).at_least_once
         @context.app_metadata[:host] = 'https://example.com'
         cmd = ShopifyCli::Commands::Serve.new(@context)
         @context.expects(:system).with(
@@ -93,9 +90,6 @@ module ShopifyCli
       end
 
       def test_open_command
-        @context.stubs(:project).returns(
-          Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-        ).at_least_once
         cmd = ShopifyCli::Commands::Open.new(@context)
         @context.expects(:system).with(
           'open',

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -3,15 +3,16 @@ require 'test_helper'
 module ShopifyCli
   module AppTypes
     class RailsTest < MiniTest::Test
-      include TestHelpers::Context
+      include TestHelpers::Project
 
       def setup
-        super
+        project_context('app_types', 'rails')
         @app = ShopifyCli::AppTypes::Rails.new(ctx: @context)
         @context.app_metadata = {
           api_key: 'api_key',
           secret: 'secret',
         }
+        Helpers::EnvFile.any_instance.stubs(:write)
       end
 
       def test_build_creates_rails_app
@@ -77,9 +78,6 @@ module ShopifyCli
       end
 
       def test_server_command
-        @context.stubs(:project).returns(
-          Project.at(File.join(FIXTURE_DIR, 'app_types/rails'))
-        ).at_least_once
         cmd = ShopifyCli::Commands::Serve.new(@context)
         @context.expects(:system).with(
           "PORT=8081 bin/rails server"
@@ -88,9 +86,6 @@ module ShopifyCli
       end
 
       def test_open_command
-        @context.stubs(:project).returns(
-          Project.at(File.join(FIXTURE_DIR, 'app_types/rails'))
-        ).at_least_once
         cmd = ShopifyCli::Commands::Open.new(@context)
         @context.expects(:system).with(
           'open',

--- a/test/shopify-cli/commands/deploy_test.rb
+++ b/test/shopify-cli/commands/deploy_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class DeployTest < MiniTest::Test
-      include TestHelpers::AppType
+      include TestHelpers::Project
 
       def setup
         super

--- a/test/shopify-cli/commands/generate/billing_test.rb
+++ b/test/shopify-cli/commands/generate/billing_test.rb
@@ -4,7 +4,7 @@ module ShopifyCli
   module Commands
     class Generate
       class BillingTest < MiniTest::Test
-        include TestHelpers::Context
+        include TestHelpers::Project
 
         def setup
           super
@@ -12,17 +12,15 @@ module ShopifyCli
         end
 
         def test_recurring_billing
-          ShopifyCli::Project.write(@context, :node)
           CLI::UI::Prompt.expects(:ask).returns(:billing_recurring)
-          @context.expects(:system).with('npm run-script generate-recurring-billing --silent')
+          @context.expects(:system).with('generate-recurring-billing')
             .returns(mock(success?: true))
           @command.call(['billing'], nil)
         end
 
         def test_one_time_billing
-          ShopifyCli::Project.write(@context, :node)
           CLI::UI::Prompt.expects(:ask).returns(:billing_one_time)
-          @context.expects(:system).with('npm run-script generate-one-time-billing --silent')
+          @context.expects(:system).with('generate-one-time-billing')
             .returns(mock(success?: true))
           @command.call(['billing'], nil)
         end

--- a/test/shopify-cli/commands/generate/page_test.rb
+++ b/test/shopify-cli/commands/generate/page_test.rb
@@ -4,7 +4,7 @@ module ShopifyCli
   module Commands
     class Generate
       class PageTest < MiniTest::Test
-        include TestHelpers::Context
+        include TestHelpers::Project
 
         def setup
           super
@@ -12,8 +12,7 @@ module ShopifyCli
         end
 
         def test_run
-          ShopifyCli::Project.write(@context, :node)
-          @context.expects(:system).with('npm run-script generate-page --silent name')
+          @context.expects(:system).with('page-generate name')
             .returns(mock(success?: true))
           @command.call(['page', 'name'], nil)
         end

--- a/test/shopify-cli/commands/generate/webhook_test.rb
+++ b/test/shopify-cli/commands/generate/webhook_test.rb
@@ -4,44 +4,28 @@ module ShopifyCli
   module Commands
     class Generate
       class WebhookTest < MiniTest::Test
-        include TestHelpers::Context
-        include TestHelpers::AppType
+        include TestHelpers::Project
+
         def setup
           super
           @command = ShopifyCli::Commands::Generate.new(@context)
         end
 
         def test_with_param
-          ShopifyCli::Project.expects(:current).returns(
-            TestHelpers::FakeProject.new(
-              directory: @context.root,
-              config: {
-                'app_type' => 'node',
-              }
-            )
-          ).at_least_once
           ShopifyCli::Tasks::Schema.expects(:call).returns(
             JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
           )
-          @context.expects(:system).with('npm run-script generate-webhook --silent PRODUCT_CREATE')
+          @context.expects(:system).with('generate-webhook PRODUCT_CREATE')
             .returns(mock(success?: true))
           @command.call(['webhook', 'PRODUCT_CREATE'], nil)
         end
 
         def test_with_selection
-          ShopifyCli::Project.expects(:current).returns(
-            TestHelpers::FakeProject.new(
-              directory: @context.root,
-              config: {
-                'app_type' => 'node',
-              }
-            )
-          ).at_least_once
           ShopifyCli::Tasks::Schema.expects(:call).returns(
             JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json"))),
           )
           CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
-          @context.expects(:system).with('npm run-script generate-webhook --silent PRODUCT_CREATE')
+          @context.expects(:system).with('generate-webhook PRODUCT_CREATE')
             .returns(mock(success?: true))
           @command.call(['webhook'], nil)
         end

--- a/test/shopify-cli/commands/generate_test.rb
+++ b/test/shopify-cli/commands/generate_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class GenerateTest < MiniTest::Test
-      include TestHelpers::AppType
+      include TestHelpers::Project
 
       def setup
         super

--- a/test/shopify-cli/commands/populate/customer_test.rb
+++ b/test/shopify-cli/commands/populate/customer_test.rb
@@ -4,14 +4,11 @@ module ShopifyCli
   module Commands
     class Populate
       class CustomerTest < MiniTest::Test
-        include TestHelpers::Context
+        include TestHelpers::Project
         include TestHelpers::Schema
 
         def setup
           super
-          @context.stubs(:project).returns(
-            Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-          )
           Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
           ShopifyCli::Helpers::API.any_instance.stubs(:latest_api_version)
             .returns('2019-04')

--- a/test/shopify-cli/commands/populate/draft_order_test.rb
+++ b/test/shopify-cli/commands/populate/draft_order_test.rb
@@ -4,14 +4,11 @@ module ShopifyCli
   module Commands
     class Populate
       class DraftOrderTest < MiniTest::Test
-        include TestHelpers::Context
+        include TestHelpers::Project
         include TestHelpers::Schema
 
         def setup
           super
-          @context.stubs(:project).returns(
-            Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-          )
           Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
           ShopifyCli::Helpers::API.any_instance.stubs(:latest_api_version)
             .returns('2019-04')

--- a/test/shopify-cli/commands/populate/product_test.rb
+++ b/test/shopify-cli/commands/populate/product_test.rb
@@ -4,14 +4,11 @@ module ShopifyCli
   module Commands
     class Populate
       class ProductTest < MiniTest::Test
-        include TestHelpers::Context
+        include TestHelpers::Project
         include TestHelpers::Schema
 
         def setup
           super
-          @context.stubs(:project).returns(
-            Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-          )
           Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
           ShopifyCli::Helpers::API.any_instance.stubs(:latest_api_version)
             .returns('2019-04')

--- a/test/shopify-cli/commands/populate/resource_test.rb
+++ b/test/shopify-cli/commands/populate/resource_test.rb
@@ -4,15 +4,12 @@ module ShopifyCli
   module Commands
     class Populate
       class ResourceTest < MiniTest::Test
-        include TestHelpers::Context
+        include TestHelpers::Project
         include TestHelpers::Schema
 
         def setup
           super
           Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
-          @context.stubs(:project).returns(
-            Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-          )
         end
 
         def test_with_schema_args_overrides_input

--- a/test/shopify-cli/commands/populate_test.rb
+++ b/test/shopify-cli/commands/populate_test.rb
@@ -3,14 +3,11 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class PopulateTest < MiniTest::Test
-      include TestHelpers::Context
+      include TestHelpers::Project
 
       def setup
         super
         @command = ShopifyCli::Commands::Populate.new(@context)
-        @context.stubs(:project).returns(
-          Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-        )
         Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
       end
 

--- a/test/shopify-cli/commands/serve_test.rb
+++ b/test/shopify-cli/commands/serve_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class ServeTest < MiniTest::Test
-      include TestHelpers::AppType
+      include TestHelpers::Project
 
       def setup
         super

--- a/test/shopify-cli/helpers/api_test.rb
+++ b/test/shopify-cli/helpers/api_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ShopifyCli
   module Helpers
     class APITest < MiniTest::Test
-      include TestHelpers::Context
+      include TestHelpers::Project
 
       def setup
         super
@@ -11,9 +11,6 @@ module ShopifyCli
         @api.stubs(:latest_api_version).returns('2019-04')
         @api.stubs(:current_sha).returns('abcde')
         @api.stubs(:uname).with(flag: 'v').returns('Mac')
-        @context.stubs(:project).returns(
-          Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-        )
       end
 
       def test_mutation_makes_request_to_shopify

--- a/test/shopify-cli/helpers/env_file_test.rb
+++ b/test/shopify-cli/helpers/env_file_test.rb
@@ -3,14 +3,15 @@ require 'test_helper'
 
 module ShopifyCli
   module Helpers
-    class EnvFileHelperTest < MiniTest::Test
-      include TestHelpers::AppType
+    class EnvFileTest < MiniTest::Test
+      include TestHelpers::Project
 
       def test_read_reads_env_content_from_file
-        env_file = EnvFile.read(TestHelpers::AppType::FakeAppType, fixture)
-        assert_equal(env_file.api_key, 'foo')
-        assert_equal(env_file.secret, 'bar')
-        assert_equal(env_file.host, 'baz')
+        env_file = EnvFile.read(TestHelpers::AppType::FakeAppType, '.env')
+        assert_equal(env_file.api_key, 'apikey')
+        assert_equal(env_file.secret, 'secret')
+        assert_equal(env_file.host, 'https://example.com')
+        assert_equal(env_file.shop, 'my-test-shop.myshopify.com')
       end
 
       def test_write_writes_env_content_to_file
@@ -20,13 +21,14 @@ module ShopifyCli
           secret: 'bar',
           host: 'baz'
         )
-        @context.expects(:write).with('.env', File.read(fixture))
+        content = <<~CONTENT
+          API_KEY=foo
+          SECRET=bar
+          HOST=baz
+        CONTENT
+        @context.expects(:write).with('.env', content)
         @context.expects(:print_task).with('writing .env file')
         env_file.write(@context, '.env')
-      end
-
-      def fixture
-        File.join(ShopifyCli::ROOT, 'test/fixtures/env_file_read.env')
       end
     end
   end

--- a/test/shopify-cli/task/schema_test.rb
+++ b/test/shopify-cli/task/schema_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ShopifyCli
   module Tasks
     class SchemaTest < MiniTest::Test
-      include TestHelpers::Context
+      include TestHelpers::Project
       include ShopifyCli::Helpers::GraphQL::Queries
       include TestHelpers::Constants
 
@@ -13,9 +13,6 @@ module ShopifyCli
         @command = ShopifyCli::Commands::Update.new
         redefine_constant(ShopifyCli, :TEMP_DIR, Dir.mktmpdir)
         FileUtils.mkdir("#{ShopifyCli::TEMP_DIR}/.shopify_schema")
-        @context.stubs(:project).returns(
-          Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
-        )
         ShopifyCli::Helpers::API.any_instance.stubs(:latest_api_version)
           .returns('2019-04')
         ShopifyCli::Helpers::AccessToken.expects(:read).returns(

--- a/test/task/authenticate_shopify_test.rb
+++ b/test/task/authenticate_shopify_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module ShopifyCli
   module Tasks
     class AuthenticateShopifyTest < MiniTest::Test
-      include TestHelpers::Context
+      include TestHelpers::Project
       include TestHelpers::Constants
 
       def setup
@@ -13,29 +13,13 @@ module ShopifyCli
       end
 
       def test_store_token
-        ShopifyCli::Project.expects(:current).returns(
-          TestHelpers::FakeProject.new(
-            directory: @context.root,
-            config: {
-              'app_type' => 'node',
-            }
-          )
-        ).at_least_once
-        ShopifyCli::Helpers::EnvFile.expects(:read).returns(
-          ShopifyCli::Helpers::EnvFile.new(
-            app_type: 'node',
-            api_key: 'apikey',
-            secret: 'secret',
-            shop: 'myshop',
-          )
-        ).at_least_once
         ShopifyCli::Helpers::AccessToken.expects(:read).returns(
           File.read(File.join(ShopifyCli::ROOT, "test/fixtures/.apikey"))
         )
         @context.expects(:system)
         File.stub(:write, true) do
           AuthenticateShopify.any_instance.expects(:wait_for_redirect).returns('mycode')
-          stub_request(:post, "https://myshop/admin/oauth/access_token")
+          stub_request(:post, "https://my-test-shop.myshopify.com/admin/oauth/access_token")
             .with(body: "client_id=apikey&client_secret=secret&code=mycode",
               headers: {
                 'Accept' => '*/*',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,6 @@ require 'byebug'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require_relative 'minitest_ext'
-require_relative 'test_helpers'
 require 'fakefs/safe'
 require 'webmock/minitest'
 
@@ -34,3 +33,5 @@ module Minitest
     end
   end
 end
+
+require_relative 'test_helpers'

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 module TestHelpers
+  autoload :AppType, 'test_helpers/app_type'
   autoload :Constants, 'test_helpers/constants'
   autoload :Context, 'test_helpers/context'
   autoload :FakeTask, 'test_helpers/fake_task'
   autoload :FakeContext, 'test_helpers/fake_context'
   autoload :FakeFS, 'test_helpers/fake_fs'
   autoload :FakeProject, 'test_helpers/fake_project'
-  autoload :AppType, 'test_helpers/app_type'
+  autoload :Project, 'test_helpers/project'
   autoload :Schema, 'test_helpers/schema'
 end

--- a/test/test_helpers/app_type.rb
+++ b/test/test_helpers/app_type.rb
@@ -1,14 +1,13 @@
 module TestHelpers
   module AppType
-    include TestHelpers::Context
-
     class FakeAppType < ShopifyCli::AppTypes::AppType
       class << self
         def env_file
           <<~ENV
-            SHOPIFY_API_KEY={api_key}
-            SHOPIFY_SECRET={secret}
-            SHOPIFY_HOST={host}
+            API_KEY={api_key}
+            SECRET={secret}
+            HOST={host}
+            SHOP={shop}
           ENV
         end
 
@@ -21,7 +20,9 @@ module TestHelpers
         def generate
           {
             page: 'page-generate',
-            billing: 'billing-generate',
+            billing_recurring: 'generate-recurring-billing',
+            billing_one_time: 'generate-one-time-billing',
+            webhook: 'generate-webhook',
           }
         end
 
@@ -34,11 +35,6 @@ module TestHelpers
     def setup
       super
       ShopifyCli::AppTypeRegistry.register(:fake, FakeAppType)
-      content = <<~CONTENT
-        ---
-        app_type: :fake
-      CONTENT
-      File.write(File.join(@context.root, '.shopify-cli.yml'), content)
     end
 
     def teardown

--- a/test/test_helpers/project.rb
+++ b/test/test_helpers/project.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module TestHelpers
+  module Project
+    include TestHelpers::AppType
+
+    def setup
+      project_context('project')
+      super
+    end
+
+    def project_context(*dir)
+      root = File.join(MiniTest::Test::FIXTURE_DIR, *dir)
+      @context = TestHelpers::FakeContext.new(
+        root: root,
+        env: {
+          'HOME' => '~',
+          'XDG_CONFIG_HOME' => root,
+        }
+      )
+      FileUtils.cd(@context.root)
+    end
+
+    def teardown
+      @context = nil
+      FileUtils.cd('/')
+      super
+    end
+  end
+end


### PR DESCRIPTION
Currently we test commands and tasks that depend on being run in a project context with a lot of stubbing and mocking. I've instead created a `Project` TestHelper that you can include in a test class and it will provide what's needed for this. 

Closes #190 