### PR TITLE
adds silent flag and updates ux

### DIFF
--- a/lib/shopify-cli/commands/populate.rb
+++ b/lib/shopify-cli/commands/populate.rb
@@ -37,6 +37,7 @@ module ShopifyCli
           {{bold:Options:}}
 
             {{cyan:--count [integer]}}: The number of dummy items to populate. Defaults to 10.
+            {{cyan:--silent}}: Silence the populate output.
 
           {{bold:Examples:}}
 


### PR DESCRIPTION



<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds a `--silent` flag to populate. Gives the user the ability to see the output of populated customers/products etc or silence it. It also adds a missing success message and uses a spinner for silent because it hangs for a second. 