### PR TITLE
Update .call methods to run_cmd in tests

### DIFF
--- a/lib/shopify-cli/commands/generate/webhook.rb
+++ b/lib/shopify-cli/commands/generate/webhook.rb
@@ -6,7 +6,7 @@ module ShopifyCli
       class Webhook < ShopifyCli::SubCommand
         def call(args, _name)
           project = ShopifyCli::Project.current
-          selected_type = args[1]
+          selected_type = args.first
           app_type = project.app_type
           schema = ShopifyCli::Helpers::SchemaParser.new(
             schema: ShopifyCli::Tasks::Schema.call(@ctx)

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -93,8 +93,6 @@ module ShopifyCli
     end
 
     class NodeTest < MiniTest::Test
-      include TestHelpers::Project
-      include TestHelpers::Constants
       include TestHelpers::FakeUI
 
       def setup
@@ -104,23 +102,22 @@ module ShopifyCli
       end
 
       def test_server_command
-        ShopifyCli::Tasks::Tunnel.stubs(:call)
-        ShopifyCli::Tasks::UpdateWhitelistURL.expects(:call)
+        Tasks::Tunnel.expects(:call).at_least_once
+        Tasks::UpdateWhitelistURL.expects(:call)
         @context.app_metadata[:host] = 'https://example.com'
-        cmd = ShopifyCli::Commands::Serve.new(@context)
         @context.expects(:system).with(
           "HOST=https://example.com PORT=8081 npm run dev"
         )
-        cmd.call([], nil)
+        run_cmd('serve')
       end
 
       def test_open_command
-        cmd = ShopifyCli::Commands::Open.new(@context)
-        cmd.expects(:open_url!).with(
+        Tasks::Tunnel.expects(:call)
+        Commands::Open.any_instance.expects(:open_url!).with(
           @context,
           'https://example.com/auth?shop=my-test-shop.myshopify.com'
         )
-        cmd.call([], nil)
+        run_cmd('open')
       end
     end
   end

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -87,8 +87,8 @@ module ShopifyCli
       end
 
       def test_server_command
-        ShopifyCli::Tasks::Tunnel.stubs(:call)
-        ShopifyCli::Tasks::UpdateWhitelistURL.expects(:call)
+        Tasks::Tunnel.expects(:call).at_least_once
+        Tasks::UpdateWhitelistURL.expects(:call)
         @context.expects(:system).with(
           "PORT=8081 bin/rails server"
         )
@@ -96,7 +96,7 @@ module ShopifyCli
       end
 
       def test_open_command
-        Tasks::Tunnel.stubs(:call)
+        Tasks::Tunnel.expects(:call).at_least_once
         Commands::Open.any_instance.expects(:open_url!).with(
           @context,
           'https://example.com/login?shop=my-test-shop.myshopify.com'

--- a/test/shopify-cli/commands/create_test.rb
+++ b/test/shopify-cli/commands/create_test.rb
@@ -3,21 +3,15 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class CreateTest < MiniTest::Test
-      def setup
-        super
-        @command = ShopifyCli::Commands::Create
-        @command.ctx = @context
-      end
-
       def test_without_arguments_calls_help
         @context.expects(:puts).with(ShopifyCli::Commands::Create.help)
-        @command.call([], nil)
+        run_cmd('create')
       end
 
       def test_with_project_calls_project
-        ShopifyCli::Commands::Create::Project.any_instance.expects(:call)
+        Create::Project.any_instance.expects(:call)
           .with(['new-app'], 'project')
-        @command.call(['project', 'new-app'], nil)
+        run_cmd('create project new-app')
       end
     end
   end

--- a/test/shopify-cli/commands/deploy/heroku_test.rb
+++ b/test/shopify-cli/commands/deploy/heroku_test.rb
@@ -21,19 +21,17 @@ module ShopifyCli
           @status_mock[:false].stubs(:success?).returns(false)
           @status_mock[:true].stubs(:success?).returns(true)
 
-          @command = Deploy::Heroku.new
-
           stub_successful_flow(os: :mac)
         end
 
         def test_call_doesnt_download_heroku_cli_if_it_is_installed
           @context.expects(:system)
             .with('curl', '-o', @download_path,
-              Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+              Deploy::Heroku::DOWNLOAD_URLS[:mac],
               chdir: ShopifyCli::ROOT)
             .never
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_downloads_heroku_cli_if_it_is_not_installed
@@ -41,11 +39,11 @@ module ShopifyCli
 
           @context.expects(:system)
             .with('curl', '-o', @download_path,
-              Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+              Deploy::Heroku::DOWNLOAD_URLS[:mac],
               chdir: ShopifyCli::ROOT)
             .returns(@status_mock[:true])
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_raises_if_heroku_cli_download_fails
@@ -54,11 +52,11 @@ module ShopifyCli
           assert_raises ShopifyCli::Abort do
             @context.expects(:system)
               .with('curl', '-o', @download_path,
-                Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+                Deploy::Heroku::DOWNLOAD_URLS[:mac],
                 chdir: ShopifyCli::ROOT)
               .returns(@status_mock[:false])
 
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -69,11 +67,11 @@ module ShopifyCli
           assert_raises ShopifyCli::Abort do
             @context.expects(:system)
               .with('curl', '-o', @download_path,
-                Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+                Deploy::Heroku::DOWNLOAD_URLS[:mac],
                 chdir: ShopifyCli::ROOT)
               .returns(@status_mock[:true])
 
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -82,7 +80,7 @@ module ShopifyCli
             .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
             .never
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_installs_heroku_cli_if_it_is_downloaded
@@ -92,7 +90,7 @@ module ShopifyCli
             .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
             .returns(@status_mock[:true])
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_raises_if_heroku_cli_install_fails
@@ -103,7 +101,7 @@ module ShopifyCli
               .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
               .returns(@status_mock[:false])
 
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -111,7 +109,7 @@ module ShopifyCli
           stub_git_init(status: false, commits: false)
 
           assert_raises ShopifyCli::Abort do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -119,7 +117,7 @@ module ShopifyCli
           stub_git_init(status: true, commits: false)
 
           assert_raises ShopifyCli::Abort do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -133,7 +131,7 @@ module ShopifyCli
           )
 
           capture_io do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -144,7 +142,7 @@ module ShopifyCli
             .with(@heroku_command, 'login')
             .returns(@status_mock[:true])
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_raises_if_heroku_auth_fails
@@ -152,7 +150,7 @@ module ShopifyCli
           stub_heroku_login(status: false)
 
           assert_raises ShopifyCli::Abort do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -166,7 +164,7 @@ module ShopifyCli
           )
 
           capture_io do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -185,7 +183,7 @@ module ShopifyCli
             .with(@heroku_command, 'git:remote', '-a', 'app-name')
             .returns(@status_mock[:true])
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_raises_if_choosing_existing_heroku_app_fails
@@ -204,7 +202,7 @@ module ShopifyCli
             .returns(@status_mock[:false])
 
           assert_raises ShopifyCli::Abort do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -228,7 +226,7 @@ module ShopifyCli
             .with('git', 'remote', 'add', 'heroku', @heroku_remote)
             .returns(@status_mock[:true])
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_raises_if_creating_new_heroku_app_fails
@@ -247,7 +245,7 @@ module ShopifyCli
             .never
 
           assert_raises ShopifyCli::Abort do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -272,7 +270,7 @@ module ShopifyCli
             .returns(@status_mock[:false])
 
           assert_raises ShopifyCli::Abort do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -286,7 +284,7 @@ module ShopifyCli
           )
 
           capture_io do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -301,7 +299,7 @@ module ShopifyCli
             .with('git', 'push', '-u', 'heroku', "other_branch:master")
             .returns(@status_mock[:true])
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_raises_if_finding_branches_fails
@@ -310,7 +308,7 @@ module ShopifyCli
             .returns(['', @status_mock[:false]])
 
           assert_raises ShopifyCli::Abort do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -319,7 +317,7 @@ module ShopifyCli
             .with('git', 'push', '-u', 'heroku', "master:master")
             .returns(@status_mock[:true])
 
-          @command.call(@context)
+          run_cmd('deploy heroku')
         end
 
         def test_call_raises_if_deploy_fails
@@ -328,7 +326,7 @@ module ShopifyCli
             .returns(@status_mock[:false])
 
           assert_raises ShopifyCli::Abort do
-            @command.call(@context)
+            run_cmd('deploy heroku')
           end
         end
 
@@ -407,7 +405,7 @@ module ShopifyCli
         def stub_heroku_downloaded(status:)
           @context.stubs(:system)
             .with('curl', '-o', @download_path,
-              Deploy::Heroku::DOWNLOAD_URLS[@command.os],
+              Deploy::Heroku::DOWNLOAD_URLS[:mac],
               chdir: ShopifyCli::ROOT)
             .returns(@status_mock[:"#{status}"])
         end
@@ -469,8 +467,7 @@ module ShopifyCli
         end
 
         def stub_os(os:)
-          @command.stubs(:os)
-            .returns(os)
+          Heroku.any_instance.stubs(:os).returns(os)
         end
       end
     end

--- a/test/shopify-cli/commands/generate/billing_test.rb
+++ b/test/shopify-cli/commands/generate/billing_test.rb
@@ -4,26 +4,20 @@ module ShopifyCli
   module Commands
     class Generate
       class BillingTest < MiniTest::Test
-        include TestHelpers::Project
         include TestHelpers::FakeUI
-
-        def setup
-          super
-          @command = ShopifyCli::Commands::Generate::Billing.new(@context)
-        end
 
         def test_recurring_billing
           CLI::UI::Prompt.expects(:ask).returns(:billing_recurring)
           @context.expects(:system).with('generate-recurring-billing')
             .returns(mock(success?: true))
-          @command.call(['billing'], nil)
+          run_cmd('generate billing')
         end
 
         def test_one_time_billing
           CLI::UI::Prompt.expects(:ask).returns(:billing_one_time)
           @context.expects(:system).with('generate-one-time-billing')
             .returns(mock(success?: true))
-          @command.call(['billing'], nil)
+          run_cmd('generate billing')
         end
       end
     end

--- a/test/shopify-cli/commands/generate/webhook_test.rb
+++ b/test/shopify-cli/commands/generate/webhook_test.rb
@@ -4,12 +4,7 @@ module ShopifyCli
   module Commands
     class Generate
       class WebhookTest < MiniTest::Test
-        include TestHelpers::Project
-
-        def setup
-          super
-          @command = ShopifyCli::Commands::Generate::Webhook.new(@context)
-        end
+        include TestHelpers::FakeUI
 
         def test_with_param
           ShopifyCli::Tasks::Schema.expects(:call).returns(
@@ -17,7 +12,7 @@ module ShopifyCli
           )
           @context.expects(:system).with('a command')
             .returns(mock(success?: true))
-          @command.call(['webhook', 'PRODUCT_CREATE'], nil)
+          run_cmd('generate webhook PRODUCT_CREATE')
         end
 
         def test_with_selection
@@ -27,7 +22,7 @@ module ShopifyCli
           CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
           @context.expects(:system).with('a command')
             .returns(mock(success?: true))
-          @command.call(['webhook'], nil)
+          run_cmd('generate webhook')
         end
       end
     end

--- a/test/shopify-cli/commands/populate/customer_test.rb
+++ b/test/shopify-cli/commands/populate/customer_test.rb
@@ -21,12 +21,11 @@ module ShopifyCli
             .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/customer_data.json'))))
           ShopifyCli::API.expects(:gid_to_id).returns(12345678)
           Resource.any_instance.stubs(:price).returns('1.00')
-          @resource = Customer.new(@context)
           @context.expects(:done).with(
             "first last added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/customers/12345678}}"
           )
-          @resource.call(['-c 1'], nil)
+          run_cmd('populate customers -c 1')
         end
       end
     end

--- a/test/shopify-cli/commands/populate/draft_order_test.rb
+++ b/test/shopify-cli/commands/populate/draft_order_test.rb
@@ -26,12 +26,11 @@ module ShopifyCli
             .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/draft_order_data.json'))))
           ShopifyCli::API.expects(:gid_to_id).returns(12345678)
           Resource.any_instance.stubs(:price).returns('1.00')
-          @resource = DraftOrder.new(@context)
           @context.expects(:done).with(
             "DraftOrders added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/draft_orders/12345678}}"
           )
-          @resource.call(['-c 1'], nil)
+          run_cmd('populate draftorders -c 1')
         end
       end
     end

--- a/test/shopify-cli/commands/tunnel_test.rb
+++ b/test/shopify-cli/commands/tunnel_test.rb
@@ -3,23 +3,19 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class TunnelTest < MiniTest::Test
-      def setup
-        @command = ShopifyCli::Commands::Tunnel.new
-      end
-
       def test_auth
         ShopifyCli::Tasks::Tunnel.any_instance.expects(:auth)
-        @command.call(['auth'], nil)
+        run_cmd('tunnel auth')
       end
 
       def test_start
         ShopifyCli::Tasks::Tunnel.any_instance.expects(:call)
-        @command.call(['start'], nil)
+        run_cmd('tunnel start')
       end
 
       def test_stop
         ShopifyCli::Tasks::Tunnel.any_instance.expects(:stop)
-        @command.call(['stop'], nil)
+        run_cmd('tunnel stop')
       end
 
       def test_stop_rescues
@@ -27,7 +23,7 @@ module ShopifyCli
         ShopifyCli::Helpers::ProcessSupervision.stubs(:stop).with(:ngrok).raises
 
         io = capture_io do
-          @command.call(['stop'], nil)
+          run_cmd('tunnel stop')
         end
         output = io.join
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

Follows up #355 by updating all remaining tests referencing `Command.call` to use `run_cmd`. Bonus found an issue with `generate webhook` not finding an argument correctly.