### PR TITLE
pass Project.env to serve commands

### DIFF
--- a/lib/shopify-cli/commands/serve.rb
+++ b/lib/shopify-cli/commands/serve.rb
@@ -26,7 +26,7 @@ module ShopifyCli
           end
         end
         CLI::UI::Frame.open('Running server...') do
-          @ctx.system(project.app_type.serve_command(@ctx))
+          @ctx.system(project.app_type.serve_command(@ctx), env: project.env.to_h)
         end
       end
 

--- a/lib/shopify-cli/helpers/env_file.rb
+++ b/lib/shopify-cli/helpers/env_file.rb
@@ -54,6 +54,17 @@ module ShopifyCli
       property :host
       property :extra, default: {}
 
+      def to_h
+        out = {}
+        KEY_MAP.each do |key, value|
+          out[key] = send(value).to_s if send(value)
+        end
+        extra.each do |key, value|
+          out[key] = value.to_s
+        end
+        out
+      end
+
       def write(ctx)
         spin_group = CLI::UI::SpinGroup.new
         spin_group.add("writing #{FILENAME} file...") do |spinner|

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -103,7 +103,8 @@ module ShopifyCli
         cmd = ShopifyCli::Commands::Serve
         cmd.ctx = @context
         @context.expects(:system).with(
-          "HOST=https://example.com PORT=8081 npm run dev"
+          "HOST=https://example.com PORT=8081 npm run dev",
+          env: Project.current.env.to_h
         )
         run_cmd('serve')
       end

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -87,7 +87,8 @@ module ShopifyCli
         ShopifyCli::Tasks::Tunnel.stubs(:call)
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         @context.expects(:system).with(
-          "PORT=8081 bin/rails server"
+          "PORT=8081 bin/rails server",
+          env: Project.current.env.to_h
         )
         run_cmd('serve')
       end

--- a/test/shopify-cli/commands/serve_test.rb
+++ b/test/shopify-cli/commands/serve_test.rb
@@ -9,7 +9,16 @@ module ShopifyCli
         Tasks::Tunnel.stubs(:call)
         Tasks::UpdateDashboardURLS.stubs(:call)
         Helpers::EnvFile.any_instance.expects(:update)
-        @context.expects(:system).with('a command')
+        @context.expects(:system).with(
+          'a command',
+          env: {
+            'SHOPIFY_API_KEY' => 'apikey',
+            'SHOPIFY_API_SECRET' => 'secret',
+            'HOST' => 'https://example.com',
+            'SHOP' => 'my-test-shop.myshopify.com',
+            'AWSKEY' => 'awskey',
+          }
+        )
         run_cmd('serve')
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

We were using `dotenv` for getting ENV variables in the generated rails app, but we can pass these in via the `system()` call, removing the need for `dotenv`.

Related to https://github.com/Shopify/shopify_app/pull/837
