### PR TITLE
Abort cleanly when ngrok tunnel cannot be stopped

### DIFF
--- a/lib/shopify-cli/tasks/tunnel.rb
+++ b/lib/shopify-cli/tasks/tunnel.rb
@@ -31,7 +31,10 @@ module ShopifyCli
             pid_file&.unlink_log
             @ctx.puts("{{green:x}} ngrok tunnel stopped")
           rescue
-            @ctx.puts("{{red:x}} ngrok tunnel could not be stopped. Try running {{command:killall -9 ngrok}}")
+            raise(
+              ShopifyCli::Abort,
+              '{{red:x}} ngrok tunnel could not be stopped. Try running {{command:killall -9 ngrok}}'
+            )
           end
         else
           @ctx.puts("{{green:x}} ngrok tunnel not running")

--- a/test/shopify-cli/commands/tunnel_test.rb
+++ b/test/shopify-cli/commands/tunnel_test.rb
@@ -17,18 +17,6 @@ module ShopifyCli
         ShopifyCli::Tasks::Tunnel.any_instance.expects(:stop)
         run_cmd('tunnel stop')
       end
-
-      def test_stop_rescues
-        ShopifyCli::Helpers::ProcessSupervision.stubs(:running?).with(:ngrok).returns(true)
-        ShopifyCli::Helpers::ProcessSupervision.stubs(:stop).with(:ngrok).raises
-
-        io = capture_io do
-          run_cmd('tunnel stop')
-        end
-        output = io.join
-
-        assert_match(/could not be stopped/, output)
-      end
     end
   end
 end

--- a/test/shopify-cli/task/tunnel_test.rb
+++ b/test/shopify-cli/task/tunnel_test.rb
@@ -71,6 +71,14 @@ module ShopifyCli
         Tunnel.new.stop(@context)
       end
 
+      def test_start_raises_error_when_ngrok_cannot_be_stopped
+        ShopifyCli::Helpers::ProcessSupervision.stubs(:running?).with(:ngrok).returns(true)
+        ShopifyCli::Helpers::ProcessSupervision.stubs(:stop).with(:ngrok).raises
+        assert_raises(ShopifyCli::Abort) do
+          Tunnel.new.stop(@context)
+        end
+      end
+
       def with_log(fixture = 'ngrok')
         log_path = File.join(ShopifyCli::ROOT, "test/fixtures/#{fixture}.log")
         pid_file = ShopifyCli::Helpers::PidFile.new(:ngrok, pid: 40000)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

If you are switching back and forth between `load-dev` and `load-system` the CLI can't keep track of the PID for ngrok easily, so it will throw a long traceback about multiple tunnels being run. I don't want to run something like `killall` behind the user's back so we'll just show a clean error instead.

<img width="476" alt="Screen Shot 2019-11-12 at 2 36 49 PM" src="https://user-images.githubusercontent.com/73874/68704382-37d31f80-055a-11ea-843f-7e0ccf24c953.png">