### PR TITLE
Add pry for debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 # `dev` uses no gems
 group :development, :test do
   gem 'rake'
+  gem 'pry'
   gem 'byebug'
   gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,14 @@ GEM
     ast (2.4.0)
     builder (3.2.3)
     byebug (8.2.2)
+    coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     fakefs (0.20.0)
     hashdiff (0.3.2)
     jaro_winkler (1.5.4)
     metaclass (0.0.4)
+    method_source (0.9.2)
     minitest (5.11.3)
     minitest-reporters (1.3.5)
       ansi
@@ -24,6 +26,9 @@ GEM
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.3)
     rainbow (3.0.0)
     rake (13.0.1)
@@ -52,6 +57,7 @@ DEPENDENCIES
   minitest (>= 5.0.0)
   minitest-reporters
   mocha
+  pry
   rake
   rubocop
   session

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'shopify_cli'
 require 'byebug'
+require 'pry'
 
 require 'minitest/autorun'
 require 'minitest/reporters'


### PR DESCRIPTION
### WHY are these changes introduced?

I like using `binding.pry` for debugging instead of `byebug`. It gives a lot of handy features that aren't necessarily available in byebug. I'd like to add it so it's available all the time.

### WHAT is this pull request doing?

Adding the use of `binding.pry` for debugging.
