### PR TITLE
Fixed Ruby installation docs

### DIFF
--- a/docs/installing-ruby.md
+++ b/docs/installing-ruby.md
@@ -9,13 +9,13 @@ We recommend using [`ruby-install`][ruby-install] and [`chruby`][chruby] from Ho
 
         brew install ruby-install chruby
 
-1. Install ruby 2.4:
+1. Install ruby 2.5.1:
 
-        ruby-install 2.4
+        ruby-install ruby 2.5.1
 
-1. Open a new terminal window and activate ruby 2.4:
+1. Open a new terminal window and activate ruby 2.5.1:
 
-        chruby ruby-2.4
+        chruby 2.5.1
 
 1. Run your Shopify App CLI command.
 

--- a/docs/installing-ruby.md
+++ b/docs/installing-ruby.md
@@ -11,11 +11,11 @@ We recommend using [`ruby-install`][ruby-install] and [`chruby`][chruby] from Ho
 
 1. Install ruby 2.5.1:
 
-        ruby-install ruby 2.5.1
+        ruby-install ruby-2.5.1
 
 1. Open a new terminal window and activate ruby 2.5.1:
 
-        chruby 2.5.1
+        chruby ruby-2.5.1
 
 1. Run your Shopify App CLI command.
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Previously the ruby-install commands in the docs were incorrect and would print
`!!! Unknown ruby: 2.4` in console.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR updates docs with correct commands

Also bumps version recommended to install to 2.5.1, aligns with ruby version defined in dev.yml
