### PR TITLE
Make tail work for small logs

### DIFF
--- a/lib/shopify-cli/log.rb
+++ b/lib/shopify-cli/log.rb
@@ -30,7 +30,7 @@ module ShopifyCli
           seek(sk, SEEK_CUR)
         end
       end
-      ret = buf.split("\n")[-n..-1]
+      ret = buf.split("\n").last(n)
       [ret, ret.join("\n").bytesize + 1]
     end
 


### PR DESCRIPTION
`[]` returns `nil` when the requested range doesn't exist.  `last(n)` returns as much as possible.