### PR TITLE
Fix EnvFile write during project create

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -52,7 +52,7 @@ module ShopifyCli
           shop: ctx.app_metadata[:shop],
           scopes: 'write_products,write_customers,write_draft_orders',
         )
-        env_file.write(ctx)
+        env_file.write(ctx, self.class.env_file)
 
         begin
           ctx.rm_r(File.join(ctx.root, '.git'))

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -83,7 +83,7 @@ module ShopifyCli
           shop: ctx.app_metadata[:shop],
           scopes: 'write_products,write_customers,write_orders',
         )
-        env_file.write(ctx)
+        env_file.write(ctx, self.class.env_file)
 
         set_custom_ua
 

--- a/lib/shopify-cli/helpers/env_file.rb
+++ b/lib/shopify-cli/helpers/env_file.rb
@@ -53,8 +53,8 @@ module ShopifyCli
       property :scopes
       property :host
 
-      def write(ctx)
-        template = self.class.parse_template(Project.current.app_type.env_file)
+      def write(ctx, template)
+        template = self.class.parse_template(template)
         output = []
         template.each do |key, value|
           output << "#{key}=#{send(value)}" if send(value)

--- a/lib/shopify-cli/helpers/gem.rb
+++ b/lib/shopify-cli/helpers/gem.rb
@@ -28,7 +28,7 @@ module ShopifyCli
 
         def apply_gem_home(ctx)
           path = File.join(ctx.getenv('HOME'), '.gem', 'ruby', RUBY_VERSION)
-          ctx.mkdir_p(path)
+          ctx.mkdir_p(path) unless Dir.exist?(path)
           ctx.setenv('GEM_HOME', path)
         end
       end

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -2,12 +2,9 @@ require 'test_helper'
 
 module ShopifyCli
   module AppTypes
-    class NodeTest < MiniTest::Test
-      include TestHelpers::Project
-      include TestHelpers::Constants
-
+    class NodeBuildTest < MiniTest::Test
       def setup
-        project_context('app_types', 'node')
+        @context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
         @app = ShopifyCli::AppTypes::Node.new(ctx: @context)
         @context.app_metadata = {
           host: 'host',
@@ -78,6 +75,16 @@ module ShopifyCli
         ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
         @context.expects(:write)
         @app.build('test-app')
+      end
+    end
+
+    class NodeTest < MiniTest::Test
+      include TestHelpers::Project
+      include TestHelpers::Constants
+
+      def setup
+        project_context('app_types', 'node')
+        @app = ShopifyCli::AppTypes::Node.new(ctx: @context)
       end
 
       def test_server_command

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -5,13 +5,7 @@ module ShopifyCli
     class RailsBuildTest < MiniTest::Test
       def setup
         root = Dir.mktmpdir
-        @context = TestHelpers::FakeContext.new(
-          root: root,
-          env: {
-            'HOME' => '~',
-            'XDG_CONFIG_HOME' => root,
-          }
-        )
+        @context = TestHelpers::FakeContext.new(root: root)
         @app = ShopifyCli::AppTypes::Rails.new(ctx: @context)
         @context.app_metadata = {
           api_key: 'api_key',
@@ -29,14 +23,16 @@ module ShopifyCli
         ShopifyCli::Helpers::Gem.expects(:install).with(@context, 'rails')
         ShopifyCli::Helpers::Gem.expects(:install).with(@context, 'bundler')
         @context.expects(:system).with(
-          "~/.gem/ruby/#{RUBY_VERSION}/bin/rails", 'new', 'test-app'
+          ShopifyCli::Helpers::Gem.binary_path_for(@context, 'rails'), 'new', 'test-app'
         )
         File.expects(:open).with(File.join(@context.root, 'Gemfile'), 'a')
         @context.expects(:system).with(
-          "~/.gem/ruby/#{RUBY_VERSION}/bin/bundle", 'install', chdir: @context.root
+          ShopifyCli::Helpers::Gem.binary_path_for(@context, 'bundle'),
+          'install',
+          chdir: @context.root
         )
         @context.expects(:system).with(
-          "~/.gem/ruby/#{RUBY_VERSION}/bin/rails",
+          ShopifyCli::Helpers::Gem.binary_path_for(@context, 'rails'),
           'generate',
           'shopify_app',
           '--api_key api_key',
@@ -44,7 +40,7 @@ module ShopifyCli
           chdir: @context.root
         )
         @context.expects(:system).with(
-          "~/.gem/ruby/#{RUBY_VERSION}/bin/rails",
+          ShopifyCli::Helpers::Gem.binary_path_for(@context, 'rails'),
           'db:migrate',
           'RAILS_ENV=development',
           chdir: @context.root

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -2,17 +2,21 @@ require 'test_helper'
 
 module ShopifyCli
   module AppTypes
-    class RailsTest < MiniTest::Test
-      include TestHelpers::Project
-
+    class RailsBuildTest < MiniTest::Test
       def setup
-        project_context('app_types', 'rails')
+        root = Dir.mktmpdir
+        @context = TestHelpers::FakeContext.new(
+          root: root,
+          env: {
+            'HOME' => '~',
+            'XDG_CONFIG_HOME' => root,
+          }
+        )
         @app = ShopifyCli::AppTypes::Rails.new(ctx: @context)
         @context.app_metadata = {
           api_key: 'api_key',
           secret: 'secret',
         }
-        Helpers::EnvFile.any_instance.stubs(:write)
       end
 
       def test_build_creates_rails_app
@@ -75,6 +79,16 @@ module ShopifyCli
           CLI::UI.fmt('Run {{command:shopify serve}} to start the local development server'),
           output
         )
+      end
+    end
+
+    class RailsTest < MiniTest::Test
+      include TestHelpers::Project
+
+      def setup
+        project_context('app_types', 'rails')
+        @app = ShopifyCli::AppTypes::Rails.new(ctx: @context)
+        Helpers::EnvFile.any_instance.stubs(:write)
       end
 
       def test_server_command

--- a/test/shopify-cli/helpers/env_file_test.rb
+++ b/test/shopify-cli/helpers/env_file_test.rb
@@ -27,7 +27,12 @@ module ShopifyCli
         CONTENT
         @context.expects(:write).with('.env', content)
         @context.expects(:print_task).with('writing .env file')
-        env_file.write(@context)
+        template = <<~TEMPLATE
+          API_KEY={api_key}
+          SECRET={secret}
+          HOST={host}
+        TEMPLATE
+        env_file.write(@context, template)
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #198 
Fixes #191 

I made a mistake in #195 in [node_test.rb](https://github.com/Shopify/shopify-app-cli/pull/195/files#diff-f1428f8b5ee35d21756214f9e8457f74) where I included the `project_context` method in the setup for all tests including tests for the `build` method. These tests should _not_ have a project context since one doesn't exist during project creation. Because of this my changes in #197 passed these tests even though they fail in real usage.

### WHAT is this pull request doing?

I'm temporarily passing in the template to the `EnvFile.write` method instead of relying on `Project.current`. This will be solved for good in an upcoming PR for #156 
