### PR TITLE
Delegate Store Class Methods

### DIFF
--- a/lib/shopify-cli/helpers/store.rb
+++ b/lib/shopify-cli/helpers/store.rb
@@ -1,35 +1,12 @@
 require 'pstore'
+require 'forwardable'
 
 module ShopifyCli
   module Helpers
     class Store
+      extend SingleForwardable
+      def_delegators :new, :keys, :exists?, :set, :get, :del, :clear
       attr_reader :db
-
-      class << self
-        def keys
-          new.keys
-        end
-
-        def exists?(key)
-          new.exists?(key)
-        end
-
-        def set(**args)
-          new.set(**args)
-        end
-
-        def get(key, &block)
-          new.get(key, &block)
-        end
-
-        def del(*args)
-          new.del(*args)
-        end
-
-        def clear
-          new.clear
-        end
-      end
 
       def initialize(path: File.join(ShopifyCli::TEMP_DIR, ".db.pstore"))
         @db = PStore.new(path)


### PR DESCRIPTION
### WHY are these changes introduced?
Last week these methods were broken and it lead me to look closer into how this is implemented and I found a lesser known function of the stdlib that allows me to remove all of that extra code.

### WHAT is this pull request doing?
Remove class methods that just delegate to the instance by importing forwardable and using SingleForwardable.