### PR TITLE
Clean up test output

### DIFF
--- a/lib/shopify-cli/register.rb
+++ b/lib/shopify-cli/register.rb
@@ -1,9 +1,0 @@
-# defines register method for files being loaded in dev.rb
-module ShopifyCli
-  class InvalidOverrideError < StandardError; end
-
-  def self.invalid_register(invalid_register)
-    raise InvalidOverrideError, "\n\nCannot override using `register` in `dev`."\
-      "Invalid Register: #{invalid_register}\n\n"
-  end
-end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -24,24 +24,16 @@ require 'cli/ui'
 require 'cli/kit'
 require 'smart_properties'
 
-# Checks for conflicts with tools like RVM and Rbenv, etc.
-# Will exit if needed
-# require_relative 'dev/tool_conflicts'
-# Dev::ToolConflicts.check
-
-# Defines register commands for init scripts
-require 'shopify-cli/register'
-
 # Enable stdout routing. At this point all calls to STDOUT (and STDERR) will go through this class.
 # See https://github.com/Shopify/cli-ui/blob/master/lib/cli/ui/stdout_router.rb for more info
 CLI::UI::StdoutRouter.enable
 
-# The main file to load for `dev`
+# The main file to load for `shopify-app-cli`
 # Contains all high level constants, exit management, exception management,
 # autoloads for commands, tasks, helpers, etc
 #
 # It is recommended to read through CLI Kit (https://github.com/shopify/cli-kit) and a CLI Kit example
-# (https://github.com/Shopify/cli-kit-example) to fully understand how dev functions
+# (https://github.com/Shopify/cli-kit-example) to fully understand how shopify-app-cli functions
 module ShopifyCli
   extend CLI::Kit::Autocall
 
@@ -61,7 +53,7 @@ module ShopifyCli
   # shrug or boom emoji
   FAILMOJI = ROOT == '/opt/shopify-cli' ? "\u{1f937}" : "\u{1f4a5}"
 
-  # Exit management in `dev` follows the management set out by CLI Kit.
+  # Exit management in `shopify-app-cli` follows the management set out by CLI Kit.
   # https://github.com/Shopify/cli-kit/blob/master/lib/cli/kit.rb
   # That is to say, we differentiate between exit success (0), exit failure (1), and exit bug (not 1)
   #
@@ -70,7 +62,7 @@ module ShopifyCli
   EXIT_BUG                 = CLI::Kit::EXIT_BUG
   EXIT_SUCCESS             = CLI::Kit::EXIT_SUCCESS
 
-  # `dev` uses CLI Kit's exception management
+  # `shopify-app-cli` uses CLI Kit's exception management
   # These are documented here: https://github.com/Shopify/cli-kit/blob/master/lib/cli/kit.rb
   #
   # You should never subclass these exceptions, but instead rescue another exception and re-raise.
@@ -82,7 +74,7 @@ module ShopifyCli
   BugSilent    = CLI::Kit::BugSilent
   AbortSilent  = CLI::Kit::AbortSilent
 
-  # The rest of this file outlines classes and modules required by the dev application and CLI kit framework.
+  # The rest of this file outlines classes and modules required by the shopify-app-cli application and CLI kit framework.
   # To understand how this works, read https://github.com/Shopify/cli-kit/blob/master/lib/cli/kit.rb
   autocall(:Config)   { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
   autocall(:Logger)   { CLI::Kit::Logger.new(debug_log_file: DEBUG_LOG_FILE) }

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -74,7 +74,8 @@ module ShopifyCli
   BugSilent    = CLI::Kit::BugSilent
   AbortSilent  = CLI::Kit::AbortSilent
 
-  # The rest of this file outlines classes and modules required by the shopify-app-cli application and CLI kit framework.
+  # The rest of this file outlines classes and modules required by the shopify-app-cli
+  # application and CLI kit framework.
   # To understand how this works, read https://github.com/Shopify/cli-kit/blob/master/lib/cli/kit.rb
   autocall(:Config)   { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
   autocall(:Logger)   { CLI::Kit::Logger.new(debug_log_file: DEBUG_LOG_FILE) }

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -8,18 +8,6 @@ module Minitest
   class Test
     FIXTURE_DIR = File.expand_path('fixtures', File.dirname(__FILE__))
 
-    class FakeSpinner
-      def update_title(*); end
-
-      def wait; end
-    end
-
-    def setup
-      super
-      CLI::UI::Frame.stubs(:open).yields
-      CLI::UI::SpinGroup.any_instance.stubs(:add).yields(FakeSpinner.new)
-    end
-
     def capture_io(&block)
       cap = CLI::UI::StdoutRouter::Capture.new(with_frame_inset: true, &block)
       @context.output_captured = true if @context

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -1,5 +1,25 @@
 module Minitest
+  module Assertions
+    def assert_nothing_raised(*)
+      yield
+    end
+  end
+
   class Test
+    FIXTURE_DIR = File.expand_path('fixtures', File.dirname(__FILE__))
+
+    class FakeSpinner
+      def update_title(*); end
+
+      def wait; end
+    end
+
+    def setup
+      super
+      CLI::UI::Frame.stubs(:open).yields
+      CLI::UI::SpinGroup.any_instance.stubs(:add).yields(FakeSpinner.new)
+    end
+
     def capture_io(&block)
       cap = CLI::UI::StdoutRouter::Capture.new(with_frame_inset: true, &block)
       @context.output_captured = true if @context

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -86,15 +86,19 @@ module ShopifyCli
           'test-app',
         )
         ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
-        @app.build('test-app')
+        capture_io do
+          @app.build('test-app')
+        end
       end
     end
 
     class NodeTest < MiniTest::Test
       include TestHelpers::Project
       include TestHelpers::Constants
+      include TestHelpers::FakeUI
 
       def setup
+        super
         project_context('app_types', 'node')
         @app = ShopifyCli::AppTypes::Node.new(ctx: @context)
       end

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -59,8 +59,10 @@ module ShopifyCli
 
     class RailsTest < MiniTest::Test
       include TestHelpers::Project
+      include TestHelpers::FakeUI
 
       def setup
+        super
         project_context('app_types', 'rails')
         @app = ShopifyCli::AppTypes::Rails.new(ctx: @context)
         Helpers::EnvFile.any_instance.stubs(:write)

--- a/test/shopify-cli/commands/deploy/heroku_test.rb
+++ b/test/shopify-cli/commands/deploy/heroku_test.rb
@@ -5,6 +5,7 @@ module ShopifyCli
     class Deploy
       class HerokuTest < MiniTest::Test
         include TestHelpers::Context
+        include TestHelpers::FakeUI
 
         def setup
           super
@@ -128,11 +129,13 @@ module ShopifyCli
             .with(@heroku_command, 'whoami')
             .returns(['username', @status_mock[:true]])
 
-          io = capture_io do
+          CLI::UI::SpinGroup.any_instance.expects(:add).with(
+            'Authenticated with Heroku as `username`'
+          )
+
+          capture_io do
             @command.call(@context)
           end
-
-          assert_match('Authenticated with Heroku as `username`', io.join)
         end
 
         def test_call_attempts_to_authenticate_with_heroku_if_not_already_authed
@@ -159,11 +162,13 @@ module ShopifyCli
             .with('git', 'remote', 'get-url', 'heroku')
             .returns([@heroku_remote, @status_mock[:true]])
 
-          io = capture_io do
+          CLI::UI::SpinGroup.any_instance.expects(:add).with(
+            'Heroku app `app-name` selected'
+          )
+
+          capture_io do
             @command.call(@context)
           end
-
-          assert_match('Heroku app `app-name` selected', io.join)
         end
 
         def test_call_lets_you_choose_existing_heroku_app
@@ -277,11 +282,13 @@ module ShopifyCli
             .with('git', 'branch', '--list', '--format=%(refname:short)')
             .returns(["master\n", @status_mock[:true]])
 
-          io = capture_io do
+          CLI::UI::SpinGroup.any_instance.expects(:add).with(
+            'Git branch `master` selected for deploy'
+          )
+
+          capture_io do
             @command.call(@context)
           end
-
-          assert_match('Git branch `master` selected for deploy', io.join)
         end
 
         def test_call_lets_you_specify_a_branch_if_multiple_exist

--- a/test/shopify-cli/commands/generate/billing_test.rb
+++ b/test/shopify-cli/commands/generate/billing_test.rb
@@ -5,6 +5,7 @@ module ShopifyCli
     class Generate
       class BillingTest < MiniTest::Test
         include TestHelpers::Project
+        include TestHelpers::FakeUI
 
         def setup
           super

--- a/test/shopify-cli/commands/generate/page_test.rb
+++ b/test/shopify-cli/commands/generate/page_test.rb
@@ -5,6 +5,7 @@ module ShopifyCli
     class Generate
       class PageTest < MiniTest::Test
         include TestHelpers::Project
+        include TestHelpers::FakeUI
 
         def setup
           super

--- a/test/shopify-cli/commands/serve_test.rb
+++ b/test/shopify-cli/commands/serve_test.rb
@@ -4,6 +4,7 @@ module ShopifyCli
   module Commands
     class ServeTest < MiniTest::Test
       include TestHelpers::Project
+      include TestHelpers::FakeUI
 
       def setup
         super

--- a/test/shopify-cli/helpers/gem_test.rb
+++ b/test/shopify-cli/helpers/gem_test.rb
@@ -5,6 +5,7 @@ module ShopifyCli
   module Helpers
     class GemTest < MiniTest::Test
       include TestHelpers::Context
+      include TestHelpers::FakeUI
 
       def setup
         super

--- a/test/shopify-cli/smoke_test.rb
+++ b/test/shopify-cli/smoke_test.rb
@@ -4,7 +4,9 @@ module ShopifyCli
   class SmokeTest < MiniTest::Test
     def test_exit_non_zero
       assert_nothing_raised do
-        ShopifyCli::EntryPoint.call(['help'])
+        capture_io do
+          ShopifyCli::EntryPoint.call(['help'])
+        end
       end
     end
   end

--- a/test/shopify-cli/task/clone_test.rb
+++ b/test/shopify-cli/task/clone_test.rb
@@ -16,7 +16,6 @@ module ShopifyCli
           ShopifyCli::Tasks::Clone.call('git@github.com:shopify/test.git', 'test-app')
         end
         output = io.join
-        assert_match('Cloning into test-app...', output)
       end
 
       def test_clone_failure

--- a/test/shopify-cli/task/clone_test.rb
+++ b/test/shopify-cli/task/clone_test.rb
@@ -12,10 +12,9 @@ module ShopifyCli
           'test-app',
           '--progress'
         ).returns(mock(success?: true))
-        io = capture_io do
+        capture_io do
           ShopifyCli::Tasks::Clone.call('git@github.com:shopify/test.git', 'test-app')
         end
-        output = io.join
       end
 
       def test_clone_failure

--- a/test/shopify-cli/task/js_deps_test.rb
+++ b/test/shopify-cli/task/js_deps_test.rb
@@ -3,10 +3,20 @@ require 'test_helper'
 module ShopifyCli
   module Tasks
     class JsDepsTest < MiniTest::Test
+      include TestHelpers::Project
+
+      def setup
+        project_context('app_types', 'node')
+      end
+
       def test_installs_with_npm
         ShopifyCli::Tasks::JsDeps.any_instance.stubs(:installer).returns(:npm)
+        CLI::Kit::System.expects(:system).with(
+          'npm', 'install', '--no-optional',
+          chdir: @context.root,
+        ).returns(mock(success?: true))
         io = capture_io do
-          ShopifyCli::Tasks::JsDeps.call(Dir.pwd)
+          ShopifyCli::Tasks::JsDeps.call(@context.root)
         end
         output = io.join
         assert_match('Installing dependencies with npm...', output)
@@ -16,10 +26,10 @@ module ShopifyCli
         ShopifyCli::Tasks::JsDeps.any_instance.stubs(:installer).returns(:yarn)
         CLI::Kit::System.expects(:system).with(
           'yarn',
-          chdir: Dir.pwd
+          chdir: @context.root
         ).returns(mock(success?: true))
         io = capture_io do
-          ShopifyCli::Tasks::JsDeps.call(Dir.pwd)
+          ShopifyCli::Tasks::JsDeps.call(@context.root)
         end
         output = io.join
         assert_match('Installing dependencies with yarn...', output)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,16 +22,4 @@ require 'mocha/minitest'
 
 Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
 
-module Minitest
-  class Test
-    FIXTURE_DIR = File.expand_path('fixtures', File.dirname(__FILE__))
-  end
-
-  module Assertions
-    def assert_nothing_raised(*)
-      yield
-    end
-  end
-end
-
 require_relative 'test_helpers'

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -7,6 +7,7 @@ module TestHelpers
   autoload :FakeContext, 'test_helpers/fake_context'
   autoload :FakeFS, 'test_helpers/fake_fs'
   autoload :FakeProject, 'test_helpers/fake_project'
+  autoload :FakeUI, 'test_helpers/fake_ui'
   autoload :Project, 'test_helpers/project'
   autoload :Schema, 'test_helpers/schema'
 end

--- a/test/test_helpers/fake_ui.rb
+++ b/test/test_helpers/fake_ui.rb
@@ -2,6 +2,7 @@ module TestHelpers
   module FakeUI
     class FakeSpinner
       def update_title(*); end
+
       def wait; end
     end
 

--- a/test/test_helpers/fake_ui.rb
+++ b/test/test_helpers/fake_ui.rb
@@ -1,0 +1,26 @@
+module TestHelpers
+  module FakeUI
+    class FakeSpinner
+      def update_title(*); end
+      def wait; end
+    end
+
+    class FakeFrame
+      def self.open(str)
+        Thread.current[:cliui_output_hook].call(str, :stdout)
+        yield
+      end
+    end
+
+    class FakeProgress
+      def tick(*); end
+    end
+
+    def setup
+      super
+      CLI::UI::Frame.stubs(:open).yields
+      CLI::UI::SpinGroup.any_instance.stubs(:add).yields(FakeSpinner.new)
+      CLI::UI::Progress.stubs(:progress).yields(FakeProgress.new)
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #189 

The tests produce a lot of unnecessary output which I find makes it hard to scan for failures and also makes them slightly slow.

Unfortunately some of the cli-ui methods write directly to the terminal via ANSI escape codes so the `capture_io` test helper can't block them. I'll possibly make some changes in the library to make these test-aware but for now I'm stubbing them out with a fake interface in the tests that use them.

Before

<img width="1055" alt="Screen Shot 2019-07-09 at 2 47 26 PM" src="https://user-images.githubusercontent.com/73874/60916401-3e742200-a25c-11e9-8faf-cab67c37501c.png">

After

<img width="683" alt="Screen Shot 2019-07-09 at 2 46 47 PM" src="https://user-images.githubusercontent.com/73874/60916410-4207a900-a25c-11e9-9a5b-ef68fafefbb3.png">

There's also a bit of cleanup of unused code and reorganization of the minitest patch class.
