### PR TITLE
Fix open behaviour during serve command

### DIFF
--- a/lib/shopify-cli/commands/open.rb
+++ b/lib/shopify-cli/commands/open.rb
@@ -8,7 +8,7 @@ module ShopifyCli
       prerequisite_task :tunnel
 
       def call(*)
-        @ctx.system(*open_cmd, "\"#{Project.current.app_type.open_url}\"")
+        @ctx.system(*open_cmd, Project.current.app_type.open_url)
       end
 
       def self.help

--- a/lib/shopify-cli/commands/serve.rb
+++ b/lib/shopify-cli/commands/serve.rb
@@ -14,7 +14,8 @@ module ShopifyCli
         if mac?
           @ctx.puts("{{*}} Press {{yellow: Control-T}} to open this project in your browser")
           on_siginfo do
-            project.app_type.open(@ctx)
+            open = Open.new(@ctx)
+            open.call
           end
         end
         CLI::UI::Frame.open('Running server...') do

--- a/lib/shopify-cli/context/system.rb
+++ b/lib/shopify-cli/context/system.rb
@@ -4,7 +4,7 @@ module ShopifyCli
   class Context
     module System
       def spawn(*args, **kwargs)
-        Kernel.spawn(*args, env: @env, **kwargs)
+        Kernel.spawn(@env, *args, **kwargs)
       end
 
       def system(*args, **kwargs)

--- a/test/commands/open_test.rb
+++ b/test/commands/open_test.rb
@@ -12,13 +12,13 @@ module ShopifyCli
 
       def test_run_mac
         @command.stubs(:mac?).returns(true)
-        @context.expects(:system).with('open', '"https://example.com"')
+        @context.expects(:system).with('open', 'https://example.com')
         @command.call([], nil)
       end
 
       def test_run_linux
         @command.stubs(:mac?).returns(false)
-        @context.expects(:system).with('python', '-m', 'webserver', '"https://example.com"')
+        @context.expects(:system).with('python', '-m', 'webserver', 'https://example.com')
         @command.call([], nil)
       end
     end

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -117,7 +117,7 @@ module ShopifyCli
         cmd.stubs(:mac?).returns(true)
         @context.expects(:system).with(
           'open',
-          '"https://example.com/auth?shop=my-test-shop.myshopify.com"'
+          'https://example.com/auth?shop=my-test-shop.myshopify.com'
         )
         cmd.call([], nil)
       end

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -104,7 +104,7 @@ module ShopifyCli
         cmd.stubs(:mac?).returns(true)
         @context.expects(:system).with(
           'open',
-          '"https://example.com/login?shop=my-test-shop.myshopify.com"'
+          'https://example.com/login?shop=my-test-shop.myshopify.com'
         )
         cmd.call([], nil)
       end

--- a/test/shopify-cli/commands/serve_test.rb
+++ b/test/shopify-cli/commands/serve_test.rb
@@ -15,6 +15,18 @@ module ShopifyCli
         @context.expects(:system).with('a command')
         @command.call([], nil)
       end
+
+      def test_open_while_run
+        @command.stubs(:on_siginfo).yields
+        @command.stubs(:mac?).returns(true)
+        Open.any_instance.stubs(:mac?).returns(true)
+        @context.expects(:system).with('a command')
+        @context.expects(:system).with(
+          'open',
+          'https://example.com',
+        )
+        @command.call([], nil)
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #295 

The Open command wasn't being called properly from `serve` and this was not tested. Now it is.