### PR TITLE
Changes required to get partners authentication working

### DIFF
--- a/lib/shopify-cli/helpers.rb
+++ b/lib/shopify-cli/helpers.rb
@@ -1,14 +1,15 @@
 module ShopifyCli
   module Helpers
-    autoload :AccessToken, 'shopify-cli/helpers/access_token'
-    autoload :PkceToken, 'shopify-cli/helpers/pkce_token'
     autoload :API, 'shopify-cli/helpers/api'
+    autoload :AccessToken, 'shopify-cli/helpers/access_token'
     autoload :EnvFile, 'shopify-cli/helpers/env_file'
     autoload :Gem, 'shopify-cli/helpers/gem'
     autoload :GraphQL, 'shopify-cli/helpers/graphql'
     autoload :Haikunator, 'shopify-cli/helpers/haikunator'
     autoload :OS, 'shopify-cli/helpers/os'
+    autoload :PartnersAPI, 'shopify-cli/helpers/partners_api'
     autoload :PidFile, 'shopify-cli/helpers/pid_file'
+    autoload :PkceToken, 'shopify-cli/helpers/pkce_token'
     autoload :ProcessSupervision, 'shopify-cli/helpers/process_supervision'
     autoload :Ruby, 'shopify-cli/helpers/ruby'
     autoload :SchemaParser, 'shopify-cli/helpers/schema_parser'

--- a/lib/shopify-cli/helpers/api.rb
+++ b/lib/shopify-cli/helpers/api.rb
@@ -12,6 +12,7 @@ module ShopifyCli
       property :url, default: -> { graphql_url }
 
       class APIRequestError < StandardError; end
+      class APIRequestNotFoundError < APIRequestError; end
       class APIRequestClientError < APIRequestError; end
       class APIRequestUnauthorizedError < APIRequestClientError; end
       class APIRequestUnexpectedError < APIRequestError; end
@@ -53,6 +54,8 @@ module ShopifyCli
             [response.code.to_i, JSON.parse(response.body)]
           when 401
             raise APIRequestUnauthorizedError, "#{response.code}\n#{response.body}"
+          when 404
+            raise APIRequestNotFoundError, "#{response.code}\n#{response.body}"
           when 429
             raise APIRequestThrottledError, "#{response.code}\n#{response.body}"
           when 400..499
@@ -99,7 +102,7 @@ module ShopifyCli
           'Content-Type' => 'application/json',
           'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} #{current_sha} | #{uname(flag: 'v')}",
           'X-Shopify-Access-Token' => token,
-          'Authorization' => token,
+          'Authorization' => "Bearer #{token}",
         }
       end
     end

--- a/lib/shopify-cli/helpers/partners_api.rb
+++ b/lib/shopify-cli/helpers/partners_api.rb
@@ -1,0 +1,66 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Helpers
+    class PartnersAPI < API
+      ENV_VAR = 'SHOPIFY_APP_CLI_LOCAL_PARTNERS'
+      AUTH_PROD_URI = 'https://accounts.shopify.com'
+      AUTH_DEV_URI = 'https://identity.myshopify.io'
+      PROD_URI = 'https://partners.shopify.com'
+      DEV_URI = 'https://partners.myshopify.io/'
+      PROD_ID = '271e16d403dfa18082ffb3d197bd2b5f4479c3fc32736d69296829cbb28d41a6'
+      DEV_ID = 'df89d73339ac3c6c5f0a98d9ca93260763e384d51d6038da129889c308973978'
+      PROD_CLI_ID = 'fbdb2649-e327-4907-8f67-908d24cfd7e3'
+      DEV_CLI_ID = 'e5380e02-312a-7408-5718-e07017e9cf52'
+
+      class << self
+        def id
+          ENV[ENV_VAR].nil? ? PROD_ID : DEV_ID
+        end
+
+        def cli_id
+          ENV[ENV_VAR].nil? ? PROD_CLI_ID : DEV_CLI_ID
+        end
+
+        def auth_endpoint
+          ENV[ENV_VAR].nil? ? AUTH_PROD_URI : AUTH_DEV_URI
+        end
+
+        def endpoint
+          ENV[ENV_VAR].nil? ? PROD_URI : DEV_URI
+        end
+
+        def mutation(ctx, body, variables: {})
+          authenticated_req(ctx) do
+            api_client(ctx).mutation(body, variables: variables)
+          end
+        end
+
+        def query(ctx, body, variables: {})
+          authenticated_req(ctx) do
+            api_client(ctx).query(body, variables: variables)
+          end
+        end
+
+        private
+
+        def authenticated_req(ctx)
+          yield
+        rescue Helpers::API::APIRequestUnauthorizedError
+          Tasks::AuthenticateIdentity.call(ctx)
+          retry
+        rescue Helpers::API::APIRequestNotFoundError
+          ctx.puts("{{error: Your account was not found. Please sign up at https://partners.shopify.com/signup}}")
+        end
+
+        def api_client(ctx)
+          new(
+            ctx: ctx,
+            token: Helpers::PkceToken.read(ctx),
+            url: "#{endpoint}/api/cli/graphql",
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/helpers/api_test.rb
+++ b/test/shopify-cli/helpers/api_test.rb
@@ -31,7 +31,6 @@ module ShopifyCli
               'Content-Type' => 'application/json',
               'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} abcde | Mac",
               'X-Shopify-Access-Token' => 'faketoken',
-              'Authorization' => 'faketoken',
             })
           .to_return(status: 200, body: '{}')
         @api.mutation(mutation)
@@ -48,7 +47,6 @@ module ShopifyCli
               'Content-Type' => 'application/json',
               'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} abcde | Mac",
               'X-Shopify-Access-Token' => 'faketoken',
-              'Authorization' => 'faketoken',
             })
           .to_return(
             status: 200,

--- a/test/shopify-cli/helpers/partners_api_test.rb
+++ b/test/shopify-cli/helpers/partners_api_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Helpers
+    class PartnersAPITest < MiniTest::Test
+      include TestHelpers::Project
+
+      def setup
+        super
+        Helpers::PkceToken.stubs(:read).returns('token123')
+      end
+
+      def test_id
+        ENV['SHOPIFY_APP_CLI_LOCAL_PARTNERS'] = '1'
+        assert_equal PartnersAPI::DEV_ID, PartnersAPI.id
+        ENV.delete('SHOPIFY_APP_CLI_LOCAL_PARTNERS')
+        assert_equal PartnersAPI::PROD_ID, PartnersAPI.id
+      end
+
+      def test_cli_id
+        ENV['SHOPIFY_APP_CLI_LOCAL_PARTNERS'] = '1'
+        assert_equal PartnersAPI::DEV_CLI_ID, PartnersAPI.cli_id
+        ENV.delete('SHOPIFY_APP_CLI_LOCAL_PARTNERS')
+        assert_equal PartnersAPI::PROD_CLI_ID, PartnersAPI.cli_id
+      end
+
+      def test_auth_endpoint
+        ENV['SHOPIFY_APP_CLI_LOCAL_PARTNERS'] = '1'
+        assert_equal PartnersAPI::AUTH_DEV_URI, PartnersAPI.auth_endpoint
+        ENV.delete('SHOPIFY_APP_CLI_LOCAL_PARTNERS')
+        assert_equal PartnersAPI::AUTH_PROD_URI, PartnersAPI.auth_endpoint
+      end
+
+      def test_endpoint
+        ENV['SHOPIFY_APP_CLI_LOCAL_PARTNERS'] = '1'
+        assert_equal PartnersAPI::DEV_URI, PartnersAPI.endpoint
+        ENV.delete('SHOPIFY_APP_CLI_LOCAL_PARTNERS')
+        assert_equal PartnersAPI::PROD_URI, PartnersAPI.endpoint
+      end
+
+      def test_mutation_calls_partners_api
+        api_stub = Object.new
+        PartnersAPI.expects(:new).with(
+          ctx: @context,
+          token: 'token123',
+          url: "#{PartnersAPI.endpoint}/api/cli/graphql",
+        ).returns(api_stub)
+        api_stub.expects(:mutation).with('query', variables: {}).returns('response')
+        assert_equal 'response', PartnersAPI.mutation(@context, 'query')
+      end
+
+      def test_mutation_can_reauth
+        api_stub = Object.new
+        PartnersAPI.expects(:new).with(
+          ctx: @context,
+          token: 'token123',
+          url: "#{PartnersAPI.endpoint}/api/cli/graphql",
+        ).returns(api_stub).twice
+        api_stub.expects(:mutation).with('query', variables: {}).returns('response')
+        api_stub.expects(:mutation).raises(Helpers::API::APIRequestUnauthorizedError)
+        Tasks::AuthenticateIdentity.expects(:call)
+        PartnersAPI.mutation(@context, 'query')
+      end
+
+      def test_mutation_fails_gracefully_without_partners_account
+        api_stub = Object.new
+        PartnersAPI.expects(:new).with(
+          ctx: @context,
+          token: 'token123',
+          url: "#{PartnersAPI.endpoint}/api/cli/graphql",
+        ).returns(api_stub)
+        api_stub.expects(:mutation).raises(Helpers::API::APIRequestNotFoundError)
+        @context.expects(:puts).with(
+          "{{error: Your account was not found. Please sign up at https://partners.shopify.com/signup}}",
+        )
+        PartnersAPI.mutation(@context, 'query')
+      end
+
+      def test_query
+        api_stub = Object.new
+        PartnersAPI.expects(:new).with(
+          ctx: @context,
+          token: 'token123',
+          url: "#{PartnersAPI.endpoint}/api/cli/graphql",
+        ).returns(api_stub)
+        api_stub.expects(:query).with('query', variables: {}).returns('response')
+        assert_equal 'response', PartnersAPI.query(@context, 'query')
+      end
+    end
+  end
+end

--- a/test/shopify-cli/oauth_test.rb
+++ b/test/shopify-cli/oauth_test.rb
@@ -81,6 +81,32 @@ module ShopifyCli
       assert_equal 'accesstoken123', client.authenticate(endpoint)
     end
 
+    def test_exchange_token
+      endpoint = "https://example.com/auth"
+      client = OAuth.new(client_id: 'key', scopes: 'test,one', secret: 'secret')
+
+      token_query = {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        client_id: 'key',
+        audience: 'audience',
+        scope: 'scopes',
+        subject_token: 'test_token',
+      }
+
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(status: 200, body: '{ "access_token": "accesstoken123" }', headers: {})
+
+      assert_equal 'accesstoken123', client.exchange_token(
+        endpoint,
+        token: "test_token",
+        audience: "audience",
+        scopes: "scopes",
+      )
+    end
+
     def test_authenticate_with_invalid_request
       endpoint = "https://example.com/auth"
       client = OAuth.new(client_id: 'key', scopes: 'test,one')


### PR DESCRIPTION
### WHY are these changes introduced?
These are all the changes that were required to get authorization working with the partners app that work is done here: https://github.com/Shopify/partners/pull/17927

### WHAT is this pull request doing?
There were a few things that helped this along
- an env var that called `SHOPIFY_APP_CLI_LOCAL_PARTNERS` that will allow the cli to work with local partners and identity. 
- A Helpers::PartnersAPI wrapper around the Helpers::API to allow it to handle some expected responses from partners in a consistent way.
- An exchange_token request from identity to fetch a special token for token exchange in partners.
- Changed from listening on localhost to 127.0.0.1 and then use our custom loopback domain to receive oauth redirect

### Tophatting
- add the orgs command shopify-cli (see snippet below)
- `shopify orgs`. This should open identity to authenticate, and then query partners then output the resulting data to the console.

### Code snippet 
```
# lib/shopify-cli/commands/orgs.rb
require 'shopify_cli'

module ShopifyCli
  module Commands
    class Orgs < ShopifyCli::Command
      def call(*)
        puts Helpers::PartnersAPI.query(@ctx, '{ organizations { edges { node { id }}}}')
      end
    end
  end
end
```