### PR TITLE
Create Project generate app config automatically and add to env 

### DIFF
--- a/lib/graphql/find_organization.graphql
+++ b/lib/graphql/find_organization.graphql
@@ -1,0 +1,17 @@
+query FindOrg($id: ID!) {
+  organizations(id: $id) {
+    nodes {
+      id
+      businessName
+      website
+      stores {
+        nodes {
+          link
+          shopDomain
+          shopName
+        }
+      }
+    }
+  }
+}
+

--- a/lib/shopify-cli/forms.rb
+++ b/lib/shopify-cli/forms.rb
@@ -1,0 +1,39 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Forms
+    class Form
+      class << self
+        def ask(ctx, args, flags)
+          attrs = {}
+          @positional_arguments.each { |name| attrs[name] = args.shift }
+          return nil if attrs.any? { |_k, v| v.nil? }
+          @flag_arguments.each { |arg| attrs[arg] = flags[arg] }
+          form = new(ctx, args, attrs)
+          form.ask
+          form
+        end
+
+        def positional_arguments(*args)
+          @positional_arguments = args
+          attr_accessor(*args)
+        end
+
+        def flag_arguments(*args)
+          @flag_arguments = args
+          attr_accessor(*args)
+        end
+      end
+
+      attr_accessor :ctx, :xargs
+
+      def initialize(ctx, xargs, attributes)
+        @ctx = ctx
+        @xargs = xargs
+        attributes.each { |k, v| send("#{k}=", v) unless v.nil? }
+      end
+    end
+
+    autoload :CreateApp, 'shopify-cli/forms/create_app'
+  end
+end

--- a/lib/shopify-cli/forms/create_app.rb
+++ b/lib/shopify-cli/forms/create_app.rb
@@ -1,0 +1,78 @@
+require 'shopify_cli'
+require 'uri'
+
+module ShopifyCli
+  module Forms
+    class CreateApp < Form
+      positional_arguments :name
+      flag_arguments :title, :type, :app_url, :organization_id, :shop_domain
+
+      def ask
+        self.title ||= fallback_title
+        self.type = ask_type
+        self.app_url = ask_app_url
+        self.organization_id ||= organization["id"].to_i
+        self.shop_domain ||= ask_shop_domain
+      end
+
+      private
+
+      def fallback_title
+        name.gsub(/(.)([A-Z])/, '\1 \2') # change camelcase to title
+          .gsub(/(-|_)/, ' ') # change snakecase to title
+          .capitalize
+      end
+
+      def ask_app_url
+        while app_url !~ /\A#{URI::DEFAULT_PARSER.regexp[:ABS_URI]}\z/
+          ctx.puts('Invalid URL') unless app_url.nil?
+          self.app_url = CLI::UI::Prompt.ask('What is your Application URL?')
+        end
+        app_url
+      end
+
+      def ask_type
+        return type unless AppTypeRegistry[type.to_s.to_sym].nil?
+        ctx.puts('Invalid App Type.') unless type.nil?
+        CLI::UI::Prompt.ask('What type of app project would you like to create?') do |handler|
+          AppTypeRegistry.each do |identifier, type|
+            handler.option(type.description) { identifier }
+          end
+        end
+      end
+
+      def organization
+        @organiztion ||= begin
+          if organization_id.nil?
+            orgs = Helpers::Organizations.fetch_all(ctx)
+            if orgs.count == 1
+              orgs.first
+            else
+              org_id = CLI::UI::Prompt.ask('Which organization do you want this app to belong to?') do |handler|
+                orgs.each { |org| handler.option(org["businessName"]) { org["id"] } }
+              end
+              orgs.find { |org| org["id"] == org_id }
+            end
+          else
+            org = Helpers::Organizations.fetch(ctx, id: organization_id)
+            raise(ShopifyCli::Abort, "Cannot find an organization with that ID") if org.nil?
+            org
+          end
+        end
+      end
+
+      def ask_shop_domain
+        if organization['stores'].count == 0
+          ctx.puts('No developement shops available.')
+          ctx.puts("Visit https://partners.shopify.com/#{organization['id']}/stores to create one")
+          return ""
+        end
+        return organization['stores'].first['shopDomain'] if organization['stores'].count == 1
+        CLI::UI::Prompt.ask(
+          'Which development store would you like to work with?',
+          options: organization["stores"].map { |s| s["shopDomain"] }
+        )
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/helpers.rb
+++ b/lib/shopify-cli/helpers.rb
@@ -6,6 +6,7 @@ module ShopifyCli
     autoload :Gem, 'shopify-cli/helpers/gem'
     autoload :GraphQL, 'shopify-cli/helpers/graphql'
     autoload :Haikunator, 'shopify-cli/helpers/haikunator'
+    autoload :Organizations, 'shopify-cli/helpers/organizations'
     autoload :OS, 'shopify-cli/helpers/os'
     autoload :PartnersAPI, 'shopify-cli/helpers/partners_api'
     autoload :PidFile, 'shopify-cli/helpers/pid_file'

--- a/lib/shopify-cli/helpers/env_file.rb
+++ b/lib/shopify-cli/helpers/env_file.rb
@@ -53,10 +53,10 @@ module ShopifyCli
       property :scopes
       property :host
 
-      def write(ctx)
+      def write(ctx, app_type: Project.current.app_type)
         spin_group = CLI::UI::SpinGroup.new
         spin_group.add("writing #{FILENAME} file...") do |spinner|
-          template = self.class.parse_template(Project.current.app_type.env_file)
+          template = self.class.parse_template(app_type.env_file)
           output = []
           template.each do |key, value|
             output << "#{key}=#{send(value)}" if send(value)

--- a/lib/shopify-cli/helpers/organizations.rb
+++ b/lib/shopify-cli/helpers/organizations.rb
@@ -1,0 +1,23 @@
+module ShopifyCli
+  module Helpers
+    class Organizations
+      class << self
+        def fetch_all(ctx)
+          resp = Helpers::PartnersAPI.query(ctx, 'all_organizations')
+          resp['data']['organizations']['nodes'].map do |org|
+            org['stores'] = org['stores']['nodes']
+            org
+          end
+        end
+
+        def fetch(ctx, id:)
+          resp = Helpers::PartnersAPI.query(ctx, 'find_organization', id: id)
+          org = resp['data']['organizations']['nodes'].first
+          return nil if org.nil?
+          org['stores'] = org['stores']['nodes']
+          org
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/oauth.rb
+++ b/lib/shopify-cli/oauth.rb
@@ -14,7 +14,8 @@ module ShopifyCli
 
     class Error < StandardError; end
 
-    REDIRECT_HOST = "http://app-cli-loopback.shopifyapps.com"
+    DEFAULT_PORT = 3456
+    REDIRECT_HOST = "http://app-cli-loopback.shopifyapps.com:#{DEFAULT_PORT}"
     TEMPLATE = %{HTTP/1.1 200
       Content-Type: text/html
 
@@ -43,7 +44,6 @@ module ShopifyCli
     property :store, default: Helpers::Store.new
     property :secret, accepts: String
     property :request_exchange, accepts: String
-    property :port, default: 3456, accepts: Integer
     property :options, default: {}, accepts: Hash
     property :auth_path, default: "/authorize", accepts: ->(path) { path.is_a?(String) && path.start_with?("/") }
     property :token_path, default: "/token", accepts: ->(path) { path.is_a?(String) && path.start_with?("/") }
@@ -56,10 +56,6 @@ module ShopifyCli
       initiate_authentication(url)
       request_access_token(url, code: receive_access_code)
       request_exchange_token(url) if should_exchange
-    end
-
-    def redirect_uri
-      "#{REDIRECT_HOST}:#{port}"
     end
 
     def code_challenge
@@ -76,7 +72,7 @@ module ShopifyCli
       params = {
         client_id: client_id,
         scope: scopes,
-        redirect_uri: redirect_uri,
+        redirect_uri: REDIRECT_HOST,
         state: state_token,
         response_type: :code,
       }
@@ -87,7 +83,7 @@ module ShopifyCli
     end
 
     def listen_local
-      server = TCPServer.new('127.0.0.1', port)
+      server = TCPServer.new('127.0.0.1', DEFAULT_PORT)
       @server_thread ||= Thread.new do
         Thread.current.abort_on_exception = true
         begin
@@ -125,7 +121,7 @@ module ShopifyCli
         {
           grant_type: :authorization_code,
           code: code,
-          redirect_uri: redirect_uri,
+          redirect_uri: REDIRECT_HOST,
           client_id: client_id,
         }.merge(confirmation_param)
       )

--- a/lib/shopify-cli/tasks.rb
+++ b/lib/shopify-cli/tasks.rb
@@ -23,6 +23,7 @@ module ShopifyCli
       Registry.add(const_get(task), name)
     end
 
+    register :CreateApiClient, :create_api_client, 'shopify-cli/tasks/create_api_client'
     register :AuthenticateIdentity, :authenticate_identity, 'shopify-cli/tasks/authenticate_identity'
     register :AuthenticateShopify, :authenticate_shopify, 'shopify-cli/tasks/authenticate_shopify'
     register :Clone, :clone, 'shopify-cli/tasks/clone'

--- a/lib/shopify-cli/tasks/create_api_client.rb
+++ b/lib/shopify-cli/tasks/create_api_client.rb
@@ -1,0 +1,25 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Tasks
+    class CreateApiClient < ShopifyCli::Task
+      def call(ctx, org_id:, title:, app_url:)
+        resp = Helpers::PartnersAPI.query(
+          ctx,
+          'create_app',
+          org: org_id.to_i,
+          title: title,
+          app_url: app_url,
+          redir: [OAuth::REDIRECT_HOST]
+        )
+
+        user_errors = resp["data"]["appCreate"]["userErrors"]
+        if !user_errors.nil? && user_errors.any?
+          raise(ShopifyCli::Abort, user_errors.map { |err| "#{err['field']} #{err['message']}" }.join(", "))
+        end
+
+        resp["data"]["appCreate"]["app"]
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -101,6 +101,7 @@ module ShopifyCli
   autoload :EntryPoint, 'shopify-cli/entry_point'
   autoload :Executor, 'shopify-cli/executor'
   autoload :Finalize, 'shopify-cli/finalize'
+  autoload :Forms, 'shopify-cli/forms'
   autoload :Helpers, 'shopify-cli/helpers'
   autoload :OAuth, 'shopify-cli/oauth'
   autoload :Options, 'shopify-cli/options'

--- a/test/shopify-cli/forms/create_app_test.rb
+++ b/test/shopify-cli/forms/create_app_test.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module ShopifyCli
+  module Forms
+    class CreateAppTest < MiniTest::Test
+      include TestHelpers::Context
+      include TestHelpers::Partners
+
+      def test_returns_all_defined_attributes_if_valid
+        form = ask
+        assert_equal(form.name, 'test-app')
+        assert_equal(form.title, 'Test app')
+        assert_equal(form.type, 'node')
+        assert_equal(form.app_url, 'http://app.com')
+        assert_equal(form.organization_id, 42)
+        assert_equal(form.shop_domain, 'shop.myshopify.com')
+      end
+
+      def test_title_can_be_provided_by_flag
+        form = ask
+        assert_equal(form.name, 'test-app')
+        assert_equal(form.title, 'Test app')
+
+        form = ask(title: 'My New App')
+        assert_equal(form.name, 'test-app')
+        assert_equal(form.title, 'My New App')
+      end
+
+      def test_type_can_be_provided_by_flag
+        form = ask
+        assert_equal(form.type, 'node')
+
+        form = ask(type: 'rails')
+        assert_equal(form.type, 'rails')
+
+        io = capture_io do
+          CLI::UI::Prompt.expects(:ask).with('What type of app project would you like to create?')
+          ask(type: 'notatype')
+        end
+        assert_match('Invalid App Type.', io.join)
+      end
+
+      def test_type_will_be_asked_for_if_not_provided
+        CLI::UI::Prompt.expects(:ask).with('What type of app project would you like to create?')
+        ask(type: nil)
+      end
+
+      def test_app_url_can_be_provided_by_flag
+        form = ask
+        assert_equal(form.app_url, 'http://app.com')
+
+        io = capture_io do
+          CLI::UI::Prompt.expects(:ask).with('What is your Application URL?').returns('http://app.com')
+          ask(app_url: 'notaurl')
+        end
+        assert_match('Invalid URL', io.join)
+      end
+
+      def test_user_will_be_promted_if_more_than_one_organization
+        stub_partner_req(
+          'all_organizations',
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    'id': 421,
+                    'businessName': "one",
+                    'stores': { 'nodes': [{ 'shopDomain': 'store.myshopify.com' }] },
+                  },
+                  {
+                    'id': 431,
+                    'businessName': "two",
+                    'stores': { 'nodes': [{ 'shopDomain': 'other.myshopify.com' }] },
+                  },
+                ],
+              },
+            },
+          },
+        )
+        CLI::UI::Prompt.expects(:ask).returns(431)
+        form = ask(org_id: nil, shop: nil)
+        assert_equal(form.organization_id, 431)
+        assert_equal(form.shop_domain, 'other.myshopify.com')
+      end
+
+      def test_will_auto_pick_with_only_one_org
+        stub_partner_req(
+          'all_organizations',
+          resp: {
+            data: {
+              organizations: {
+                nodes: [{
+                    'id': 421,
+                    'businessName': "one",
+                    'stores': { 'nodes': [{ 'shopDomain': 'next.myshopify.com' }] },
+                }],
+              },
+            },
+          },
+        )
+        form = ask(org_id: nil, shop: nil)
+        assert_equal(form.organization_id, 421)
+        assert_equal(form.shop_domain, 'next.myshopify.com')
+      end
+
+      def test_organization_will_be_fetched_if_id_is_provided_but_not_shop
+        stub_partner_req(
+          'find_organization',
+          variables: { id: 123 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 123,
+                    stores: { nodes: [{ shopDomain: 'shopdomain.myshopify.com' }] },
+                  },
+                ],
+              },
+            },
+          }
+        )
+        form = ask(org_id: 123, shop: nil)
+        assert_equal(form.organization_id, 123)
+        assert_equal(form.shop_domain, 'shopdomain.myshopify.com')
+      end
+
+      def test_returns_no_shop_if_none_are_available
+        stub_partner_req(
+          'find_organization',
+          variables: { id: 123 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [{ id: 123, stores: { nodes: [] } }],
+              },
+            },
+          }
+        )
+
+        io = capture_io do
+          form = ask(org_id: 123, shop: nil)
+          assert_equal(form.shop_domain, '')
+        end
+        log = io.join
+        assert_match('No developement shops available.', log)
+        assert_match("Visit https://partners.shopify.com/123/stores to create one", log)
+      end
+
+      def test_autopicks_only_shop
+        stub_partner_req(
+          'find_organization',
+          variables: { id: 123 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 123,
+                    stores: { nodes: [{ shopDomain: 'shopdomain.myshopify.com' }] },
+                  },
+                ],
+              },
+            },
+          }
+        )
+        form = ask(org_id: 123, shop: nil)
+        assert_equal(form.shop_domain, 'shopdomain.myshopify.com')
+      end
+
+      def test_prompts_user_to_pick_from_shops
+        stub_partner_req(
+          'find_organization',
+          variables: { id: 123 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 123,
+                    stores: { nodes: [
+                      { shopDomain: 'shopdomain.myshopify.com' },
+                      { shopDomain: 'shop.myshopify.com' },
+                    ] },
+                  },
+                ],
+              },
+            },
+          }
+        )
+
+        CLI::UI::Prompt.expects(:ask)
+          .with(
+            'Which development store would you like to work with?',
+            options: %w(shopdomain.myshopify.com shop.myshopify.com)
+          )
+          .returns('selected')
+        form = ask(org_id: 123, shop: nil)
+        assert_equal(form.shop_domain, 'selected')
+      end
+
+      private
+
+      def ask(name: 'test-app', title: nil, type: 'node', app_url: 'http://app.com',
+        org_id: 42, shop: 'shop.myshopify.com')
+        CreateApp.ask(
+          @context,
+          [name],
+          title: title,
+          type: type,
+          app_url: app_url,
+          organization_id: org_id,
+          shop_domain: shop,
+        )
+      end
+    end
+  end
+end

--- a/test/shopify-cli/forms_test.rb
+++ b/test/shopify-cli/forms_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+module ShopifyCli
+  class FormsTest < MiniTest::Test
+    include TestHelpers::Context
+
+    class TestForm < Forms::Form
+      positional_arguments :one, :two
+      flag_arguments :three, :four
+
+      def ask
+      end
+    end
+
+    def test_that_all_attributes_are_defined
+      TestForm.any_instance.expects(:ask)
+      form = TestForm.ask(
+        @context,
+        ['a', 'b', 'c', 'd'],
+        three: 'one', four: 'two',
+      )
+      assert_equal(form.one, 'a')
+      assert_equal(form.two, 'b')
+      assert_equal(form.xargs, ['c', 'd'])
+      assert_equal(form.three, 'one')
+      assert_equal(form.four, 'two')
+    end
+
+    def test_that_the_form_returns_nil_if_not_all_pos_args_are_present
+      TestForm.any_instance.expects(:ask).never
+      form = TestForm.ask(
+        @context,
+        ['a'],
+        {}
+      )
+      assert_nil(form)
+    end
+  end
+end

--- a/test/shopify-cli/helpers/organizations_test.rb
+++ b/test/shopify-cli/helpers/organizations_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module ShopifyCli
+  module Helpers
+    class OrganizationsTest < MiniTest::Test
+      include TestHelpers::Context
+      include TestHelpers::Partners
+
+      def test_fetch_all_queries_partners
+        stub_partner_req(
+          'all_organizations',
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 42,
+                    stores: {
+                      nodes: [
+                        {
+                          shopDomain: 'shopdomain.myshopify.com',
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          }
+        )
+
+        orgs = Helpers::Organizations.fetch_all(@context)
+        assert_equal(orgs.count, 1)
+        assert_equal(orgs.first['id'], 42)
+        assert_equal(orgs.first['stores'].count, 1)
+        assert_equal(orgs.first['stores'].first['shopDomain'], 'shopdomain.myshopify.com')
+      end
+
+      def test_fetch_queries_partners
+        stub_partner_req(
+          'find_organization',
+          variables: { id: 42 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 42,
+                    stores: {
+                      nodes: [
+                        {
+                          shopDomain: 'shopdomain.myshopify.com',
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          }
+        )
+
+        org = Helpers::Organizations.fetch(@context, id: 42)
+        assert_equal(org['id'], 42)
+        assert_equal(org['stores'].count, 1)
+        assert_equal(org['stores'].first['shopDomain'], 'shopdomain.myshopify.com')
+      end
+
+      def test_fetch_returns_nil_when_not_found
+        stub_partner_req(
+          'find_organization',
+          variables: { id: 42 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [],
+              },
+            },
+          }
+        )
+
+        org = Helpers::Organizations.fetch(@context, id: 42)
+        assert_nil(org)
+      end
+    end
+  end
+end

--- a/test/shopify-cli/oauth_test.rb
+++ b/test/shopify-cli/oauth_test.rb
@@ -11,13 +11,11 @@ module ShopifyCli
       assert_equal 'key', client.client_id
       assert_equal 'test,one', client.scopes
       assert_nil(client.secret)
-      assert_equal 3456, client.port
       assert_equal({}, client.options)
 
-      client = oauth(port: 9876, secret: 'secret', options: { foo: :bar })
+      client = oauth(secret: 'secret', options: { foo: :bar })
       assert_equal 'key', client.client_id
       assert_equal 'test,one', client.scopes
-      assert_equal 9876, client.port
       assert_equal 'secret', client.secret
       assert_equal({ foo: :bar }, client.options)
     end
@@ -32,7 +30,7 @@ module ShopifyCli
       authorize_query = {
         client_id: client.client_id,
         scope: client.scopes,
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         state: client.state_token,
         response_type: :code,
       }
@@ -41,7 +39,7 @@ module ShopifyCli
       token_query = {
         grant_type: :authorization_code,
         code: "mycode",
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         client_id: client.client_id,
         client_secret: 'secret',
       }
@@ -64,7 +62,7 @@ module ShopifyCli
       authorize_query = {
         client_id: client.client_id,
         scope: client.scopes,
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         state: client.state_token,
         response_type: :code,
       }
@@ -73,7 +71,7 @@ module ShopifyCli
       token_query = {
         grant_type: :authorization_code,
         code: "mycode",
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         client_id: client.client_id,
         code_verifier: client.code_verifier,
       }
@@ -96,7 +94,7 @@ module ShopifyCli
       authorize_query = {
         client_id: client.client_id,
         scope: client.scopes,
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         state: client.state_token,
         response_type: :code,
       }
@@ -105,7 +103,7 @@ module ShopifyCli
       token_query = {
         grant_type: :authorization_code,
         code: "mycode",
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         client_id: client.client_id,
         code_verifier: client.code_verifier,
       }
@@ -260,7 +258,7 @@ module ShopifyCli
       authorize_query = {
         client_id: client.client_id,
         scope: client.scopes,
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         state: client.state_token,
         response_type: :code,
       }
@@ -269,7 +267,7 @@ module ShopifyCli
       token_query = {
         grant_type: :authorization_code,
         code: "mycode",
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         client_id: client.client_id,
         client_secret: 'secret',
       }
@@ -303,7 +301,7 @@ module ShopifyCli
       query = {
         client_id: client.client_id,
         scope: client.scopes,
-        redirect_uri: client.redirect_uri,
+        redirect_uri: OAuth::REDIRECT_HOST,
         state: client.state_token,
         response_type: :code,
       }

--- a/test/shopify-cli/task/create_api_client_test.rb
+++ b/test/shopify-cli/task/create_api_client_test.rb
@@ -1,0 +1,73 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Tasks
+    class CreateApiClientTest < MiniTest::Test
+      include TestHelpers::Context
+      include TestHelpers::Partners
+
+      def test_call_will_query_partners_dashboard
+        stub_partner_req(
+          'create_app',
+          variables: {
+            org: 42,
+            title: 'Test app',
+            app_url: 'http://app.com',
+            redir: ["http://app-cli-loopback.shopifyapps.com:3456"],
+          },
+          resp: {
+            'data': {
+              'appCreate': {
+                'app': {
+                  'apiKey': 'newapikey',
+                  'apiSecretKeys': [{ 'secret': 'secret' }],
+                },
+              },
+            },
+          }
+        )
+
+        api_client = Tasks::CreateApiClient.call(
+          @context,
+          org_id: 42,
+          title: 'Test app',
+          app_url: 'http://app.com',
+        )
+
+        refute_nil(api_client)
+        assert_equal(api_client['apiKey'], 'newapikey')
+      end
+
+      def test_call_will_return_any_user_errors
+        stub_partner_req(
+          'create_app',
+          variables: {
+            org: 42,
+            title: 'Test app',
+            app_url: 'http://app.com',
+            redir: ["http://app-cli-loopback.shopifyapps.com:3456"],
+          },
+          resp: {
+            'data': {
+              'appCreate': {
+                'userErrors': [
+                  { 'field': 'app_url', 'message': 'is not a valid url' },
+                ],
+              },
+            },
+          }
+        )
+
+        err = assert_raises ShopifyCli::Abort do
+          Tasks::CreateApiClient.call(
+            @context,
+            org_id: 42,
+            title: 'Test app',
+            app_url: 'http://app.com',
+          )
+        end
+        assert_equal(err.message, "app_url is not a valid url")
+      end
+    end
+  end
+end

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -8,6 +8,7 @@ module TestHelpers
   autoload :FakeFS, 'test_helpers/fake_fs'
   autoload :FakeProject, 'test_helpers/fake_project'
   autoload :FakeUI, 'test_helpers/fake_ui'
+  autoload :Partners, 'test_helpers/partners'
   autoload :Project, 'test_helpers/project'
   autoload :Schema, 'test_helpers/schema'
 end

--- a/test/test_helpers/partners.rb
+++ b/test/test_helpers/partners.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module TestHelpers
+  module Partners
+    def setup
+      ShopifyCli::Helpers::Store.set(identity_exchange_token: 'faketoken')
+      super
+    end
+
+    def teardown
+      ShopifyCli::Helpers::Store.del(:identity_exchange_token)
+      super
+    end
+
+    def stub_partner_req(query, variables: {}, status: 200, resp: {})
+      stub_request(:post, "https://partners.shopify.com/api/cli/graphql").with(body: {
+          query: File.read(File.join(ShopifyCli::ROOT, "lib/graphql/#{query}.graphql")).tr("\n", ''),
+          variables: variables,
+      }.to_json).to_return(status: status, body: resp.to_json)
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Now that we have the integration with Partners Dashboard ready, this adds the ability to create and app on the Partners Dashboard and automatically get apiKey and secret then automatically adding it to the env file. It will also add a dev shop to the config as well if it is available so that the app can be installed easier.

This should set up an app ready to install and use right away.

### WHAT is this pull request doing?

SOOOOOO Much
- Extract input of the create command into a presenter/decorator to format our user inputs
- Add ApiClientCreate task to generate an app in the partners dash and call it from create
- Add writing of the env file to the create command with all of the collected information.

# Demo
![out](https://user-images.githubusercontent.com/463193/66683975-dd872c00-ec46-11e9-8192-ba6dc1199ad9.gif)
