### PR TITLE
Emphasize opening a new terminal window

### DIFF
--- a/docs/installing-ruby.md
+++ b/docs/installing-ruby.md
@@ -13,7 +13,7 @@ We recommend using [`ruby-install`][ruby-install] and [`chruby`][chruby] from Ho
 
         ruby-install ruby-2.5.1
 
-1. Open a new terminal window and activate ruby 2.5.1:
+1. **Open a new terminal window** and activate ruby 2.5.1:
 
         chruby ruby-2.5.1
 


### PR DESCRIPTION
It's too easy to overlook that opening a new terminal window (or reloading the environment) is necessary to activate the new ruby.

### WHY are these changes introduced?

Improve documentation.

### WHAT is this pull request doing?

Just a tiny documentation change.
