### PR TITLE
[WIP] Add Zeit Now option to `deploy` command

### DIFF
--- a/lib/shopify-cli/commands/deploy.rb
+++ b/lib/shopify-cli/commands/deploy.rb
@@ -6,12 +6,15 @@ module ShopifyCli
   module Commands
     class Deploy < ShopifyCli::Command
       autoload :Heroku, 'shopify-cli/commands/deploy/heroku'
+      autoload :Now, 'shopify-cli/commands/deploy/now'
 
       def call(args, _name)
         subcommand = args.shift
         case subcommand
         when 'heroku'
           Heroku.call(@ctx, args)
+        when 'now'
+          Now.call(@ctx, args)
         else
           @ctx.puts(self.class.help)
         end

--- a/lib/shopify-cli/commands/deploy.rb
+++ b/lib/shopify-cli/commands/deploy.rb
@@ -22,18 +22,21 @@ module ShopifyCli
 
       def self.help
         <<~HELP
-          Deploy the current app project to a hosting service. Heroku (https://www.heroku.com) is currently the only option, but more will be added in the future.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy [heroku]}}
+          Deploy the current app project to a hosting platform.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy [ heroku | now ]}}
         HELP
       end
 
       def self.extended_help
         <<~HELP
-          Subcommands:
-
-          * heroku: Deploys the current app project to Heroku. Usage:
-
-              {{command:#{ShopifyCli::TOOL_NAME} deploy heroku}}
+          {{bold:Subcommands:}}
+            
+            {{cyan:heroku}} Deploys the current app project to Heroku. 
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy heroku }}
+            
+            {{cyan:now}} Deploys the current app project to Zeit Now. 
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy now }}
+              
         HELP
       end
     end

--- a/lib/shopify-cli/commands/deploy/now.rb
+++ b/lib/shopify-cli/commands/deploy/now.rb
@@ -1,0 +1,191 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class Deploy
+      class Now < ShopifyCli::Task
+        include Helpers::OS
+
+        # DOWNLOAD_URLS = {
+        #   linux: 'https://cli-assets.heroku.com/heroku-linux-x64.tar.gz',
+        #   mac: 'https://cli-assets.heroku.com/heroku-darwin-x64.tar.gz',
+        #   windows: 'https://cli-assets.heroku.com/heroku-win32-x64.tar.gz',
+        # }
+
+        def self.help
+          <<~HELP
+            Deploy the current app project to Zeit Now
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy now}}
+          HELP
+        end
+
+        def call(ctx, _name = nil)
+          @ctx = ctx
+
+          if (now_installed?)
+            now_deploy
+          else 
+            now_install
+            now_deploy
+          end
+          # spin_group = CLI::UI::SpinGroup.new
+          
+
+        #   if (account = heroku_whoami)
+        #     spin_group.add("Authenticated with Heroku as `#{account}`") { true }
+        #     spin_group.wait
+        #   else
+        #     CLI::UI::Frame.open("Authenticating with Heroku…", success_text: '{{v}} Authenticated with Heroku') do
+        #       heroku_authenticate
+        #     end
+        #   end
+
+        #   if (app_name = heroku_app)
+        #     spin_group.add("Heroku app `#{app_name}` selected") { true }
+        #     spin_group.wait
+        #   else
+        #     app_type = CLI::UI::Prompt.ask('No existing Heroku app found. What would you like to do?') do |handler|
+        #       handler.option('Create a new Heroku app') { :new }
+        #       handler.option('Specify an existing Heroku app') { :existing }
+        #     end
+
+        #     if app_type == :existing
+        #       app_name = CLI::UI::Prompt.ask('What is your Heroku app’s name?')
+        #       CLI::UI::Frame.open(
+        #         "Selecting Heroku app `#{app_name}`…",
+        #         success_text: "{{v}} Heroku app `#{app_name}` selected"
+        #       ) do
+        #         heroku_select_existing_app(app_name)
+        #       end
+        #     elsif app_type == :new
+        #       CLI::UI::Frame.open('Creating new Heroku app…', success_text: '{{v}} New Heroku app created') do
+        #         heroku_create_new_app
+        #       end
+        #     end
+        #   end
+
+        #   branches = git_branches
+        #   if branches.length == 1
+        #     branch_to_deploy = branches[0]
+        #     spin_group.add("Git branch `#{branch_to_deploy}` selected for deploy") { true }
+        #     spin_group.wait
+        #   else
+        #     branch_to_deploy = CLI::UI::Prompt.ask('What branch would you like to deploy?') do |handler|
+        #       branches.each do |branch|
+        #         handler.option(branch) { branch }
+        #       end
+        #     end
+        #   end
+
+        #   CLI::UI::Frame.open('Deploying to Heroku…', success_text: '{{v}} Deployed to Heroku') do
+        #     heroku_deploy(branch_to_deploy)
+        #   end
+        end
+
+        private
+
+        # def git_branches
+        #   output, status = @ctx.capture2e('git', 'branch', '--list', '--format=%(refname:short)')
+        #   raise(ShopifyCli::Abort, "Could not find any git branches") unless status.success?
+
+        #   branches = if output == ''
+        #     ['master']
+        #   else
+        #     output.split("\n")
+        #   end
+
+        #   branches
+        # end
+
+        # def git_init
+        #   output, status = @ctx.capture2e('git', 'status')
+
+        #   unless status.success?
+        #     raise(ShopifyCli::Abort, "Git repo is not initiated. Please run `git init` and make at least one commit.")
+        #   end
+
+        #   if output.include?('No commits yet')
+        #     raise(ShopifyCli::Abort, "No git commits have been made. Please make at least one commit.")
+        #   end
+        # end
+
+        # def heroku_app
+        #   return nil if heroku_git_remote.nil?
+        #   app = heroku_git_remote
+        #   app = app.split('/').last
+        #   app = app.split('.').first
+        #   app
+        # end
+
+        # def heroku_authenticate
+        #   result = @ctx.system(heroku_command, 'login')
+        #   raise(ShopifyCli::Abort, "Could not authenticate with Heroku") unless result.success?
+        # end
+
+        # def now_command
+        #   # local_path = File.join(ShopifyCli::ROOT, 'heroku', 'bin', 'heroku').to_s
+        #   if File.exist?(local_path)
+        #     local_path
+        #   else
+        #     'now'
+        #   end
+        # end
+
+        # def heroku_create_new_app
+        #   output, status = @ctx.capture2e(heroku_command, 'create')
+        #   raise(ShopifyCli::Abort, 'Heroku app could not be created') unless status.success?
+        #   @ctx.puts(output)
+
+        #   new_remote = output.split("\n").last.split("|").last.strip
+        #   result = @ctx.system('git', 'remote', 'add', 'heroku', new_remote)
+        #   raise(ShopifyCli::Abort, 'Heroku app created, but couldn’t be set as a git remote') unless result.success?
+        # end
+
+        # def heroku_deploy(branch_to_deploy)
+        #   result = @ctx.system('git', 'push', '-u', 'heroku', "#{branch_to_deploy}:master")
+        #   raise(ShopifyCli::Abort, "Could not deploy to Heroku") unless result.success?
+        # end
+
+        # def heroku_git_remote
+        #   output, status = @ctx.capture2e('git', 'remote', 'get-url', 'heroku')
+        #   status.success? ? output : nil
+        # end
+
+        def now_deploy
+          CLI::UI::Frame.open("Deploying to Now", success_text: '{{v}} Successfully deployed to Now') do
+            result = @ctx.system('now')
+            raise(ShopifyCli::Abort, "Could not deploy to Now") unless result.success?
+          end
+        end
+
+        def now_install
+          return if now_installed?
+
+          CLI::UI::Frame.open("Installing Now CLI with npm", success_text: '{{v}} Now installed') do
+            result = @ctx.system('npm i -g now')
+            raise(ShopifyCli::Abort, "Could not install Now CLI") unless result.success?
+          end
+        end
+
+        def now_installed?
+          _output, status = @ctx.capture2e('now --version')
+          status.success?
+        rescue
+          false
+        end
+
+        # def heroku_select_existing_app(app_name)
+        #   result = @ctx.system(heroku_command, 'git:remote', '-a', app_name)
+        #   raise(ShopifyCli::Abort, "Heroku app `#{app_name}` could not be selected") unless result.success?
+        # end
+
+        # def heroku_whoami
+        #   output, status = @ctx.capture2e(heroku_command, 'whoami')
+        #   return output.strip if status.success?
+        #   nil
+        # end
+      
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/commands/deploy/now.rb
+++ b/lib/shopify-cli/commands/deploy/now.rb
@@ -4,13 +4,6 @@ module ShopifyCli
   module Commands
     class Deploy
       class Now < ShopifyCli::Task
-        include Helpers::OS
-
-        # DOWNLOAD_URLS = {
-        #   linux: 'https://cli-assets.heroku.com/heroku-linux-x64.tar.gz',
-        #   mac: 'https://cli-assets.heroku.com/heroku-darwin-x64.tar.gz',
-        #   windows: 'https://cli-assets.heroku.com/heroku-win32-x64.tar.gz',
-        # }
 
         def self.help
           <<~HELP
@@ -28,163 +21,33 @@ module ShopifyCli
             now_install
             now_deploy
           end
-          # spin_group = CLI::UI::SpinGroup.new
-          
-
-        #   if (account = heroku_whoami)
-        #     spin_group.add("Authenticated with Heroku as `#{account}`") { true }
-        #     spin_group.wait
-        #   else
-        #     CLI::UI::Frame.open("Authenticating with Heroku…", success_text: '{{v}} Authenticated with Heroku') do
-        #       heroku_authenticate
-        #     end
-        #   end
-
-        #   if (app_name = heroku_app)
-        #     spin_group.add("Heroku app `#{app_name}` selected") { true }
-        #     spin_group.wait
-        #   else
-        #     app_type = CLI::UI::Prompt.ask('No existing Heroku app found. What would you like to do?') do |handler|
-        #       handler.option('Create a new Heroku app') { :new }
-        #       handler.option('Specify an existing Heroku app') { :existing }
-        #     end
-
-        #     if app_type == :existing
-        #       app_name = CLI::UI::Prompt.ask('What is your Heroku app’s name?')
-        #       CLI::UI::Frame.open(
-        #         "Selecting Heroku app `#{app_name}`…",
-        #         success_text: "{{v}} Heroku app `#{app_name}` selected"
-        #       ) do
-        #         heroku_select_existing_app(app_name)
-        #       end
-        #     elsif app_type == :new
-        #       CLI::UI::Frame.open('Creating new Heroku app…', success_text: '{{v}} New Heroku app created') do
-        #         heroku_create_new_app
-        #       end
-        #     end
-        #   end
-
-        #   branches = git_branches
-        #   if branches.length == 1
-        #     branch_to_deploy = branches[0]
-        #     spin_group.add("Git branch `#{branch_to_deploy}` selected for deploy") { true }
-        #     spin_group.wait
-        #   else
-        #     branch_to_deploy = CLI::UI::Prompt.ask('What branch would you like to deploy?') do |handler|
-        #       branches.each do |branch|
-        #         handler.option(branch) { branch }
-        #       end
-        #     end
-        #   end
-
-        #   CLI::UI::Frame.open('Deploying to Heroku…', success_text: '{{v}} Deployed to Heroku') do
-        #     heroku_deploy(branch_to_deploy)
-        #   end
         end
 
         private
-
-        # def git_branches
-        #   output, status = @ctx.capture2e('git', 'branch', '--list', '--format=%(refname:short)')
-        #   raise(ShopifyCli::Abort, "Could not find any git branches") unless status.success?
-
-        #   branches = if output == ''
-        #     ['master']
-        #   else
-        #     output.split("\n")
-        #   end
-
-        #   branches
-        # end
-
-        # def git_init
-        #   output, status = @ctx.capture2e('git', 'status')
-
-        #   unless status.success?
-        #     raise(ShopifyCli::Abort, "Git repo is not initiated. Please run `git init` and make at least one commit.")
-        #   end
-
-        #   if output.include?('No commits yet')
-        #     raise(ShopifyCli::Abort, "No git commits have been made. Please make at least one commit.")
-        #   end
-        # end
-
-        # def heroku_app
-        #   return nil if heroku_git_remote.nil?
-        #   app = heroku_git_remote
-        #   app = app.split('/').last
-        #   app = app.split('.').first
-        #   app
-        # end
-
-        # def heroku_authenticate
-        #   result = @ctx.system(heroku_command, 'login')
-        #   raise(ShopifyCli::Abort, "Could not authenticate with Heroku") unless result.success?
-        # end
-
-        # def now_command
-        #   # local_path = File.join(ShopifyCli::ROOT, 'heroku', 'bin', 'heroku').to_s
-        #   if File.exist?(local_path)
-        #     local_path
-        #   else
-        #     'now'
-        #   end
-        # end
-
-        # def heroku_create_new_app
-        #   output, status = @ctx.capture2e(heroku_command, 'create')
-        #   raise(ShopifyCli::Abort, 'Heroku app could not be created') unless status.success?
-        #   @ctx.puts(output)
-
-        #   new_remote = output.split("\n").last.split("|").last.strip
-        #   result = @ctx.system('git', 'remote', 'add', 'heroku', new_remote)
-        #   raise(ShopifyCli::Abort, 'Heroku app created, but couldn’t be set as a git remote') unless result.success?
-        # end
-
-        # def heroku_deploy(branch_to_deploy)
-        #   result = @ctx.system('git', 'push', '-u', 'heroku', "#{branch_to_deploy}:master")
-        #   raise(ShopifyCli::Abort, "Could not deploy to Heroku") unless result.success?
-        # end
-
-        # def heroku_git_remote
-        #   output, status = @ctx.capture2e('git', 'remote', 'get-url', 'heroku')
-        #   status.success? ? output : nil
-        # end
-
+        
+        def now_installed?
+          _output, status = @ctx.capture2e('now --version')
+          status.success?
+        rescue
+          false
+        end      
+        
+        def now_install
+          return if now_installed?
+          
+          CLI::UI::Frame.open("Installing Now CLI with npm", success_text: '{{v}} Now installed') do
+            result = @ctx.system('npm i -g now')
+            raise(ShopifyCli::Abort, "Could not install Now CLI") unless result.success?
+          end
+        end
+        
         def now_deploy
           CLI::UI::Frame.open("Deploying to Now", success_text: '{{v}} Successfully deployed to Now') do
             result = @ctx.system('now')
             raise(ShopifyCli::Abort, "Could not deploy to Now") unless result.success?
           end
         end
-
-        def now_install
-          return if now_installed?
-
-          CLI::UI::Frame.open("Installing Now CLI with npm", success_text: '{{v}} Now installed') do
-            result = @ctx.system('npm i -g now')
-            raise(ShopifyCli::Abort, "Could not install Now CLI") unless result.success?
-          end
-        end
-
-        def now_installed?
-          _output, status = @ctx.capture2e('now --version')
-          status.success?
-        rescue
-          false
-        end
-
-        # def heroku_select_existing_app(app_name)
-        #   result = @ctx.system(heroku_command, 'git:remote', '-a', app_name)
-        #   raise(ShopifyCli::Abort, "Heroku app `#{app_name}` could not be selected") unless result.success?
-        # end
-
-        # def heroku_whoami
-        #   output, status = @ctx.capture2e(heroku_command, 'whoami')
-        #   return output.strip if status.success?
-        #   nil
-        # end
-      
+        
       end
     end
   end

--- a/test/shopify-cli/commands/deploy/now_test.rb
+++ b/test/shopify-cli/commands/deploy/now_test.rb
@@ -7,6 +7,11 @@ module ShopifyCli
         include TestHelpers::Context
         include TestHelpers::FakeUI
 
+        def test_for_truth
+          @context.expects(:system)
+          assert true          
+        end
+
         # def setup
         #   super
 
@@ -31,7 +36,7 @@ module ShopifyCli
         #   @context.expects(:system)
         #     .with('now --version')
 
-
+  
         #   @command.call(@context)
         # end
 

--- a/test/shopify-cli/commands/deploy/now_test.rb
+++ b/test/shopify-cli/commands/deploy/now_test.rb
@@ -1,0 +1,488 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Commands
+    class Deploy
+      class NowTest < MiniTest::Test
+        include TestHelpers::Context
+        include TestHelpers::FakeUI
+
+        # def setup
+        #   super
+
+        #   @download_filename = 'heroku-darwin-x64.tar.gz'
+        #   @download_path = File.join(ShopifyCli::ROOT, @download_filename)
+        #   @heroku_command = File.join(ShopifyCli::ROOT, 'heroku', 'bin', 'heroku').to_s
+        #   @heroku_remote = 'https://git.heroku.com/app-name.git'
+
+        #   @status_mock = {
+        #     false: mock,
+        #     true: mock,
+        #   }
+        #   @status_mock[:false].stubs(:success?).returns(false)
+        #   @status_mock[:true].stubs(:success?).returns(true)
+
+          #   @command = Deploy::Now.new
+
+        #   stub_successful_flow(os: :mac)
+        # end
+
+        # def test_foo
+        #   @context.expects(:system)
+        #     .with('now --version')
+
+
+        #   @command.call(@context)
+        # end
+
+
+        # def test_call_doesnt_download_heroku_cli_if_it_is_installed
+        #   @context.expects(:system)
+        #     .with('curl', '-o', @download_path,
+        #       Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+        #       chdir: ShopifyCli::ROOT)
+        #     .never
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_downloads_heroku_cli_if_it_is_not_installed
+        #   stub_heroku_installed(status: false)
+
+        #   @context.expects(:system)
+        #     .with('curl', '-o', @download_path,
+        #       Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+        #       chdir: ShopifyCli::ROOT)
+        #     .returns(@status_mock[:true])
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_raises_if_heroku_cli_download_fails
+        #   stub_heroku_installed(status: false)
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @context.expects(:system)
+        #       .with('curl', '-o', @download_path,
+        #         Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+        #         chdir: ShopifyCli::ROOT)
+        #       .returns(@status_mock[:false])
+
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_raises_if_heroku_cli_download_is_missing
+        #   stub_heroku_installed(status: false)
+        #   stub_heroku_download_exists(status: false)
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @context.expects(:system)
+        #       .with('curl', '-o', @download_path,
+        #         Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+        #         chdir: ShopifyCli::ROOT)
+        #       .returns(@status_mock[:true])
+
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_doesnt_install_heroku_cli_if_it_is_already_installed
+        #   @context.expects(:system)
+        #     .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
+        #     .never
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_installs_heroku_cli_if_it_is_downloaded
+        #   stub_heroku_installed(status: false)
+
+        #   @context.expects(:system)
+        #     .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
+        #     .returns(@status_mock[:true])
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_raises_if_heroku_cli_install_fails
+        #   stub_heroku_installed(status: false)
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @context.expects(:system)
+        #       .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
+        #       .returns(@status_mock[:false])
+
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_raises_if_git_isnt_inited
+        #   stub_git_init(status: false, commits: false)
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_raises_if_git_is_inited_but_there_are_no_commits
+        #   stub_git_init(status: true, commits: false)
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_uses_existing_heroku_auth_if_available
+        #   @context.expects(:capture2e)
+        #     .with(@heroku_command, 'whoami')
+        #     .returns(['username', @status_mock[:true]])
+
+        #   CLI::UI::SpinGroup.any_instance.expects(:add).with(
+        #     'Authenticated with Heroku as `username`'
+        #   )
+
+        #   capture_io do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_attempts_to_authenticate_with_heroku_if_not_already_authed
+        #   stub_heroku_whoami(status: false)
+
+        #   @context.expects(:system)
+        #     .with(@heroku_command, 'login')
+        #     .returns(@status_mock[:true])
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_raises_if_heroku_auth_fails
+        #   stub_heroku_whoami(status: false)
+        #   stub_heroku_login(status: false)
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_uses_existing_heroku_app_if_available
+        #   @context.expects(:capture2e)
+        #     .with('git', 'remote', 'get-url', 'heroku')
+        #     .returns([@heroku_remote, @status_mock[:true]])
+
+        #   CLI::UI::SpinGroup.any_instance.expects(:add).with(
+        #     'Heroku app `app-name` selected'
+        #   )
+
+        #   capture_io do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_lets_you_choose_existing_heroku_app
+        #   stub_git_remote(status: false, remote: 'heroku')
+
+        #   CLI::UI::Prompt.expects(:ask)
+        #     .with('No existing Heroku app found. What would you like to do?')
+        #     .returns(:existing)
+
+        #   CLI::UI::Prompt.expects(:ask)
+        #     .with('What is your Heroku app’s name?')
+        #     .returns('app-name')
+
+        #   @context.expects(:system)
+        #     .with(@heroku_command, 'git:remote', '-a', 'app-name')
+        #     .returns(@status_mock[:true])
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_raises_if_choosing_existing_heroku_app_fails
+        #   stub_git_remote(status: false, remote: 'heroku')
+
+        #   CLI::UI::Prompt.expects(:ask)
+        #     .with('No existing Heroku app found. What would you like to do?')
+        #     .returns(:existing)
+
+        #   CLI::UI::Prompt.expects(:ask)
+        #     .with('What is your Heroku app’s name?')
+        #     .returns('app-name')
+
+        #   @context.expects(:system)
+        #     .with(@heroku_command, 'git:remote', '-a', 'app-name')
+        #     .returns(@status_mock[:false])
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_lets_you_create_new_heroku_app
+        #   stub_git_remote(status: false, remote: 'heroku')
+
+        #   CLI::UI::Prompt.expects(:ask)
+        #     .with('No existing Heroku app found. What would you like to do?')
+        #     .returns(:new)
+
+        #   output = <<~EOS
+        #     Creating app... done, ⬢ app-name
+        #     https://app-name.herokuapp.com/ | #{@heroku_remote}
+        #   EOS
+
+        #   @context.expects(:capture2e)
+        #     .with(@heroku_command, 'create')
+        #     .returns([output, @status_mock[:true]])
+
+        #   @context.expects(:system)
+        #     .with('git', 'remote', 'add', 'heroku', @heroku_remote)
+        #     .returns(@status_mock[:true])
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_raises_if_creating_new_heroku_app_fails
+        #   stub_git_remote(status: false, remote: 'heroku')
+
+        #   CLI::UI::Prompt.expects(:ask)
+        #     .with('No existing Heroku app found. What would you like to do?')
+        #     .returns(:new)
+
+        #   @context.expects(:capture2e)
+        #     .with(@heroku_command, 'create')
+        #     .returns(['', @status_mock[:false]])
+
+        #   @context.expects(:system)
+        #     .with('git', 'remote', 'add', 'heroku', @heroku_remote)
+        #     .never
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_raises_if_setting_remote_heroku_fails
+        #   stub_git_remote(status: false, remote: 'heroku')
+
+        #   CLI::UI::Prompt.expects(:ask)
+        #     .with('No existing Heroku app found. What would you like to do?')
+        #     .returns(:new)
+
+        #   output = <<~EOS
+        #     Creating app... done, ⬢ app-name
+        #     https://app-name.herokuapp.com/ | #{@heroku_remote}
+        #   EOS
+
+        #   @context.expects(:capture2e)
+        #     .with(@heroku_command, 'create')
+        #     .returns([output, @status_mock[:true]])
+
+        #   @context.expects(:system)
+        #     .with('git', 'remote', 'add', 'heroku', @heroku_remote)
+        #     .returns(@status_mock[:false])
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_doesnt_prompt_if_only_one_branch_exists
+        #   @context.expects(:capture2e)
+        #     .with('git', 'branch', '--list', '--format=%(refname:short)')
+        #     .returns(["master\n", @status_mock[:true]])
+
+        #   CLI::UI::SpinGroup.any_instance.expects(:add).with(
+        #     'Git branch `master` selected for deploy'
+        #   )
+
+        #   capture_io do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_lets_you_specify_a_branch_if_multiple_exist
+        #   stub_git_branches(multiple: true)
+
+        #   CLI::UI::Prompt.expects(:ask)
+        #     .with('What branch would you like to deploy?')
+        #     .returns('other_branch')
+
+        #   @context.expects(:system)
+        #     .with('git', 'push', '-u', 'heroku', "other_branch:master")
+        #     .returns(@status_mock[:true])
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_raises_if_finding_branches_fails
+        #   @context.stubs(:capture2e)
+        #     .with('git', 'branch', '--list', '--format=%(refname:short)')
+        #     .returns(['', @status_mock[:false]])
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # def test_call_tries_to_deploy_to_heroku
+        #   @context.expects(:system)
+        #     .with('git', 'push', '-u', 'heroku', "master:master")
+        #     .returns(@status_mock[:true])
+
+        #   @command.call(@context)
+        # end
+
+        # def test_call_raises_if_deploy_fails
+        #   @context.expects(:system)
+        #     .with('git', 'push', '-u', 'heroku', "master:master")
+        #     .returns(@status_mock[:false])
+
+        #   assert_raises ShopifyCli::Abort do
+        #     @command.call(@context)
+        #   end
+        # end
+
+        # private
+
+        def stub_successful_flow(os:)
+          stub_git_init(status: true, commits: true)
+          # stub_os(os: os)
+          # stub_heroku_downloaded(status: true)
+          # stub_heroku_download_exists(status: true)
+          # stub_tar(status: true)
+          # stub_heroku_installed(status: true)
+          # stub_heroku_whoami(status: true)
+          # stub_heroku_login(status: true)
+          # stub_heroku_select_app(status: true)
+          # stub_git_remote(status: true, remote: 'heroku')
+          # stub_git_remote(status: true, remote: 'origin')
+          # stub_git_branches(multiple: false)
+          # stub_heroku_deploy(status: true)
+        end
+
+        # def stub_git_branches(multiple:)
+        #   output = "master\n"
+        #   output << "other_branch\n" if multiple
+
+        #   @context.stubs(:capture2e)
+        #     .with('git', 'branch', '--list', '--format=%(refname:short)')
+        #     .returns([output, @status_mock[:true]])
+        # end
+
+        def stub_git_init(status:, commits:)
+          output = if commits == true
+            <<~EOS
+              On branch master
+              Your branch is up to date with 'heroku/master'.
+
+              nothing to commit, working tree clean
+            EOS
+          else
+            <<~EOS
+              On branch master
+
+              No commits yet
+            EOS
+          end
+
+          @context.stubs(:capture2e)
+            .with('git', 'status')
+            .returns([output, @status_mock[:"#{status}"]])
+        end
+
+        # def stub_git_remote(status:, remote:)
+        #   output = if status == true
+        #     @heroku_remote
+        #   else
+        #     "fatal: No such remote '#{remote}'"
+        #   end
+
+        #   @context.stubs(:capture2e)
+        #     .with('git', 'remote', 'get-url', remote)
+        #     .returns([output, @status_mock[:"#{status}"]])
+        # end
+
+        # def stub_heroku_deploy(status:)
+        #   @context.stubs(:system)
+        #     .with('git', 'push', '-u', 'heroku', "master:master")
+        #     .returns(@status_mock[:"#{status}"])
+        # end
+
+        # def stub_heroku_download_exists(status:)
+        #   File.stubs(:exist?)
+        #     .with(@download_path)
+        #     .returns(status)
+        # end
+
+        # def stub_heroku_downloaded(status:)
+        #   @context.stubs(:system)
+        #     .with('curl', '-o', @download_path,
+        #       Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+        #       chdir: ShopifyCli::ROOT)
+        #     .returns(@status_mock[:"#{status}"])
+        # end
+
+        # def stub_heroku_installed(status:)
+        #   File.stubs(:exist?)
+        #     .with(@heroku_command)
+        #     .returns(status)
+
+        #   @context.stubs(:capture2e)
+        #     .with(@heroku_command, '--version')
+        #     .returns(['', @status_mock[:"#{status}"]])
+
+        #   @context.stubs(:capture2e)
+        #     .with('heroku', '--version')
+        #     .returns(['', @status_mock[:"#{status}"]])
+        # end
+
+        # def stub_heroku_login(status:)
+        #   @context.stubs(:system)
+        #     .with(@heroku_command, 'login')
+        #     .returns(@status_mock[:"#{status}"])
+
+        #   @context.stubs(:system)
+        #     .with('heroku', 'login')
+        #     .returns(@status_mock[:"#{status}"])
+        # end
+
+        # def stub_heroku_select_app(status:)
+        #   @context.stubs(:capture2e)
+        #     .with(@heroku_command, 'git:remote', '-a', 'app-name')
+        #     .returns(['', @status_mock[:"#{status}"]])
+
+        #   @context.stubs(:capture2e)
+        #     .with(@heroku_command, 'git:remote', '-a', 'app-name')
+        #     .returns(['', @status_mock[:"#{status}"]])
+        # end
+
+        # def stub_heroku_whoami(status:)
+        #   output = status ? 'username' : nil
+
+        #   @context.stubs(:capture2e)
+        #     .with(@heroku_command, 'whoami')
+        #     .returns([output, @status_mock[:"#{status}"]])
+
+        #   @context.stubs(:capture2e)
+        #     .with('heroku', 'whoami')
+        #     .returns([output, @status_mock[:"#{status}"]])
+        # end
+
+        # def stub_tar(status:)
+        #   @context.stubs(:system)
+        #     .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
+        #     .returns(@status_mock[:"#{status}"])
+
+        #   FileUtils.stubs(:rm)
+        #     .with(@download_path)
+        #     .returns(status)
+        # end
+
+        # def stub_os(os:)
+        #   @command.stubs(:os)
+        #     .returns(os)
+        # end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/commands/deploy_test.rb
+++ b/test/shopify-cli/commands/deploy_test.rb
@@ -15,6 +15,11 @@ module ShopifyCli
         @command.call(['heroku'], nil)
       end
 
+      def test_now_subcommand_calls_now
+        Deploy::Now.expects(:call)
+        @command.call(['now'], nil)
+      end
+
       def test_without_arguments_calls_help
         @context.expects(:puts).with(ShopifyCli::Commands::Deploy.help)
         @command.call([], nil)


### PR DESCRIPTION
Currently, Heroku is the only option available for `shopify deploy`. This PR adds rudimentary support for deploying with Zeit’s [Now CLI](https://zeit.co/download#open-source).

**Current functionality:**
- [x] `shopify deploy now` command registered
- [x] installs `now` using npm if it’s not installed
- [x] uploads app codebase to Zeit platform
- [x] basic help text

**To do:**
- [ ] Tests — currently just copied and commented out the Heroku tests
- [ ] Login behavior if the user doesn’t have a Now account already (?)
- [ ] Next app build step currently fails on Now — something related to fetch, a quirk of serverless behavior perhaps
- [ ] Now is only suitable for the Node/React app type. Hide feature or surface warning if using inside a Rails app.