### PR TITLE
Populate help fix

### DIFF
--- a/lib/shopify-cli/commands/populate.rb
+++ b/lib/shopify-cli/commands/populate.rb
@@ -39,10 +39,10 @@ module ShopifyCli
               Usage: {{command:#{ShopifyCli::TOOL_NAME} populate products}}
 
             {{cyan:customers [options]}}: Add dummy customers to the specified development store.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate webhook [type]}}
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} populate customers}}
 
             {{cyan:draftorders [options]}}: Add dummy orders to the specified development store.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate billing}}
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} populate draftorders}}
 
           {{bold:Options:}}
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes `populate help` pages having `generate help` content

### WHAT is this pull request doing?

Updating help copy to the correct examples.
