### PR TITLE
Changeing the location of installation for debian installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ is_linux() {
   test -n "${linux}"
 }
 
-install_dir="${XDG_RUNTIME_DIR:-$HOME}/.shopify-app-cli"
+install_dir="$HOME/.shopify-app-cli"
 
 postmsg() {
   echo -e "\x1b[36mshopify-app-cli\x1b[0m is installed!"

--- a/install.sh
+++ b/install.sh
@@ -253,7 +253,7 @@ install_bash_shell_shim() {
     {
       echo ''
       echo '# load shopify-app-cli, but only if present and the shell is interactive'
-      echo "if [[ -f "${install_dir}/shopify.sh" ]]; then source "${install_dir}/shopify.sh"; fi"
+      echo "if [[ -f \"${install_dir}/shopify.sh\" ]]; then source \"${install_dir}/shopify.sh\"; fi"
     } >> "${bp}"
   fi
 
@@ -261,8 +261,8 @@ install_bash_shell_shim() {
     {
       echo ''
       echo '# load shopify-app-cli, but only if present and the shell is interactive'
-      echo 'if [[ -f "${install_dir}/shopify.sh"  ]] && [[ $- == *i* ]]; then'
-      echo '  source "${install_dir}/shopify.sh"'
+      echo "if [[ -f \"${install_dir}/shopify.sh\"  ]] && [[ $- == *i* ]]; then"
+      echo "  source \"${install_dir}/shopify.sh\""
       echo 'fi'
     } >> "${HOME}/.bashrc"
   fi

--- a/shopify.sh
+++ b/shopify.sh
@@ -86,7 +86,7 @@ __shopify_cli__() {
 
   local return_from_shopify_cli
   local with_gems
-  local install_dir="${XDG_RUNTIME_DIR:-$HOME}/.shopify-cli"
+  local install_dir="$HOME/.shopify-cli"
   if [[ "${__shopify_cli_source_dir}" == "${install_dir}" ]] || [ ! -t 0 ]; then
     with_gems="FALSE"
   else


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes #246 
Currently the install path for debian based systems is XDG_Runtime_dir which is temporary and it deleted on restart.

### WHAT is this pull request doing?
This PR unifies installation directories to $HOME/.shopify_app_cli directory. I made this decision because quite a few other applications do this as well and it seems like the safest course of action. I would love feedback if there is another location that is should be located in.

This PR is also fixing the bash shim because the string interpolation was broken while echoing the  the installation path into the bashrc.