### PR TITLE
fix help output when no command is given

### DIFF
--- a/lib/shopify-cli/help_resolver.rb
+++ b/lib/shopify-cli/help_resolver.rb
@@ -4,6 +4,7 @@ module ShopifyCli
   class HelpResolver < CLI::Kit::Resolver
     def call(args)
       args = args.dup
+      return super(args) unless args.first
       if args.first.include?('-h') || args.first.include?('--help')
         help = Commands::Help
         help.ctx = Context.new

--- a/test/shopify-cli/help_resolver_test.rb
+++ b/test/shopify-cli/help_resolver_test.rb
@@ -8,5 +8,10 @@ module ShopifyCli
         run_cmd('-h')
       end
     end
+
+    def test_outputs_help_without_argument
+      ShopifyCli::Commands::Help.expects(:call)
+      run_cmd('')
+    end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Displaying help output when no command is given.
