### PR TITLE
checks for shopify project in resource

### DIFF
--- a/lib/shopify-cli/commands/populate.rb
+++ b/lib/shopify-cli/commands/populate.rb
@@ -3,7 +3,7 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Populate < ShopifyCli::Command
-      prerequisite_task :schema, :ensure_env
+      prerequisite_task :schema
 
       autoload :Resource, 'shopify-cli/commands/populate/resource'
       subcommand :Product, 'products', 'shopify-cli/commands/populate/product'

--- a/lib/shopify-cli/commands/populate/resource.rb
+++ b/lib/shopify-cli/commands/populate/resource.rb
@@ -20,30 +20,33 @@ module ShopifyCli
         end
 
         def call(args, _)
-          @args = args
-          @input = Hash.new
-          @count = DEFAULT_COUNT
-          @help = false
-          input_options
-          resource_options.parse(@args)
+          if Project.at(Dir.pwd)
+            Tasks::EnsureEnv.call(@ctx)
+            @args = args
+            @input = Hash.new
+            @count = DEFAULT_COUNT
+            @help = false
+            input_options
+            resource_options.parse(@args)
 
-          if @help
-            output = Populate.extended_help
-            output += "\n{{bold:{{cyan:#{resource_type.capitalize}}} options:}}\n"
-            output += resource_options.help
-            return @ctx.page(output)
-          end
-
-          if @silent
-            spin_group = CLI::UI::SpinGroup.new
-            spin_group.add("Populating #{@count} #{resource_type}s...") do |spinner|
-              populate
-              spinner.update_title(completion_message)
+            if @help
+              output = Populate.extended_help
+              output += "\n{{bold:{{cyan:#{resource_type.capitalize}}} options:}}\n"
+              output += resource_options.help
+              return @ctx.page(output)
             end
-            spin_group.wait
-          else
-            populate
-            @ctx.puts(completion_message)
+
+            if @silent
+              spin_group = CLI::UI::SpinGroup.new
+              spin_group.add("Populating #{@count} #{resource_type}s...") do |spinner|
+                populate
+                spinner.update_title(completion_message)
+              end
+              spin_group.wait
+            else
+              populate
+              @ctx.puts(completion_message)
+            end
           end
         end
 

--- a/lib/shopify-cli/commands/populate/resource.rb
+++ b/lib/shopify-cli/commands/populate/resource.rb
@@ -20,33 +20,32 @@ module ShopifyCli
         end
 
         def call(args, _)
-          if Project.at(Dir.pwd)
-            Tasks::EnsureEnv.call(@ctx)
-            @args = args
-            @input = Hash.new
-            @count = DEFAULT_COUNT
-            @help = false
-            input_options
-            resource_options.parse(@args)
+          return unless Project.at(Dir.pwd)
+          Tasks::EnsureEnv.call(@ctx)
+          @args = args
+          @input = Hash.new
+          @count = DEFAULT_COUNT
+          @help = false
+          input_options
+          resource_options.parse(@args)
 
-            if @help
-              output = Populate.extended_help
-              output += "\n{{bold:{{cyan:#{resource_type.capitalize}}} options:}}\n"
-              output += resource_options.help
-              return @ctx.page(output)
-            end
+          if @help
+            output = Populate.extended_help
+            output += "\n{{bold:{{cyan:#{resource_type.capitalize}}} options:}}\n"
+            output += resource_options.help
+            return @ctx.page(output)
+          end
 
-            if @silent
-              spin_group = CLI::UI::SpinGroup.new
-              spin_group.add("Populating #{@count} #{resource_type}s...") do |spinner|
-                populate
-                spinner.update_title(completion_message)
-              end
-              spin_group.wait
-            else
+          if @silent
+            spin_group = CLI::UI::SpinGroup.new
+            spin_group.add("Populating #{@count} #{resource_type}s...") do |spinner|
               populate
-              @ctx.puts(completion_message)
+              spinner.update_title(completion_message)
             end
+            spin_group.wait
+          else
+            populate
+            @ctx.puts(completion_message)
           end
         end
 


### PR DESCRIPTION
Fixes #415

Moves the ensure_env task because it runs before we have the chance to check if you're in a shopify project. 