### PR TITLE
add ux details to auth task

### DIFF
--- a/lib/shopify-cli/commands/authenticate.rb
+++ b/lib/shopify-cli/commands/authenticate.rb
@@ -10,18 +10,16 @@ module ShopifyCli
           case command
           when 'identity'
             run_task(ShopifyCli::Tasks::AuthenticateIdentity.call(@ctx))
-          else
-            opt = ask_for_auth
+          when 'shop'
+            opt = CLI::UI::Prompt.confirm('Open default browser to authenticate with the Partner Dashboard?')
             opt ? run_task(ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)) : abort
+          else
+            @ctx.puts(self.class.help)
           end
         rescue OAuth::Error
           @ctx.puts("{{error:Failed to Authenticate}}")
           raise(::ShopifyCli::Abort, "Failed to Authenticate")
         end
-      end
-
-      def ask_for_auth
-        CLI::UI::Prompt.confirm('Open default browser to authenticate with the Partner Dashboard?')
       end
 
       def run_task(task_to_run)
@@ -33,8 +31,8 @@ module ShopifyCli
 
       def self.help
         <<~HELP
-          Request a new access token from the Shopify Admin API.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} authenticate}}
+          Request a new access token for Shop or App creation.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} authenticate shop || identity}}
         HELP
       end
     end

--- a/lib/shopify-cli/commands/authenticate.rb
+++ b/lib/shopify-cli/commands/authenticate.rb
@@ -6,19 +6,28 @@ module ShopifyCli
       def call(args, _name)
         command = args.shift
         ShopifyCli::Tasks::EnsureLoopbackURL.call(@ctx)
-        CLI::UI::Spinner.spin("Requesting access token...") do |spinner|
-          begin
-            case command
-            when 'identity'
-              ShopifyCli::Tasks::AuthenticateIdentity.call(@ctx)
-            else
-              ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)
-            end
-            spinner.update_title("Authetication token stored")
-          rescue OAuth::Error
-            @ctx.puts("{{error:Failed to Authenticate}}")
-            raise(::ShopifyCli::Abort, "Failed to Authenticate")
+        begin
+          case command
+          when 'identity'
+            run_task(ShopifyCli::Tasks::AuthenticateIdentity.call(@ctx))
+          else
+            opt = ask_for_auth
+            opt ? run_task(ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)) : abort
           end
+        rescue OAuth::Error
+          @ctx.puts("{{error:Failed to Authenticate}}")
+          raise(::ShopifyCli::Abort, "Failed to Authenticate")
+        end
+      end
+
+      def ask_for_auth
+        CLI::UI::Prompt.confirm('Open default browser to authenticate with the Partner Dashboard?')
+      end
+
+      def run_task(task_to_run)
+        CLI::UI::Spinner.spin("Waiting to authenticate") do |spinner|
+          spinner.update_title("Authetication token stored")
+          task_to_run
         end
       end
 


### PR DESCRIPTION
This adds a prompt to ensure the user wants to auth against admin as per our figma mocks.

I did not add this ability to identity, I wasn't sure if we wanted to surface that as part of the command?

If we do, I can update this task to be a bit more simple and add information to help about this.