### PR TITLE
update api_secret to match gem

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -7,7 +7,7 @@ module ShopifyCli
         def env_file
           <<~KEYS
             SHOPIFY_API_KEY={api_key}
-            SHOPIFY_API_SECRET_KEY={secret}
+            SHOPIFY_API_SECRET={secret}
             HOST={host}
             SHOP={shop}
             SCOPES={scopes}

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -10,7 +10,7 @@ module ShopifyCli
         def env_file
           <<~KEYS
             SHOPIFY_API_KEY={api_key}
-            SHOPIFY_API_SECRET_KEY={secret}
+            SHOPIFY_API_SECRET={secret}
             HOST={host}
             SHOP={shop}
             SCOPES={scopes}

--- a/test/fixtures/app_types/node/.env
+++ b/test/fixtures/app_types/node/.env
@@ -1,5 +1,5 @@
 SHOPIFY_API_KEY=mykey
-SHOPIFY_API_SECRET_KEY=mysecretkey
+SHOPIFY_API_SECRET=mysecretkey
 HOST=https://example.com
 SHOP=my-test-shop.myshopify.com
 SCOPES=read_products

--- a/test/fixtures/app_types/rails/.env
+++ b/test/fixtures/app_types/rails/.env
@@ -1,5 +1,5 @@
 SHOPIFY_API_KEY=api_key
-SHOPIFY_API_SECRET_KEY=secret
+SHOPIFY_API_SECRET=secret
 SCOPES=write_products,write_customers,write_orders
 HOST=https://example.com
 SHOP=my-test-shop.myshopify.com


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

In #323  <!-- link to issue if one exists --> Tim pointed out the [Rails gem is expecting](https://github.com/Shopify/shopify_app/blob/55c607d27d9c1395d4e1d1003965882772e0f2a6/lib/generators/shopify_app/install/templates/shopify_app.rb) `SHOPIFY_API_SECRET` and we have it listed as `SHOPIFY_API_SECRET_KEY`. I wasn't going to change it across both apps to match, but then I figured it should be as consistent as possible. I didn't want to update the gem because people use that without the CLI.

The node app has changes that need to be reviewed [here](https://github.com/Shopify/shopify-app-node/pull/52)