### PR TITLE
Hidden commands and project types

### DIFF
--- a/docs/implementing_a_new_project_type.md
+++ b/docs/implementing_a_new_project_type.md
@@ -4,7 +4,7 @@ Implementing a new project type
 Implementing a new project type is easy.
 
 - First create a new folder `lib/project_types/<type name>`. This type name
-  will setup how your project is loaded. For instance the if you name your folder
+  will setup how your project is loaded. For instance if you name your folder
   `foo`, it can be loaded by calling `ProjectType.load_type(:foo)`
 - Inside your new project type create a cli.rb file with the following contents.
 
@@ -24,7 +24,7 @@ module Foo
     register_command('Foo::Commands::Build', "build")
   end
 
-  # define/autoload project specific Commads
+  # define/autoload project specific Commands
   # We leverage autoload so that we do not require all of our source code at startup.
   # if we required all of our files at startup, the cli would be slow
   module Commands

--- a/docs/implementing_a_new_project_type.md
+++ b/docs/implementing_a_new_project_type.md
@@ -1,0 +1,51 @@
+Implementing a new project type
+-------------------------------
+
+Implementing a new project type is easy.
+
+- First create a new folder `lib/project_types/<type name>`. This type name
+  will setup how your project is loaded. For instance the if you name your folder
+  `foo`, it can be loaded by calling `ProjectType.load_type(:foo)`
+- Inside your new project type create a cli.rb file with the following contents.
+
+```ruby
+# frozen_string_literal: true
+module Foo
+  class Project < ShopifyCli::ProjectType
+    # hidden_project_type will hide this type from the create command so that users
+    # wont discover it while you are developing it.
+    hidden_project_type
+
+    # creator defines the class to be loaded to create your app along with a title for it
+    creator 'Foo App', 'Foo::Commands::Create'
+
+    # register_command is used to define other commands on your project type.
+    # This means providing the class to call, along with its calling name `shopify build`
+    register_command('Foo::Commands::Build', "build")
+  end
+
+  # define/autoload project specific Commads
+  # We leverage autoload so that we do not require all of our source code at startup.
+  # if we required all of our files at startup, the cli would be slow
+  module Commands
+    # Project.project_filepath is used so that your filepaths will not break if
+    # our setup changes. It defines the filepath, relative to your project type.
+    autoload :Create, Project.project_filepath('commands/create')
+    autoload :Build, Project.project_filepath('commands/build')
+  end
+
+  # define/autoload project specific Tasks
+  module Tasks
+  end
+
+  # define/autoload project specific Forms
+  module Forms
+  end
+
+  # define/autoload project specific service objects
+  autoload :FooBulder, Project.project_filepath('foo_builder')
+end
+```
+
+- Now you have defined a new project type. Please refer to Rails::Commands::Create
+  for how to define a creator and commands.

--- a/lib/project_types/rails/cli.rb
+++ b/lib/project_types/rails/cli.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 module Rails
   class Project < ShopifyCli::ProjectType
+    # hidden_project_type
     creator 'Ruby on Rails App', 'Rails::Commands::Create'
 
     register_command('Rails::Commands::Open', "open")
     register_command('Rails::Commands::Serve', "serve")
-    # register_task('Rails::Tasks::RailsTask', 'rails_task')
   end
 
   # define/autoload project specific Commads

--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -8,6 +8,7 @@ module ShopifyCli
 
     class << self
       attr_writer :ctx
+      attr_reader :hidden
 
       def call(args, command_name)
         subcommand, resolved_name = subcommand_registry.lookup_command(args.first)
@@ -22,6 +23,10 @@ module ShopifyCli
           return call_help(command_name) if cmd.options.help
           cmd.call(args, command_name)
         end
+      end
+
+      def hidden_command
+        @hidden = true
       end
 
       def options(&block)

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -15,7 +15,7 @@ module ShopifyCli
         end
 
         type_name = CLI::UI::Prompt.ask('What type of project would you like to create?') do |handler|
-          ProjectType.load_all.each do |type|
+          self.class.all_visible_type.each do |type|
             handler.option(type.project_name) { type.project_type }
           end
         end
@@ -25,8 +25,14 @@ module ShopifyCli
         klass.call(args, command_name, 'create')
       end
 
+      def self.all_visible_type
+        ProjectType
+          .load_all
+          .select { |type| !type.hidden }
+      end
+
       def self.help
-        project_types = ProjectType.load_all.map(&:project_type).join("|")
+        project_types = all_visible_type.map(&:project_type).join("|")
         <<~HELP
           Create a new project.
             Usage: {{command:#{ShopifyCli::TOOL_NAME} create [#{project_types}]}}
@@ -36,7 +42,7 @@ module ShopifyCli
       def self.extended_help
         <<~HELP
           #{
-            ProjectType.load_all.map do |type|
+            all_visible_type.map do |type|
               type.create_command.help
             end.join("\n")
           }

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -28,7 +28,7 @@ module ShopifyCli
 
         visible_commands = ShopifyCli::Commands::Registry
           .resolved_commands
-          .select {|name, cmd| !cmd.hidden }
+          .select { |_name, c| !c.hidden }
           .sort
 
         visible_commands.each do |name, klass|

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -26,7 +26,12 @@ module ShopifyCli
         @ctx.puts('Use {{command:shopify help [command]}} to display detailed information about a specific command.')
         puts ""
 
-        ShopifyCli::Commands::Registry.resolved_commands.sort.each do |name, klass|
+        visible_commands = ShopifyCli::Commands::Registry
+          .resolved_commands
+          .select {|name, cmd| !cmd.hidden }
+          .sort
+
+        visible_commands.each do |name, klass|
           next if name == 'help'
           puts CLI::UI.fmt("{{command:#{ShopifyCli::TOOL_NAME} #{name}}}")
           if (help = klass.help)

--- a/lib/shopify-cli/commands/load_dev.rb
+++ b/lib/shopify-cli/commands/load_dev.rb
@@ -3,6 +3,8 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class LoadDev < ShopifyCli::Command
+      hidden_command
+
       def call(args, _name)
         project_dir = File.expand_path(args.shift || Dir.pwd)
         unless File.exist?(project_dir)

--- a/lib/shopify-cli/commands/load_system.rb
+++ b/lib/shopify-cli/commands/load_system.rb
@@ -3,6 +3,8 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class LoadSystem < ShopifyCli::Command
+      hidden_command
+
       def call(_args, _name)
         @ctx.done("Reloading #{TOOL_FULL_NAME} from #{ShopifyCli::INSTALL_DIR}")
         ShopifyCli::Finalize.reload_shopify_from(ShopifyCli::INSTALL_DIR)

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -4,6 +4,7 @@ module ShopifyCli
       attr_accessor :project_type,
         :project_name,
         :project_creator_command_class
+      attr_reader :hidden
 
       def repository
         @repository ||= []
@@ -46,6 +47,10 @@ module ShopifyCli
 
       def create_command
         const_get(@project_creator_command_class)
+      end
+
+      def hidden_project_type
+        @hidden = true
       end
 
       def register_command(const, cmd)


### PR DESCRIPTION
### WHY are these changes introduced?
We need a way of hiding commands and project types so that the users dont see things that will confuse them. Also so that people developing project types don't need to worry about half rolled out states.

### WHAT is this pull request doing?
- Adds `hidden_command` to commands to hide them from help but still makes it callable
- Adds `hidden_project_type` to project types to hide the project types from the create command.

shopify load commands are hidden:
![image](https://user-images.githubusercontent.com/463193/76999387-ed5d1780-692c-11ea-9b50-7071a7aa90f9.png)

#### Notes
we currently don't really have any setup to test help output so I am not sure I know how to test this currently.