### PR TITLE
Allow Gem.install to take a version

### DIFF
--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -42,7 +42,10 @@ module ShopifyCli
 
       def build(name)
         Gem.install(ctx, 'rails')
-        Gem.install(ctx, 'bundler')
+        CLI::UI::Frame.open("Installing bundler…") do
+          Gem.install(ctx, 'bundler', '~>1.0')
+          Gem.install(ctx, 'bundler', '~>2.0')
+        end
         CLI::UI::Frame.open("Generating new rails app project in #{name}...") do
           ctx.system(Gem.binary_path_for(ctx, 'rails'), 'new', name)
         end
@@ -51,10 +54,6 @@ module ShopifyCli
           f.puts "\ngem 'shopify_app'"
         end
         ctx.puts("{{green:✔︎}} Adding shopify_app gem…")
-        CLI::UI::Frame.open("Installing bundler…") do
-          ctx.system('gem', 'install', 'bundler', '-v', '~>1.0', chdir: ctx.root)
-          ctx.system('gem', 'install', 'bundler', '-v', '~>2.0', chdir: ctx.root)
-        end
         CLI::UI::Frame.open("Running bundle install...") do
           ctx.system(Gem.binary_path_for(ctx, 'bundle'), 'install', chdir: ctx.root)
         end

--- a/lib/shopify-cli/helpers/gem.rb
+++ b/lib/shopify-cli/helpers/gem.rb
@@ -6,12 +6,15 @@ module ShopifyCli
     class Gem
       include SmartProperties
 
-      property :ctx, accepts: ShopifyCli::Context
-      property :name, converts: :to_s
+      property :ctx, accepts: ShopifyCli::Context, required: true
+      property :name, converts: :to_s, required: true
+      property :version, converts: :to_s
 
       class << self
-        def install(ctx, name)
-          gem = new(ctx: ctx, name: name)
+        def install(ctx, *args)
+          name = args.shift
+          version = args.shift
+          gem = new(ctx: ctx, name: name, version: version)
           ctx.debug("#{name} installed: #{gem.installed?}")
           gem.install! unless gem.installed?
         end
@@ -42,7 +45,10 @@ module ShopifyCli
       def install!
         spin = CLI::UI::SpinGroup.new
         spin.add("Installing #{name} gem...") do |spinner|
-          ctx.system("gem install #{name}")
+          args = %w(gem install)
+          args.push(name)
+          args.push('-v', version) unless version.nil?
+          ctx.system(*args)
           spinner.update_title("Installed #{name} gem")
         end
         spin.wait

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -21,7 +21,8 @@ module ShopifyCli
           'user_agent.rb'
         ), 'w').returns(nil)
         ShopifyCli::Helpers::Gem.expects(:install).with(@context, 'rails')
-        ShopifyCli::Helpers::Gem.expects(:install).with(@context, 'bundler')
+        ShopifyCli::Helpers::Gem.expects(:install).with(@context, 'bundler', '~>1.0')
+        ShopifyCli::Helpers::Gem.expects(:install).with(@context, 'bundler', '~>2.0')
         @context.expects(:system).with(
           ShopifyCli::Helpers::Gem.binary_path_for(@context, 'rails'), 'new', 'test-app'
         )
@@ -43,22 +44,6 @@ module ShopifyCli
           ShopifyCli::Helpers::Gem.binary_path_for(@context, 'rails'),
           'db:migrate',
           'RAILS_ENV=development',
-          chdir: @context.root
-        )
-        @context.expects(:system).with(
-          'gem',
-          'install',
-          'bundler',
-          '-v',
-          '~>1.0',
-          chdir: @context.root
-        )
-        @context.expects(:system).with(
-          'gem',
-          'install',
-          'bundler',
-          '-v',
-          '~>2.0',
           chdir: @context.root
         )
         @context.expects(:system).with(

--- a/test/shopify-cli/helpers/gem_test.rb
+++ b/test/shopify-cli/helpers/gem_test.rb
@@ -17,13 +17,18 @@ module ShopifyCli
       end
 
       def test_install_installs_with_gem_home_unpopulated
-        @context.expects(:system).with('gem install mygem')
+        @context.expects(:system).with('gem', 'install', 'mygem')
         Gem.install(@context, 'mygem')
+      end
+
+      def test_install_installs_gem_with_version
+        @context.expects(:system).with('gem', 'install', 'mygem', '-v', '> 5.0.0')
+        Gem.install(@context, 'mygem', '> 5.0.0')
       end
 
       def test_install_installs_with_gem_home_populated
         @context.setenv('GEM_HOME', "#{@home}/.gem/ruby/#{RUBY_VERSION}")
-        @context.expects(:system).with('gem install mygem')
+        @context.expects(:system).with('gem', 'install', 'mygem')
         Gem.install(@context, 'mygem')
       end
 
@@ -32,7 +37,7 @@ module ShopifyCli
         Dir.expects(:glob).with("#{@home}/.gem/ruby/#{RUBY_VERSION}/gems/mygem-*").returns([
           "#{@home}/.gem/ruby/#{RUBY_VERSION}/gems/mygem-1.0.0",
         ]).at_least_once
-        @context.expects(:system).with('gem install mygem').never
+        @context.expects(:system).with('gem', 'install', 'mygem').never
         Gem.install(@context, 'mygem')
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Quick cleanup allowing the Gem.install method to accept another argument for version.
