### PR TITLE
make Project access consistent

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,16 @@
+# Development notes
+
+## ShopifyCli::Context
+
+## What to use it for
+- Reading from the user's ENV
+- Executing things: `system`, `capture2`, `exec`, etc.
+- Displaying output
+
+
+## ShopifyCli::Project
+
+## What to use it for
+- Accessing information about the current project (app/codebase):
+    - You can read from the `.env` file with the `Project.env` method
+    - Accessing the `AppType` via `Project.app_type`

--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -18,9 +18,9 @@ module ShopifyCli
           'node embedded app'
         end
 
-        def serve_command(ctx)
+        def serve_command(_ctx)
           %W(
-            HOST=#{ctx.project.env.host}
+            HOST=#{Project.current.env.host}
             PORT=#{ShopifyCli::Tasks::Tunnel::PORT}
             npm run dev
           ).join(' ')
@@ -36,7 +36,7 @@ module ShopifyCli
         end
 
         def open(ctx)
-          ctx.system('open', "#{ctx.project.env.host}/auth?shop=#{ctx.project.env.shop}")
+          ctx.system('open', "#{Project.current.env.host}/auth?shop=#{Project.current.env.shop}")
         end
       end
 

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -36,7 +36,7 @@ module ShopifyCli
         end
 
         def open(ctx)
-          ctx.system('open', "#{ctx.project.env.host}/login?shop=#{ctx.project.env.shop}")
+          ctx.system('open', "#{Project.current.env.host}/login?shop=#{Project.current.env.shop}")
         end
       end
 

--- a/lib/shopify-cli/commands/generate/billing.rb
+++ b/lib/shopify-cli/commands/generate/billing.rb
@@ -6,12 +6,13 @@ module ShopifyCli
       class Billing < ShopifyCli::Task
         def call(ctx, args)
           ctx.puts(self.class.help) if args.empty?
+          project = ShopifyCli::Project.current
+
           # temporary check until we build for rails
-          if ctx.project.app_type == ShopifyCli::AppTypes::Rails
+          if project.app_type == ShopifyCli::AppTypes::Rails
             raise(ShopifyCli::Abort, 'This feature is not yet available for Rails apps')
           end
 
-          project = ShopifyCli::Project.current
           type = CLI::UI::Prompt.ask('Which kind of billing?') do |handler|
             handler.option('recurring billing') { :billing_recurring }
             handler.option('one-time billing') { :billing_one_time }

--- a/lib/shopify-cli/commands/generate/page.rb
+++ b/lib/shopify-cli/commands/generate/page.rb
@@ -9,12 +9,13 @@ module ShopifyCli
             ctx.puts(self.class.help)
             return
           end
+          project = ShopifyCli::Project.current
+
           # temporary check until we build for rails
-          if ctx.project.app_type == ShopifyCli::AppTypes::Rails
+          if project.app_type == ShopifyCli::AppTypes::Rails
             raise(ShopifyCli::Abort, 'This feature is not yet available for Rails apps')
           end
           name = args.first
-          project = ShopifyCli::Project.current
           ShopifyCli::Commands::Generate.run_generate("#{project.app_type.generate[:page]} #{name}", name, ctx)
           ctx.puts("{{green:✔︎}} Generating page: #{name}")
         end

--- a/lib/shopify-cli/commands/generate/webhook.rb
+++ b/lib/shopify-cli/commands/generate/webhook.rb
@@ -5,8 +5,9 @@ module ShopifyCli
     class Generate
       class Webhook < ShopifyCli::Task
         def call(ctx, args)
+          project = ShopifyCli::Project.current
           # temporary check until we build for rails
-          if ctx.project.app_type == ShopifyCli::AppTypes::Rails
+          if project.app_type == ShopifyCli::AppTypes::Rails
             raise(ShopifyCli::Abort, 'This feature is not yet available for Rails apps')
           end
           selected_type = args.first
@@ -23,7 +24,6 @@ module ShopifyCli
             end
           end
 
-          project = ShopifyCli::Project.current
           app_type = project.app_type
           ShopifyCli::Commands::Generate
             .run_generate("#{app_type.generate[:webhook]} #{selected_type}", selected_type, ctx)

--- a/lib/shopify-cli/commands/open.rb
+++ b/lib/shopify-cli/commands/open.rb
@@ -6,7 +6,7 @@ module ShopifyCli
       prerequisite_task :tunnel
 
       def call(*)
-        @ctx.project.app_type.open(@ctx)
+        Project.current.app_type.open(@ctx)
       end
 
       def self.help

--- a/lib/shopify-cli/commands/populate/resource.rb
+++ b/lib/shopify-cli/commands/populate/resource.rb
@@ -128,7 +128,7 @@ module ShopifyCli
         end
 
         def admin_url(type, id)
-          "https://#{ctx.project.env.shop}/admin/#{type}s/#{id}"
+          "https://#{Project.current.env.shop}/admin/#{type}s/#{id}"
         end
 
         def price

--- a/lib/shopify-cli/commands/serve.rb
+++ b/lib/shopify-cli/commands/serve.rb
@@ -10,13 +10,14 @@ module ShopifyCli
       prerequisite_task :tunnel
 
       def call(*)
+        project = Project.current
         if mac?
           @ctx.puts("{{green:! tip}} Press Control-T to open this project in your browser")
           on_siginfo do
-            @ctx.project.app_type.open(@ctx)
+            project.app_type.open(@ctx)
           end
         end
-        @ctx.system(@ctx.project.app_type.serve_command(@ctx))
+        @ctx.system(project.app_type.serve_command(@ctx))
       end
 
       def self.help

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -15,10 +15,6 @@ module ShopifyCli
     property :root, default: lambda { Dir.pwd }, converts: :to_s
     property :env, default: lambda { ($original_env || ENV).clone }
 
-    def project
-      @project ||= ShopifyCli::Project.at(root)
-    end
-
     def getenv(name)
       v = @env[name]
       v == '' ? nil : v

--- a/lib/shopify-cli/helpers/api.rb
+++ b/lib/shopify-cli/helpers/api.rb
@@ -18,7 +18,7 @@ module ShopifyCli
       class APIRequestThrottledError < APIRequestRetriableError; end
 
       def graphql_url
-        "https://#{ctx.project.env.shop}/admin/api/#{latest_api_version}/graphql.json"
+        "https://#{Project.current.env.shop}/admin/api/#{latest_api_version}/graphql.json"
       end
 
       def latest_api_version
@@ -26,7 +26,7 @@ module ShopifyCli
       end
 
       def fetch_latest_api_version
-        url = "https://#{ctx.project.env.shop}/admin/api/unstable/graphql.json"
+        url = "https://#{Project.current.env.shop}/admin/api/unstable/graphql.json"
 
         query = <<~QUERY
           {


### PR DESCRIPTION
This PRs attempts to begin a clearer delineation between Context and Project. A lot of stuff was accessing Project via the `ctx.project` convenience method, which I've removed. Instead everything should access it the same way, via `Project.current`. I also started a development.md file for documenting some of this thinking.