### PR TITLE
Fixing fallback app title replacements

### DIFF
--- a/lib/shopify-cli/forms/create_app.rb
+++ b/lib/shopify-cli/forms/create_app.rb
@@ -17,7 +17,8 @@ module ShopifyCli
       private
 
       def fallback_title
-        name.gsub(/(.)([A-Z])/, '\1\2') # change camelcase to title
+        name.gsub(/([A-Z]+)([A-Z][a-z])/, '\1 \2')
+          .gsub(/([a-z\d])([A-Z])/, '\1 \2') # change camelcase to title
           .gsub(/(-|_)/, ' ') # change snakecase to title
           .capitalize
       end

--- a/test/shopify-cli/forms/create_app_test.rb
+++ b/test/shopify-cli/forms/create_app_test.rb
@@ -15,13 +15,20 @@ module ShopifyCli
         assert_equal(form.shop_domain, 'shop.myshopify.com')
       end
 
-      def test_transforms_uppercase_titles_properly
-        form = ask_uppercase
-        assert_equal(form.name, 'TEST-APP')
-        assert_equal(form.title, 'Test app')
-        assert_equal(form.type, 'node')
-        assert_equal(form.organization_id, 42)
-        assert_equal(form.shop_domain, 'shop.myshopify.com')
+      def test_transforms_fallback_titles_properly
+        title_tests = {
+          'TEST-APP1' => 'Test app1',
+          'testApp2' => 'Test app2',
+          'TestApp3' => 'Test app3',
+          'test_app4' => 'Test app4',
+          'testAPI5' => 'Test api5',
+          'TESTApp6' => 'Test app6',
+        }
+
+        title_tests.each do |input, expected|
+          form = ask(name: input)
+          assert_equal(form.title, expected)
+        end
       end
 
       def test_title_can_be_provided_by_flag
@@ -220,17 +227,6 @@ module ShopifyCli
       private
 
       def ask(name: 'test-app', title: nil, type: 'node', org_id: 42, shop: 'shop.myshopify.com')
-        CreateApp.ask(
-          @context,
-          [name],
-          title: title,
-          type: type,
-          organization_id: org_id,
-          shop_domain: shop,
-        )
-      end
-
-      def ask_uppercase(name: 'TEST-APP', title: nil, type: 'node', org_id: 42, shop: 'shop.myshopify.com')
         CreateApp.ask(
           @context,
           [name],

--- a/test/shopify-cli/forms/create_app_test.rb
+++ b/test/shopify-cli/forms/create_app_test.rb
@@ -23,6 +23,7 @@ module ShopifyCli
           'test_app4' => 'Test app4',
           'testAPI5' => 'Test api5',
           'TESTApp6' => 'Test app6',
+          'INCAPS' => 'Incaps',
         }
 
         title_tests.each do |input, expected|


### PR DESCRIPTION
### WHY are these changes introduced?
There was an issue with screaming case titles https://github.com/Shopify/shopify-app-cli/issues/388

This appropriately fixes this issue so that the fallback title will work with SCREAM_CASE, camelCase, snake_case and kebab-case

### WHAT is this pull request doing?
I actually stole most of the implementation here from rails active support's `to_underscore` so it should work in most cases because it has been used for quite some time.