### PR TITLE
Simplify graphql query interface

### DIFF
--- a/lib/shopify-cli/commands/populate/resource.rb
+++ b/lib/shopify-cli/commands/populate/resource.rb
@@ -99,9 +99,11 @@ module ShopifyCli
 
         def mutation
           <<~MUTATION
-            #{self.class.field}(input: {#{to_input(@input)}}) {
-              #{self.class.type} {
-                #{payload}
+            mutation {
+              #{self.class.field}(input: {#{to_input(@input)}}) {
+                #{self.class.type} {
+                  #{payload}
+                }
               }
             }
           MUTATION
@@ -123,7 +125,7 @@ module ShopifyCli
         end
 
         def run_mutation
-          resp = @api.mutation(mutation)
+          resp = @api.query(mutation)
           raise(ShopifyCli::Abort, resp['errors']) if resp['errors']
           ctx.done(message(resp['data']))
         end

--- a/lib/shopify-cli/helpers/api.rb
+++ b/lib/shopify-cli/helpers/api.rb
@@ -20,12 +20,6 @@ module ShopifyCli
       class APIRequestServerError < APIRequestRetriableError; end
       class APIRequestThrottledError < APIRequestRetriableError; end
 
-      def mutation(mutation, variables: {})
-        _, resp = request("mutation { #{mutation} }", variables: variables)
-        @ctx.debug(resp)
-        resp
-      end
-
       def query(body, variables: {})
         _, resp = request(body, variables: variables)
         @ctx.debug(resp)

--- a/lib/shopify-cli/helpers/partners_api.rb
+++ b/lib/shopify-cli/helpers/partners_api.rb
@@ -30,13 +30,7 @@ module ShopifyCli
           ENV[ENV_VAR].nil? ? PROD_URI : DEV_URI
         end
 
-        def mutation(ctx, body, variables: {})
-          authenticated_req(ctx) do
-            api_client(ctx).mutation(body, variables: variables)
-          end
-        end
-
-        def query(ctx, body, variables: {})
+        def query(ctx, body, **variables)
           authenticated_req(ctx) do
             api_client(ctx).query(body, variables: variables)
           end

--- a/test/fixtures/api/mutation.json
+++ b/test/fixtures/api/mutation.json
@@ -1,1 +1,1 @@
-{"query":"mutation { fakeMutation(input: {  title: \"fake title\"}) {  id} }","variables":{}}
+{"query":"mutation {  fakeMutation(input: {    title: \"fake title\"  }) {    id  }}","variables":{}}

--- a/test/fixtures/populate/customer.graphql
+++ b/test/fixtures/populate/customer.graphql
@@ -1,5 +1,7 @@
-customerCreate(input: {firstName: "first",lastName: "last"}) {
-  customer {
-    acceptsMarketing,acceptsMarketingUpdatedAt,canDelete,createdAt,displayName,hasNote,hasTimelineComment,id,legacyResourceId,lifetimeDuration,ordersCount,taxExempt,totalSpent,updatedAt,validEmailAddress,verifiedEmail
+mutation {
+  customerCreate(input: {firstName: "first",lastName: "last"}) {
+    customer {
+      acceptsMarketing,acceptsMarketingUpdatedAt,canDelete,createdAt,displayName,hasNote,hasTimelineComment,id,legacyResourceId,lifetimeDuration,ordersCount,taxExempt,totalSpent,updatedAt,validEmailAddress,verifiedEmail
+    }
   }
 }

--- a/test/fixtures/populate/draft_order.graphql
+++ b/test/fixtures/populate/draft_order.graphql
@@ -1,11 +1,13 @@
-draftOrderCreate(input: {lineItems: [{
+mutation {
+  draftOrderCreate(input: {lineItems: [{
   originalUnitPrice: "1.00",
   quantity: 1,
   weight: {value: 10, unit: GRAMS},
   title: "fake order"
 }]
 }) {
-  draftOrder {
-    createdAt,hasTimelineComment,id,legacyResourceId,name,subtotalPrice,taxExempt,taxesIncluded,totalPrice,totalShippingPrice,totalTax,totalWeight,updatedAt
+    draftOrder {
+      createdAt,hasTimelineComment,id,legacyResourceId,name,subtotalPrice,taxExempt,taxesIncluded,totalPrice,totalShippingPrice,totalTax,totalWeight,updatedAt
+    }
   }
 }

--- a/test/fixtures/populate/product.graphql
+++ b/test/fixtures/populate/product.graphql
@@ -1,5 +1,7 @@
-productCreate(input: {title: "fake product",variants: [{price: "1.00"}]}) {
-  product {
-    createdAt,defaultCursor,descriptionHtml,descriptionPlainSummary,handle,hasOnlyDefaultVariant,hasOutOfStockVariants,id,isGiftCard,legacyResourceId,productType,storefrontId,title,totalInventory,totalVariants,tracksInventory,updatedAt,vendor
+mutation {
+  productCreate(input: {title: "fake product",variants: [{price: "1.00"}]}) {
+    product {
+      createdAt,defaultCursor,descriptionHtml,descriptionPlainSummary,handle,hasOnlyDefaultVariant,hasOutOfStockVariants,id,isGiftCard,legacyResourceId,productType,storefrontId,title,totalInventory,totalVariants,tracksInventory,updatedAt,vendor
+    }
   }
 }

--- a/test/shopify-cli/commands/populate/customer_test.rb
+++ b/test/shopify-cli/commands/populate/customer_test.rb
@@ -15,7 +15,7 @@ module ShopifyCli
 
         def test_populate_calls_api_with_mutation
           api = api_stub
-          api.expects(:mutation)
+          api.expects(:query)
             .with(@mutation)
             .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/customer_data.json'))))
           api.expects(:gid_to_id).returns(12345678)

--- a/test/shopify-cli/commands/populate/draft_order_test.rb
+++ b/test/shopify-cli/commands/populate/draft_order_test.rb
@@ -15,7 +15,7 @@ module ShopifyCli
 
         def test_populate_calls_api_with_mutation
           api = api_stub
-          api.expects(:mutation)
+          api.expects(:query)
             .with(@mutation)
             .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/draft_order_data.json'))))
           api.expects(:gid_to_id).returns(12345678)

--- a/test/shopify-cli/commands/populate/product_test.rb
+++ b/test/shopify-cli/commands/populate/product_test.rb
@@ -15,7 +15,7 @@ module ShopifyCli
 
         def test_populate_calls_api_with_mutation
           api = api_stub
-          api.expects(:mutation)
+          api.expects(:query)
             .with(@mutation)
             .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/product_data.json'))))
           api.expects(:gid_to_id).returns(12345678)

--- a/test/shopify-cli/helpers/api_test.rb
+++ b/test/shopify-cli/helpers/api_test.rb
@@ -19,10 +19,12 @@ module ShopifyCli
       def test_mutation_makes_request_to_shopify
         @api.stubs(:latest_api_version).returns('2019-04')
         mutation = <<~MUTATION
-          fakeMutation(input: {
-            title: "fake title"
-          }) {
-            id
+          mutation {
+            fakeMutation(input: {
+              title: "fake title"
+            }) {
+              id
+            }
           }
         MUTATION
         stub_request(:post, 'https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json')
@@ -33,7 +35,7 @@ module ShopifyCli
               'X-Shopify-Access-Token' => 'faketoken',
             })
           .to_return(status: 200, body: '{}')
-        @api.mutation(mutation)
+        @api.query(mutation)
       end
 
       def test_latest_api_version

--- a/test/shopify-cli/helpers/partners_api_test.rb
+++ b/test/shopify-cli/helpers/partners_api_test.rb
@@ -45,8 +45,8 @@ module ShopifyCli
           token: 'token123',
           url: "#{PartnersAPI.endpoint}/api/cli/graphql",
         ).returns(api_stub)
-        api_stub.expects(:mutation).with('query', variables: {}).returns('response')
-        assert_equal 'response', PartnersAPI.mutation(@context, 'query')
+        api_stub.expects(:query).with('query', variables: {}).returns('response')
+        assert_equal 'response', PartnersAPI.query(@context, 'query')
       end
 
       def test_mutation_can_reauth
@@ -56,10 +56,10 @@ module ShopifyCli
           token: 'token123',
           url: "#{PartnersAPI.endpoint}/api/cli/graphql",
         ).returns(api_stub).twice
-        api_stub.expects(:mutation).with('query', variables: {}).returns('response')
-        api_stub.expects(:mutation).raises(Helpers::API::APIRequestUnauthorizedError)
+        api_stub.expects(:query).with('query', variables: {}).returns('response')
+        api_stub.expects(:query).raises(Helpers::API::APIRequestUnauthorizedError)
         Tasks::AuthenticateIdentity.expects(:call)
-        PartnersAPI.mutation(@context, 'query')
+        PartnersAPI.query(@context, 'query')
       end
 
       def test_mutation_fails_gracefully_without_partners_account
@@ -69,11 +69,11 @@ module ShopifyCli
           token: 'token123',
           url: "#{PartnersAPI.endpoint}/api/cli/graphql",
         ).returns(api_stub)
-        api_stub.expects(:mutation).raises(Helpers::API::APIRequestNotFoundError)
+        api_stub.expects(:query).raises(Helpers::API::APIRequestNotFoundError)
         @context.expects(:puts).with(
           "{{error: Your account was not found. Please sign up at https://partners.shopify.com/signup}}",
         )
-        PartnersAPI.mutation(@context, 'query')
+        PartnersAPI.query(@context, 'query')
       end
 
       def test_query


### PR DESCRIPTION
### WHY are these changes introduced?
Since the mutation was the exact same as the query call except that it is wrapped in `mutation {}` and that wrapping was not allowing us to name mutations I thought it would be just simpler to have a single call for all graphql calls. This way we can pass in any mutation or query and we have full power of the queries. Also to be able to fully instrument the calls we will need to name the queries.

### WHAT is this pull request doing?
- remove `mutation` from Helpers::Api
- Accept `**variables` into partners API so that variables can be passed in, in-line