### PR TITLE
warns users they must use 10.0.0 min of node

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Developers should have some prior knowledge of the Shopify app ecosystem. Curren
 
 - If you don’t have one, [create a Shopify partner account](https://partners.shopify.com/signup).
 - If you don’t have one, [create a Development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) where you can install and test your app.
+- You should have Node.js version 10.0.0 or higher installed. If you're looking for a way to manage your node versions we recommend [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md)
 
 ## Commands
 

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -81,6 +81,9 @@ module ShopifyCli
         unless Helpers::Ruby.version(ctx).satisfies?('~>2.4')
           raise ShopifyCli::Abort, invalid_ruby_message
         end
+        unless Helpers::Node.version(ctx).satisfies?('>=10.0.0')
+          raise ShopifyCli::Abort, invalid_node_message
+        end
         Gem.install(ctx, 'rails')
         Gem.install(ctx, 'bundler')
       end
@@ -92,6 +95,14 @@ module ShopifyCli
           This project requires a ruby version ~> 2.4.
           See {{underline:https://github.com/Shopify/shopify-app-cli/blob/master/docs/installing-ruby.md}}
           for our recommended method of installing ruby.
+        MSG
+      end
+
+      def invalid_node_message
+        <<~MSG
+          This project requires a Node.js version >= 10.0
+          See {{underline:https://github.com/Shopify/shopify-app-cli/blob/master/README.md}}
+          for our recommended method of switching Node.js versions.
         MSG
       end
 

--- a/lib/shopify-cli/helpers.rb
+++ b/lib/shopify-cli/helpers.rb
@@ -9,6 +9,7 @@ module ShopifyCli
     autoload :Git, 'shopify-cli/helpers/git'
     autoload :GraphQL, 'shopify-cli/helpers/graphql'
     autoload :Haikunator, 'shopify-cli/helpers/haikunator'
+    autoload :Node, 'shopify-cli/helpers/node'
     autoload :Organizations, 'shopify-cli/helpers/organizations'
     autoload :OS, 'shopify-cli/helpers/os'
     autoload :PartnersAPI, 'shopify-cli/helpers/partners_api'

--- a/lib/shopify-cli/helpers/node.rb
+++ b/lib/shopify-cli/helpers/node.rb
@@ -1,0 +1,17 @@
+module ShopifyCli
+  module Helpers
+    class Node
+      include SmartProperties
+      property :ctx, accepts: ShopifyCli::Context, required: true
+
+      class << self
+        def version(ctx)
+          require 'semantic/semantic'
+          out, _ = ctx.capture2('node', '-v')
+          version = out.delete!('v')
+          Semantic::Version.new(version)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #462 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
The shopify_app has a dependency of webpacker, which requires a node version of higher than 8. Users are having errors building the app if they don't have a high enough node version (and then, serving) the error messages are hard to read in the out put after failure. This adds a helper to check for a min of 10.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
