### PR TITLE
add tunnel auth command to add ngrok token

### DIFF
--- a/lib/shopify-cli/commands/tunnel.rb
+++ b/lib/shopify-cli/commands/tunnel.rb
@@ -15,6 +15,9 @@ module ShopifyCli
           task.call(@ctx)
         when 'stop'
           task.stop(@ctx)
+        when 'auth'
+          token = args.shift
+          task.auth(@ctx, token)
         else
           puts CLI::UI.fmt(self.class.help)
         end
@@ -23,7 +26,23 @@ module ShopifyCli
       def self.help
         <<~HELP
           Start or stop an http tunnel to your local development app using ngrok.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel [ start | stop ]}}
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel [ auth | start | stop ]}}
+        HELP
+      end
+
+      def self.extended_help
+        <<~HELP
+          {{bold:Subcommands:}}
+
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to allow connecting with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} auth <token>}}
+
+            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel start}}
+
+            {{cyan:stop}}: Stops the ngrok tunnel.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel stop}}
+
         HELP
       end
     end

--- a/lib/shopify-cli/tasks/tunnel.rb
+++ b/lib/shopify-cli/tasks/tunnel.rb
@@ -51,6 +51,12 @@ module ShopifyCli
         url
       end
 
+      def auth(ctx, token)
+        install
+
+        ctx.system(File.join(ShopifyCli::ROOT, 'ngrok'), 'authtoken', token)
+      end
+
       def running?
         ShopifyCli::Helpers::ProcessSupervision.running?(:ngrok)
       end

--- a/lib/shopify-cli/tasks/tunnel.rb
+++ b/lib/shopify-cli/tasks/tunnel.rb
@@ -45,10 +45,14 @@ module ShopifyCli
           ShopifyCli::Helpers::ProcessSupervision.start(:ngrok, ngrok_command)
         end
         pid_file = ShopifyCli::Helpers::PidFile.for(:ngrok)
-        url = fetch_url(pid_file.log_path)
-        @ctx.puts("{{v}} ngrok tunnel running at {{underline: #{url}}}")
-        @ctx.app_metadata = { host: url }
-        url
+        log = fetch_url(pid_file.log_path)
+        if log.account
+          @ctx.puts("{{v}} ngrok tunnel running at {{underline: #{log.url}}}, with account #{log.account}")
+        else
+          @ctx.puts("{{v}} ngrok tunnel running at {{underline: #{log.url}}}")
+        end
+        @ctx.app_metadata = { host: log.url }
+        log.url
       end
 
       def auth(ctx, token)
@@ -78,27 +82,52 @@ module ShopifyCli
       end
 
       def fetch_url(log_path)
-        counter = 0
-        while counter < TIMEOUT
-          log_content = File.read(log_path)
-          result = log_content.match(/msg="started tunnel".*url=(https:\/\/.+)/)
-          return result[1] if result
-
-          counter += 1
-          sleep(1)
-
-          error = log_content.scan(/msg="command failed" err="([^"]+)"/).flatten
-          unless error.empty?
-            stop(@ctx)
-            raise NgrokError, error.first
-          end
-        end
-
-        raise FetchUrlError, "Unable to fetch external url"
+        LogParser.new(log_path)
+      rescue RuntimeError => e
+        stop(@ctx)
+        raise e.class, e.message
       end
 
       def ngrok_command
         "exec #{File.join(ShopifyCli::ROOT, 'ngrok')} http -log=stdout -log-level=debug #{PORT}"
+      end
+
+      class LogParser
+        attr_reader :url, :account
+
+        def initialize(log_path)
+          @log_path = log_path
+          counter = 0
+          while counter < TIMEOUT
+            parse
+            return if url
+            counter += 1
+            sleep(1)
+          end
+
+          raise FetchUrlError, "Unable to fetch external url" unless url
+        end
+
+        def parse
+          @log = File.read(@log_path)
+          unless error.empty?
+            raise NgrokError, error.first
+          end
+          parse_account
+          parse_url
+        end
+
+        def parse_url
+          @url, _ = @log.match(/msg="started tunnel".*url=(https:\/\/.+)/)&.captures
+        end
+
+        def parse_account
+          @account, _ = @log.match(/AccountName:([\w\s]+) SessionDuration/)&.captures
+        end
+
+        def error
+          @log.scan(/msg="command failed" err="([^"]+)"/).flatten
+        end
       end
     end
   end

--- a/test/fixtures/ngrok_account.log
+++ b/test/fixtures/ngrok_account.log
@@ -1,0 +1,4 @@
+t=2019-08-09T15:35:57-0400 lvl=dbug msg="decoded response" obj=csess id=63b552dbb648 sid=3 resp="&{Version:2 ClientID:640713d23ff34283f8d9c211fb8f2839 Error: Extra:{Version:prod Cookie:redacted AccountName:Tom Cruise SessionDuration:0 PlanName:Free}}" err=nil
+t=2019-03-26T14:45:57-0400 lvl=dbug msg="start tunnel listen" obj=tunnels.session name="command_line (http)" proto=http opts="&{Hostname:example.ngrok.io Auth: Subdomain: HostHeaderRewrite:false LocalURLScheme:http}" err=nil
+t=2019-03-26T14:45:57-0400 lvl=info msg="started tunnel" obj=tunnels name="command_line (http)" addr=http://localhost:8081 url=http://example.ngrok.io
+t=2019-03-26T14:45:57-0400 lvl=info msg="started tunnel" obj=tunnels name=command_line addr=http://localhost:8081 url=https://example.ngrok.io

--- a/test/shopify-cli/commands/tunnel_test.rb
+++ b/test/shopify-cli/commands/tunnel_test.rb
@@ -7,13 +7,18 @@ module ShopifyCli
         @command = ShopifyCli::Commands::Tunnel.new
       end
 
+      def test_auth
+        ShopifyCli::Tasks::Tunnel.any_instance.expects(:auth)
+        @command.call(['auth'], nil)
+      end
+
       def test_start
-        ShopifyCli::Tasks::Tunnel.any_instance.stubs(:call)
+        ShopifyCli::Tasks::Tunnel.any_instance.expects(:call)
         @command.call(['start'], nil)
       end
 
       def test_stop
-        ShopifyCli::Tasks::Tunnel.any_instance.stubs(:stop)
+        ShopifyCli::Tasks::Tunnel.any_instance.expects(:stop)
         @command.call(['stop'], nil)
       end
 

--- a/test/shopify-cli/task/ensure_env_test.rb
+++ b/test/shopify-cli/task/ensure_env_test.rb
@@ -11,6 +11,7 @@ module ShopifyCli
         @context = TestHelpers::FakeContext.new(root: root)
         Project.write(@context, :fake)
         FileUtils.cd(@context.root)
+        Tasks::Tunnel.stubs(:call)
       end
 
       def test_ask_strips_out_https_from_shop

--- a/test/shopify-cli/task/tunnel_test.rb
+++ b/test/shopify-cli/task/tunnel_test.rb
@@ -10,6 +10,11 @@ module ShopifyCli
         super
       end
 
+      def test_auth_calls_ngrok_authtoken
+        @context.expects(:system).with("#{ShopifyCli::ROOT}/ngrok", 'authtoken', 'token')
+        Tunnel.new.auth(@context, 'token')
+      end
+
       def test_start_running_returns_url
         ShopifyCli::Helpers::ProcessSupervision.stubs(:running?)
           .with(:ngrok).returns(:true)

--- a/test/shopify-cli/task/tunnel_test.rb
+++ b/test/shopify-cli/task/tunnel_test.rb
@@ -39,6 +39,20 @@ module ShopifyCli
         end
       end
 
+      def test_start_displays_url_with_account
+        with_log('ngrok_account') do
+          ShopifyCli::Helpers::ProcessSupervision.stubs(:running?).returns(false)
+          ShopifyCli::Helpers::ProcessSupervision.expects(:start).with(
+            :ngrok,
+            "exec #{File.join(ShopifyCli::ROOT, 'ngrok')} http -log=stdout -log-level=debug 8081"
+          )
+          @context.expects(:puts).with(
+            "{{v}} ngrok tunnel running at {{underline: https://example.ngrok.io}}, with account Tom Cruise"
+          )
+          assert_equal 'https://example.ngrok.io', ShopifyCli::Tasks::Tunnel.new.call(@context)
+        end
+      end
+
       def test_start_raises_error_on_ngrok_failure
         Tunnel.any_instance.stubs(:running?).returns(false)
         with_log('ngrok_error') do


### PR DESCRIPTION
### WHY are these changes introduced?

Adds an `auth` subcommand to the `tunnel` command to automate writing a user token to their ngrok config, which the ngrok binary we download will read from. I'm also printing the account name when the tunnel starts.

![image](https://user-images.githubusercontent.com/73874/62805613-820db600-babe-11e9-9bbc-8ccfcdd18f70.png)