### PR TITLE
Directly call system for serve

### DIFF
--- a/lib/shopify-cli/commands/serve/node.rb
+++ b/lib/shopify-cli/commands/serve/node.rb
@@ -7,13 +7,9 @@ module ShopifyCli
         def call(*)
           setup
           CLI::UI::Frame.open('Running server...') do
-            @ctx.system(
-              'npm run dev',
-              env: {
-                'HOST' => Project.current.env.host,
-                'PORT' => ShopifyCli::Tasks::Tunnel::PORT.to_s,
-              }
-            )
+            env = Project.current.env.to_h
+            env['PORT'] = ShopifyCli::Tasks::Tunnel::PORT.to_s
+            @ctx.system('npm run dev', env: env)
           end
         end
       end

--- a/lib/shopify-cli/commands/serve/rails.rb
+++ b/lib/shopify-cli/commands/serve/rails.rb
@@ -8,12 +8,10 @@ module ShopifyCli
           setup
           Helpers::Gem.gem_home(@ctx)
           CLI::UI::Frame.open('Running server...') do
-            @ctx.system(
-              'bin/rails server',
-              env: {
-                'PORT' => ShopifyCli::Tasks::Tunnel::PORT.to_s,
-              }
-            )
+            env = Project.current.env.to_h
+            env.delete('HOST')
+            env['PORT'] = ShopifyCli::Tasks::Tunnel::PORT.to_s
+            @ctx.system('bin/rails server', env: env)
           end
         end
       end

--- a/test/shopify-cli/commands/serve/node_serve_test.rb
+++ b/test/shopify-cli/commands/serve/node_serve_test.rb
@@ -19,8 +19,12 @@ module ShopifyCli
           @context.expects(:system).with(
             'npm run dev',
             env: {
-              'HOST' => 'https://example.com',
-              'PORT' => '8081',
+              "SHOPIFY_API_KEY" => "mykey",
+              "SHOPIFY_API_SECRET" => "mysecretkey",
+              "SHOP" => "my-test-shop.myshopify.com",
+              "SCOPES" => "read_products",
+              "HOST" => "https://example.com",
+              "PORT" => "8081",
             }
           )
           run_cmd('serve')

--- a/test/shopify-cli/commands/serve/rails_serve_test.rb
+++ b/test/shopify-cli/commands/serve/rails_serve_test.rb
@@ -19,6 +19,10 @@ module ShopifyCli
           @context.expects(:system).with(
             'bin/rails server',
             env: {
+              "SHOPIFY_API_KEY" => "api_key",
+              "SHOPIFY_API_SECRET" => "secret",
+              "SHOP" => "my-test-shop.myshopify.com",
+              "SCOPES" => "write_products,write_customers,write_orders",
               'PORT' => '8081',
             }
           )


### PR DESCRIPTION
### WHY are these changes introduced?
I was finding, often that my API key was not being loaded while calling shopify serve even though it was all available. 

### WHAT is this pull request doing?
I changed the system call to use the direct system class instead of calling the context system command since all it was doing was adding in another env key which causes confusion. 

After this change, my serve calls are no longer failing.
