### PR TITLE
Fix resource titles in populate

### DIFF
--- a/lib/shopify-cli/commands/populate/customer.rb
+++ b/lib/shopify-cli/commands/populate/customer.rb
@@ -8,8 +8,10 @@ module ShopifyCli
 
         def defaults
           first_name, last_name = Helpers::Haikunator.name
-          @input.firstName = first_name
-          @input.lastName = last_name
+          {
+            firstName: first_name,
+            lastName: last_name,
+          }
         end
 
         def message(data)

--- a/lib/shopify-cli/commands/populate/draft_order.rb
+++ b/lib/shopify-cli/commands/populate/draft_order.rb
@@ -7,12 +7,14 @@ module ShopifyCli
         @input_type = :DraftOrderInput
 
         def defaults
-          @input.lineItems = [{
-            originalUnitPrice: price,
-            quantity: 1,
-            weight: { value: 10, unit: 'GRAMS' },
-            title: Helpers::Haikunator.title,
-          }]
+          {
+            lineItems: [{
+              originalUnitPrice: price,
+              quantity: 1,
+              weight: { value: 10, unit: 'GRAMS' },
+              title: Helpers::Haikunator.title,
+            }],
+          }
         end
 
         def message(data)

--- a/lib/shopify-cli/commands/populate/product.rb
+++ b/lib/shopify-cli/commands/populate/product.rb
@@ -7,8 +7,10 @@ module ShopifyCli
         @input_type = :ProductInput
 
         def defaults
-          @input.title = Helpers::Haikunator.title
-          @input.variants = [{ price: price }]
+          {
+            title: Helpers::Haikunator.title,
+            variants: [{ price: price }],
+          }
         end
 
         def message(data)

--- a/lib/shopify-cli/commands/populate/resource.rb
+++ b/lib/shopify-cli/commands/populate/resource.rb
@@ -15,10 +15,9 @@ module ShopifyCli
 
         def call(args, _)
           @args = args
-          @input = OpenStruct.new
+          @input = Hash.new
           @count = DEFAULT_COUNT
           input_options
-          defaults
           resource_options.parse(@args)
           if @silent
             spin_group = CLI::UI::SpinGroup.new
@@ -58,7 +57,9 @@ module ShopifyCli
         end
 
         def populate
-          @count.times { run_mutation }
+          @count.times do
+            run_mutation(defaults.merge(@input))
+          end
         end
 
         def input_options
@@ -80,8 +81,8 @@ module ShopifyCli
           @schema ||= ShopifyCli::Helpers::SchemaParser.new(schema: @ctx.app_metadata[:schema])
         end
 
-        def run_mutation
-          resp = Helpers::AdminAPI.query(@ctx, "create_#{resource_type}", input: @input.to_h)
+        def run_mutation(data)
+          resp = Helpers::AdminAPI.query(@ctx, "create_#{resource_type}", input: data)
           raise(ShopifyCli::Abort, resp['errors']) if resp['errors']
           @ctx.done(message(resp['data'])) unless @silent
         end

--- a/test/shopify-cli/commands/populate/product_test.rb
+++ b/test/shopify-cli/commands/populate/product_test.rb
@@ -12,20 +12,28 @@ module ShopifyCli
         end
 
         def test_populate_calls_api_with_mutation
-          Helpers::Haikunator.stubs(:title).returns('fake product')
+          Helpers::Haikunator.expects(:title).returns('fake product')
+          Helpers::Haikunator.expects(:title).returns('fake producttwo')
           Resource.any_instance.stubs(:price).returns('1.00')
+          return_data = JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/product_data.json')))
           ShopifyCli::Helpers::AdminAPI.expects(:query)
             .with(@context, 'create_product', input: {
-              title: 'fake product',
+              'title': 'fake product',
               variants: [{ price: '1.00' }],
             })
-            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/product_data.json'))))
-          ShopifyCli::API.expects(:gid_to_id).returns(12345678)
+            .returns(return_data)
+          ShopifyCli::Helpers::AdminAPI.expects(:query)
+            .with(@context, 'create_product', input: {
+              'title': 'fake producttwo',
+              variants: [{ price: '1.00' }],
+            })
+            .returns(return_data)
+          ShopifyCli::API.expects(:gid_to_id).returns(12345678).twice
           @context.expects(:done).with(
             "fake product added to {{green:my-test-shop.myshopify.com}} at" \
             " {{underline:https://my-test-shop.myshopify.com/admin/products/12345678}}"
-          )
-          run_cmd('populate products -c 1')
+          ).twice
+          run_cmd('populate products -c 2')
         end
       end
     end

--- a/test/shopify-cli/commands/populate/resource_test.rb
+++ b/test/shopify-cli/commands/populate/resource_test.rb
@@ -19,8 +19,8 @@ module ShopifyCli
           @resource.call([
             '-c 1', '--title="bad jeggings"', '--variants=[{price: "4.99"}]'
           ], nil)
-          assert_equal('"bad jeggings"', @resource.input.title)
-          assert_equal('[{price: "4.99"}]', @resource.input.variants)
+          assert_equal('"bad jeggings"', @resource.input['title'])
+          assert_equal('[{price: "4.99"}]', @resource.input['variants'])
         end
 
         def test_populate_runs_mutation_default_number_of_times


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Default values for resources were being calculated at command call time and not per mutation, which means that products get generated with the same title by default and not randomized. This updates the structure of the `defaults` method to return a hash that gets merged into the mutation data during each iteration.

Fixes #372  <!-- link to issue if one exists -->
