### PR TITLE
implement an AppType-aware command

### DIFF
--- a/lib/shopify-cli/app_type_command.rb
+++ b/lib/shopify-cli/app_type_command.rb
@@ -3,23 +3,27 @@ require 'shopify_cli'
 module ShopifyCli
   class AppTypeCommand < ShopifyCli::Command
     class << self
-      def type(identifier, const, path)
+      def app_type(identifier, const, path)
         autoload(const, "shopify-cli/commands/#{path}") if path
-        lookup[self] ||= {}
-        lookup[self][identifier] = const_get(const)
+        app_type_lookup[self] ||= {}
+        app_type_lookup[self][identifier] = const_get(const)
       end
 
-      def lookup
-        @lookup ||= {}
+      def app_type_lookup
+        @app_type_lookup ||= {}
       end
     end
 
-    def call(*args)
+    def call(args, command_name)
       project = Project.current
-      cmd = self.class.lookup[self.class][project.app_type_id].new
+      cmd_klass = self.class.app_type_lookup[self.class][project.app_type_id]
+      unless cmd_klass
+        @ctx.error("{{command:#{command_name}}} not supported in #{project.app_type_id} apps}}")
+      end
+      cmd = cmd_klass.new
       cmd.ctx = @ctx
       cmd.options = options
-      cmd.call(*args)
+      cmd.call(args, command_name)
     end
   end
 end

--- a/lib/shopify-cli/app_type_command.rb
+++ b/lib/shopify-cli/app_type_command.rb
@@ -1,0 +1,25 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  class AppTypeCommand < ShopifyCli::Command
+    class << self
+      def type(identifier, const, path)
+        autoload(const, "shopify-cli/commands/#{path}") if path
+        lookup[self] ||= {}
+        lookup[self][identifier] = const_get(const)
+      end
+
+      def lookup
+        @lookup ||= {}
+      end
+    end
+
+    def call(*args)
+      project = Project.current
+      cmd = self.class.lookup[self.class][project.app_type_id].new
+      cmd.ctx = @ctx
+      cmd.options = options
+      cmd.call(*args)
+    end
+  end
+end

--- a/lib/shopify-cli/app_types.rb
+++ b/lib/shopify-cli/app_types.rb
@@ -12,10 +12,6 @@ module ShopifyCli
           raise NotImplementedError
         end
 
-        def serve_command
-          raise NotImplementedError
-        end
-
         def generate
           raise NotImplementedError
         end

--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -8,13 +8,6 @@ module ShopifyCli
           'node embedded app'
         end
 
-        def serve_command(_ctx)
-          %W(
-            PORT=#{ShopifyCli::Tasks::Tunnel::PORT}
-            npm run dev
-          ).join(' ')
-        end
-
         def generate
           {
             empty_state: './node_modules/.bin/generate-node-app empty-state-page',

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -20,11 +20,6 @@ module ShopifyCli
           }
         end
 
-        def serve_command(ctx)
-          Helpers::Gem.gem_home(ctx)
-          "PORT=#{ShopifyCli::Tasks::Tunnel::PORT} bin/rails server"
-        end
-
         def generate_command(selected_type)
           parts = selected_type.downcase.split("_")
           selected_type = parts[0..-2].join("_") + "/" + parts[-1]

--- a/lib/shopify-cli/commands/serve.rb
+++ b/lib/shopify-cli/commands/serve.rb
@@ -4,7 +4,10 @@ require 'shopify_cli'
 
 module ShopifyCli
   module Commands
-    class Serve < ShopifyCli::Command
+    class Serve < ShopifyCli::AppTypeCommand
+      type :node, :ServeNode, 'serve/node'
+      type :rails, :ServeRails, 'serve/rails'
+
       include ShopifyCli::Helpers::OS
       prerequisite_task :ensure_env
       options do |parser, flags|
@@ -13,7 +16,7 @@ module ShopifyCli
         end
       end
 
-      def call(*)
+      def setup
         project = Project.current
         url = options.flags[:host] || Tasks::Tunnel.call(@ctx)
         update_env(url)
@@ -24,12 +27,6 @@ module ShopifyCli
             open = Open.new(@ctx)
             open.call
           end
-        end
-        CLI::UI::Frame.open('Running server...') do
-          # fix for rails, where HOST is used for binding address
-          env = project.env.to_h
-          env.delete('HOST')
-          @ctx.system(project.app_type.serve_command(@ctx), env: env)
         end
       end
 

--- a/lib/shopify-cli/commands/serve.rb
+++ b/lib/shopify-cli/commands/serve.rb
@@ -5,8 +5,8 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Serve < ShopifyCli::AppTypeCommand
-      type :node, :ServeNode, 'serve/node'
-      type :rails, :ServeRails, 'serve/rails'
+      app_type :node, :ServeNode, 'serve/node'
+      app_type :rails, :ServeRails, 'serve/rails'
 
       include ShopifyCli::Helpers::OS
       prerequisite_task :ensure_env

--- a/lib/shopify-cli/commands/serve/node.rb
+++ b/lib/shopify-cli/commands/serve/node.rb
@@ -1,0 +1,22 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class Serve
+      class ServeNode < ShopifyCli::Commands::Serve
+        def call(*)
+          setup
+          CLI::UI::Frame.open('Running server...') do
+            @ctx.system(
+              'npm run dev',
+              env: {
+                HOST: Project.current.env.host,
+                PORT: ShopifyCli::Tasks::Tunnel::PORT,
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/commands/serve/node.rb
+++ b/lib/shopify-cli/commands/serve/node.rb
@@ -10,8 +10,8 @@ module ShopifyCli
             @ctx.system(
               'npm run dev',
               env: {
-                HOST: Project.current.env.host,
-                PORT: ShopifyCli::Tasks::Tunnel::PORT,
+                'HOST' => Project.current.env.host,
+                'PORT' => ShopifyCli::Tasks::Tunnel::PORT.to_s,
               }
             )
           end

--- a/lib/shopify-cli/commands/serve/rails.rb
+++ b/lib/shopify-cli/commands/serve/rails.rb
@@ -1,0 +1,22 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class Serve
+      class ServeRails < ShopifyCli::Commands::Serve
+        def call(*)
+          setup
+          Helpers::Gem.gem_home(@ctx)
+          CLI::UI::Frame.open('Running server...') do
+            @ctx.system(
+              'bin/rails server',
+              env: {
+                PORT: ShopifyCli::Tasks::Tunnel::PORT,
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/commands/serve/rails.rb
+++ b/lib/shopify-cli/commands/serve/rails.rb
@@ -11,7 +11,7 @@ module ShopifyCli
             @ctx.system(
               'bin/rails server',
               env: {
-                PORT: ShopifyCli::Tasks::Tunnel::PORT,
+                'PORT' => ShopifyCli::Tasks::Tunnel::PORT.to_s,
               }
             )
           end

--- a/lib/shopify-cli/context/output.rb
+++ b/lib/shopify-cli/context/output.rb
@@ -13,6 +13,10 @@ module ShopifyCli
         puts("{{v}} #{string}")
       end
 
+      def error(string)
+        raise ShopifyCli::Abort, "{{x}} #{string}"
+      end
+
       def debug(string)
         puts("{{red:DEBUG}} #{string}") if getenv('DEBUG')
       end

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -60,7 +60,11 @@ module ShopifyCli
     property :directory
 
     def app_type
-      ShopifyCli::AppTypeRegistry[config['app_type'].to_sym]
+      ShopifyCli::AppTypeRegistry[app_type_id]
+    end
+
+    def app_type_id
+      config['app_type'].to_sym
     end
 
     def env

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -95,6 +95,7 @@ module ShopifyCli
   end
 
   autoload :API, 'shopify-cli/api'
+  autoload :AppTypeCommand, 'shopify-cli/app_type_command'
   autoload :AppTypeRegistry, 'shopify-cli/app_type_registry'
   autoload :AppTypes, 'shopify-cli/app_types'
   autoload :Command, 'shopify-cli/command'

--- a/test/shopify-cli/app_type_command_test.rb
+++ b/test/shopify-cli/app_type_command_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+module ShopifyCli
+  class AppTypeCommandTest < MiniTest::Test
+    def test_non_existant_command
+      assert_raises(ShopifyCli::Abort) do
+        run_cmd('serve')
+      end
+    end
+  end
+end

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -92,23 +92,6 @@ module ShopifyCli
       def setup
         super
         project_context('app_types', 'node')
-        @app = ShopifyCli::AppTypes::Node.new(ctx: @context)
-      end
-
-      def test_server_command
-        ShopifyCli::Tasks::Tunnel.stubs(:call)
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
-        Helpers::EnvFile.any_instance.expects(:update)
-        @context.app_metadata[:host] = 'https://example.com'
-        cmd = ShopifyCli::Commands::Serve
-        cmd.ctx = @context
-        env = Project.current.env.to_h
-        env.delete('HOST')
-        @context.expects(:system).with(
-          "PORT=8081 npm run dev",
-          env: env
-        )
-        run_cmd('serve')
       end
 
       def test_open_command

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -76,23 +76,8 @@ module ShopifyCli
       def setup
         super
         project_context('app_types', 'rails')
-        @app = ShopifyCli::AppTypes::Rails.new(ctx: @context)
         Helpers::EnvFile.any_instance.stubs(:write)
         Helpers::EnvFile.any_instance.stubs(:update)
-      end
-
-      def test_server_command
-        cmd = ShopifyCli::Commands::Serve
-        cmd.ctx = @context
-        ShopifyCli::Tasks::Tunnel.stubs(:call)
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
-        env = Project.current.env.to_h
-        env.delete('HOST')
-        @context.expects(:system).with(
-          "PORT=8081 bin/rails server",
-          env: env
-        )
-        run_cmd('serve')
       end
 
       def test_open_command

--- a/test/shopify-cli/commands/serve/node_serve_test.rb
+++ b/test/shopify-cli/commands/serve/node_serve_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Commands
+    class Serve
+      class NodeServeTest < MiniTest::Test
+        include TestHelpers::FakeUI
+
+        def setup
+          super
+          project_context('app_types', 'node')
+          Helpers::EnvFile.any_instance.stubs(:write)
+          Helpers::EnvFile.any_instance.stubs(:update)
+        end
+
+        def test_server_command
+          ShopifyCli::Tasks::Tunnel.stubs(:call)
+          ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
+          @context.expects(:system).with(
+            'npm run dev',
+            env: {
+              HOST: 'https://example.com',
+              PORT: 8081,
+            }
+          )
+          run_cmd('serve')
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/commands/serve/node_serve_test.rb
+++ b/test/shopify-cli/commands/serve/node_serve_test.rb
@@ -19,8 +19,8 @@ module ShopifyCli
           @context.expects(:system).with(
             'npm run dev',
             env: {
-              HOST: 'https://example.com',
-              PORT: 8081,
+              'HOST' => 'https://example.com',
+              'PORT' => '8081',
             }
           )
           run_cmd('serve')

--- a/test/shopify-cli/commands/serve/rails_serve_test.rb
+++ b/test/shopify-cli/commands/serve/rails_serve_test.rb
@@ -19,7 +19,7 @@ module ShopifyCli
           @context.expects(:system).with(
             'bin/rails server',
             env: {
-              PORT: 8081,
+              'PORT' => '8081',
             }
           )
           run_cmd('serve')

--- a/test/shopify-cli/commands/serve/rails_serve_test.rb
+++ b/test/shopify-cli/commands/serve/rails_serve_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Commands
+    class Serve
+      class RailsServeTest < MiniTest::Test
+        include TestHelpers::FakeUI
+
+        def setup
+          super
+          project_context('app_types', 'rails')
+          Helpers::EnvFile.any_instance.stubs(:write)
+          Helpers::EnvFile.any_instance.stubs(:update)
+        end
+
+        def test_server_command
+          ShopifyCli::Tasks::Tunnel.stubs(:call)
+          ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
+          @context.expects(:system).with(
+            'bin/rails server',
+            env: {
+              PORT: 8081,
+            }
+          )
+          run_cmd('serve')
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/commands/serve_test.rb
+++ b/test/shopify-cli/commands/serve_test.rb
@@ -5,19 +5,16 @@ module ShopifyCli
     class ServeTest < MiniTest::Test
       include TestHelpers::FakeUI
 
+      def setup
+        super
+        project_context('app_types', 'rails')
+        @context.stubs(:system)
+      end
+
       def test_run
         Tasks::Tunnel.stubs(:call)
         Tasks::UpdateDashboardURLS.stubs(:call)
         Helpers::EnvFile.any_instance.expects(:update)
-        @context.expects(:system).with(
-          'a command',
-          env: {
-            'SHOPIFY_API_KEY' => 'apikey',
-            'SHOPIFY_API_SECRET' => 'secret',
-            'SHOP' => 'my-test-shop.myshopify.com',
-            'AWSKEY' => 'awskey',
-          }
-        )
         run_cmd('serve')
       end
 
@@ -31,7 +28,7 @@ module ShopifyCli
         Serve.any_instance.stubs(:mac?).returns(true)
         Open.any_instance.expects(:open_url!).with(
           @context,
-          'https://example.com',
+          'https://example.com/login?shop=my-test-shop.myshopify.com',
         )
         run_cmd('serve')
       end

--- a/test/test_helpers/app_type.rb
+++ b/test/test_helpers/app_type.rb
@@ -13,10 +13,6 @@ module TestHelpers
 
         def description; end
 
-        def serve_command(_ctx)
-          "a command"
-        end
-
         def generate_command(_ctx)
           "a command"
         end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

As discussed in https://github.com/Shopify/temp-shopify-app-cli/issues/8, it's difficult for us to define commands that vary a lot by AppType. Currently we have strings defined for commands in each AppType class, that a given command will reach for conditionally based on the project type, which is fine for small differences but upcoming projects could introduce the need for wildly different behaviour.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Implements a new `AppTypeCommand` that has a `type` classmethod, allowing you to define classes whose `call` methods will be executed by the command dynamically. I've moved `Serve` to this new format in this PR as an example and will move other commands to this structure if we agree on the approach.
