### PR TITLE
Updating create flow

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+You have not started your application. Try running `shopify serve` in your project to get started

--- a/lib/shopify-cli/app_types.rb
+++ b/lib/shopify-cli/app_types.rb
@@ -24,10 +24,6 @@ module ShopifyCli
       def build
         raise NotImplementedError
       end
-
-      def post_clone
-        "{{*}} Run {{command:shopify serve}} to start the local development server"
-      end
     end
   end
 end

--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -70,8 +70,6 @@ module ShopifyCli
         rescue Errno::ENOENT => e
           ctx.debug(e)
         end
-
-        puts CLI::UI.fmt(post_clone)
       end
 
       def check_dependencies

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -80,8 +80,6 @@ module ShopifyCli
         ShopifyCli::Finalize.request_cd(name)
 
         set_custom_ua
-
-        puts CLI::UI.fmt(post_clone)
       end
 
       def check_dependencies

--- a/lib/shopify-cli/commands/create/project.rb
+++ b/lib/shopify-cli/commands/create/project.rb
@@ -7,7 +7,6 @@ module ShopifyCli
         options do |parser, flags|
           parser.on('--title=TITLE') { |t| title[:title] = t }
           parser.on('--type=TYPE') { |t| flags[:type] = t.downcase.to_sym }
-          parser.on('--app_url=APPURL') { |url| flags[:app_url] = url }
           parser.on('--organization_id=ID') { |url| flags[:organization_id] = url }
           parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
         end
@@ -24,7 +23,7 @@ module ShopifyCli
             @ctx,
             org_id: form.organization_id,
             title: form.title,
-            app_url: form.app_url,
+            app_url: 'https://shopify.github.io/shopify-app-cli/getting-started',
           )
 
           Helpers::EnvFile.new(

--- a/lib/shopify-cli/commands/create/project.rb
+++ b/lib/shopify-cli/commands/create/project.rb
@@ -32,6 +32,12 @@ module ShopifyCli
             shop: form.shop_domain,
             scopes: 'write_products,write_customers,write_draft_orders',
           ).write(@ctx)
+
+          @ctx.puts("{{v}} {{green:#{form.title}}} was created in your Partners" \
+                    " Dashboard https://partners.shopify.com/#{form.organization_id}/apps/#{api_client['id']}")
+          @ctx.puts("{{v}} {{green:#{form.title}}} is ready to install on " \
+                    "{{green:#{form.shop_domain}}}") unless form.shop_domain.nil?
+          @ctx.puts("{{*}} Run {{cyan:shopify serve}} to start a local server and install {{green:#{form.title}}}")
         end
 
         def self.help

--- a/lib/shopify-cli/forms/create_app.rb
+++ b/lib/shopify-cli/forms/create_app.rb
@@ -5,12 +5,11 @@ module ShopifyCli
   module Forms
     class CreateApp < Form
       positional_arguments :name
-      flag_arguments :title, :type, :app_url, :organization_id, :shop_domain
+      flag_arguments :title, :type, :organization_id, :shop_domain
 
       def ask
         self.title ||= fallback_title
         self.type = ask_type
-        self.app_url = ask_app_url
         self.organization_id ||= organization["id"].to_i
         self.shop_domain ||= ask_shop_domain
       end
@@ -23,14 +22,6 @@ module ShopifyCli
           .capitalize
       end
 
-      def ask_app_url
-        while app_url !~ /\A#{URI::DEFAULT_PARSER.regexp[:ABS_URI]}\z/
-          ctx.puts('Invalid URL') unless app_url.nil?
-          self.app_url = CLI::UI::Prompt.ask('What is your Application URL?')
-        end
-        app_url
-      end
-
       def ask_type
         return type unless AppTypeRegistry[type.to_s.to_sym].nil?
         ctx.puts('Invalid App Type.') unless type.nil?
@@ -41,40 +32,43 @@ module ShopifyCli
         end
       end
 
+      def organizations
+        @organizations ||= Helpers::Organizations.fetch_all(ctx)
+      end
+
       def organization
-        @organiztion ||= begin
-          if organization_id.nil?
-            orgs = Helpers::Organizations.fetch_all(ctx)
-            if orgs.count == 0
-              ctx.puts('Please visit https://partners.shopify.com/ to create a partners account')
-              raise(ShopifyCli::Abort, 'No organizations available.')
-            elsif orgs.count == 1
-              orgs.first
-            else
-              org_id = CLI::UI::Prompt.ask('Which organization do you want this app to belong to?') do |handler|
-                orgs.each { |org| handler.option(org["businessName"]) { org["id"] } }
-              end
-              orgs.find { |org| org["id"] == org_id }
-            end
-          else
-            org = Helpers::Organizations.fetch(ctx, id: organization_id)
-            raise(ShopifyCli::Abort, "Cannot find an organization with that ID") if org.nil?
-            org
+        @organiztion ||= if !organization_id.nil?
+          org = Helpers::Organizations.fetch(ctx, id: organization_id)
+          raise(ShopifyCli::Abort, 'Cannot find an organization with that ID') if org.nil?
+          org
+        elsif organizations.count == 0
+          ctx.puts('Please visit https://partners.shopify.com/ to create a partners account')
+          raise(ShopifyCli::Abort, 'No organizations available.')
+        elsif organizations.count == 1
+          ctx.puts("Organization {{green:#{organizations.first['businessName']}}}")
+          organizations.first
+        else
+          org_id = CLI::UI::Prompt.ask('Which organization do you want this app to belong to?') do |handler|
+            organizations.each { |o| handler.option(o['businessName']) { o['id'] } }
           end
+          organizations.find { |o| o['id'] == org_id }
         end
       end
 
       def ask_shop_domain
         if organization['stores'].count == 0
           ctx.puts('No developement shops available.')
-          ctx.puts("Visit https://partners.shopify.com/#{organization['id']}/stores to create one")
-          return ""
+          ctx.puts("Visit {{green:https://partners.shopify.com/#{organization['id']}/stores}} to create one")
+        elsif organization['stores'].count == 1
+          domain = organization['stores'].first['shopDomain']
+          ctx.puts("Using development shop {{green:#{domain}}}")
+          domain
+        else
+          CLI::UI::Prompt.ask(
+            'Which development store would you like to work with?',
+            options: organization["stores"].map { |s| s["shopDomain"] }
+          )
         end
-        return organization['stores'].first['shopDomain'] if organization['stores'].count == 1
-        CLI::UI::Prompt.ask(
-          'Which development store would you like to work with?',
-          options: organization["stores"].map { |s| s["shopDomain"] }
-        )
       end
     end
   end

--- a/lib/shopify-cli/tasks/js_deps.rb
+++ b/lib/shopify-cli/tasks/js_deps.rb
@@ -6,7 +6,7 @@ module ShopifyCli
       include SmartProperties
 
       INSTALL_COMMANDS = {
-        yarn: %w(yarn),
+        yarn: %w(yarn install --silent),
         npm: %w(npm install --no-audit --no-optional --silent),
       }.freeze
 

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -17,15 +17,9 @@ module ShopifyCli
         @context.expects(:rm_r).with(File.join(@context.root, '.git'))
         @context.expects(:rm_r).with(File.join(@context.root, '.github'))
         @context.expects(:rm).with(File.join(@context.root, 'server', 'handlers', 'client.js'))
-        io = capture_io do
+        capture_io do
           @app.build('test-app')
         end
-        output = io.join
-
-        assert_match(
-          CLI::UI.fmt('{{*}} Run {{command:shopify serve}} to start the local development server'),
-          output
-        )
       end
 
       def test_check_dependencies_command

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -57,15 +57,9 @@ module ShopifyCli
           'stop',
           chdir: @context.root
         )
-        io = capture_io do
+        capture_io do
           @app.build('test-app')
         end
-        output = io.join
-
-        assert(
-          CLI::UI.fmt("{{*}} Run {{command:shopify serve}} to start the local development server"),
-          output
-        )
       end
 
       def test_check_dependencies_exits_if_incorrect_ruby_version

--- a/test/shopify-cli/commands/create/project_test.rb
+++ b/test/shopify-cli/commands/create/project_test.rb
@@ -21,7 +21,7 @@ module ShopifyCli
             variables: {
               org: 42,
               title: 'Test app',
-              app_url: 'http://app.com',
+              app_url: 'https://shopify.github.io/shopify-app-cli/getting-started',
               redir: ["http://app-cli-loopback.shopifyapps.com:3456"],
             },
             resp: {
@@ -61,7 +61,6 @@ module ShopifyCli
           run_cmd("create project \
             test-app \
             --type=node \
-            --app_url=http://app.com \
             --organization_id=42 \
             --shop_domain=testshop.myshopify.com")
         end

--- a/test/shopify-cli/task/js_deps_test.rb
+++ b/test/shopify-cli/task/js_deps_test.rb
@@ -24,7 +24,7 @@ module ShopifyCli
       def test_installs_with_yarn
         ShopifyCli::Tasks::JsDeps.any_instance.stubs(:installer).returns(:yarn)
         CLI::Kit::System.expects(:system).with(
-          'yarn',
+          'yarn', 'install', '--silent',
           chdir: @context.root
         ).returns(mock(success?: true))
         io = capture_io do


### PR DESCRIPTION
### WHY are these changes introduced?
After review, we realized we could make the app create flow a lot easier and more transparent.

### WHAT is this pull request doing?
- Output automatically selected Organization
- Output automatically selected Dev Store
- Added a getting-started page to be displayed as the application url incase `shopify serve` did not update the app url.
- Changed the app url in project create to be a link to that getting started url so that the user does not have to enter it.
- Added green highlights to the Org and Shop so that they stick out and any links that may need to be followed stick out as well.