### PR TITLE
Revert "Update path for authentication (#325)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ http://app-cli-loopback.shopifyapps.com:3456
 
 For Rails Apps:
 ```
-https://<LIVE_NGROK_URL>/login/shopify/callback
+https://<LIVE_NGROK_URL>/auth/shopify/callback
 http://app-cli-loopback.shopifyapps.com:3456
 ```
 


### PR DESCRIPTION
This reverts commit aa3552e80912d03d8ca91cd0fd65d8703ccb2306.

The `install` route is /login
the callback route still has auth