### PR TITLE
exclude HOST env var from being passed to serve command

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -10,7 +10,6 @@ module ShopifyCli
 
         def serve_command(_ctx)
           %W(
-            HOST=#{Project.current.env.host}
             PORT=#{ShopifyCli::Tasks::Tunnel::PORT}
             npm run dev
           ).join(' ')

--- a/lib/shopify-cli/commands/serve.rb
+++ b/lib/shopify-cli/commands/serve.rb
@@ -26,7 +26,10 @@ module ShopifyCli
           end
         end
         CLI::UI::Frame.open('Running server...') do
-          @ctx.system(project.app_type.serve_command(@ctx), env: project.env.to_h)
+          # fix for rails, where HOST is used for binding address
+          env = project.env.to_h
+          env.delete('HOST')
+          @ctx.system(project.app_type.serve_command(@ctx), env: env)
         end
       end
 

--- a/test/shopify-cli/app_types/node_test.rb
+++ b/test/shopify-cli/app_types/node_test.rb
@@ -102,9 +102,11 @@ module ShopifyCli
         @context.app_metadata[:host] = 'https://example.com'
         cmd = ShopifyCli::Commands::Serve
         cmd.ctx = @context
+        env = Project.current.env.to_h
+        env.delete('HOST')
         @context.expects(:system).with(
-          "HOST=https://example.com PORT=8081 npm run dev",
-          env: Project.current.env.to_h
+          "PORT=8081 npm run dev",
+          env: env
         )
         run_cmd('serve')
       end

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -86,9 +86,11 @@ module ShopifyCli
         cmd.ctx = @context
         ShopifyCli::Tasks::Tunnel.stubs(:call)
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
+        env = Project.current.env.to_h
+        env.delete('HOST')
         @context.expects(:system).with(
           "PORT=8081 bin/rails server",
-          env: Project.current.env.to_h
+          env: env
         )
         run_cmd('serve')
       end

--- a/test/shopify-cli/commands/serve_test.rb
+++ b/test/shopify-cli/commands/serve_test.rb
@@ -14,7 +14,6 @@ module ShopifyCli
           env: {
             'SHOPIFY_API_KEY' => 'apikey',
             'SHOPIFY_API_SECRET' => 'secret',
-            'HOST' => 'https://example.com',
             'SHOP' => 'my-test-shop.myshopify.com',
             'AWSKEY' => 'awskey',
           }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Rails uses the HOST env var to set which IP address to bind the server to, which caused a SocketError in rails apps with my previous change #421 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

For now, it deletes the HOST var from the env hash before passing it to the serve command. I don't think it's even necessary that we store this value in the env file, we should just pull it from the Tunnel task directly.