### PR TITLE
Fix link to DESIGN.MD from CONTRIBUtING.MD

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We expect all participants to read our [code of conduct](https://github.com/Shop
 All work on Shopify App CLI happens directly on GitHub. Both team members and external contributors send pull requests which go through the same review process.
 
 ## Design guidelines
-When contributing to the Shopify App CLI, there are a set of [design guidelines](https://github.com/Shopify/shopify-app-cli/blob/design-guidelines/.github/DESIGN.md) that should be followed. The design guidelines are meant to help create a consistent and predictable experience for all users of the tool, and help make descisions quicker when creating new commands or adding to existing ones.
+When contributing to the Shopify App CLI, there are a set of [design guidelines](https://github.com/Shopify/shopify-app-cli/blob/master/.github/DESIGN.md) that should be followed. The design guidelines are meant to help create a consistent and predictable experience for all users of the tool, and help make descisions quicker when creating new commands or adding to existing ones.
 
 ## Bugs
 


### PR DESCRIPTION
### WHY are these changes introduced?

Link to DESIGN.MD points to the branch, not master.

### WHAT is this pull request doing?

Pointing the link to the master version of DESIGN.MD