### PR TITLE
add before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 rvm:
  - 2.3.7
  - 2.5.1
+before_install:
+- gem install bundler
+cache:
+  bundler: true
 install:
 - bundle install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
  - 2.3.7
  - 2.5.1
 before_install:
-- gem install bundler
+- gem install bundler -v '1.17.3'
 cache:
   bundler: true
 install:


### PR DESCRIPTION
Adding a before install step to travis config to install bundler. 

I had to add a version because:
```Bundler 2 introduced a new feature that will automatically switch between Bundler v1 and v2 based on the lockfile. This feature is enabled by RubyGems (only on versions 2.7.0+) which unfortunately has a bug when you run Bundler without the appropriate version installed.```