### PR TITLE
Implement command line switch parsing and a subcommand structure

### DIFF
--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -10,15 +10,33 @@ module ShopifyCli
       attr_writer :ctx
 
       def call(args, command_name)
-        cmd = new
-        cmd.ctx = @ctx
-        cmd.options = Options.new
-        cmd.options.parse(@_options, args)
-        cmd.call(args, command_name)
+        subcommand, resolved_name = subcommand_registry.lookup_command(args.first)
+        if subcommand
+          subcommand.ctx = @ctx
+          subcommand.call(args, resolved_name)
+        else
+          cmd = new
+          cmd.ctx = @ctx
+          cmd.options = Options.new
+          cmd.options.parse(@_options, args)
+          cmd.call(args, command_name)
+        end
       end
 
       def options(&block)
         @_options = block
+      end
+
+      def subcommand(const, cmd, path = nil)
+        autoload(const, path) if path
+        subcommand_registry.add(->() { const_get(const) }, cmd)
+      end
+
+      def subcommand_registry
+        @subcommand_registry ||= CLI::Kit::CommandRegistry.new(
+          default: nil,
+          contextual_resolver: nil,
+        )
       end
 
       def prerequisite_task(*tasks)

--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -4,6 +4,7 @@ require 'shopify_cli'
 module ShopifyCli
   class Command < CLI::Kit::BaseCommand
     attr_writer :ctx
+    attr_accessor :options
 
     class << self
       attr_writer :ctx
@@ -11,7 +12,13 @@ module ShopifyCli
       def call(args, command_name)
         cmd = new
         cmd.ctx = @ctx
+        cmd.options = Options.new
+        cmd.options.parse(@_options, args)
         cmd.call(args, command_name)
+      end
+
+      def options(&block)
+        @_options = block
       end
 
       def prerequisite_task(*tasks)

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -3,18 +3,10 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Create < ShopifyCli::Command
-      autoload :Project, 'shopify-cli/commands/create/project'
+      subcommand :Project, 'project', 'shopify-cli/commands/create/project'
 
-      def call(args, name)
-        subcommand = args.shift
-        case subcommand
-        when 'project'
-          Project.new(@ctx).call(args, name)
-        when 'dev-store'
-          raise(ShopifyCli::Abort, 'This feature is not yet available')
-        else
-          @ctx.puts(self.class.help)
-        end
+      def call(*)
+        @ctx.puts(self.class.help)
       end
 
       def self.help

--- a/lib/shopify-cli/commands/create/project.rb
+++ b/lib/shopify-cli/commands/create/project.rb
@@ -3,7 +3,7 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Create
-      class Project < ShopifyCli::Command
+      class Project < ShopifyCli::SubCommand
         def call(args, _name)
           if args.empty?
             @ctx.puts(self.class.help)

--- a/lib/shopify-cli/commands/populate.rb
+++ b/lib/shopify-cli/commands/populate.rb
@@ -6,22 +6,12 @@ module ShopifyCli
       prerequisite_task :schema, :ensure_env
 
       autoload :Resource, 'shopify-cli/commands/populate/resource'
-      autoload :Product, 'shopify-cli/commands/populate/product'
-      autoload :Customer, 'shopify-cli/commands/populate/customer'
-      autoload :DraftOrder, 'shopify-cli/commands/populate/draft_order'
+      subcommand :Product, 'products', 'shopify-cli/commands/populate/product'
+      subcommand :Customer, 'customers', 'shopify-cli/commands/populate/customer'
+      subcommand :DraftOrder, 'draftorders', 'shopify-cli/commands/populate/draft_order'
 
-      def call(args, _name)
-        subcommand = args.shift
-        case subcommand
-        when 'products'
-          Product.new(ctx: @ctx, args: args).populate
-        when 'customers'
-          Customer.new(ctx: @ctx, args: args).populate
-        when 'draftorders'
-          DraftOrder.new(ctx: @ctx, args: args).populate
-        else
-          @ctx.puts(self.class.help)
-        end
+      def call(*)
+        @ctx.puts(self.class.help)
       end
 
       def self.help

--- a/lib/shopify-cli/commands/populate/resource.rb
+++ b/lib/shopify-cli/commands/populate/resource.rb
@@ -4,11 +4,8 @@ require 'optparse'
 module ShopifyCli
   module Commands
     class Populate
-      class Resource
+      class Resource < ShopifyCli::Command
         include SmartProperties
-
-        property :ctx, required: true, accepts: ShopifyCli::Context
-        property :args, required: true, accepts: Array
 
         DEFAULT_COUNT = 5
         PAYLOAD_TYPE_WHITELIST = %w(SCALAR NON_NULL)
@@ -17,6 +14,11 @@ module ShopifyCli
 
         class << self
           attr_accessor :type, :field, :input_type, :payload, :payload_blacklist
+        end
+
+        def call(args, _name)
+          @args = args
+          populate
         end
 
         def initialize(*)

--- a/lib/shopify-cli/commands/populate/resource.rb
+++ b/lib/shopify-cli/commands/populate/resource.rb
@@ -18,22 +18,18 @@ module ShopifyCli
 
         def call(args, _name)
           @args = args
-          populate
-        end
-
-        def initialize(*)
-          super
-          token = Helpers::AccessToken.read(ctx)
-          @api = Helpers::API.new(ctx: ctx, token: token)
+          token = Helpers::AccessToken.read(@ctx)
+          @api = Helpers::API.new(ctx: @ctx, token: token)
           @input = OpenStruct.new
           @count = DEFAULT_COUNT
           input_options
           options.parse(args)
+          populate
         end
 
         def set_input
           defaults
-          options.parse(args)
+          options.parse(@args)
         end
 
         def message
@@ -68,7 +64,7 @@ module ShopifyCli
         def populate
           @count.times do
             set_input
-            ctx.debug(mutation)
+            @ctx.debug(mutation)
             run_mutation
           end
           completion_message
@@ -121,13 +117,13 @@ module ShopifyCli
         end
 
         def schema
-          @schema ||= ShopifyCli::Helpers::SchemaParser.new(schema: ctx.app_metadata[:schema])
+          @schema ||= ShopifyCli::Helpers::SchemaParser.new(schema: @ctx.app_metadata[:schema])
         end
 
         def run_mutation
           resp = @api.mutation(mutation)
           raise(ShopifyCli::Abort, resp['errors']) if resp['errors']
-          ctx.done(message(resp['data']))
+          @ctx.done(message(resp['data']))
         end
 
         def success
@@ -138,7 +134,7 @@ module ShopifyCli
         end
 
         def completion_message
-          ctx.puts(success)
+          @ctx.puts(success)
         end
 
         def admin_url

--- a/lib/shopify-cli/options.rb
+++ b/lib/shopify-cli/options.rb
@@ -14,15 +14,7 @@ module ShopifyCli
 
     def parse(options_block, args)
       @args = args
-      parse_subcommand
-      parse_flags(options_block) if options_block
-    end
-
-    def parse_subcommand
-      @subcommand = @args.find do |arg|
-        arg.match(/\w/)
-      end
-      @args.delete(@subcommand)
+      parse_flags(options_block) if options_block.respond_to?(:call)
     end
 
     def parse_flags(block)

--- a/lib/shopify-cli/options.rb
+++ b/lib/shopify-cli/options.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+require 'optparse'
+
+module ShopifyCli
+  class Options
+    include SmartProperties
+
+    attr_reader :flags, :subcommand
+
+    def initialize
+      @flags = {}
+    end
+
+    def parse(options_block, args)
+      @args = args
+      parse_subcommand
+      parse_flags(options_block) if options_block
+    end
+
+    def parse_subcommand
+      @subcommand = @args.find do |arg|
+        arg.match(/\w/)
+      end
+      @args.delete(@subcommand)
+    end
+
+    def parse_flags(block)
+      block.call(parser, @flags)
+      parser.parse!(@args)
+    end
+
+    def parser
+      @parser ||= OptionParser.new
+    end
+  end
+end

--- a/lib/shopify-cli/sub_command.rb
+++ b/lib/shopify-cli/sub_command.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module ShopifyCli
+  class SubCommand < Command
+    class << self
+      def call(args, command_name)
+        cmd = new
+        cmd.ctx = @ctx
+        cmd.options = Options.new
+        cmd.options.parse(@_options, args)
+        cmd.call(args, command_name)
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -104,6 +104,7 @@ module ShopifyCli
   autoload :OAuth, 'shopify-cli/oauth'
   autoload :Options, 'shopify-cli/options'
   autoload :Project, 'shopify-cli/project'
+  autoload :SubCommand, 'shopify-cli/sub_command'
   autoload :Task, 'shopify-cli/task'
   autoload :Tasks, 'shopify-cli/tasks'
   autoload :Update, 'shopify-cli/update'

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -102,6 +102,7 @@ module ShopifyCli
   autoload :Finalize, 'shopify-cli/finalize'
   autoload :Helpers, 'shopify-cli/helpers'
   autoload :OAuth, 'shopify-cli/oauth'
+  autoload :Options, 'shopify-cli/options'
   autoload :Project, 'shopify-cli/project'
   autoload :Task, 'shopify-cli/task'
   autoload :Tasks, 'shopify-cli/tasks'

--- a/test/shopify-cli/commands/create_test.rb
+++ b/test/shopify-cli/commands/create_test.rb
@@ -14,12 +14,6 @@ module ShopifyCli
         @context.expects(:puts).with(ShopifyCli::Commands::Create.help)
         @command.call([], nil)
       end
-
-      def test_with_project_calls_project
-        ShopifyCli::Commands::Create::Project.any_instance.expects(:call)
-          .with(['new-app'], 'create')
-        @command.call(['project', 'new-app'], 'create')
-      end
     end
   end
 end

--- a/test/shopify-cli/commands/populate/customer_test.rb
+++ b/test/shopify-cli/commands/populate/customer_test.rb
@@ -21,12 +21,12 @@ module ShopifyCli
           api.expects(:gid_to_id).returns(12345678)
           Helpers::Haikunator.stubs(:name).returns(['first', 'last'])
           Resource.any_instance.stubs(:price).returns('1.00')
-          @resource = Customer.new(ctx: @context, args: ['-c 1'])
+          @resource = Customer.new(@context)
           @context.expects(:done).with(
             "first last added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/customers/12345678}}"
           )
-          @resource.populate
+          @resource.call(['-c 1'], nil)
         end
 
         private

--- a/test/shopify-cli/commands/populate/draft_order_test.rb
+++ b/test/shopify-cli/commands/populate/draft_order_test.rb
@@ -21,12 +21,12 @@ module ShopifyCli
           api.expects(:gid_to_id).returns(12345678)
           Helpers::Haikunator.stubs(:title).returns('fake order')
           Resource.any_instance.stubs(:price).returns('1.00')
-          @resource = DraftOrder.new(ctx: @context, args: ['-c 1'])
+          @resource = DraftOrder.new(@context)
           @context.expects(:done).with(
             "DraftOrders added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/draft_order/12345678}}"
           )
-          @resource.populate
+          @resource.call(['-c 1'], nil)
         end
 
         private

--- a/test/shopify-cli/commands/populate/product_test.rb
+++ b/test/shopify-cli/commands/populate/product_test.rb
@@ -21,12 +21,12 @@ module ShopifyCli
           api.expects(:gid_to_id).returns(12345678)
           Helpers::Haikunator.stubs(:title).returns('fake product')
           Resource.any_instance.stubs(:price).returns('1.00')
-          @resource = Product.new(ctx: @context, args: ['-c 1'])
+          @resource = Product.new(@context)
           @context.expects(:done).with(
             "fake product added to {{green:my-test-shop.myshopify.com}} at" \
             " {{underline:https://my-test-shop.myshopify.com/admin/products/12345678}}"
           )
-          @resource.populate
+          @resource.call(['-c 1'], nil)
         end
 
         private

--- a/test/shopify-cli/commands/populate/resource_test.rb
+++ b/test/shopify-cli/commands/populate/resource_test.rb
@@ -14,23 +14,25 @@ module ShopifyCli
         end
 
         def test_with_schema_args_overrides_input
-          resource = Product.new(ctx: @context, args: [
+          resource = Product.new(@context)
+          resource.expects(:run_mutation).times(1)
+          resource.call([
             '-c 1', '--title="bad jeggings"', '--variants=[{price: "4.99"}]'
-          ])
+          ], nil)
           assert_equal('"bad jeggings"', resource.input.title)
           assert_equal('[{price: "4.99"}]', resource.input.variants)
         end
 
         def test_populate_runs_mutation_default_number_of_times
-          resource = Product.new(ctx: @context, args: [])
+          resource = Product.new(@context)
           resource.expects(:run_mutation).times(Product::DEFAULT_COUNT)
-          resource.populate
+          resource.call([], nil)
         end
 
         def test_populate_runs_mutation_count_number_of_times
-          resource = Product.new(ctx: @context, args: ['-c 2'])
+          resource = Product.new(@context)
           resource.expects(:run_mutation).times(2)
-          resource.populate
+          resource.call(['-c 2'], nil)
         end
       end
     end

--- a/test/shopify-cli/commands/populate_test.rb
+++ b/test/shopify-cli/commands/populate_test.rb
@@ -17,27 +17,23 @@ module ShopifyCli
       end
 
       def test_with_products_calls_product_resource_with_default_count
-        Populate::Product.expects(:new).with(ctx: @context, args: [])
-          .returns(mock(:populate))
-        @command.call(['products'], nil)
+        Populate::Product.expects(:call).with(['products'], 'products')
+        @command.class.call(['products'], nil)
       end
 
       def test_with_count_flag_calls_product_resource_with_default_count
-        Populate::Product.expects(:new).with(ctx: @context, args: ['--count=10'])
-          .returns(mock(:populate))
-        @command.call(['products', '--count=10'], nil)
+        Populate::Product.expects(:call).with(['products', '--count=10'], 'products')
+        @command.class.call(['products', '--count=10'], nil)
       end
 
       def test_with_customers_arg_calls_customer_resource
-        Populate::Customer.expects(:new).with(ctx: @context, args: ['--count=10'])
-          .returns(mock(:populate))
-        @command.call(['customers', '--count=10'], nil)
+        Populate::Customer.expects(:call).with(['customers', '--count=10'], 'customers')
+        @command.class.call(['customers', '--count=10'], nil)
       end
 
       def test_with_draftorders_arg_calls_draftorder_resource
-        Populate::DraftOrder.expects(:new).with(ctx: @context, args: ['--count=10'])
-          .returns(mock(:populate))
-        @command.call(['draftorders', '--count=10'], nil)
+        Populate::DraftOrder.expects(:call).with(['draftorders', '--count=10'], 'draftorders')
+        @command.class.call(['draftorders', '--count=10'], nil)
       end
     end
   end

--- a/test/shopify-cli/executor_test.rb
+++ b/test/shopify-cli/executor_test.rb
@@ -8,6 +8,14 @@ module ShopifyCli
     class FakeCommand < ShopifyCli::Command
       prerequisite_task :fake
 
+      class FakeSubCommand < ShopifyCli::Command
+        def call(*)
+          @ctx.puts('subcommand!')
+        end
+      end
+
+      subcommand :FakeSubCommand, 'fakesub'
+
       options do |parser, flags|
         parser.on('-v', '--verbose', 'print verbosely') do |v|
           flags[:verbose] = v
@@ -43,7 +51,16 @@ module ShopifyCli
       reg.add(FakeCommand, :fake)
       @context.expects(:puts).with('success!')
       @context.expects(:puts).with('verbose!')
-      executor.call(FakeCommand, 'fake', ['foo', '-v'])
+      executor.call(FakeCommand, 'fake', ['-v'])
+    end
+
+    def test_subcommand
+      executor = ShopifyCli::Executor.new(@context, @registry, log_file: @log)
+      reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
+      reg.add(FakeCommand, :fake)
+      @context.expects(:puts).with('success!')
+      @context.expects(:puts).with('subcommand!')
+      executor.call(FakeCommand, 'fake', ['fakesub'])
     end
   end
 end

--- a/test/shopify-cli/executor_test.rb
+++ b/test/shopify-cli/executor_test.rb
@@ -8,8 +8,18 @@ module ShopifyCli
     class FakeCommand < ShopifyCli::Command
       prerequisite_task :fake
 
+      options do |parser, flags|
+        parser.on('-v', '--verbose', 'print verbosely') do |v|
+          flags[:verbose] = v
+        end
+      end
+
       def call(_args, _name)
-        @ctx.puts('command!')
+        if options.flags[:verbose]
+          @ctx.puts('verbose!')
+        else
+          @ctx.puts('command!')
+        end
       end
     end
 
@@ -25,6 +35,15 @@ module ShopifyCli
       @context.expects(:puts).with('success!')
       @context.expects(:puts).with('command!')
       executor.call(FakeCommand, 'fake', [])
+    end
+
+    def test_options
+      executor = ShopifyCli::Executor.new(@context, @registry, log_file: @log)
+      reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
+      reg.add(FakeCommand, :fake)
+      @context.expects(:puts).with('success!')
+      @context.expects(:puts).with('verbose!')
+      executor.call(FakeCommand, 'fake', ['foo', '-v'])
     end
   end
 end

--- a/test/shopify-cli/options_test.rb
+++ b/test/shopify-cli/options_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+module ShopifyCli
+  class OptionsTest < MiniTest::Test
+    def test_parses_subcommand_and_flags
+      block = proc do |parser, flags|
+        parser.on('-v', '--verbose', 'run verbosely') do |v|
+          flags[:verbose] = v
+        end
+      end
+      opts = Options.new
+      opts.parse(block, ['subc', '-v'])
+      assert_equal 'subc', opts.subcommand
+      assert_equal true, opts.flags[:verbose]
+    end
+  end
+end

--- a/test/shopify-cli/options_test.rb
+++ b/test/shopify-cli/options_test.rb
@@ -10,7 +10,6 @@ module ShopifyCli
       end
       opts = Options.new
       opts.parse(block, ['subc', '-v'])
-      assert_equal 'subc', opts.subcommand
       assert_equal true, opts.flags[:verbose]
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

We want to add more switches (like `--verbose`) to this tool. Right now we have only added them to the `populate` command which does all the parsing within that command. In order to do this well, I also needed to come up with a more robust structure for organizing subcommands.

### WHAT is this pull request doing?

This PR implements switch parsing at the Command level so that commands only need to call an `options` classmethod, which gives them an [OptionParser](https://docs.ruby-lang.org/en/2.1.0/OptionParser.html) instance to define options with.

It also introduces a `subcommand` classmethod which takes the path to a file containing a subclass of `ShopifyCli::SubCommand` for adding a subcommand to a Command without having to parse it manually and execute it conditionally.

TODO
- [x] Figure out solution for subcommands