### PR TITLE
fix send_events when log is empty

### DIFF
--- a/lib/shopify-cli/log.rb
+++ b/lib/shopify-cli/log.rb
@@ -10,7 +10,7 @@ module ShopifyCli
     end
 
     def tail(n)
-      return [] if n < 1
+      return [[], 0] if n < 1
 
       if size < TAIL_BUF_LENGTH
         return [readlines.reverse[0..n - 1], 0]

--- a/lib/shopify-cli/monorail.rb
+++ b/lib/shopify-cli/monorail.rb
@@ -34,6 +34,7 @@ module ShopifyCli
         return unless enabled?
         return unless consented?
         new_events, pos = events.tail(200)
+        return unless new_events
         new_events.select! do |line|
           event = JSON.parse(line, symbolize_names: true)
           Time.parse(event[:payload][:timestamp]) > mtime


### PR DESCRIPTION
We received a report that the array of events returned from `Log` is nil. This PR protects against that in a few ways.
