### PR TITLE
Support opening URLs on Linux and escape them

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -39,8 +39,8 @@ module ShopifyCli
           "#{generate[:webhook]} #{selected_type}"
         end
 
-        def open(ctx)
-          ctx.system('open', "#{Project.current.env.host}/auth?shop=#{Project.current.env.shop}")
+        def open_url
+          "#{Project.current.env.host}/auth?shop=#{Project.current.env.shop}"
         end
       end
 

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -41,8 +41,8 @@ module ShopifyCli
           "#{generate[:webhook]} -t #{selected_type} -a #{Project.current.env.host}/webhooks/#{selected_type.downcase}"
         end
 
-        def open(ctx)
-          ctx.system('open', "#{Project.current.env.host}/login?shop=#{Project.current.env.shop}")
+        def open_url
+          "#{Project.current.env.host}/login?shop=#{Project.current.env.shop}"
         end
       end
 

--- a/lib/shopify-cli/commands/open.rb
+++ b/lib/shopify-cli/commands/open.rb
@@ -6,7 +6,7 @@ module ShopifyCli
       prerequisite_task :tunnel
 
       def call(*)
-        Project.current.app_type.open(@ctx)
+        @ctx.system('open', "\"#{Project.current.app_type.open_url}\"")
       end
 
       def self.help

--- a/lib/shopify-cli/commands/open.rb
+++ b/lib/shopify-cli/commands/open.rb
@@ -3,10 +3,12 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Open < ShopifyCli::Command
+      include Helpers::OS
+
       prerequisite_task :tunnel
 
       def call(*)
-        @ctx.system('open', "\"#{Project.current.app_type.open_url}\"")
+        @ctx.system(*open_cmd, "\"#{Project.current.app_type.open_url}\"")
       end
 
       def self.help
@@ -14,6 +16,16 @@ module ShopifyCli
           Open your local development app in the default browser.
             Usage: {{command:#{ShopifyCli::TOOL_NAME} open}}
         HELP
+      end
+
+      private
+
+      def open_cmd
+        if mac?
+          %w(open)
+        else
+          %w(python -m webserver)
+        end
       end
     end
   end

--- a/test/commands/open_test.rb
+++ b/test/commands/open_test.rb
@@ -11,7 +11,7 @@ module ShopifyCli
       end
 
       def test_run
-        @context.expects(:system).with('open https://example.com')
+        @context.expects(:system).with('open', '"https://example.com"')
         @command.call([], nil)
       end
     end

--- a/test/commands/open_test.rb
+++ b/test/commands/open_test.rb
@@ -10,8 +10,15 @@ module ShopifyCli
         @command = ShopifyCli::Commands::Open.new(@context)
       end
 
-      def test_run
+      def test_run_mac
+        @command.stubs(:mac?).returns(true)
         @context.expects(:system).with('open', '"https://example.com"')
+        @command.call([], nil)
+      end
+
+      def test_run_linux
+        @command.stubs(:mac?).returns(false)
+        @context.expects(:system).with('python', '-m', 'webserver', '"https://example.com"')
         @command.call([], nil)
       end
     end

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -114,6 +114,7 @@ module ShopifyCli
 
       def test_open_command
         cmd = ShopifyCli::Commands::Open.new(@context)
+        cmd.stubs(:mac?).returns(true)
         @context.expects(:system).with(
           'open',
           '"https://example.com/auth?shop=my-test-shop.myshopify.com"'

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -116,7 +116,7 @@ module ShopifyCli
         cmd = ShopifyCli::Commands::Open.new(@context)
         @context.expects(:system).with(
           'open',
-          'https://example.com/auth?shop=my-test-shop.myshopify.com'
+          '"https://example.com/auth?shop=my-test-shop.myshopify.com"'
         )
         cmd.call([], nil)
       end

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -101,6 +101,7 @@ module ShopifyCli
 
       def test_open_command
         cmd = ShopifyCli::Commands::Open.new(@context)
+        cmd.stubs(:mac?).returns(true)
         @context.expects(:system).with(
           'open',
           '"https://example.com/login?shop=my-test-shop.myshopify.com"'

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -103,7 +103,7 @@ module ShopifyCli
         cmd = ShopifyCli::Commands::Open.new(@context)
         @context.expects(:system).with(
           'open',
-          'https://example.com/login?shop=my-test-shop.myshopify.com'
+          '"https://example.com/login?shop=my-test-shop.myshopify.com"'
         )
         cmd.call([], nil)
       end

--- a/test/test_helpers/app_type.rb
+++ b/test/test_helpers/app_type.rb
@@ -30,8 +30,8 @@ module TestHelpers
           }
         end
 
-        def open(ctx)
-          ctx.system('open https://example.com')
+        def open_url
+          'https://example.com'
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

Related to #267 

Makes the `open` command OS-aware and escapes the URL being opened in quotes, which I've had issues with in zsh.
