### PR TITLE
Changing identity authentication to use production identity

### DIFF
--- a/lib/shopify-cli/oauth.rb
+++ b/lib/shopify-cli/oauth.rb
@@ -54,7 +54,7 @@ module ShopifyCli
     end
 
     def redirect_uri
-      "#{REDIRECT_HOST}:#{port}/"
+      "#{REDIRECT_HOST}:#{port}"
     end
 
     def state_token
@@ -113,7 +113,7 @@ module ShopifyCli
 
     def receive_access_code
       @access_code ||= begin
-        query = @server_thread.join(5).value
+        query = @server_thread.join(120).value
         raise Error, query['error_description'] unless query['error'].nil?
         query['code']
       end

--- a/lib/shopify-cli/tasks/authenticate_identity.rb
+++ b/lib/shopify-cli/tasks/authenticate_identity.rb
@@ -4,7 +4,7 @@ module ShopifyCli
   module Tasks
     class AuthenticateIdentity < ShopifyCli::Task
       def call(ctx)
-        token = oauth_client.authenticate("https://identity.myshopify.io/oauth")
+        token = oauth_client.authenticate("https://accounts.shopify.com/oauth")
         Helpers::PkceToken.write(token)
         ctx.puts "{{success:Authentication Token saved}}"
       rescue OAuth::Error => e
@@ -15,8 +15,8 @@ module ShopifyCli
 
       def oauth_client
         OAuth.new(
-          client_id: 'e5380e02-312a-7408-5718-e07017e9cf52',
-          scopes: ['openid', 'profile', 'email'],
+          client_id: 'fbdb2649-e327-4907-8f67-908d24cfd7e3',
+          scopes: ['openid'],
         )
       end
     end

--- a/test/task/authenticate_identity_test.rb
+++ b/test/task/authenticate_identity_test.rb
@@ -11,12 +11,12 @@ module ShopifyCli
         ShopifyCli::OAuth
           .expects(:new)
           .with(
-            client_id: 'e5380e02-312a-7408-5718-e07017e9cf52',
-            scopes: ['openid', 'profile', 'email'],
+            client_id: 'fbdb2649-e327-4907-8f67-908d24cfd7e3',
+            scopes: ['openid'],
           ).returns(@oauth_client)
         @oauth_client
           .expects(:authenticate)
-          .with("https://identity.myshopify.io/oauth")
+          .with("https://accounts.shopify.com/oauth")
           .returns("this_is_token")
         Helpers::PkceToken.expects(:write).with("this_is_token")
         AuthenticateIdentity.new.call(@context)
@@ -27,7 +27,7 @@ module ShopifyCli
         ShopifyCli::OAuth.stubs(:new).returns(@oauth_client)
         @oauth_client
           .expects(:authenticate)
-          .with("https://identity.myshopify.io/oauth")
+          .with("https://accounts.shopify.com/oauth")
           .raises(OAuth::Error, 'invalid request')
         assert_nothing_raised do
           AuthenticateIdentity.new.call(@context)


### PR DESCRIPTION
### WHY are these changes introduced?
This will allow us to authenticate with partners soon and then use the graphapi.

### WHAT is this pull request doing?
just change client id and endpoint