### PR TITLE
Corrects `authenticate` help text

### DIFF
--- a/lib/shopify-cli/commands/authenticate.rb
+++ b/lib/shopify-cli/commands/authenticate.rb
@@ -21,8 +21,8 @@ module ShopifyCli
 
       def self.help
         <<~HELP
-          Request a new access token from the Shopify admin API.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} auth}}
+          Request a new access token from the Shopify Admin API.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} authenticate}}
         HELP
       end
     end


### PR DESCRIPTION
This PR corrects the help text for the `shopify authenticate` command. Currently the help text says usage is `shopify auth`:

<img width="692" alt="Screen Shot 2019-07-24 at 10 52 42" src="https://user-images.githubusercontent.com/547470/61804656-4c03dd00-ae02-11e9-81d9-d6762227bf74.png">

Which doesn't actually exist:

<img width="497" alt="Screen Shot 2019-07-24 at 11 01 28" src="https://user-images.githubusercontent.com/547470/61804738-748bd700-ae02-11e9-92b6-cf96e19c641b.png">

It also corrects the capitalization of "Admin API"