### PR TITLE
Convert subcommands to new structure

### DIFF
--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -3,18 +3,10 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Create < ShopifyCli::Command
-      autoload :Project, 'shopify-cli/commands/create/project'
+      subcommand :Project, 'project', 'shopify-cli/commands/create/project'
 
-      def call(args, name)
-        subcommand = args.shift
-        case subcommand
-        when 'project'
-          Project.new(@ctx).call(args, name)
-        when 'dev-store'
-          raise(ShopifyCli::Abort, 'This feature is not yet available')
-        else
-          @ctx.puts(self.class.help)
-        end
+      def call(*)
+        @ctx.puts(self.class.help)
       end
 
       def self.help

--- a/lib/shopify-cli/commands/create/project.rb
+++ b/lib/shopify-cli/commands/create/project.rb
@@ -3,13 +3,13 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Create
-      class Project < ShopifyCli::Command
+      class Project < ShopifyCli::SubCommand
         def call(args, _name)
           if args.empty?
             @ctx.puts(self.class.help)
             return
           end
-          name = args.first
+          name = args[1]
           app_type = CLI::UI::Prompt.ask('What type of app project would you like to create?') do |handler|
             AppTypeRegistry.each do |identifier, type|
               handler.option(type.description) { identifier }

--- a/lib/shopify-cli/commands/populate.rb
+++ b/lib/shopify-cli/commands/populate.rb
@@ -6,22 +6,12 @@ module ShopifyCli
       prerequisite_task :schema, :ensure_env
 
       autoload :Resource, 'shopify-cli/commands/populate/resource'
-      autoload :Product, 'shopify-cli/commands/populate/product'
-      autoload :Customer, 'shopify-cli/commands/populate/customer'
-      autoload :DraftOrder, 'shopify-cli/commands/populate/draft_order'
+      subcommand :Product, 'products', 'shopify-cli/commands/populate/product'
+      subcommand :Customer, 'customers', 'shopify-cli/commands/populate/customer'
+      subcommand :DraftOrder, 'draftorders', 'shopify-cli/commands/populate/draft_order'
 
-      def call(args, _name)
-        subcommand = args.shift
-        case subcommand
-        when 'products'
-          Product.new(ctx: @ctx, args: args).populate
-        when 'customers'
-          Customer.new(ctx: @ctx, args: args).populate
-        when 'draftorders'
-          DraftOrder.new(ctx: @ctx, args: args).populate
-        else
-          @ctx.puts(self.class.help)
-        end
+      def call(_args, _name)
+        @ctx.puts(self.class.help)
       end
 
       def self.help

--- a/lib/shopify-cli/sub_command.rb
+++ b/lib/shopify-cli/sub_command.rb
@@ -5,8 +5,7 @@ module ShopifyCli
   class SubCommand < Command
     class << self
       def call(args, command_name)
-        cmd = new
-        cmd.ctx = @ctx
+        cmd = new(@ctx)
         cmd.options = Options.new
         cmd.options.parse(@_options, args)
         cmd.call(args, command_name)

--- a/test/shopify-cli/commands/create/project_test.rb
+++ b/test/shopify-cli/commands/create/project_test.rb
@@ -25,7 +25,7 @@ module ShopifyCli
           CLI::UI::Prompt.expects(:ask).returns(:node)
           ShopifyCli::AppTypes::Node.any_instance.stubs(:check_dependencies)
           ShopifyCli::AppTypes::Node.any_instance.stubs(:build)
-          @command.call(['test-app'], nil)
+          @command.call(['project', 'test-app'], nil)
         end
       end
     end

--- a/test/shopify-cli/commands/create_test.rb
+++ b/test/shopify-cli/commands/create_test.rb
@@ -7,7 +7,8 @@ module ShopifyCli
 
       def setup
         super
-        @command = ShopifyCli::Commands::Create.new(@context)
+        @command = ShopifyCli::Commands::Create
+        @command.ctx = @context
       end
 
       def test_without_arguments_calls_help
@@ -17,8 +18,8 @@ module ShopifyCli
 
       def test_with_project_calls_project
         ShopifyCli::Commands::Create::Project.any_instance.expects(:call)
-          .with(['new-app'], 'create')
-        @command.call(['project', 'new-app'], 'create')
+          .with(['project', 'new-app'], 'project')
+        @command.call(['project', 'new-app'], nil)
       end
     end
   end

--- a/test/shopify-cli/commands/populate/customer_test.rb
+++ b/test/shopify-cli/commands/populate/customer_test.rb
@@ -21,12 +21,12 @@ module ShopifyCli
           api.expects(:gid_to_id).returns(12345678)
           Helpers::Haikunator.stubs(:name).returns(['first', 'last'])
           Resource.any_instance.stubs(:price).returns('1.00')
-          @resource = Customer.new(ctx: @context, args: ['-c 1'])
+          @resource = Customer.new(@context)
           @context.expects(:done).with(
             "first last added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/customers/12345678}}"
           )
-          @resource.populate
+          @resource.call(['-c 1'], nil)
         end
 
         private

--- a/test/shopify-cli/commands/populate/draft_order_test.rb
+++ b/test/shopify-cli/commands/populate/draft_order_test.rb
@@ -21,12 +21,12 @@ module ShopifyCli
           api.expects(:gid_to_id).returns(12345678)
           Helpers::Haikunator.stubs(:title).returns('fake order')
           Resource.any_instance.stubs(:price).returns('1.00')
-          @resource = DraftOrder.new(ctx: @context, args: ['-c 1'])
+          @resource = DraftOrder.new(@context)
           @context.expects(:done).with(
             "DraftOrders added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/draft_order/12345678}}"
           )
-          @resource.populate
+          @resource.call(['-c 1'], nil)
         end
 
         private

--- a/test/shopify-cli/commands/populate/product_test.rb
+++ b/test/shopify-cli/commands/populate/product_test.rb
@@ -21,12 +21,12 @@ module ShopifyCli
           api.expects(:gid_to_id).returns(12345678)
           Helpers::Haikunator.stubs(:title).returns('fake product')
           Resource.any_instance.stubs(:price).returns('1.00')
-          @resource = Product.new(ctx: @context, args: ['-c 1'])
+          @resource = Product.new(@context)
           @context.expects(:done).with(
             "fake product added to {{green:my-test-shop.myshopify.com}} at" \
             " {{underline:https://my-test-shop.myshopify.com/admin/products/12345678}}"
           )
-          @resource.populate
+          @resource.call(['-c 1'], nil)
         end
 
         private

--- a/test/shopify-cli/commands/populate/resource_test.rb
+++ b/test/shopify-cli/commands/populate/resource_test.rb
@@ -9,28 +9,28 @@ module ShopifyCli
 
         def setup
           super
+          @resource = Product.new(@context)
           Helpers::AccessToken.stubs(:read).returns('myaccesstoken')
           ShopifyCli::Helpers::API.stubs(:new).returns(Object.new)
         end
 
         def test_with_schema_args_overrides_input
-          resource = Product.new(ctx: @context, args: [
+          @resource.expects(:run_mutation).times(1)
+          @resource.call([
             '-c 1', '--title="bad jeggings"', '--variants=[{price: "4.99"}]'
-          ])
-          assert_equal('"bad jeggings"', resource.input.title)
-          assert_equal('[{price: "4.99"}]', resource.input.variants)
+          ], nil)
+          assert_equal('"bad jeggings"', @resource.input.title)
+          assert_equal('[{price: "4.99"}]', @resource.input.variants)
         end
 
         def test_populate_runs_mutation_default_number_of_times
-          resource = Product.new(ctx: @context, args: [])
-          resource.expects(:run_mutation).times(Product::DEFAULT_COUNT)
-          resource.populate
+          @resource.expects(:run_mutation).times(Product::DEFAULT_COUNT)
+          @resource.call([], nil)
         end
 
         def test_populate_runs_mutation_count_number_of_times
-          resource = Product.new(ctx: @context, args: ['-c 2'])
-          resource.expects(:run_mutation).times(2)
-          resource.populate
+          @resource.expects(:run_mutation).times(2)
+          @resource.call(['-c 2'], nil)
         end
       end
     end

--- a/test/shopify-cli/commands/populate_test.rb
+++ b/test/shopify-cli/commands/populate_test.rb
@@ -15,30 +15,6 @@ module ShopifyCli
         @context.expects(:puts).with(ShopifyCli::Commands::Populate.help)
         @command.call([], nil)
       end
-
-      def test_with_products_calls_product_resource_with_default_count
-        Populate::Product.expects(:new).with(ctx: @context, args: [])
-          .returns(mock(:populate))
-        @command.call(['products'], nil)
-      end
-
-      def test_with_count_flag_calls_product_resource_with_default_count
-        Populate::Product.expects(:new).with(ctx: @context, args: ['--count=10'])
-          .returns(mock(:populate))
-        @command.call(['products', '--count=10'], nil)
-      end
-
-      def test_with_customers_arg_calls_customer_resource
-        Populate::Customer.expects(:new).with(ctx: @context, args: ['--count=10'])
-          .returns(mock(:populate))
-        @command.call(['customers', '--count=10'], nil)
-      end
-
-      def test_with_draftorders_arg_calls_draftorder_resource
-        Populate::DraftOrder.expects(:new).with(ctx: @context, args: ['--count=10'])
-          .returns(mock(:populate))
-        @command.call(['draftorders', '--count=10'], nil)
-      end
     end
   end
 end


### PR DESCRIPTION
Converts Create and Populate commands to use the `subcommand` helper method. I've :tophat:ed but could use a double check.
