### PR TITLE
add info about installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Use the `stop` command to close the tunnel:
 ```sh
 $ shopify tunnel stop
 ```
+### Loading your app within the admin
+
+As the Shopify App CLI creates an embedded app, you'll need to install it on a development store. To do so, you'll need to head to `HTTPS://your-ngrok-url.io/auth?shop=your-development-store.myshopify.com`. This will prompt you to install on your development store. App Bridge and some Polaris components are only available within the admin.
 
 ### Generate new app features
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ shopify tunnel stop
 ```
 ### Loading your app within the admin
 
-As the Shopify App CLI creates an embedded app, you'll need to install it on a development store. To do so, you'll need to head to `HTTPS://your-ngrok-url.io/auth?shop=your-development-store.myshopify.com`. This will prompt you to install on your development store. App Bridge and some Polaris components are only available within the admin.
+As the Shopify App CLI creates an embedded app, you'll need to install it on a development store. To do so, open the installation URL in your web browser:  `https://<LIVE_NGROK_URL>/auth?shop=your-development-store.myshopify.com`. This will prompt you to install on your development store. It’s necessary to view and test your app in a live development store because some App Bridge and Polaris features are only available for use by your app when it’s embedded in the Shopify admin.
 
 ### Generate new app features
 


### PR DESCRIPTION
### WHY are these changes introduced?
We haven't provided information to the user about installing their app. This is causing confusion when the shopOrigin prop is returned undefined, or they cannot access app bridge features. 


Let me know if this is the right place to put this, or if the wording should be changed.