### PR TITLE
remove Authentication header from api requests

### DIFF
--- a/lib/shopify-cli/helpers/api.rb
+++ b/lib/shopify-cli/helpers/api.rb
@@ -102,7 +102,6 @@ module ShopifyCli
           'Content-Type' => 'application/json',
           'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} #{current_sha} | #{uname(flag: 'v')}",
           'X-Shopify-Access-Token' => token,
-          'Authorization' => "Bearer #{token}",
         }
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

At some point Shopify stopped accepting the `Authentication` header, returning a `[API] Service is not valid for authentication` error. We should just be using `X-Shopify-Access-Token` anyway.
<!--
  Context about the problem that’s being addressed.
-->
