### PR TITLE
Refactor TestHelpers::FakeFS to work in any test file when included

### DIFF
--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -6,15 +6,14 @@ module ShopifyCli
     include TestHelpers::FakeFS
 
     def setup
+      super
       @ctx = Context.new
     end
 
     def test_write_writes_to_file_in_project
-      FakeFS do
-        @ctx.root = Dir.mktmpdir
-        @ctx.write('.env', 'foobar')
-        assert File.exist?(File.join(@ctx.root, '.env'))
-      end
+      @ctx.root = Dir.mktmpdir
+      @ctx.write('.env', 'foobar')
+      assert File.exist?(File.join(@ctx.root, '.env'))
     end
   end
 end

--- a/test/test_helpers/fake_fs.rb
+++ b/test/test_helpers/fake_fs.rb
@@ -2,8 +2,9 @@
 module TestHelpers
   module FakeFS
     def setup
-      ::FakeFS.activate!
       super
+      ::FakeFS.clear!
+      ::FakeFS.activate!
     end
 
     def teardown


### PR DESCRIPTION
### WHY are these changes introduced?

This change only affects tests. My team is working on the private temp fork of this repo for our work, and we use [FakeFS](https://github.com/fakefs/fakefs) in a lot of our tests. Currently in master, FakeFS is only used in a single test and the `setup` method defined in the FakeFS helper is overridden. Any test using `TestHelper::FakeFS` without overriding `setup` would actually fail, because many tests inherit from `MiniTest::Test` where the [setup method](https://github.com/Shopify/shopify-app-cli/blob/bb37b966c78ba19b25e4ae8829fca65cb41253e8/test/minitest_ext.rb#L13) relies on a physical file.

These changes fix that problem so FakeFS can be used in any test file without causing failures or requiring overriding `setup`. 

### WHAT is this pull request doing?

- In _test/test_helpers/fake_fs.rb_ I move the `super` call to above the FakeFS invocation so the `MiniTest::Test` setup method is called first. I also added `::FakeFS.clear!` before activating FakeFS to clear the filesystem which ensures atomicity between tests.

- _test/shopify-cli/context_test.rb_ is the only test in master using FakeFS at the moment. 

```ruby
FakeFS.do
# code
end
```

is identical to 

```ruby
FakeFS.activate!
# code
FakeFS.deactivate!
```

so I just converted that test to use the `setup` and `teardown` methods that we have in our helper so the file would be a bit cleaner. But if you prefer the old way, I can change that and simply remove the inclusion of the helper instead.
