### PR TITLE
Fix reload command for fish shell users

### DIFF
--- a/shopify.fish
+++ b/shopify.fish
@@ -72,8 +72,8 @@ function __shopify__
       case setenv:\*
         set -l assignment (echo "$fin" | sed 's/^setenv://' | tr = \\n)
         set -x "$assignment[1]" "$assignment[2]"
-      case reload_shopify_from:\*
-        set -l root (echo "$fin" | sed 's/^reload_shopify_from://')
+      case reload_shopify_cli_from:\*
+        set -l root (echo "$fin" | sed 's/^reload_shopify_cli_from://')
         source "$root/shopify.fish"
     end
   end < "$finalizers"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where reloading using the `shopify load-dev` command did not work while using the `fish` shell.

### WHAT is this pull request doing?

The problem was that the message sent from `lib/finalize.rb` [here](https://github.com/Shopify/shopify-app-cli/blob/master/lib/shopify-cli/finalize.rb#L40) did not have the prefix expected by `shopify.fish` [here](https://github.com/Shopify/shopify-app-cli/blob/master/shopify.fish#L75-L76). Fixing these two lines in the latter to match the correct prefix of `reload_shopify_cli_from` fixes the problem.
