### PR TITLE
Making Api Helper sharable

### DIFF
--- a/test/fixtures/api/mutation.json
+++ b/test/fixtures/api/mutation.json
@@ -1,1 +1,1 @@
-{"query":"mutation {  fakeMutation(input: {  title: \"fake title\"}) {  id}}","variables":{}}
+{"query":"mutation { fakeMutation(input: {  title: \"fake title\"}) {  id} }","variables":{}}

--- a/test/shopify-cli/commands/populate/draft_order_test.rb
+++ b/test/shopify-cli/commands/populate/draft_order_test.rb
@@ -10,31 +10,30 @@ module ShopifyCli
         def setup
           super
           Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
-          ShopifyCli::Helpers::API.any_instance.stubs(:latest_api_version)
-            .returns('2019-04')
           @mutation = File.read(File.join(FIXTURE_DIR, 'populate/draft_order.graphql'))
         end
 
         def test_populate_calls_api_with_mutation
+          api = api_stub
+          api.expects(:mutation)
+            .with(@mutation)
+            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/draft_order_data.json'))))
+          api.expects(:gid_to_id).returns(12345678)
           Helpers::Haikunator.stubs(:title).returns('fake order')
           Resource.any_instance.stubs(:price).returns('1.00')
           @resource = DraftOrder.new(ctx: @context, args: ['-c 1'])
-          body = @resource.api.mutation_body(@mutation)
-          stub_request(:post, "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")
-            .with(body: body,
-               headers: {
-                 'Content-Type' => 'application/json',
-                 'X-Shopify-Access-Token' => 'myaccesstoken',
-               })
-            .to_return(
-              status: 200,
-              body: File.read(File.join(FIXTURE_DIR, 'populate/draft_order_data.json')),
-              headers: {}
-            )
           @context.expects(:done).with(
             "draft order created: https://my-test-shop.myshopify.com/admin/draft_orders/12345678"
           )
           @resource.populate
+        end
+
+        private
+
+        def api_stub
+          api_stub = Object.new
+          ShopifyCli::Helpers::API.stubs(:new).returns(api_stub)
+          api_stub
         end
       end
     end

--- a/test/shopify-cli/commands/populate/product_test.rb
+++ b/test/shopify-cli/commands/populate/product_test.rb
@@ -10,31 +10,30 @@ module ShopifyCli
         def setup
           super
           Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
-          ShopifyCli::Helpers::API.any_instance.stubs(:latest_api_version)
-            .returns('2019-04')
           @mutation = File.read(File.join(FIXTURE_DIR, 'populate/product.graphql'))
         end
 
         def test_populate_calls_api_with_mutation
+          api = api_stub
+          api.expects(:mutation)
+            .with(@mutation)
+            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/product_data.json'))))
+          api.expects(:gid_to_id).returns(12345678)
           Helpers::Haikunator.stubs(:title).returns('fake product')
           Resource.any_instance.stubs(:price).returns('1.00')
           @resource = Product.new(ctx: @context, args: ['-c 1'])
-          body = @resource.api.mutation_body(@mutation)
-          stub_request(:post, "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")
-            .with(body: body,
-               headers: {
-                 'Content-Type' => 'application/json',
-                 'X-Shopify-Access-Token' => 'myaccesstoken',
-               })
-            .to_return(
-              status: 200,
-              body: File.read(File.join(FIXTURE_DIR, 'populate/product_data.json')),
-              headers: {}
-            )
           @context.expects(:done).with(
             "product 'fake product' created: https://my-test-shop.myshopify.com/admin/products/12345678"
           )
           @resource.populate
+        end
+
+        private
+
+        def api_stub
+          api_stub = Object.new
+          ShopifyCli::Helpers::API.stubs(:new).returns(api_stub)
+          api_stub
         end
       end
     end

--- a/test/shopify-cli/commands/populate/resource_test.rb
+++ b/test/shopify-cli/commands/populate/resource_test.rb
@@ -10,6 +10,7 @@ module ShopifyCli
         def setup
           super
           Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
+          ShopifyCli::Helpers::API.stubs(:new).returns(Object.new)
         end
 
         def test_with_schema_args_overrides_input

--- a/test/shopify-cli/task/schema_test.rb
+++ b/test/shopify-cli/task/schema_test.rb
@@ -9,43 +9,45 @@ module ShopifyCli
 
       def setup
         super
-        @dir = Dir.mktmpdir
-        @command = ShopifyCli::Commands::Update.new
-        redefine_constant(ShopifyCli, :TEMP_DIR, Dir.mktmpdir)
-        FileUtils.mkdir("#{ShopifyCli::TEMP_DIR}/.shopify_schema")
-        ShopifyCli::Helpers::API.any_instance.stubs(:latest_api_version)
-          .returns('2019-04')
         ShopifyCli::Helpers::AccessToken.expects(:read).returns(
           File.read(File.join(ShopifyCli::ROOT, "test/fixtures/.apikey"))
         ).at_least_once
       end
 
       def test_gets_schema
-        stub_request(:post, "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")
-          .with(body: JSON.dump(query: introspection, variables: {}),
-            headers: { 'X-Shopify-Access-Token' => 'accesstoken123' })
-          .to_return(status: 200, body: '{"foo":"baz"}', headers: {})
+        api_stub.expects(:query).with(introspection).returns("foo" => "baz")
         assert_equal({ "foo" => "baz" }, ShopifyCli::Tasks::Schema.call(@context))
-        assert_equal('{"foo":"baz"}', File.read(File.join(ShopifyCli::TEMP_DIR, 'shopify_schema.json')))
+        assert_equal('{"foo":"baz"}', File.read(Schema::FILEPATH))
       end
 
       def test_gets_schema_if_already_downloaded
-        File.write(File.join(ShopifyCli::TEMP_DIR, 'shopify_schema.json'), '{"foo":"baz"}')
+        api_stub
+        File.write(Schema::FILEPATH, '{"foo":"baz"}')
         assert_equal({ "foo" => "baz" }, ShopifyCli::Tasks::Schema.call(@context))
       end
 
       def test_error_gets_access_token
+        api = api_stub
         ShopifyCli::Tasks::AuthenticateShopify.expects(:call).returns(
           File.read(File.join(ShopifyCli::ROOT, "test/fixtures/.apikey"))
         )
-        stub_request(:post, "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")
-          .with(body: JSON.dump(query: introspection, variables: {}),
-          headers: { 'X-Shopify-Access-Token' => 'accesstoken123' })
-          .to_return(
-            { status: 401, body: "{}", headers: {} },
-            status: 200, body: '{}', headers: {}
-          )
-        ShopifyCli::Tasks::Schema.call(@context)
+        api.expects(:query)
+          .with(introspection)
+          .returns("foo" => "baz")
+        api.expects(:query)
+          .with(introspection)
+          .raises(Helpers::API::APIRequestUnauthorizedError)
+        assert_equal({ "foo" => "baz" }, ShopifyCli::Tasks::Schema.call(@context))
+        assert_equal('{"foo":"baz"}', File.read(Schema::FILEPATH))
+      end
+
+      private
+
+      def api_stub
+        api_stub = Object.new
+        redefine_constant(Schema, :FILEPATH, File.join(Dir.mktmpdir, "shopify_schema.json"))
+        ShopifyCli::Helpers::API.stubs(:new).returns(api_stub)
+        api_stub
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?
I need this to be able to use it for the admin API and the Partners API

### WHAT is this pull request doing?
- refactored the API to take a URI argument to point it at with a default to the latest admin api.
- refactored the API to have a smaller public interface. Making it easier to reason about and easier to maintain in the future.
- added an `Authorization` header with the token as well to support partners.
- fixes the constant loading issue with Net, in the API class.