### PR TITLE
add global help flags

### DIFF
--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -19,6 +19,7 @@ module ShopifyCli
           cmd.ctx = @ctx
           cmd.options = Options.new
           cmd.options.parse(@_options, args)
+          return @ctx.puts(cmd.class.help) if cmd.options.help
           cmd.call(args, command_name)
         end
       end

--- a/lib/shopify-cli/options.rb
+++ b/lib/shopify-cli/options.rb
@@ -6,10 +6,11 @@ module ShopifyCli
   class Options
     include SmartProperties
 
-    attr_reader :flags, :subcommand
+    attr_reader :flags, :subcommand, :help
 
     def initialize
       @flags = {}
+      @help = false
     end
 
     def parse(options_block, args)
@@ -24,7 +25,12 @@ module ShopifyCli
     end
 
     def parser
-      @parser ||= OptionParser.new
+      @parser ||= begin
+        opt = OptionParser.new
+        opt.on('--help', '-h', 'Print help for command') do
+          @help = true
+        end
+      end
     end
   end
 end

--- a/lib/shopify-cli/sub_command.rb
+++ b/lib/shopify-cli/sub_command.rb
@@ -8,6 +8,7 @@ module ShopifyCli
         cmd = new(@ctx)
         cmd.options = Options.new
         args = cmd.options.parse(@_options, args[1..-1] || [])
+        return @ctx.puts(cmd.class.help) if cmd.options.help
         cmd.call(args, command_name)
       end
     end

--- a/test/shopify-cli/commands/command_test.rb
+++ b/test/shopify-cli/commands/command_test.rb
@@ -12,6 +12,22 @@ module ShopifyCli
 
         assert_match(/foobar.*was not found/, io.join)
       end
+
+      def test_calls_help_with_h_flag
+        io = capture_io do
+          run_cmd('create -h')
+        end
+
+        assert_match(CLI::UI.fmt(Create.help), io.join)
+      end
+
+      def test_calls_help_with_subcommand_h_flag
+        io = capture_io do
+          run_cmd('create project -h')
+        end
+
+        assert_match(CLI::UI.fmt(Create::Project.help), io.join)
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Adds a help flag to the default OptionsParser, which means it gets added to every command and subcommand.

Fixes #321  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->
