### PR TITLE
[WIP] Add generator for mkting activities extensions

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -25,7 +25,7 @@ module ShopifyCli
             billing_recurring: './node_modules/.bin/generate-node-app recurring-billing',
             billing_one_time: './node_modules/.bin/generate-node-app one-time-billing',
             webhook: './node_modules/.bin/generate-node-app webhook',
-            marketing_activities_extension: './node_modules/.bin/generate-node-app marketing-activity-extension'
+            marketing_activities_extension: './node_modules/.bin/generate-node-app marketing-activity-extension',
           }
         end
 

--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -25,6 +25,7 @@ module ShopifyCli
             billing_recurring: './node_modules/.bin/generate-node-app recurring-billing',
             billing_one_time: './node_modules/.bin/generate-node-app one-time-billing',
             webhook: './node_modules/.bin/generate-node-app webhook',
+            marketing_activities_extension: './node_modules/.bin/generate-node-app marketing-activity-extension'
           }
         end
 
@@ -47,6 +48,10 @@ module ShopifyCli
 
         def webhook_location
           "server/server.js"
+        end
+
+        def extension_location(type)
+          "server/api/#{type.to_s.split('_')[0..1].join('-')}.js"
         end
 
         def callback_url

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -17,7 +17,7 @@ module ShopifyCli
             billing_recurring: NotImplementedError,
             billing_one_time: NotImplementedError,
             webhook: 'rails g shopify_app:add_webhook',
-            marketing_activities_extension: 'rails g shopify_app:add_marketing_activity_extension'
+            marketing_activities_extension: 'rails g shopify_app:add_marketing_activity_extension',
           }
         end
 
@@ -41,9 +41,6 @@ module ShopifyCli
         end
 
         def extension_location(type)
-          if type.nil?
-            return
-          end
           "controllers/#{type.to_s.split('_')[0..1].join('_')}_controller.rb"
         end
 

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -17,6 +17,7 @@ module ShopifyCli
             billing_recurring: NotImplementedError,
             billing_one_time: NotImplementedError,
             webhook: 'rails g shopify_app:add_webhook',
+            marketing_activities_extension: 'rails g shopify_app:add_marketing_activity_extension'
           }
         end
 
@@ -37,6 +38,13 @@ module ShopifyCli
 
         def webhook_location
           "config/webhooks"
+        end
+
+        def extension_location(type)
+          if type.nil?
+            return
+          end
+          "controllers/#{type.to_s.split('_')[0..1].join('_')}_controller.rb"
         end
 
         def callback_url

--- a/lib/shopify-cli/commands/generate.rb
+++ b/lib/shopify-cli/commands/generate.rb
@@ -5,6 +5,7 @@ module ShopifyCli
     class Generate < ShopifyCli::Command
       subcommand :Page, 'page', 'shopify-cli/commands/generate/page'
       subcommand :Billing, 'billing', 'shopify-cli/commands/generate/billing'
+      subcommand :Extension, 'extension', 'shopify-cli/commands/generate/extension'
       subcommand :Webhook, 'webhook', 'shopify-cli/commands/generate/webhook'
 
       def call(*)
@@ -13,8 +14,8 @@ module ShopifyCli
 
       def self.help
         <<~HELP
-          Generate code in your app project. Supports generating new pages, new billing API calls, or new webhooks.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} generate [ page | billing | webhook ]}}
+          Generate code in your app project. Supports generating new pages, new billing API calls, app extensions, or new webhooks.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} generate [ page | billing | webhook | extension ]}}
         HELP
       end
 
@@ -43,6 +44,14 @@ module ShopifyCli
 
             {{cyan:webhook}}: Generate and register a new webhook that listens for the specified Shopify store event.
               Usage: {{command:#{ShopifyCli::TOOL_NAME} generate webhook [type]}}
+
+            {{cyan:extension}}: Generate endpoints for a Shopify app extension feature.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate extension [type]}}
+
+              Types:
+              {{cyan:marketing-activities}}: generate marketing activities extension
+              {{underline:https://help.shopify.com/en/api/embedded-apps/app-extensions/shopify-admin/marketing-activities/manage-marketing-activity-extension}}
+
 
           {{bold:Examples:}}
 

--- a/lib/shopify-cli/commands/generate/extension.rb
+++ b/lib/shopify-cli/commands/generate/extension.rb
@@ -1,0 +1,42 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class Generate
+      class Extension < ShopifyCli::SubCommand
+        def call(args, _name)
+          project = ShopifyCli::Project.current
+          extension_types = {
+            'marketing-activities-extension' => :marketing_activities_extension
+          }
+          selected_type = extension_types[args[1]]
+          app_type = project.app_type
+          unless selected_type
+            selected_type = CLI::UI::Prompt.ask('Which extension would you like to generate?') do |handler|
+              extension_types.each do |key, value|
+                handler.option(key) { value }
+              end
+            end
+          end
+          spin_group = CLI::UI::SpinGroup.new
+          spin_group.add("Generating #{extension_types.key(selected_type)} code ...") do |spinner|
+            ShopifyCli::Commands::Generate.run_generate(
+              project.app_type.generate[selected_type], selected_type, @ctx
+            )
+            spinner.update_title(
+              "#{extension_types.key(selected_type)} generated in #{app_type.extension_location(selected_type)}"
+            )
+          end
+          spin_group.wait
+        end
+
+        def self.help
+          <<~HELP
+            Generate a new extension as documented in https://help.shopify.com/en/api/embedded-apps/app-extensions.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate extension}}
+          HELP
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/commands/generate/extension.rb
+++ b/lib/shopify-cli/commands/generate/extension.rb
@@ -7,7 +7,7 @@ module ShopifyCli
         def call(args, _name)
           project = ShopifyCli::Project.current
           extension_types = {
-            'marketing-activities-extension' => :marketing_activities_extension
+            'marketing-activities-extension' => :marketing_activities_extension,
           }
           selected_type = extension_types[args[1]]
           app_type = project.app_type

--- a/test/shopify-cli/commands/generate/extension_test.rb
+++ b/test/shopify-cli/commands/generate/extension_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Commands
+    class Generate
+      class ExtensionTest < MiniTest::Test
+        include TestHelpers::Project
+        include TestHelpers::FakeUI
+
+        def setup
+          super
+          @command = ShopifyCli::Commands::Generate::Extension.new(@context)
+        end
+
+        def test_marketing_activities_extension
+          CLI::UI::Prompt.expects(:ask).returns(:marketing_activities_extension)
+          @context.expects(:system).with('generate-marketing-activities-extension')
+            .returns(mock(success?: true))
+          @command.call(['extension'], nil)
+        end
+      end
+    end
+  end
+end

--- a/test/test_helpers/app_type.rb
+++ b/test/test_helpers/app_type.rb
@@ -30,6 +30,7 @@ module TestHelpers
             billing_recurring: 'generate-recurring-billing',
             billing_one_time: 'generate-one-time-billing',
             webhook: 'generate-webhook',
+            marketing_activities_extension: 'generate-marketing-activities-extension',
           }
         end
 
@@ -48,6 +49,10 @@ module TestHelpers
 
         def webhook_location
           "im fake"
+        end
+
+        def extension_location(type)
+          "fake/extension/location/#{type}"
         end
 
         def callback_url


### PR DESCRIPTION
### WHY are these changes introduced?

This adds the calls to run generators that create marketing activity extensions. Followup pull requests will be added for this to actually go into partners and perform the following steps; Create the marketing activity extension then configure the api base endpoint. 


### WHAT is this pull request doing?

This pull request just adds the command to generate marketing activity extension code. 
