### PR TITLE
Abstracting the oauth functionality into a separate class

### DIFF
--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -12,6 +12,7 @@ module ShopifyCli
       Registry.add(->() { const_get(const) }, cmd)
     end
 
+    register :Authenticate, 'auth', 'shopify-cli/commands/authenticate'
     register :Create, 'create', 'shopify-cli/commands/create'
     register :Deploy, 'deploy', 'shopify-cli/commands/deploy'
     register :Generate, 'generate', 'shopify-cli/commands/generate'

--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -12,7 +12,7 @@ module ShopifyCli
       Registry.add(->() { const_get(const) }, cmd)
     end
 
-    register :Authenticate, 'auth', 'shopify-cli/commands/authenticate'
+    register :Authenticate, 'authenticate', 'shopify-cli/commands/authenticate'
     register :Create, 'create', 'shopify-cli/commands/create'
     register :Deploy, 'deploy', 'shopify-cli/commands/deploy'
     register :Generate, 'generate', 'shopify-cli/commands/generate'

--- a/lib/shopify-cli/commands/authenticate.rb
+++ b/lib/shopify-cli/commands/authenticate.rb
@@ -1,0 +1,30 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class Authenticate < ShopifyCli::Command
+      def call(args, _name)
+        spin_group = CLI::UI::SpinGroup.new
+        spin_group.add("Requesting access token...") do |spinner|
+          case args.shift
+          when 'ident'
+            ShopifyCli::Tasks::AuthenticateIdentity.call(@ctx)
+          when 'shop'
+            ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)
+          else
+            ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)
+          end
+          spinner.update_title("Authetication token stored")
+        end
+        spin_group.wait
+      end
+
+      def self.help
+        <<~HELP
+          Request a new access token from the Shopify admin API.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} auth}}
+        HELP
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/commands/authenticate.rb
+++ b/lib/shopify-cli/commands/authenticate.rb
@@ -7,7 +7,7 @@ module ShopifyCli
         spin_group = CLI::UI::SpinGroup.new
         spin_group.add("Requesting access token...") do |spinner|
           case args.shift
-          when 'ident'
+          when 'identity'
             ShopifyCli::Tasks::AuthenticateIdentity.call(@ctx)
           when 'shop'
             ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)

--- a/lib/shopify-cli/helpers/access_token.rb
+++ b/lib/shopify-cli/helpers/access_token.rb
@@ -11,8 +11,8 @@ module ShopifyCli
           )
         end
 
-        def write(res)
-          File.write(File.join(ShopifyCli::TEMP_DIR, ".#{file_name}"), res['access_token'])
+        def write(token)
+          File.write(File.join(ShopifyCli::TEMP_DIR, ".#{file_name}"), token)
         end
 
         def file_name

--- a/lib/shopify-cli/oauth.rb
+++ b/lib/shopify-cli/oauth.rb
@@ -1,0 +1,165 @@
+require 'base64'
+require 'digest'
+require 'json'
+require 'net/http'
+require 'securerandom'
+require 'openssl'
+require 'shopify_cli'
+require 'socket'
+require 'uri'
+
+module ShopifyCli
+  class OAuth
+    include SmartProperties
+
+    class Error < StandardError; end
+
+    REDIRECT_HOST = "http://localhost"
+    TEMPLATE = %{HTTP/1.1 200
+      Content-Type: text/html
+
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>%{title}</title>
+      </head>
+      <body>
+        <h1 style="color: #%{color};">%{message}</h1>
+        %{autoclose}
+      </body>
+      </html>
+    }
+    AUTOCLOSE_TEMPLATE = %{
+      <script>
+        setTimeout(function() { window.close(); }, 3000)
+      </script>
+    }
+    SUCCESS_RESP = 'Authenticated Successfully, this page will close shortly.'
+    INVALID_STATE_RESP = 'Anti-forgery state token does not match the initial request.'
+
+    property! :client_id, accepts: String
+    property! :scopes
+    property :secret, accepts: String
+    property :port, default: 3456, accepts: Integer
+    property :options, default: {}, accepts: Hash
+    property :auth_path, default: "/authorize", accepts: ->(path) { path.is_a?(String) && path.start_with?("/") }
+    property :token_path, default: "/token", accepts: ->(path) { path.is_a?(String) && path.start_with?("/") }
+
+    def authenticate(url)
+      listen_local
+      initiate_authentication(url)
+      res = request_token(url, code: receive_access_code)
+      raise Error, JSON.parse(res.body)['error_description'] unless res.is_a?(Net::HTTPSuccess)
+      JSON.parse(res.body)["access_token"]
+    end
+
+    def redirect_uri
+      "#{REDIRECT_HOST}:#{port}/"
+    end
+
+    def state_token
+      @state_token ||= SecureRandom.hex(30)
+    end
+
+    def code_verifier
+      @code_verifier ||= SecureRandom.hex(30)
+    end
+
+    def code_challenge
+      @code_challenge ||= Base64.urlsafe_encode64(
+        OpenSSL::Digest::SHA256.digest(code_verifier),
+        padding: false,
+      )
+    end
+
+    private
+
+    def initiate_authentication(url)
+      params = {
+        client_id: client_id,
+        scope: scopes,
+        redirect_uri: redirect_uri,
+        state: state_token,
+        response_type: :code,
+      }
+      params.merge!(challange_params) if secret.nil?
+      uri = URI.parse("#{url}#{auth_path}")
+      uri.query = URI.encode_www_form(params.merge(options))
+      CLI::Kit::System.system("open '#{uri}'")
+    end
+
+    def listen_local
+      server = TCPServer.new('localhost', port)
+      @server_thread ||= Thread.new do
+        Thread.current.abort_on_exception = true
+        begin
+          socket = server.accept
+          query = Hash[URI.decode_www_form(socket.gets.split[1][2..-1])]
+          if !query['error'].nil?
+            respond_with(socket, 400, "Invalid Request: #{query['error_description']}")
+          elsif query['state'] != state_token
+            query.merge!('error' => 'invalid_state', 'error_description' => INVALID_STATE_RESP)
+            respond_with(socket, 403, INVALID_STATE_RESP)
+          else
+            respond_with(socket, 200, SUCCESS_RESP)
+          end
+          query
+        ensure
+          socket.close_write
+          server.close
+        end
+      end
+    end
+
+    def receive_access_code
+      @access_code ||= begin
+        query = @server_thread.join(5).value
+        raise Error, query['error_description'] unless query['error'].nil?
+        query['code']
+      end
+    end
+
+    def request_token(url, code:)
+      uri = URI.parse("#{url}#{token_path}")
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      request = Net::HTTP::Post.new(uri.path)
+      request['User-Agent'] = "Shopify App CLI #{::ShopifyCli::VERSION}"
+      params = {
+        grant_type: :authorization_code,
+        code: code,
+        redirect_uri: redirect_uri,
+        client_id: client_id,
+      }.merge(confirmation_param)
+      request.body = URI.encode_www_form(params)
+      https.request(request)
+    end
+
+    def respond_with(resp, status, message)
+      successful = status == 200
+      locals = {
+        status: status,
+        message: message,
+        color: successful ? 'black' : 'red',
+        title: successful ? 'Authenticate Successfully' : 'Failed to Authenticate',
+        autoclose: successful ? AUTOCLOSE_TEMPLATE : '',
+      }
+      resp.print(format(TEMPLATE, locals))
+    end
+
+    def challange_params
+      {
+        code_challenge: code_challenge,
+        code_challenge_method: 'S256',
+      }
+    end
+
+    def confirmation_param
+      if secret.nil?
+        { code_verifier: code_verifier }
+      else
+        { client_secret: secret }
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/tasks.rb
+++ b/lib/shopify-cli/tasks.rb
@@ -23,6 +23,7 @@ module ShopifyCli
       Registry.add(const_get(task), name)
     end
 
+    register :AuthenticateIdentity, :authenticate_identity, 'shopify-cli/tasks/authenticate_identity'
     register :AuthenticateShopify, :authenticate_shopify, 'shopify-cli/tasks/authenticate_shopify'
     register :Clone, :clone, 'shopify-cli/tasks/clone'
     register :EnsureEnv, :ensure_env, 'shopify-cli/tasks/ensure_env'

--- a/lib/shopify-cli/tasks/authenticate_identity.rb
+++ b/lib/shopify-cli/tasks/authenticate_identity.rb
@@ -1,0 +1,23 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Tasks
+    class AuthenticateIdentity < ShopifyCli::Task
+      def call(ctx)
+        token = oauth_client.authenticate("https://identity.myshopify.io/oauth")
+        ctx.puts "{{success:Authentication Token #{token}}}"
+      rescue OAuth::Error => e
+        ctx.puts("{{error: #{e}}}")
+      end
+
+      private
+
+      def oauth_client
+        OAuth.new(
+          client_id: 'e5380e02-312a-7408-5718-e07017e9cf52',
+          scopes: ['openid', 'profile', 'email'],
+        )
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/tasks/authenticate_shopify.rb
+++ b/lib/shopify-cli/tasks/authenticate_shopify.rb
@@ -1,93 +1,34 @@
 require 'shopify_cli'
-require 'base64'
-require 'securerandom'
-require 'socket'
-require 'net/http'
-require 'uri'
-require 'json'
 
 module ShopifyCli
   module Tasks
     class AuthenticateShopify < ShopifyCli::Task
-      PORT = 3456
-      REDIRECT_URI = "http://localhost:#{PORT}/"
-
       def call(ctx)
-        @ctx = ctx
-        Tasks::EnsureEnv.call(@ctx)
-        server = TCPServer.new('localhost', PORT)
-        @ctx.puts("opening #{authorize_url}")
-        @ctx.system("open '#{authorize_url}'")
-        code = wait_for_redirect(server)
-        case res = send_token_request(code)
-        when Net::HTTPSuccess
-          body = JSON.parse(res.body)
-          url = "https://localhost:3456"
-          @env = Helpers::AccessToken.write(body)
-          @ctx.puts "{{success:Token stored!}}"
-          @ctx.puts "{{*}} Add {{underline: #{url} to the whitelisted redirection URLs in your app setup"
-        else
-          @ctx.puts("{{error:Response was #{res.body}}}")
-          @ctx.puts("{{error:Failed to retrieve ID & Refresh tokens}}")
-        end
+        Tasks::EnsureEnv.call(ctx)
+        token = oauth_client.authenticate("https://#{env.shop}/admin/oauth")
+        @env = Helpers::AccessToken.write(token)
+        ctx.puts "{{success:Authentication Token written to env file}}"
+      rescue OAuth::Error => e
+        ctx.puts("{{error: #{e}}}")
+        ctx.puts("{{error:Failed to retrieve ID & Refresh tokens}}")
+        ctx.puts "{{*}} Remeber to add {{underline: #{oauth_client.redirect_uri} "\
+          "to the whitelisted redirection URLs in your app setup"
       end
 
-      def wait_for_redirect(server)
-        socket = server.accept # Wait for redirect
-        @ctx.puts "Authenticated"
-        request = socket.gets
-
-        unless extract_query_param('state', request) == state_token
-          socket.close
-          raise(StandardError, "Anti-forgery state token does not match the initial request.")
-        end
-
-        socket.print("HTTP/1.1 200\r\n")
-        socket.print("Content-Type: text/plain\r\n\r\n")
-        socket.print("SUCCESS - please return to the CLI for the rest of this process.")
-        socket.close
-        extract_query_param("code", request)
-      end
-
-      def send_token_request(code)
-        uri = URI("https://#{env.shop}/admin/oauth/access_token")
-        https = Net::HTTP.new(uri.host, uri.port)
-        https.use_ssl = true
-        request = Net::HTTP::Post.new(uri.path)
-        request.body = URI.encode_www_form(
-          client_id: env.api_key,
-          client_secret: env.secret,
-          code: code
-        )
-        @ctx.puts "Fetching tokens..."
-        https.request(request)
-      end
-
-      def authorize_url
-        params = {
-          client_id: env.api_key,
-          scope: env.scopes,
-          redirect_uri: REDIRECT_URI,
-          state: state_token,
-          'grant_options[]' => 'per user',
-        }
-        uri = URI.parse("https://#{env.shop}/admin/oauth/authorize")
-        uri.query = URI.encode_www_form(params)
-        uri
-      end
+      private
 
       def env
         @env = Helpers::EnvFile.read
       end
 
-      def extract_query_param(key, request)
-        paramstring = request.split('?')[1]
-        paramstring = paramstring.split(' ')[0]
-        URI.decode_www_form(paramstring).assoc(key).last
-      end
-
-      def state_token
-        @state_token ||= SecureRandom.hex(30)
+      def oauth_client
+        OAuth.new(
+          client_id: env.api_key,
+          secret: env.secret,
+          scopes: env.scopes,
+          token_path: "/access_token",
+          options: { 'grant_options[]' => 'per user' },
+        )
       end
     end
   end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -101,6 +101,7 @@ module ShopifyCli
   autoload :Executor, 'shopify-cli/executor'
   autoload :Finalize, 'shopify-cli/finalize'
   autoload :Helpers, 'shopify-cli/helpers'
+  autoload :OAuth, 'shopify-cli/oauth'
   autoload :Project, 'shopify-cli/project'
   autoload :Task, 'shopify-cli/task'
   autoload :Tasks, 'shopify-cli/tasks'

--- a/test/shopify-cli/oauth_test.rb
+++ b/test/shopify-cli/oauth_test.rb
@@ -1,0 +1,181 @@
+require 'test_helper'
+
+module ShopifyCli
+  class OAuthTest < MiniTest::Test
+    include TestHelpers::Project
+    include TestHelpers::Constants
+
+    def test_new
+      client = OAuth.new(client_id: 'key', scopes: 'test,one')
+      assert_equal 'key', client.client_id
+      assert_equal 'test,one', client.scopes
+      assert_nil(client.secret)
+      assert_equal 3456, client.port
+      assert_equal({}, client.options)
+
+      client = OAuth.new(client_id: 'key', scopes: 'test,one', port: 9876, secret: 'secret', options: { foo: :bar })
+      assert_equal 'key', client.client_id
+      assert_equal 'test,one', client.scopes
+      assert_equal 9876, client.port
+      assert_equal 'secret', client.secret
+      assert_equal({ foo: :bar }, client.options)
+    end
+
+    def test_authenticate_with_secret
+      endpoint = "https://example.com/auth"
+      client = OAuth.new(client_id: 'key', scopes: 'test,one', secret: 'secret')
+      CLI::Kit::System.expects(:system).with do |param|
+        auth_repsonse(client, endpoint, param)
+      end
+
+      authorize_query = {
+        client_id: client.client_id,
+        scope: client.scopes,
+        redirect_uri: client.redirect_uri,
+        state: client.state_token,
+        response_type: :code,
+      }
+      stub_request(:post, "#{endpoint}/authorize?#{URI.encode_www_form(authorize_query)}")
+
+      token_query = {
+        grant_type: :authorization_code,
+        code: "mycode",
+        redirect_uri: client.redirect_uri,
+        client_id: client.client_id,
+        client_secret: 'secret',
+      }
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(status: 200, body: '{ "access_token": "accesstoken123" }', headers: {})
+
+      assert_equal 'accesstoken123', client.authenticate(endpoint)
+    end
+
+    def test_authenticate_pkce
+      endpoint = "https://example.com/auth"
+      client = OAuth.new(client_id: 'key', scopes: 'test,one')
+      CLI::Kit::System.expects(:system).with do |param|
+        auth_repsonse(client, endpoint, param)
+      end
+
+      authorize_query = {
+        client_id: client.client_id,
+        scope: client.scopes,
+        redirect_uri: client.redirect_uri,
+        state: client.state_token,
+        response_type: :code,
+      }
+      stub_request(:post, "#{endpoint}/authorize?#{URI.encode_www_form(authorize_query)}")
+
+      token_query = {
+        grant_type: :authorization_code,
+        code: "mycode",
+        redirect_uri: client.redirect_uri,
+        client_id: client.client_id,
+        code_verifier: client.code_verifier,
+      }
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(status: 200, body: '{ "access_token": "accesstoken123" }', headers: {})
+
+      assert_equal 'accesstoken123', client.authenticate(endpoint)
+    end
+
+    def test_authenticate_with_invalid_request
+      endpoint = "https://example.com/auth"
+      client = OAuth.new(client_id: 'key', scopes: 'test,one')
+      CLI::Kit::System.stubs(:system).with do |_param|
+        WebMock.disable!
+        https = Net::HTTP.new('localhost', 3456)
+        request = Net::HTTP::Get.new("/?error=err&error_description=error")
+        https.request(request)
+        WebMock.enable!
+        true
+      end
+      stub_request(:post, "#{endpoint}/authorize")
+      assert_raises OAuth::Error do
+        client.authenticate(endpoint)
+      end
+    end
+
+    def test_authenticate_with_invalid_state
+      endpoint = "https://example.com/auth"
+      client = OAuth.new(client_id: 'key', scopes: 'test,one')
+      CLI::Kit::System.stubs(:system).with do |_param|
+        WebMock.disable!
+        https = Net::HTTP.new('localhost', 3456)
+        request = Net::HTTP::Get.new("/?code=mycode&state=notyourstate")
+        https.request(request)
+        WebMock.enable!
+        true
+      end
+      stub_request(:post, "#{endpoint}/authorize")
+      assert_raises OAuth::Error do
+        client.authenticate(endpoint)
+      end
+    end
+
+    def test_authenticate_with_invalid_code
+      endpoint = "https://example.com/auth"
+      client = OAuth.new(client_id: 'key', scopes: 'test,one', secret: 'secret')
+      CLI::Kit::System.expects(:system).with do |param|
+        auth_repsonse(client, endpoint, param)
+      end
+
+      authorize_query = {
+        client_id: client.client_id,
+        scope: client.scopes,
+        redirect_uri: client.redirect_uri,
+        state: client.state_token,
+        response_type: :code,
+      }
+      stub_request(:post, "#{endpoint}/authorize?#{URI.encode_www_form(authorize_query)}")
+
+      token_query = {
+        grant_type: :authorization_code,
+        code: "mycode",
+        redirect_uri: client.redirect_uri,
+        client_id: client.client_id,
+        client_secret: 'secret',
+      }
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(
+          status: 400,
+          body: '{ "error": "invalid_code", "error_description": "your code has expired or is invalid" }',
+          headers: {},
+        )
+
+      assert_raises OAuth::Error do
+        client.authenticate(endpoint)
+      end
+    end
+
+    private
+
+    def auth_repsonse(client, endpoint, param)
+      query = {
+        client_id: client.client_id,
+        scope: client.scopes,
+        redirect_uri: client.redirect_uri,
+        state: client.state_token,
+        response_type: :code,
+      }
+      if client.secret.nil?
+        query.merge!(
+          code_challenge: client.code_challenge,
+          code_challenge_method: 'S256',
+        )
+      end
+      command = "open '#{endpoint}/authorize?#{URI.encode_www_form(query)}'"
+      if command == param
+        WebMock.disable!
+        https = Net::HTTP.new('localhost', 3456)
+        request = Net::HTTP::Get.new("/?code=mycode&state=#{client.state_token}")
+        https.request(request)
+        WebMock.enable!
+      end
+      command == param
+    end
+  end
+end

--- a/test/task/authenticate_identity_test.rb
+++ b/test/task/authenticate_identity_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module ShopifyCli
   module Tasks
-    class AuthenticateShopifyTest < MiniTest::Test
+    class AuthenticateIdentityTest < MiniTest::Test
       include TestHelpers::Project
       include TestHelpers::Constants
 
@@ -11,18 +11,14 @@ module ShopifyCli
         ShopifyCli::OAuth
           .expects(:new)
           .with(
-            client_id: 'apikey',
-            secret: 'secret',
-            scopes: nil,
-            token_path: "/access_token",
-            options: { 'grant_options[]' => 'per user' },
+            client_id: 'e5380e02-312a-7408-5718-e07017e9cf52',
+            scopes: ['openid', 'profile', 'email'],
           ).returns(@oauth_client)
         @oauth_client
           .expects(:authenticate)
-          .with("https://my-test-shop.myshopify.com/admin/oauth")
+          .with("https://identity.myshopify.io/oauth")
           .returns("this_is_token")
-        Helpers::AccessToken.expects(:write).with("this_is_token")
-        AuthenticateShopify.new.call(@context)
+        AuthenticateIdentity.new.call(@context)
       end
 
       def test_handles_oauth_errors
@@ -30,11 +26,10 @@ module ShopifyCli
         ShopifyCli::OAuth.stubs(:new).returns(@oauth_client)
         @oauth_client
           .expects(:authenticate)
-          .with("https://my-test-shop.myshopify.com/admin/oauth")
+          .with("https://identity.myshopify.io/oauth")
           .raises(OAuth::Error, 'invalid request')
-        @oauth_client.expects(:redirect_uri).returns("http://localhost:3456")
         assert_nothing_raised do
-          AuthenticateShopify.new.call(@context)
+          AuthenticateIdentity.new.call(@context)
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?
There are a few services that we will need to authenticate with, so I am hoping to refactor the authentication code into something we can share between the multiple actions.

### WHAT is this pull request doing?
- creates `ShopifyCli::OAuth`
- added temporary auth command to allow me to test the functionally (copied from @katiedavis ) with a shop and ident subcommand
- created `ShopifyCli::Tasks::AuthenticateIdentityTest` to call authentication with identity
- Error handling/raising for different authentication errors.
- Added a response page that automatically closes itself if the request was successful. If it wasn't successful then the page stays open to display the error.