### PR TITLE
adds expectation of system call

### DIFF
--- a/test/shopify-cli/commands/serve_test.rb
+++ b/test/shopify-cli/commands/serve_test.rb
@@ -27,6 +27,7 @@ module ShopifyCli
           @context,
           'https://example.com',
         )
+        @context.expects(:system).with('a command')
         @command.call([], nil)
       end
     end


### PR DESCRIPTION
### WHAT is this pull request doing?

I've been having trouble while working on another PR that touches serve, because I keeping this error `sh: a: command not found` on a test.

It turns out this test was missing the expectation that system would be called so it was throwing it on master.