### PR TITLE
remove spring from rails generation

### DIFF
--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -46,7 +46,7 @@ module ShopifyCli
           Gem.install(ctx, 'bundler', '~>2.0')
         end
         CLI::UI::Frame.open("Generating new rails app project in #{name}...") do
-          ctx.system(Gem.binary_path_for(ctx, 'rails'), 'new', name)
+          ctx.system(Gem.binary_path_for(ctx, 'rails'), 'new --skip-spring', name)
         end
 
         File.open(File.join(ctx.root, 'Gemfile'), 'a') do |f|

--- a/test/shopify-cli/app_types/rails_test.rb
+++ b/test/shopify-cli/app_types/rails_test.rb
@@ -32,7 +32,7 @@ module ShopifyCli
         ShopifyCli::Helpers::Gem.expects(:install).with(@context, 'bundler', '~>1.0')
         ShopifyCli::Helpers::Gem.expects(:install).with(@context, 'bundler', '~>2.0')
         @context.expects(:system).with(
-          ShopifyCli::Helpers::Gem.binary_path_for(@context, 'rails'), 'new', 'test-app'
+          ShopifyCli::Helpers::Gem.binary_path_for(@context, 'rails'), 'new --skip-spring', 'test-app'
         )
         File.expects(:open).with(File.join(@context.root, 'Gemfile'), 'a')
         @context.expects(:system).with(


### PR DESCRIPTION
This PR removes [Spring](https://github.com/rails/spring) from our rails generation. 

Recently users have reported issues [running their servers](https://github.com/rails/spring/issues/610) with Spring, and it's not required for our apps. When required, users can add Spring to their projects.