### PR TITLE
Fixing a no org situation for project create

### DIFF
--- a/lib/shopify-cli/forms.rb
+++ b/lib/shopify-cli/forms.rb
@@ -10,8 +10,13 @@ module ShopifyCli
           return nil if attrs.any? { |_k, v| v.nil? }
           @flag_arguments.each { |arg| attrs[arg] = flags[arg] }
           form = new(ctx, args, attrs)
-          form.ask
-          form
+          begin
+            form.ask
+            form
+          rescue ShopifyCli::Abort => err
+            ctx.puts(err.message)
+            nil
+          end
         end
 
         def positional_arguments(*args)

--- a/lib/shopify-cli/forms/create_app.rb
+++ b/lib/shopify-cli/forms/create_app.rb
@@ -45,7 +45,10 @@ module ShopifyCli
         @organiztion ||= begin
           if organization_id.nil?
             orgs = Helpers::Organizations.fetch_all(ctx)
-            if orgs.count == 1
+            if orgs.count == 0
+              ctx.puts('Please visit https://partners.shopify.com/ to create a partners account')
+              raise(ShopifyCli::Abort, 'No organizations available.')
+            elsif orgs.count == 1
               orgs.first
             else
               org_id = CLI::UI::Prompt.ask('Which organization do you want this app to belong to?') do |handler|

--- a/test/shopify-cli/forms/create_app_test.rb
+++ b/test/shopify-cli/forms/create_app_test.rb
@@ -57,7 +57,7 @@ module ShopifyCli
         assert_match('Invalid URL', io.join)
       end
 
-      def test_user_will_be_promted_if_more_than_one_organization
+      def test_user_will_be_prompted_if_more_than_one_organization
         stub_partner_req(
           'all_organizations',
           resp: {
@@ -125,6 +125,20 @@ module ShopifyCli
         form = ask(org_id: 123, shop: nil)
         assert_equal(form.organization_id, 123)
         assert_equal(form.shop_domain, 'shopdomain.myshopify.com')
+      end
+
+      def test_it_will_fail_if_no_orgs_are_available
+        stub_partner_req(
+          'all_organizations',
+          resp: { data: { organizations: { nodes: [] } } },
+        )
+
+        io = capture_io do
+          form = ask(org_id: nil, shop: nil)
+          assert_nil(form)
+        end
+        assert_match('Please visit https://partners.shopify.com/ to create a partners account', io.join)
+        assert_match('No organizations available.', io.join)
       end
 
       def test_returns_no_shop_if_none_are_available

--- a/test/shopify-cli/forms_test.rb
+++ b/test/shopify-cli/forms_test.rb
@@ -9,6 +9,7 @@ module ShopifyCli
       flag_arguments :three, :four
 
       def ask
+        raise ShopifyCli::Abort, 'I was asked to raise' if three == 'raise'
       end
     end
 
@@ -34,6 +35,18 @@ module ShopifyCli
         {}
       )
       assert_nil(form)
+    end
+
+    def test_that_the_form_returns_nil_if_shopify_abort_is_raised
+      io = capture_io do
+        form = TestForm.ask(
+          @context,
+          ['a', 'b', 'c', 'd'],
+          three: 'raise', four: 'two',
+        )
+        assert_nil(form)
+      end
+      assert_match('I was asked to raise', io.join)
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #344 

Create project crashes if the user has never signed into partners dash before and has access to no orgs

### WHAT is this pull request doing?
It adds a case to handle this but also a way to abort forms and output how they are invalid in a critical way.
