### PR TITLE
add missing scopes

### DIFF
--- a/lib/shopify-cli/tasks/ensure_env.rb
+++ b/lib/shopify-cli/tasks/ensure_env.rb
@@ -21,6 +21,7 @@ module ShopifyCli
           api_key: api_key,
           secret: api_secret,
           shop: shop,
+          scopes: 'write_products,write_customers,write_draft_orders',
         ).write(@ctx)
         env
       end


### PR DESCRIPTION

### WHY are these changes introduced?

When we created the ensure_env tasks, we forgot to add the scopes required to make requests for webhook etc. 

