### PR TITLE
truncate logfile after sending events

### DIFF
--- a/lib/shopify-cli/log.rb
+++ b/lib/shopify-cli/log.rb
@@ -13,7 +13,7 @@ module ShopifyCli
       return [] if n < 1
 
       if size < TAIL_BUF_LENGTH
-        return readlines.reverse[0..n - 1]
+        return [readlines.reverse[0..n - 1], 0]
       end
 
       seek(-TAIL_BUF_LENGTH, SEEK_END)
@@ -21,10 +21,21 @@ module ShopifyCli
       buf = ""
       while buf.count("\n") <= n
         buf = read(TAIL_BUF_LENGTH) + buf
-        seek(2 * -TAIL_BUF_LENGTH, SEEK_CUR)
+        sk = 2 * -TAIL_BUF_LENGTH
+        if sk < -size
+          seek(0)
+          buf = read(size - buf.size) + buf
+          break
+        else
+          seek(sk, SEEK_CUR)
+        end
       end
+      ret = buf.split("\n")[-n..-1]
+      [ret, ret.join("\n").bytesize + 1]
+    end
 
-      buf.split("\n")[-n..-1]
+    def clear(pos)
+      truncate(size - pos)
     end
   end
 end

--- a/lib/shopify-cli/monorail.rb
+++ b/lib/shopify-cli/monorail.rb
@@ -33,7 +33,8 @@ module ShopifyCli
       def send_events
         return unless enabled?
         return unless consented?
-        new_events = events.tail(200).select do |line|
+        new_events, pos = events.tail(200)
+        new_events.select! do |line|
           event = JSON.parse(line, symbolize_names: true)
           Time.parse(event[:payload][:timestamp]) > mtime
         end
@@ -43,6 +44,7 @@ module ShopifyCli
           produce(event)
           File.write(ShopifyCli::EVENTS_MTIME, event[:payload][:timestamp])
         end
+        events.clear(pos)
       end
 
       def produce(event, num_retries: 3)


### PR DESCRIPTION
### WHY are these changes introduced?

The code we're using to `tail` wasn't protected against seeking to a negative index. Also we should be truncating the events log file after sending them successfully.

Fixes #411 