### PR TITLE
Expanding query page sizes so that limits are not reached

### DIFF
--- a/lib/graphql/all_organizations.graphql
+++ b/lib/graphql/all_organizations.graphql
@@ -4,7 +4,7 @@ query AllOrgs{
       id
       businessName
       website
-      stores {
+      stores(first: 500) {
         nodes {
           link
           shopDomain

--- a/lib/graphql/all_orgs_with_apps.graphql
+++ b/lib/graphql/all_orgs_with_apps.graphql
@@ -4,14 +4,14 @@ query AllOrgs{
       id
       businessName
       website
-      stores {
+      stores(first: 500) {
         nodes {
           link
           shopDomain
           shopName
         }
       }
-      apps {
+      apps(first: 500) {
         nodes {
           id
           title

--- a/lib/graphql/find_organization.graphql
+++ b/lib/graphql/find_organization.graphql
@@ -4,7 +4,7 @@ query FindOrg($id: ID!) {
       id
       businessName
       website
-      stores {
+      stores(first: 500) {
         nodes {
           link
           shopDomain


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #434 

I am arbitrarily expanding both app and store queries so that no one hits a limit. I faintly remember the average app per org and store per org and 500 should cover *most* cases. I am worried about exapanding the query any further

### WHAT is this pull request doing?
Just updating our queries that query apps and stores to request the first 500