### PR TITLE
Backoff Oauth Flow

### DIFF
--- a/lib/shopify-cli/commands/authenticate.rb
+++ b/lib/shopify-cli/commands/authenticate.rb
@@ -4,19 +4,25 @@ module ShopifyCli
   module Commands
     class Authenticate < ShopifyCli::Command
       def call(args, _name)
-        spin_group = CLI::UI::SpinGroup.new
-        spin_group.add("Requesting access token...") do |spinner|
-          case args.shift
-          when 'identity'
-            ShopifyCli::Tasks::AuthenticateIdentity.call(@ctx)
-          when 'shop'
-            ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)
-          else
-            ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)
+        command = args.shift
+        CLI::UI::Spinner.spin("Requesting access token...") do |spinner|
+          begin
+            case command
+            when 'identity'
+              ShopifyCli::Tasks::AuthenticateIdentity.call(@ctx)
+            else
+              ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)
+            end
+            spinner.update_title("Authetication token stored")
+          rescue OAuth::Error
+            @ctx.puts("{{error:Failed to Authenticate}}")
+            if command == 'shop' || command.nil?
+              @ctx.puts "{{*}} Remeber to add {{underline: #{OAuth::REDIRECT_HOST}:3456"\
+                "to the whitelisted redirection URLs in your app setup"
+            end
+            raise(::ShopifyCli::Abort, "Failed to Authenticate")
           end
-          spinner.update_title("Authetication token stored")
         end
-        spin_group.wait
       end
 
       def self.help

--- a/lib/shopify-cli/helpers.rb
+++ b/lib/shopify-cli/helpers.rb
@@ -14,6 +14,7 @@ module ShopifyCli
     autoload :Ruby, 'shopify-cli/helpers/ruby'
     autoload :SchemaParser, 'shopify-cli/helpers/schema_parser'
     autoload :ShopifySchema, 'shopify-cli/helpers/shopify_schema'
+    autoload :Store, 'shopify-cli/helpers/store'
     autoload :String, 'shopify-cli/helpers/string'
   end
 end

--- a/lib/shopify-cli/helpers/access_token.rb
+++ b/lib/shopify-cli/helpers/access_token.rb
@@ -3,21 +3,10 @@ module ShopifyCli
     class AccessToken
       class << self
         def read(ctx)
-          unless File.file?("#{ShopifyCli::TEMP_DIR}/.#{file_name}")
+          Store.get(:admin_access_token) do
             ShopifyCli::Tasks::AuthenticateShopify.call(ctx)
+            Store.get(:admin_access_token)
           end
-          File.read(
-            File.join(ShopifyCli::TEMP_DIR, ".#{file_name}")
-          )
-        end
-
-        def write(token)
-          File.write(File.join(ShopifyCli::TEMP_DIR, ".#{file_name}"), token)
-        end
-
-        def file_name
-          env = Helpers::EnvFile.read
-          @file_name = env.api_key
         end
       end
     end

--- a/lib/shopify-cli/helpers/pkce_token.rb
+++ b/lib/shopify-cli/helpers/pkce_token.rb
@@ -3,16 +3,10 @@ module ShopifyCli
     class PkceToken
       class << self
         def read(ctx)
-          ShopifyCli::Tasks::AuthenticateIdentity.call(ctx) unless File.file?(file_name)
-          File.read(file_name)
-        end
-
-        def write(token)
-          File.write(file_name, token)
-        end
-
-        def file_name
-          File.join(ShopifyCli::TEMP_DIR, ".pkce")
+          Store.get(:identity_exchange_token) do
+            ShopifyCli::Tasks::AuthenticateIdentity.call(ctx)
+            Store.get(:identity_exchange_token)
+          end
         end
       end
     end

--- a/lib/shopify-cli/helpers/store.rb
+++ b/lib/shopify-cli/helpers/store.rb
@@ -1,0 +1,73 @@
+require 'pstore'
+
+module ShopifyCli
+  module Helpers
+    class Store
+      attr_reader :db
+
+      class << self
+        def keys
+          new.keys
+        end
+
+        def exists?(key)
+          new.exists?(key)
+        end
+
+        def set(**args)
+          new.set(**args)
+        end
+
+        def get(key, &block)
+          new.get(key, &block)
+        end
+
+        def del(*args)
+          new.del(*args)
+        end
+
+        def clear
+          new.clear
+        end
+      end
+
+      def initialize(path: File.join(ShopifyCli::TEMP_DIR, ".db.pstore"))
+        @db = PStore.new(path)
+      end
+
+      def keys
+        db.transaction(true) { db.roots }
+      end
+
+      def exists?(key)
+        db.transaction(true) { db.root?(key) }
+      end
+
+      def set(**args)
+        db.transaction do
+          args.each do |key, val|
+            if val.nil?
+              db.delete(key)
+            else
+              db[key] = val
+            end
+          end
+        end
+      end
+
+      def get(key)
+        val = db.transaction(true) { db[key] }
+        val = yield if val.nil? && block_given?
+        val
+      end
+
+      def del(*args)
+        db.transaction { args.each { |key| db.delete(key) } }
+      end
+
+      def clear
+        del(*keys)
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/tasks/authenticate_identity.rb
+++ b/lib/shopify-cli/tasks/authenticate_identity.rb
@@ -5,25 +5,13 @@ module ShopifyCli
     class AuthenticateIdentity < ShopifyCli::Task
       SCOPES = 'openid https://api.shopify.com/auth/partners.app.cli.access'
 
-      def call(ctx)
-        client = oauth_client
-        auth_endpoint = "#{Helpers::PartnersAPI.auth_endpoint}/oauth"
-        exchange = client.exchange_token(
-          auth_endpoint,
-          token: client.authenticate(auth_endpoint),
-          audience: Helpers::PartnersAPI.id,
+      def call(_ctx)
+        OAuth.new(
+          service: 'identity',
+          client_id: Helpers::PartnersAPI.cli_id,
           scopes: SCOPES,
-        )
-        Helpers::PkceToken.write(exchange)
-        ctx.puts "{{success:Authentication Token saved}}"
-      rescue OAuth::Error => e
-        ctx.puts("{{error: #{e}}}")
-      end
-
-      private
-
-      def oauth_client
-        OAuth.new(client_id: Helpers::PartnersAPI.cli_id, scopes: SCOPES)
+          request_exchange: Helpers::PartnersAPI.id,
+        ).authenticate("#{Helpers::PartnersAPI.auth_endpoint}/oauth")
       end
     end
   end

--- a/lib/shopify-cli/tasks/authenticate_shopify.rb
+++ b/lib/shopify-cli/tasks/authenticate_shopify.rb
@@ -5,30 +5,15 @@ module ShopifyCli
     class AuthenticateShopify < ShopifyCli::Task
       def call(ctx)
         Tasks::EnsureEnv.call(ctx)
-        token = oauth_client.authenticate("https://#{env.shop}/admin/oauth")
-        @env = Helpers::AccessToken.write(token)
-        ctx.puts "{{success:Authentication Token written to env file}}"
-      rescue OAuth::Error => e
-        ctx.puts("{{error: #{e}}}")
-        ctx.puts("{{error:Failed to retrieve ID & Refresh tokens}}")
-        ctx.puts "{{*}} Remeber to add {{underline: #{oauth_client.redirect_uri} "\
-          "to the whitelisted redirection URLs in your app setup"
-      end
-
-      private
-
-      def env
-        @env = Helpers::EnvFile.read
-      end
-
-      def oauth_client
+        env = Helpers::EnvFile.read
         OAuth.new(
+          service: 'admin',
           client_id: env.api_key,
           secret: env.secret,
           scopes: env.scopes,
           token_path: "/access_token",
           options: { 'grant_options[]' => 'per user' },
-        )
+        ).authenticate("https://#{env.shop}/admin/oauth")
       end
     end
   end

--- a/test/shopify-cli/helpers/store_test.rb
+++ b/test/shopify-cli/helpers/store_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Helpers
+    class StoreTest < MiniTest::Test
+      def test_set
+        store = new_store
+        store.set(foo: 'bar', life: 42)
+        store.db.transaction do
+          assert_equal store.db[:foo], 'bar'
+          assert_equal store.db[:life], 42
+        end
+      end
+
+      def test_get
+        store = new_store
+        assert_equal store.get(:keyone), 'value'
+        assert_equal store.get(:keytwo), 42
+      end
+
+      def test_keys
+        store = new_store
+        assert_equal store.keys, [:keyone, :keytwo]
+      end
+
+      def test_exists?
+        store = new_store
+        assert store.exists?(:keyone)
+        assert store.exists?(:keytwo)
+        refute store.exists?(:nothere)
+      end
+
+      def test_del
+        store = new_store
+        store.set(foo: 'bar', life: 42)
+        store.del(:keytwo, :foo)
+        assert store.exists?(:keyone)
+        assert store.exists?(:life)
+        refute store.exists?(:foo)
+        refute store.exists?(:keytwo)
+      end
+
+      def test_clear
+        store = new_store
+        store.clear
+        refute store.exists?(:keyone)
+        refute store.exists?(:keytwo)
+      end
+
+      private
+
+      def new_store
+        store = Helpers::Store.new(path: File.join(ShopifyCli::TEMP_DIR, ".test_db.pstore"))
+        store.clear
+        store.db.transaction do
+          store.db[:keyone] = 'value'
+          store.db[:keytwo] = 42
+        end
+        store
+      end
+    end
+  end
+end

--- a/test/shopify-cli/oauth_test.rb
+++ b/test/shopify-cli/oauth_test.rb
@@ -6,14 +6,15 @@ module ShopifyCli
     include TestHelpers::Constants
 
     def test_new
-      client = OAuth.new(client_id: 'key', scopes: 'test,one')
+      client = oauth
+      assert_equal 'test', client.service
       assert_equal 'key', client.client_id
       assert_equal 'test,one', client.scopes
       assert_nil(client.secret)
       assert_equal 3456, client.port
       assert_equal({}, client.options)
 
-      client = OAuth.new(client_id: 'key', scopes: 'test,one', port: 9876, secret: 'secret', options: { foo: :bar })
+      client = oauth(port: 9876, secret: 'secret', options: { foo: :bar })
       assert_equal 'key', client.client_id
       assert_equal 'test,one', client.scopes
       assert_equal 9876, client.port
@@ -23,7 +24,7 @@ module ShopifyCli
 
     def test_authenticate_with_secret
       endpoint = "https://example.com/auth"
-      client = OAuth.new(client_id: 'key', scopes: 'test,one', secret: 'secret')
+      client = oauth(secret: 'secret')
       CLI::Kit::System.expects(:system).with do |param|
         auth_repsonse(client, endpoint, param)
       end
@@ -46,14 +47,16 @@ module ShopifyCli
       }
       stub_request(:post, "#{endpoint}/token")
         .with(body: URI.encode_www_form(token_query))
-        .to_return(status: 200, body: '{ "access_token": "accesstoken123" }', headers: {})
+        .to_return(status: 200, body: token_resp, headers: {})
 
-      assert_equal 'accesstoken123', client.authenticate(endpoint)
+      client.authenticate(endpoint)
+      assert_equal client.store.get(:test_access_token), 'accesstoken123'
+      assert_equal client.store.get(:test_refresh_token), 'refreshtoken123'
     end
 
-    def test_authenticate_pkce
+    def test_authenticate_without_secret
       endpoint = "https://example.com/auth"
-      client = OAuth.new(client_id: 'key', scopes: 'test,one')
+      client = oauth
       CLI::Kit::System.expects(:system).with do |param|
         auth_repsonse(client, endpoint, param)
       end
@@ -76,40 +79,146 @@ module ShopifyCli
       }
       stub_request(:post, "#{endpoint}/token")
         .with(body: URI.encode_www_form(token_query))
-        .to_return(status: 200, body: '{ "access_token": "accesstoken123" }', headers: {})
+        .to_return(status: 200, body: token_resp, headers: {})
 
-      assert_equal 'accesstoken123', client.authenticate(endpoint)
+      client.authenticate(endpoint)
+      assert_equal client.store.get(:test_access_token), 'accesstoken123'
+      assert_equal client.store.get(:test_refresh_token), 'refreshtoken123'
     end
 
-    def test_exchange_token
+    def test_request_exchange_token
       endpoint = "https://example.com/auth"
-      client = OAuth.new(client_id: 'key', scopes: 'test,one', secret: 'secret')
+      client = oauth(request_exchange: '123')
+      CLI::Kit::System.expects(:system).with do |param|
+        auth_repsonse(client, endpoint, param)
+      end
+
+      authorize_query = {
+        client_id: client.client_id,
+        scope: client.scopes,
+        redirect_uri: client.redirect_uri,
+        state: client.state_token,
+        response_type: :code,
+      }
+      stub_request(:post, "#{endpoint}/authorize?#{URI.encode_www_form(authorize_query)}")
+
+      token_query = {
+        grant_type: :authorization_code,
+        code: "mycode",
+        redirect_uri: client.redirect_uri,
+        client_id: client.client_id,
+        code_verifier: client.code_verifier,
+      }
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(status: 200, body: token_resp, headers: {})
 
       token_query = {
         grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
         requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
         subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
-        client_id: 'key',
-        audience: 'audience',
-        scope: 'scopes',
-        subject_token: 'test_token',
+        client_id: client.client_id,
+        audience: '123',
+        scope: client.scopes,
+        subject_token: 'accesstoken123',
+      }
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(status: 200, body: '{"access_token":"exchangetoken123"}', headers: {})
+
+      client.authenticate(endpoint)
+      assert_equal client.store.get(:test_access_token), 'accesstoken123'
+      assert_equal client.store.get(:test_refresh_token), 'refreshtoken123'
+      assert_equal client.store.get(:test_exchange_token), 'exchangetoken123'
+    end
+
+    def test_refresh_exchange_token
+      endpoint = "https://example.com/auth"
+      client = oauth(request_exchange: '123')
+      client.store.set(
+        test_access_token: 'accesstoken123',
+        test_refresh_token: 'refreshtoken123',
+        test_exchange_token: 'exchangetoken123',
+      )
+
+      token_query = {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        client_id: client.client_id,
+        audience: '123',
+        scope: client.scopes,
+        subject_token: 'accesstoken123',
+      }
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(status: 200, body: '{"access_token":"exchangetoken456"}', headers: {})
+
+      client.authenticate(endpoint)
+      assert_equal client.store.get(:test_exchange_token), 'exchangetoken456'
+    end
+
+    def test_refresh_access_token_fallback
+      endpoint = "https://example.com/auth"
+      client = oauth(request_exchange: '123')
+      client.store.set(
+        test_access_token: 'accesstoken123',
+        test_refresh_token: 'refreshtoken123',
+        test_exchange_token: 'exchangetoken123',
+      )
+
+      token_query = {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        client_id: client.client_id,
+        audience: '123',
+        scope: client.scopes,
+        subject_token: 'accesstoken123',
       }
 
       stub_request(:post, "#{endpoint}/token")
         .with(body: URI.encode_www_form(token_query))
-        .to_return(status: 200, body: '{ "access_token": "accesstoken123" }', headers: {})
+        .to_return(status: 403)
 
-      assert_equal 'accesstoken123', client.exchange_token(
-        endpoint,
-        token: "test_token",
-        audience: "audience",
-        scopes: "scopes",
-      )
+      token_query = {
+        grant_type: :refresh_token,
+        access_token: 'accesstoken123',
+        refresh_token: 'refreshtoken123',
+        client_id: client.client_id,
+      }
+
+      token_resp = {
+        access_token: "accesstoken456",
+        refresh_token: "refreshtoken456",
+      }.to_json
+
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(status: 200, body: token_resp, headers: {})
+
+      token_query = {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        client_id: client.client_id,
+        audience: '123',
+        scope: client.scopes,
+        subject_token: 'accesstoken456',
+      }
+      stub_request(:post, "#{endpoint}/token")
+        .with(body: URI.encode_www_form(token_query))
+        .to_return(status: 200, body: '{"access_token":"exchangetoken456"}', headers: {})
+
+      client.authenticate(endpoint)
+      assert_equal client.store.get(:test_access_token), 'accesstoken456'
+      assert_equal client.store.get(:test_refresh_token), 'refreshtoken456'
+      assert_equal client.store.get(:test_exchange_token), 'exchangetoken456'
     end
 
     def test_authenticate_with_invalid_request
       endpoint = "https://example.com/auth"
-      client = OAuth.new(client_id: 'key', scopes: 'test,one')
+      client = oauth
       CLI::Kit::System.stubs(:system).with do |_param|
         WebMock.disable!
         https = Net::HTTP.new('localhost', 3456)
@@ -126,7 +235,7 @@ module ShopifyCli
 
     def test_authenticate_with_invalid_state
       endpoint = "https://example.com/auth"
-      client = OAuth.new(client_id: 'key', scopes: 'test,one')
+      client = oauth
       CLI::Kit::System.stubs(:system).with do |_param|
         WebMock.disable!
         https = Net::HTTP.new('localhost', 3456)
@@ -143,7 +252,7 @@ module ShopifyCli
 
     def test_authenticate_with_invalid_code
       endpoint = "https://example.com/auth"
-      client = OAuth.new(client_id: 'key', scopes: 'test,one', secret: 'secret')
+      client = oauth(secret: 'secret')
       CLI::Kit::System.expects(:system).with do |param|
         auth_repsonse(client, endpoint, param)
       end
@@ -179,6 +288,17 @@ module ShopifyCli
 
     private
 
+    def oauth(**args)
+      store = Helpers::Store.new(path: File.join(ShopifyCli::TEMP_DIR, ".test_db.pstore"))
+      store.clear
+      OAuth.new({
+        service: 'test',
+        client_id: 'key',
+        scopes: 'test,one',
+        store: store,
+      }.merge(args))
+    end
+
     def auth_repsonse(client, endpoint, param)
       query = {
         client_id: client.client_id,
@@ -202,6 +322,13 @@ module ShopifyCli
         WebMock.enable!
       end
       command == param
+    end
+
+    def token_resp
+      {
+        access_token: "accesstoken123",
+        refresh_token: "refreshtoken123",
+      }.to_json
     end
   end
 end

--- a/test/task/authenticate_identity_test.rb
+++ b/test/task/authenticate_identity_test.rb
@@ -11,36 +11,15 @@ module ShopifyCli
         ShopifyCli::OAuth
           .expects(:new)
           .with(
-            client_id: 'fbdb2649-e327-4907-8f67-908d24cfd7e3',
+            service: 'identity',
+            client_id: Helpers::PartnersAPI.cli_id,
             scopes: AuthenticateIdentity::SCOPES,
+            request_exchange: Helpers::PartnersAPI.id,
           ).returns(@oauth_client)
         @oauth_client
           .expects(:authenticate)
           .with("https://accounts.shopify.com/oauth")
-          .returns("this_is_token")
-        @oauth_client
-          .expects(:exchange_token)
-          .with(
-            "https://accounts.shopify.com/oauth",
-            token: "this_is_token",
-            audience: '271e16d403dfa18082ffb3d197bd2b5f4479c3fc32736d69296829cbb28d41a6',
-            scopes: AuthenticateIdentity::SCOPES,
-          )
-          .returns("this_is_exchange_token")
-        Helpers::PkceToken.expects(:write).with("this_is_exchange_token")
         AuthenticateIdentity.call(@context)
-      end
-
-      def test_handles_oauth_errors
-        @oauth_client = Object.new
-        ShopifyCli::OAuth.stubs(:new).returns(@oauth_client)
-        @oauth_client
-          .expects(:authenticate)
-          .with("https://accounts.shopify.com/oauth")
-          .raises(OAuth::Error, 'invalid request')
-        assert_nothing_raised do
-          AuthenticateIdentity.call(@context)
-        end
       end
     end
   end

--- a/test/task/authenticate_shopify_test.rb
+++ b/test/task/authenticate_shopify_test.rb
@@ -11,6 +11,7 @@ module ShopifyCli
         ShopifyCli::OAuth
           .expects(:new)
           .with(
+            service: 'admin',
             client_id: 'apikey',
             secret: 'secret',
             scopes: nil,
@@ -20,22 +21,7 @@ module ShopifyCli
         @oauth_client
           .expects(:authenticate)
           .with("https://my-test-shop.myshopify.com/admin/oauth")
-          .returns("this_is_token")
-        Helpers::AccessToken.expects(:write).with("this_is_token")
         AuthenticateShopify.new.call(@context)
-      end
-
-      def test_handles_oauth_errors
-        @oauth_client = Object.new
-        ShopifyCli::OAuth.stubs(:new).returns(@oauth_client)
-        @oauth_client
-          .expects(:authenticate)
-          .with("https://my-test-shop.myshopify.com/admin/oauth")
-          .raises(OAuth::Error, 'invalid request')
-        @oauth_client.expects(:redirect_uri).returns("http://localhost:3456")
-        assert_nothing_raised do
-          AuthenticateShopify.new.call(@context)
-        end
       end
     end
   end

--- a/test/test_helpers/app_type.rb
+++ b/test/test_helpers/app_type.rb
@@ -33,6 +33,10 @@ module TestHelpers
         def open_url
           'https://example.com'
         end
+
+        def webhook_location
+          "im fake"
+        end
       end
     end
 


### PR DESCRIPTION
fixes #17359

### WHY are these changes introduced?
The Oauth flow, especially for identity, is not quite fully featured yet. There are many mechanisms that we are no using and so we are forcing the user to log in again when it is not required. 

#### Some info
- exchange tokens have 2 hour expiry
- we get a refresh token from identity
- Once we have that, we can keep refreshing our access_token as long as the user has not logged out of identity

This means we should VERY rarely have to open the browser again after the initial authentication but I need to implement this refresh token behaviour.

### WHAT is this pull request doing?
I am re-writing the Oauth mechanism to do a few things

- Use a storage system to control storing tokens within the flow. This is because I needed first party access to token stores to check for existence of tokens. The reason being point 2
- Implement a fallback mechanism in re-auth. 
    - If we do exchange and the request fails, it will try to request a new exchange token. 
    - If the exchange token fails then it will try to refresh the access_token
        - If that succeeds, we will request a new exchange token
    - If the refresh fails or we do not have a refresh token, we need to reinitiate the authentication flow from the browser.
- I have added a PStore for storing all of our tokens easily. This store can be used for other data in the future. This is a native ruby library so it has cross-platform functionality, and it will be better than just using plain files. It comes with corruption protection and write locking.