### PR TITLE
check page type

### DIFF
--- a/lib/shopify-cli/commands/generate/page.rb
+++ b/lib/shopify-cli/commands/generate/page.rb
@@ -25,6 +25,9 @@ module ShopifyCli
           end
 
           selected_type = if flag
+            unless types.key?(flag)
+              raise ShopifyCli::Abort, 'Invalid page type.'
+            end
             types[flag]
           else
             CLI::UI::Prompt.ask('Which template would you like to use?') do |handler|

--- a/test/shopify-cli/commands/generate/page_test.rb
+++ b/test/shopify-cli/commands/generate/page_test.rb
@@ -27,6 +27,12 @@ module ShopifyCli
           @command.call(['page', 'name', '--type=list'], nil)
         end
 
+        def test_raises_with_invalid_type
+          assert_raises ShopifyCli::Abort do
+            @command.call(['project', '--type=list_TYPE', 'test-app'], nil)
+          end
+        end
+
         def test_no_name_calls_help
           io = capture_io do
             @command.call([], nil)


### PR DESCRIPTION
WHY are these changes introduced?

When we generate a page with the --type flag we should also check to make sure it's a valid type and throw error if it isn't. 

