### PR TITLE
Adding persistence of the token

### DIFF
--- a/lib/shopify-cli/helpers.rb
+++ b/lib/shopify-cli/helpers.rb
@@ -1,6 +1,7 @@
 module ShopifyCli
   module Helpers
     autoload :AccessToken, 'shopify-cli/helpers/access_token'
+    autoload :PkceToken, 'shopify-cli/helpers/pkce_token'
     autoload :API, 'shopify-cli/helpers/api'
     autoload :EnvFile, 'shopify-cli/helpers/env_file'
     autoload :Gem, 'shopify-cli/helpers/gem'

--- a/lib/shopify-cli/helpers/pkce_token.rb
+++ b/lib/shopify-cli/helpers/pkce_token.rb
@@ -1,0 +1,20 @@
+module ShopifyCli
+  module Helpers
+    class PkceToken
+      class << self
+        def read(ctx)
+          ShopifyCli::Tasks::AuthenticateIdentity.call(ctx) unless File.file?(file_name)
+          File.read(file_name)
+        end
+
+        def write(token)
+          File.write(file_name, token)
+        end
+
+        def file_name
+          File.join(ShopifyCli::TEMP_DIR, ".pkce")
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/tasks/authenticate_identity.rb
+++ b/lib/shopify-cli/tasks/authenticate_identity.rb
@@ -5,7 +5,8 @@ module ShopifyCli
     class AuthenticateIdentity < ShopifyCli::Task
       def call(ctx)
         token = oauth_client.authenticate("https://identity.myshopify.io/oauth")
-        ctx.puts "{{success:Authentication Token #{token}}}"
+        Helpers::PkceToken.write(token)
+        ctx.puts "{{success:Authentication Token saved}}"
       rescue OAuth::Error => e
         ctx.puts("{{error: #{e}}}")
       end

--- a/test/task/authenticate_identity_test.rb
+++ b/test/task/authenticate_identity_test.rb
@@ -18,6 +18,7 @@ module ShopifyCli
           .expects(:authenticate)
           .with("https://identity.myshopify.io/oauth")
           .returns("this_is_token")
+        Helpers::PkceToken.expects(:write).with("this_is_token")
         AuthenticateIdentity.new.call(@context)
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?
Need a way to persist the identity token for later usage with Partners.

### WHAT is this pull request doing?
I copied the patterns of the AccessToken but simpler since there is only one pkce token rather than a token per store.