### PR TITLE
Simplify EnvFile's interface

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -46,14 +46,13 @@ module ShopifyCli
         ShopifyCli::Tasks::JsDeps.call(ctx.root)
 
         env_file = Helpers::EnvFile.new(
-          app_type: self,
           api_key: ctx.app_metadata[:api_key],
           secret: ctx.app_metadata[:secret],
           host: ctx.app_metadata[:host],
           shop: ctx.app_metadata[:shop],
           scopes: 'write_products,write_customers,write_draft_orders',
         )
-        env_file.write(ctx, '.env')
+        env_file.write(ctx)
 
         begin
           ctx.rm_r(File.join(ctx.root, '.git'))

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -77,14 +77,13 @@ module ShopifyCli
         ShopifyCli::Finalize.request_cd(name)
 
         env_file = Helpers::EnvFile.new(
-          app_type: self,
           api_key: ctx.app_metadata[:api_key],
           secret: ctx.app_metadata[:secret],
           host: ctx.app_metadata[:host],
           shop: ctx.app_metadata[:shop],
           scopes: 'write_products,write_customers,write_orders',
         )
-        env_file.write(ctx, '.env')
+        env_file.write(ctx)
 
         set_custom_ua
 

--- a/lib/shopify-cli/helpers/access_token.rb
+++ b/lib/shopify-cli/helpers/access_token.rb
@@ -16,9 +16,7 @@ module ShopifyCli
         end
 
         def file_name
-          project = ShopifyCli::Project.current
-          env = Helpers::EnvFile.read(project.app_type,
-            File.join(project.directory, '.env'))
+          env = Helpers::EnvFile.read
           @file_name = env.api_key
         end
       end

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -57,7 +57,7 @@ module ShopifyCli
     end
 
     def env
-      @env ||= ShopifyCli::Helpers::EnvFile.read(app_type, File.join(directory, '.env'))
+      @env ||= Helpers::EnvFile.read(directory)
     end
 
     def config

--- a/lib/shopify-cli/tasks/authenticate_shopify.rb
+++ b/lib/shopify-cli/tasks/authenticate_shopify.rb
@@ -74,12 +74,8 @@ module ShopifyCli
         uri
       end
 
-      def project
-        @project = ShopifyCli::Project.current
-      end
-
       def env
-        @env = Helpers::EnvFile.read(project.app_type, File.join(project.directory, '.env'))
+        @env = Helpers::EnvFile.read
       end
 
       def extract_query_param(key, request)

--- a/lib/shopify-cli/tasks/schema.rb
+++ b/lib/shopify-cli/tasks/schema.rb
@@ -21,9 +21,7 @@ module ShopifyCli
       end
 
       def shop_name
-        project = ShopifyCli::Project.current
-        env = Helpers::EnvFile.read(project.app_type,
-          File.join(ShopifyCli::Project.current.directory, '.env'))
+        env = Helpers::EnvFile.read
         @shop_name = env.shop
       end
 

--- a/test/shopify-cli/helpers/env_file_test.rb
+++ b/test/shopify-cli/helpers/env_file_test.rb
@@ -7,7 +7,7 @@ module ShopifyCli
       include TestHelpers::Project
 
       def test_read_reads_env_content_from_file
-        env_file = EnvFile.read(TestHelpers::AppType::FakeAppType, '.env')
+        env_file = EnvFile.read
         assert_equal(env_file.api_key, 'apikey')
         assert_equal(env_file.secret, 'secret')
         assert_equal(env_file.host, 'https://example.com')
@@ -16,7 +16,6 @@ module ShopifyCli
 
       def test_write_writes_env_content_to_file
         env_file = EnvFile.new(
-          app_type: TestHelpers::AppType::FakeAppType.new(ctx: @context),
           api_key: 'foo',
           secret: 'bar',
           host: 'baz'
@@ -28,7 +27,7 @@ module ShopifyCli
         CONTENT
         @context.expects(:write).with('.env', content)
         @context.expects(:print_task).with('writing .env file')
-        env_file.write(@context, '.env')
+        env_file.write(@context)
       end
     end
   end


### PR DESCRIPTION
Right now EnvFile takes a bunch of unnecessary arguments: it asks for `app_type`, but we can just use `Project.current` to get that, and `write` takes a filename although we only have stacks that read from `.env` files.

Prerequisite for #156 