### PR TITLE
Redo "Implement command line switch parsing and a subcommand structure"

### DIFF
--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -10,15 +10,33 @@ module ShopifyCli
       attr_writer :ctx
 
       def call(args, command_name)
-        cmd = new
-        cmd.ctx = @ctx
-        cmd.options = Options.new
-        cmd.options.parse(@_options, args)
-        cmd.call(args, command_name)
+        subcommand, resolved_name = subcommand_registry.lookup_command(args.first)
+        if subcommand
+          subcommand.ctx = @ctx
+          subcommand.call(args, resolved_name)
+        else
+          cmd = new
+          cmd.ctx = @ctx
+          cmd.options = Options.new
+          cmd.options.parse(@_options, args)
+          cmd.call(args, command_name)
+        end
       end
 
       def options(&block)
         @_options = block
+      end
+
+      def subcommand(const, cmd, path = nil)
+        autoload(const, path) if path
+        subcommand_registry.add(->() { const_get(const) }, cmd)
+      end
+
+      def subcommand_registry
+        @subcommand_registry ||= CLI::Kit::CommandRegistry.new(
+          default: nil,
+          contextual_resolver: nil,
+        )
       end
 
       def prerequisite_task(*tasks)

--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -4,6 +4,7 @@ require 'shopify_cli'
 module ShopifyCli
   class Command < CLI::Kit::BaseCommand
     attr_writer :ctx
+    attr_accessor :options
 
     class << self
       attr_writer :ctx
@@ -11,7 +12,13 @@ module ShopifyCli
       def call(args, command_name)
         cmd = new
         cmd.ctx = @ctx
+        cmd.options = Options.new
+        cmd.options.parse(@_options, args)
         cmd.call(args, command_name)
+      end
+
+      def options(&block)
+        @_options = block
       end
 
       def prerequisite_task(*tasks)

--- a/lib/shopify-cli/options.rb
+++ b/lib/shopify-cli/options.rb
@@ -14,15 +14,7 @@ module ShopifyCli
 
     def parse(options_block, args)
       @args = args
-      parse_subcommand
-      parse_flags(options_block) if options_block
-    end
-
-    def parse_subcommand
-      @subcommand = @args.find do |arg|
-        arg.match(/\w/)
-      end
-      @args.delete(@subcommand)
+      parse_flags(options_block) if options_block.respond_to?(:call)
     end
 
     def parse_flags(block)

--- a/lib/shopify-cli/options.rb
+++ b/lib/shopify-cli/options.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+require 'optparse'
+
+module ShopifyCli
+  class Options
+    include SmartProperties
+
+    attr_reader :flags, :subcommand
+
+    def initialize
+      @flags = {}
+    end
+
+    def parse(options_block, args)
+      @args = args
+      parse_subcommand
+      parse_flags(options_block) if options_block
+    end
+
+    def parse_subcommand
+      @subcommand = @args.find do |arg|
+        arg.match(/\w/)
+      end
+      @args.delete(@subcommand)
+    end
+
+    def parse_flags(block)
+      block.call(parser, @flags)
+      parser.parse!(@args)
+    end
+
+    def parser
+      @parser ||= OptionParser.new
+    end
+  end
+end

--- a/lib/shopify-cli/sub_command.rb
+++ b/lib/shopify-cli/sub_command.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module ShopifyCli
+  class SubCommand < Command
+    class << self
+      def call(args, command_name)
+        cmd = new
+        cmd.ctx = @ctx
+        cmd.options = Options.new
+        cmd.options.parse(@_options, args)
+        cmd.call(args, command_name)
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -104,6 +104,7 @@ module ShopifyCli
   autoload :OAuth, 'shopify-cli/oauth'
   autoload :Options, 'shopify-cli/options'
   autoload :Project, 'shopify-cli/project'
+  autoload :SubCommand, 'shopify-cli/sub_command'
   autoload :Task, 'shopify-cli/task'
   autoload :Tasks, 'shopify-cli/tasks'
   autoload :Update, 'shopify-cli/update'

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -102,6 +102,7 @@ module ShopifyCli
   autoload :Finalize, 'shopify-cli/finalize'
   autoload :Helpers, 'shopify-cli/helpers'
   autoload :OAuth, 'shopify-cli/oauth'
+  autoload :Options, 'shopify-cli/options'
   autoload :Project, 'shopify-cli/project'
   autoload :Task, 'shopify-cli/task'
   autoload :Tasks, 'shopify-cli/tasks'

--- a/test/shopify-cli/executor_test.rb
+++ b/test/shopify-cli/executor_test.rb
@@ -8,6 +8,14 @@ module ShopifyCli
     class FakeCommand < ShopifyCli::Command
       prerequisite_task :fake
 
+      class FakeSubCommand < ShopifyCli::Command
+        def call(*)
+          @ctx.puts('subcommand!')
+        end
+      end
+
+      subcommand :FakeSubCommand, 'fakesub'
+
       options do |parser, flags|
         parser.on('-v', '--verbose', 'print verbosely') do |v|
           flags[:verbose] = v
@@ -43,7 +51,16 @@ module ShopifyCli
       reg.add(FakeCommand, :fake)
       @context.expects(:puts).with('success!')
       @context.expects(:puts).with('verbose!')
-      executor.call(FakeCommand, 'fake', ['foo', '-v'])
+      executor.call(FakeCommand, 'fake', ['-v'])
+    end
+
+    def test_subcommand
+      executor = ShopifyCli::Executor.new(@context, @registry, log_file: @log)
+      reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
+      reg.add(FakeCommand, :fake)
+      @context.expects(:puts).with('success!')
+      @context.expects(:puts).with('subcommand!')
+      executor.call(FakeCommand, 'fake', ['fakesub'])
     end
   end
 end

--- a/test/shopify-cli/executor_test.rb
+++ b/test/shopify-cli/executor_test.rb
@@ -8,8 +8,18 @@ module ShopifyCli
     class FakeCommand < ShopifyCli::Command
       prerequisite_task :fake
 
+      options do |parser, flags|
+        parser.on('-v', '--verbose', 'print verbosely') do |v|
+          flags[:verbose] = v
+        end
+      end
+
       def call(_args, _name)
-        @ctx.puts('command!')
+        if options.flags[:verbose]
+          @ctx.puts('verbose!')
+        else
+          @ctx.puts('command!')
+        end
       end
     end
 
@@ -25,6 +35,15 @@ module ShopifyCli
       @context.expects(:puts).with('success!')
       @context.expects(:puts).with('command!')
       executor.call(FakeCommand, 'fake', [])
+    end
+
+    def test_options
+      executor = ShopifyCli::Executor.new(@context, @registry, log_file: @log)
+      reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
+      reg.add(FakeCommand, :fake)
+      @context.expects(:puts).with('success!')
+      @context.expects(:puts).with('verbose!')
+      executor.call(FakeCommand, 'fake', ['foo', '-v'])
     end
   end
 end

--- a/test/shopify-cli/options_test.rb
+++ b/test/shopify-cli/options_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+module ShopifyCli
+  class OptionsTest < MiniTest::Test
+    def test_parses_subcommand_and_flags
+      block = proc do |parser, flags|
+        parser.on('-v', '--verbose', 'run verbosely') do |v|
+          flags[:verbose] = v
+        end
+      end
+      opts = Options.new
+      opts.parse(block, ['subc', '-v'])
+      assert_equal 'subc', opts.subcommand
+      assert_equal true, opts.flags[:verbose]
+    end
+  end
+end

--- a/test/shopify-cli/options_test.rb
+++ b/test/shopify-cli/options_test.rb
@@ -10,7 +10,6 @@ module ShopifyCli
       end
       opts = Options.new
       opts.parse(block, ['subc', '-v'])
-      assert_equal 'subc', opts.subcommand
       assert_equal true, opts.flags[:verbose]
     end
   end


### PR DESCRIPTION
Redo of #290 but without touching the create and populate commands. Still working on some better ways to test that implementation but want to unblock @katiedavis on using this pattern.