### PR TITLE
Silence npm install and output number of deps

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -67,7 +67,7 @@ module ShopifyCli
       def build(name)
         ShopifyCli::Tasks::Clone.call('https://github.com/Shopify/shopify-app-node.git', name)
         ShopifyCli::Finalize.request_cd(name)
-        ShopifyCli::Tasks::JsDeps.call(ctx.root)
+        ShopifyCli::Tasks::JsDeps.call(ctx)
 
         begin
           ctx.rm_r(File.join(ctx.root, '.git'))

--- a/lib/shopify-cli/tasks/js_deps.rb
+++ b/lib/shopify-cli/tasks/js_deps.rb
@@ -3,16 +3,19 @@ require 'shopify_cli'
 module ShopifyCli
   module Tasks
     class JsDeps < ShopifyCli::Task
+      include SmartProperties
+
       INSTALL_COMMANDS = {
         yarn: %w(yarn),
-        npm: %w(npm install --no-optional),
+        npm: %w(npm install --no-audit --no-optional --silent),
       }.freeze
 
-      def call(*args)
-        @dir = args.shift || Dir.pwd
+      def call(ctx)
+        @ctx = ctx
+        @dir = ctx.root
 
         CLI::UI::Frame.open("Installing dependencies with #{installer}...") do
-          install_progress
+          send(installer)
         end
         puts CLI::UI.fmt("{{v}} Dependencies installed")
       end
@@ -26,7 +29,7 @@ module ShopifyCli
         CLI::Kit::System.system('which', 'yarn').success?
       end
 
-      def install_progress
+      def yarn
         success = CLI::Kit::System.system(*INSTALL_COMMANDS[installer], chdir: @dir) do |out, err|
           puts out
           err.lines.each do |e|
@@ -35,6 +38,27 @@ module ShopifyCli
         end.success?
         return false unless success
         true
+      end
+
+      def npm
+        package_json = File.join(@dir, 'package.json')
+        pkg = begin
+                JSON.parse(File.read(package_json))
+              rescue Errno::ENOENT, Errno::ENOTDIR
+                raise(ShopifyCli::Abort, "expected to have a file at: #{package_json}")
+              end
+
+        deps = %w(dependencies devDependencies).map do |key|
+          pkg.fetch(key, []).keys
+        end.flatten
+        @ctx.puts("Installing #{deps.size} dependencies")
+        CLI::Kit::System.system(*INSTALL_COMMANDS[installer], chdir: @dir)
+      rescue JSON::ParserError
+        ctx.puts(
+          "{{info:#{File.read(File.join(path, 'package.json'))}}} was not valid JSON. Fix this then try again",
+          error: true
+        )
+        raise ShopifyCli::AbortSilent
       end
     end
   end

--- a/test/fixtures/app_types/node/package.json
+++ b/test/fixtures/app_types/node/package.json
@@ -1,0 +1,43 @@
+{
+  "dependencies": {
+    "@babel/core": "7.6.4",
+    "@babel/polyfill": "^7.6.0",
+    "@babel/preset-env": "^7.6.2",
+    "@babel/register": "^7.6.2",
+    "@shopify/app-bridge-react": "^1.6.8",
+    "@shopify/app-cli-node-generator-helper": "^1.1.2",
+    "@shopify/koa-shopify-auth": "^3.1.41",
+    "@shopify/koa-shopify-graphql-proxy": "^3.1.2",
+    "@shopify/koa-shopify-webhooks": "^2.0.0",
+    "@shopify/polaris": "^4.7.1",
+    "@zeit/next-css": "^1.0.1",
+    "apollo-boost": "^0.4.4",
+    "dotenv": "^8.2.0",
+    "graphql": "^14.5.8",
+    "isomorphic-fetch": "^2.1.1",
+    "js-cookie": "^2.2.1",
+    "koa": "^2.8.2",
+    "koa-router": "^7.4.0",
+    "koa-session": "^5.12.3",
+    "next": "^8.1.0",
+    "next-env": "^1.1.0",
+    "react": "^16.10.1",
+    "react-apollo": "^2.5.8",
+    "react-dom": "^16.10.1"
+  },
+  "devDependencies": {
+    "@babel/plugin-transform-runtime": "^7.6.2",
+    "@babel/preset-stage-3": "^7.0.0",
+    "babel-jest": "24.9.0",
+    "babel-register": "^6.26.0",
+    "enzyme": "3.10.0",
+    "enzyme-adapter-react-16": "1.15.1",
+    "husky": "^3.0.9",
+    "jest": "24.9.0",
+    "lint-staged": "^9.4.2",
+    "nodemon": "^1.19.3",
+    "prettier": "1.18.2",
+    "react-addons-test-utils": "15.6.2",
+    "react-test-renderer": "16.11.0"
+  }
+}

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -13,7 +13,7 @@ module ShopifyCli
           'https://github.com/Shopify/shopify-app-node.git',
           'test-app',
         )
-        ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
+        ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context)
         @context.expects(:rm_r).with(File.join(@context.root, '.git'))
         @context.expects(:rm_r).with(File.join(@context.root, '.github'))
         @context.expects(:rm).with(File.join(@context.root, 'server', 'handlers', 'client.js'))
@@ -85,7 +85,7 @@ module ShopifyCli
           'https://github.com/Shopify/shopify-app-node.git',
           'test-app',
         )
-        ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
+        ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context)
         capture_io do
           @app.build('test-app')
         end

--- a/test/shopify-cli/task/js_deps_test.rb
+++ b/test/shopify-cli/task/js_deps_test.rb
@@ -10,14 +10,15 @@ module ShopifyCli
       def test_installs_with_npm
         ShopifyCli::Tasks::JsDeps.any_instance.stubs(:installer).returns(:npm)
         CLI::Kit::System.expects(:system).with(
-          'npm', 'install', '--no-optional',
+          'npm', 'install', '--no-audit', '--no-optional', '--silent',
           chdir: @context.root,
-        ).returns(mock(success?: true))
+        )
         io = capture_io do
-          ShopifyCli::Tasks::JsDeps.call(@context.root)
+          ShopifyCli::Tasks::JsDeps.call(@context)
         end
         output = io.join
         assert_match('Installing dependencies with npm...', output)
+        assert_match('Installing 37 dependencies', output)
       end
 
       def test_installs_with_yarn
@@ -27,7 +28,7 @@ module ShopifyCli
           chdir: @context.root
         ).returns(mock(success?: true))
         io = capture_io do
-          ShopifyCli::Tasks::JsDeps.call(@context.root)
+          ShopifyCli::Tasks::JsDeps.call(@context)
         end
         output = io.join
         assert_match('Installing dependencies with yarn...', output)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

`npm install` is unnecessarily noisy.

Fixes #264 
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Parses the package.json file and shows a number of dependencies the tool is installing.

<img width="661" alt="Screen Shot 2019-11-05 at 3 57 09 PM" src="https://user-images.githubusercontent.com/73874/68245809-8fffa400-ffe5-11e9-9ca3-aedf1aca2422.png">

