### PR TITLE
Add missing single quote for Shopify registry command

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -83,7 +83,7 @@ module ShopifyCli
           registry, _ = ctx.capture2('npm', 'config', 'get', '@shopify:registry')
           msg = <<~MSG
             You are not using the public npm registry for Shopify packages. This can cause issues with installing @shopify packages.
-            Please run `npm config set @shopify:registry https://registry.yarnpkg.com and try this command again,
+            Please run `npm config set @shopify:registry https://registry.yarnpkg.com` and try this command again,
             or preface the command with `DISABLE_NPM_REGISTRY_CHECK=1`.
           MSG
           raise(ShopifyCli::Abort, msg) unless registry.include?('https://registry.yarnpkg.com')


### PR DESCRIPTION
### WHY are these changes introduced?

The missing end quote confused me at first. This adds it to reduce future confusion.

![Screen Shot 2019-07-12 at 4 36 57 PM](https://user-images.githubusercontent.com/3484527/61157158-4f729c80-a4c3-11e9-93cf-2979e9ce1101.png)


### WHAT is this pull request doing?

Add a missing end singlequote
