### PR TITLE
removes space in gsub

### DIFF
--- a/lib/shopify-cli/forms/create_app.rb
+++ b/lib/shopify-cli/forms/create_app.rb
@@ -17,7 +17,7 @@ module ShopifyCli
       private
 
       def fallback_title
-        name.gsub(/(.)([A-Z])/, '\1 \2') # change camelcase to title
+        name.gsub(/(.)([A-Z])/, '\1\2') # change camelcase to title
           .gsub(/(-|_)/, ' ') # change snakecase to title
           .capitalize
       end

--- a/test/shopify-cli/forms/create_app_test.rb
+++ b/test/shopify-cli/forms/create_app_test.rb
@@ -15,6 +15,15 @@ module ShopifyCli
         assert_equal(form.shop_domain, 'shop.myshopify.com')
       end
 
+      def test_transforms_uppercase_titles_properly
+        form = ask_uppercase
+        assert_equal(form.name, 'TEST-APP')
+        assert_equal(form.title, 'Test app')
+        assert_equal(form.type, 'node')
+        assert_equal(form.organization_id, 42)
+        assert_equal(form.shop_domain, 'shop.myshopify.com')
+      end
+
       def test_title_can_be_provided_by_flag
         form = ask
         assert_equal(form.name, 'test-app')
@@ -211,6 +220,17 @@ module ShopifyCli
       private
 
       def ask(name: 'test-app', title: nil, type: 'node', org_id: 42, shop: 'shop.myshopify.com')
+        CreateApp.ask(
+          @context,
+          [name],
+          title: title,
+          type: type,
+          organization_id: org_id,
+          shop_domain: shop,
+        )
+      end
+
+      def ask_uppercase(name: 'TEST-APP', title: nil, type: 'node', org_id: 42, shop: 'shop.myshopify.com')
         CreateApp.ask(
           @context,
           [name],


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #388  <!-- link to issue if one exists -->

The space in this regex was causing capitalized titles to print with spaces in them. 