### PR TITLE
Add top-level Heroku class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 # `dev` uses no gems
 group :development, :test do
   gem 'rake'
-  gem 'pry'
+  gem 'pry-byebug'
   gem 'byebug'
   gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     public_suffix (3.0.3)
     rainbow (3.0.0)
     rake (13.0.1)
@@ -57,7 +60,7 @@ DEPENDENCIES
   minitest (>= 5.0.0)
   minitest-reporters
   mocha
-  pry
+  pry-byebug
   rake
   rubocop
   session

--- a/lib/shopify-cli/commands/deploy/heroku.rb
+++ b/lib/shopify-cli/commands/deploy/heroku.rb
@@ -4,12 +4,6 @@ module ShopifyCli
   module Commands
     class Deploy
       class Heroku < ShopifyCli::Task
-        DOWNLOAD_URLS = {
-          linux: 'https://cli-assets.heroku.com/heroku-linux-x64.tar.gz',
-          mac: 'https://cli-assets.heroku.com/heroku-darwin-x64.tar.gz',
-          windows: 'https://cli-assets.heroku.com/heroku-win32-x64.tar.gz',
-        }
-
         def self.help
           <<~HELP
             Deploy the current app project to Heroku
@@ -22,15 +16,16 @@ module ShopifyCli
 
           spin_group = CLI::UI::SpinGroup.new
           git_service = ShopifyCli::Git.new(@ctx)
+          heroku_service = ShopifyCli::Heroku.new(@ctx)
 
           spin_group.add('Downloading Heroku CLI…') do |spinner|
-            heroku_download
+            heroku_service.download
             spinner.update_title('Downloaded Heroku CLI')
           end
           spin_group.wait
 
           spin_group.add('Installing Heroku CLI…') do |spinner|
-            heroku_install
+            heroku_service.install
             spinner.update_title('Installed Heroku CLI')
           end
           spin_group.add('Checking git repo…') do |spinner|
@@ -39,16 +34,16 @@ module ShopifyCli
           end
           spin_group.wait
 
-          if (account = heroku_whoami)
+          if (account = heroku_service.whoami)
             spin_group.add("Authenticated with Heroku as `#{account}`") { true }
             spin_group.wait
           else
             CLI::UI::Frame.open("Authenticating with Heroku…", success_text: '{{v}} Authenticated with Heroku') do
-              heroku_authenticate
+              heroku_service.authenticate
             end
           end
 
-          if (app_name = heroku_app)
+          if (app_name = heroku_service.app)
             spin_group.add("Heroku app `#{app_name}` selected") { true }
             spin_group.wait
           else
@@ -63,11 +58,11 @@ module ShopifyCli
                 "Selecting Heroku app `#{app_name}`…",
                 success_text: "{{v}} Heroku app `#{app_name}` selected"
               ) do
-                heroku_select_existing_app(app_name)
+                heroku_service.select_existing_app(app_name)
               end
             elsif app_type == :new
               CLI::UI::Frame.open('Creating new Heroku app…', success_text: '{{v}} New Heroku app created') do
-                heroku_create_new_app
+                heroku_service.create_new_app
               end
             end
           end
@@ -86,97 +81,8 @@ module ShopifyCli
           end
 
           CLI::UI::Frame.open('Deploying to Heroku…', success_text: '{{v}} Deployed to Heroku') do
-            heroku_deploy(branch_to_deploy)
+            heroku_service.deploy(branch_to_deploy)
           end
-        end
-
-        private
-
-        def heroku_app
-          return nil if heroku_git_remote.nil?
-          app = heroku_git_remote
-          app = app.split('/').last
-          app = app.split('.').first
-          app
-        end
-
-        def heroku_authenticate
-          result = @ctx.system(heroku_command, 'login')
-          @ctx.abort("Could not authenticate with Heroku") unless result.success?
-        end
-
-        def heroku_command
-          local_path = File.join(ShopifyCli::ROOT, 'heroku', 'bin', 'heroku').to_s
-          if File.exist?(local_path)
-            local_path
-          else
-            'heroku'
-          end
-        end
-
-        def heroku_create_new_app
-          output, status = @ctx.capture2e(heroku_command, 'create')
-          @ctx.abort('Heroku app could not be created') unless status.success?
-          @ctx.puts(output)
-
-          new_remote = output.split("\n").last.split("|").last.strip
-          result = @ctx.system('git', 'remote', 'add', 'heroku', new_remote)
-          msg = "Heroku app created, but couldn’t be set as a git remote"
-          @ctx.abort(msg) unless result.success?
-        end
-
-        def heroku_deploy(branch_to_deploy)
-          result = @ctx.system('git', 'push', '-u', 'heroku', "#{branch_to_deploy}:master")
-          @ctx.abort("Could not deploy to Heroku") unless result.success?
-        end
-
-        def heroku_download
-          return if heroku_installed?
-
-          result = @ctx.system('curl', '-o', heroku_download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCli::ROOT)
-          @ctx.abort("Heroku CLI could not be downloaded") unless result.success?
-          @ctx.abort("Heroku CLI could not be downloaded") unless File.exist?(heroku_download_path)
-        end
-
-        def heroku_download_filename
-          URI.parse(DOWNLOAD_URLS[@ctx.os]).path.split('/').last
-        end
-
-        def heroku_download_path
-          File.join(ShopifyCli::ROOT, heroku_download_filename)
-        end
-
-        def heroku_git_remote
-          output, status = @ctx.capture2e('git', 'remote', 'get-url', 'heroku')
-          status.success? ? output : nil
-        end
-
-        def heroku_install
-          return if heroku_installed?
-
-          result = @ctx.system('tar', '-xf', heroku_download_path, chdir: ShopifyCli::ROOT)
-          @ctx.abort("Could not install Heroku CLI") unless result.success?
-
-          @ctx.rm(heroku_download_path)
-        end
-
-        def heroku_installed?
-          _output, status = @ctx.capture2e(heroku_command, '--version')
-          status.success?
-        rescue
-          false
-        end
-
-        def heroku_select_existing_app(app_name)
-          result = @ctx.system(heroku_command, 'git:remote', '-a', app_name)
-          msg = "Heroku app `#{app_name}` could not be selected"
-          @ctx.abort(msg) unless result.success?
-        end
-
-        def heroku_whoami
-          output, status = @ctx.capture2e(heroku_command, 'whoami')
-          return output.strip if status.success?
-          nil
         end
       end
     end

--- a/lib/shopify-cli/heroku.rb
+++ b/lib/shopify-cli/heroku.rb
@@ -1,0 +1,104 @@
+module ShopifyCli
+  class Heroku
+    DOWNLOAD_URLS = {
+      linux: 'https://cli-assets.heroku.com/heroku-linux-x64.tar.gz',
+      mac: 'https://cli-assets.heroku.com/heroku-darwin-x64.tar.gz',
+      windows: 'https://cli-assets.heroku.com/heroku-win32-x64.tar.gz',
+    }
+
+    def initialize(ctx)
+      @ctx = ctx
+    end
+
+    def app
+      return nil if git_remote.nil?
+      app = git_remote
+      app = app.split('/').last
+      app = app.split('.').first
+      app
+    end
+
+    def authenticate
+      result = @ctx.system(heroku_path, 'login')
+      @ctx.abort("Could not authenticate with Heroku") unless result.success?
+    end
+
+    def create_new_app
+      output, status = @ctx.capture2e(heroku_path, 'create')
+      @ctx.abort('Heroku app could not be created') unless status.success?
+      @ctx.puts(output)
+
+      new_remote = output.split("\n").last.split("|").last.strip
+      result = @ctx.system('git', 'remote', 'add', 'heroku', new_remote)
+
+      msg = "Heroku app created, but couldn’t be set as a git remote"
+      @ctx.abort(msg) unless result.success?
+    end
+
+    def deploy(branch_to_deploy)
+      result = @ctx.system('git', 'push', '-u', 'heroku', "#{branch_to_deploy}:master")
+      @ctx.abort("Could not deploy to Heroku") unless result.success?
+    end
+
+    def download
+      return if installed?
+
+      result = @ctx.system('curl', '-o', download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCli::ROOT)
+      @ctx.abort("Heroku CLI could not be downloaded") unless result.success?
+      @ctx.abort("Heroku CLI could not be downloaded") unless File.exist?(download_path)
+    end
+
+    def install
+      return if installed?
+
+      result = @ctx.system('tar', '-xf', download_path, chdir: ShopifyCli::ROOT)
+      @ctx.abort("Could not install Heroku CLI") unless result.success?
+
+      @ctx.rm(download_path)
+    end
+
+    def select_existing_app(app_name)
+      result = @ctx.system(heroku_path, 'git:remote', '-a', app_name)
+
+      msg = "Heroku app `#{app_name}` could not be selected"
+      @ctx.abort(msg) unless result.success?
+    end
+
+    def whoami
+      output, status = @ctx.capture2e(heroku_path, 'whoami')
+      return output.strip if status.success?
+      nil
+    end
+
+    private
+
+    def download_filename
+      URI.parse(DOWNLOAD_URLS[@ctx.os]).path.split('/').last
+    end
+
+    def download_path
+      File.join(ShopifyCli::ROOT, download_filename)
+    end
+
+    def git_remote
+      output, status = @ctx.capture2e('git', 'remote', 'get-url', 'heroku')
+      status.success? ? output : nil
+    end
+
+    def heroku_path
+      local_path = File.join(ShopifyCli::ROOT, 'heroku', 'bin', 'heroku').to_s
+      if File.exist?(local_path)
+        local_path
+      else
+        'heroku'
+      end
+    end
+
+    def installed?
+      _output, status = @ctx.capture2e(heroku_path, '--version')
+      status.success?
+    rescue
+      false
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -105,6 +105,7 @@ module ShopifyCli
   autoload :Form, 'shopify-cli/form'
   autoload :Git, 'shopify-cli/git'
   autoload :Helpers, 'shopify-cli/helpers'
+  autoload :Heroku, 'shopify-cli/heroku'
   autoload :Log, 'shopify-cli/log'
   autoload :Monorail, 'shopify-cli/monorail'
   autoload :OAuth, 'shopify-cli/oauth'

--- a/test/shopify-cli/commands/deploy/heroku_test.rb
+++ b/test/shopify-cli/commands/deploy/heroku_test.rb
@@ -29,7 +29,7 @@ module ShopifyCli
         def test_call_doesnt_download_heroku_cli_if_it_is_installed
           @context.expects(:system)
             .with('curl', '-o', @download_path,
-              Deploy::Heroku::DOWNLOAD_URLS[:mac],
+              ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
               chdir: ShopifyCli::ROOT)
             .never
 
@@ -41,7 +41,7 @@ module ShopifyCli
 
           @context.expects(:system)
             .with('curl', '-o', @download_path,
-              Deploy::Heroku::DOWNLOAD_URLS[:mac],
+              ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
               chdir: ShopifyCli::ROOT)
             .returns(@status_mock[:true])
 
@@ -54,7 +54,7 @@ module ShopifyCli
           assert_raises ShopifyCli::Abort do
             @context.expects(:system)
               .with('curl', '-o', @download_path,
-                Deploy::Heroku::DOWNLOAD_URLS[:mac],
+                ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
                 chdir: ShopifyCli::ROOT)
               .returns(@status_mock[:false])
 
@@ -69,7 +69,7 @@ module ShopifyCli
           assert_raises ShopifyCli::Abort do
             @context.expects(:system)
               .with('curl', '-o', @download_path,
-                Deploy::Heroku::DOWNLOAD_URLS[:mac],
+                ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
                 chdir: ShopifyCli::ROOT)
               .returns(@status_mock[:true])
 
@@ -407,7 +407,7 @@ module ShopifyCli
         def stub_heroku_downloaded(status:)
           @context.stubs(:system)
             .with('curl', '-o', @download_path,
-              Deploy::Heroku::DOWNLOAD_URLS[:mac],
+              ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
               chdir: ShopifyCli::ROOT)
             .returns(@status_mock[:"#{status}"])
         end
@@ -442,7 +442,7 @@ module ShopifyCli
             .returns(['', @status_mock[:"#{status}"]])
 
           @context.stubs(:capture2e)
-            .with(@heroku_command, 'git:remote', '-a', 'app-name')
+            .with('heroku', 'git:remote', '-a', 'app-name')
             .returns(['', @status_mock[:"#{status}"]])
         end
 

--- a/test/shopify-cli/heroku_test.rb
+++ b/test/shopify-cli/heroku_test.rb
@@ -1,0 +1,353 @@
+require 'test_helper'
+
+module ShopifyCli
+  class HerokuTest < MiniTest::Test
+    def setup
+      super
+
+      @download_filename = 'heroku-darwin-x64.tar.gz'
+      @download_path = File.join(ShopifyCli::ROOT, @download_filename)
+      @heroku_path = File.join(ShopifyCli::ROOT, 'heroku', 'bin', 'heroku').to_s
+      @heroku_remote = 'https://git.heroku.com/app-name.git'
+
+      @status_mock = {
+        false: mock,
+        true: mock,
+      }
+      @status_mock[:false].stubs(:success?).returns(false)
+      @status_mock[:true].stubs(:success?).returns(true)
+
+      File.stubs(:exist?).returns(false)
+      stub_os(os: :mac)
+    end
+
+    def test_app_uses_existing_heroku_app_if_available
+      stub_git_remote_get_url(status: true, remote: 'heroku')
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_equal 'app-name', heroku_service.app
+    end
+
+    def test_app_returns_nil_if_choosing_existing_heroku_app_fails
+      stub_git_remote_get_url(status: false, remote: 'heroku')
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.app)
+    end
+
+    def test_authenticate_uses_existing_heroku_auth_if_available
+      stub_heroku_login(status: true)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.authenticate)
+    end
+
+    def test_authenticate_uses_local_path_heroku_existing_auth_if_available
+      File.stubs(:exist?).returns(true)
+      stub_heroku_login(status: true)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.authenticate)
+    end
+
+    def test_authenticate_raises_if_heroku_auth_fails
+      stub_heroku_login(status: false)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_raises ShopifyCli::Abort do
+        heroku_service.authenticate
+      end
+    end
+
+    def test_create_new_app_lets_you_create_new_heroku_app
+      File.stubs(:exist?).returns(true)
+      stub_git_create(status: true, heroku_path: @heroku_path)
+      stub_git_remote_add(status: true)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.create_new_app)
+    end
+
+    def test_create_new_app_raises_if_creating_new_heroku_app_fails
+      stub_git_create(status: false, heroku_path: 'heroku')
+      stub_git_remote_add(status: nil)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_raises ShopifyCli::Abort do
+        heroku_service.create_new_app
+      end
+    end
+
+    def test_create_new_app_raises_if_setting_remote_heroku_fails
+      stub_git_create(status: true, heroku_path: 'heroku')
+      stub_git_remote_add(status: false)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_raises ShopifyCli::Abort do
+        heroku_service.create_new_app
+      end
+    end
+
+    def test_deploy_tries_to_deploy_to_heroku
+      stub_heroku_deploy(status: true)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.deploy("master"))
+    end
+
+    def test_deploy_raises_if_deploy_fails
+      stub_heroku_deploy(status: false)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_raises ShopifyCli::Abort do
+        heroku_service.deploy("master")
+      end
+    end
+
+    def test_download_doesnt_download_heroku_cli_if_it_is_installed
+      stub_heroku_installed(status: true)
+      stub_heroku_download(status: nil)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.download)
+    end
+
+    def test_download_downloads_heroku_cli_if_it_is_not_installed
+      stub_heroku_installed(status: false)
+      stub_heroku_download(status: true)
+      stub_heroku_download_exists(status: true)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.download)
+    end
+
+    def test_download_raises_if_heroku_cli_download_fails
+      stub_heroku_installed(status: false)
+      stub_heroku_download(status: false)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_raises ShopifyCli::Abort do
+        heroku_service.download
+      end
+    end
+
+    def test_download_raises_if_heroku_cli_download_is_missing
+      stub_heroku_installed(status: false)
+      stub_heroku_download(status: true)
+      stub_heroku_download_exists(status: false)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_raises ShopifyCli::Abort do
+        heroku_service.download
+      end
+    end
+
+    def test_install_doesnt_install_heroku_cli_if_it_is_already_installed
+      stub_heroku_installed(status: true)
+      stub_tar(status: nil)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.install)
+    end
+
+    def test_install_installs_heroku_cli_if_it_is_downloaded
+      stub_heroku_installed(status: false)
+      stub_tar(status: true)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert heroku_service.install
+    end
+
+    def test_install_raises_if_heroku_cli_install_fails
+      stub_heroku_installed(status: false)
+      stub_tar(status: false)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_raises ShopifyCli::Abort do
+        heroku_service.install
+      end
+    end
+
+    def test_select_existing_app_lets_you_choose_existing_heroku_app
+      stub_heroku_select_app(status: true)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.select_existing_app('app-name'))
+    end
+
+    def test_select_existing_app_raises_if_choosing_existing_heroku_app_fails
+      stub_heroku_select_app(status: false)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_raises ShopifyCli::Abort do
+        heroku_service.select_existing_app('app-name')
+      end
+    end
+
+    def test_whoami_returns_username_if_logged_in
+      stub_heroku_whoami(status: true)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_equal 'username', heroku_service.whoami
+    end
+
+    def test_whoami_returns_nil_if_not_logged_in
+      stub_heroku_whoami(status: false)
+
+      heroku_service = ShopifyCli::Heroku.new(@context)
+
+      assert_nil(heroku_service.whoami)
+    end
+
+    private
+
+    def stub_git_remote_get_url(status:, remote:)
+      output = if status == true
+        @heroku_remote
+      else
+        "fatal: No such remote '#{remote}'"
+      end
+
+      @context.stubs(:capture2e)
+        .with('git', 'remote', 'get-url', remote)
+        .returns([output, @status_mock[:"#{status}"]])
+    end
+
+    def stub_git_remote_add(status:)
+      if status.nil?
+        @context.expects(:system)
+          .with('git', 'remote', 'add', 'heroku', @heroku_remote)
+          .never
+      else
+        @context.expects(:system)
+          .with('git', 'remote', 'add', 'heroku', @heroku_remote)
+          .returns(@status_mock[:"#{status}"])
+      end
+    end
+
+    def stub_git_create(status:, heroku_path: 'heroku')
+      output = <<~EOS
+        Creating app... done, ⬢ app-name
+        https://app-name.herokuapp.com/ | #{@heroku_remote}
+      EOS
+
+      @context.expects(:capture2e)
+        .with(heroku_path, 'create')
+        .returns([output, @status_mock[:"#{status}"]])
+    end
+
+    def stub_heroku_login(status:)
+      @context.stubs(:system)
+        .with(@heroku_path, 'login')
+        .returns(@status_mock[:"#{status}"])
+
+      @context.stubs(:system)
+        .with('heroku', 'login')
+        .returns(@status_mock[:"#{status}"])
+    end
+
+    def stub_heroku_deploy(status:)
+      @context.stubs(:system)
+        .with('git', 'push', '-u', 'heroku', "master:master")
+        .returns(@status_mock[:"#{status}"])
+    end
+
+    def stub_heroku_download_exists(status:)
+      File.stubs(:exist?)
+        .with(@download_path)
+        .returns(status)
+    end
+
+    def stub_heroku_download(status:)
+      if status.nil?
+        @context.stubs(:system)
+          .with('curl', '-o', @download_path,
+          ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
+          chdir: ShopifyCli::ROOT)
+          .never
+      else
+        @context.stubs(:system)
+          .with('curl', '-o', @download_path,
+            ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
+            chdir: ShopifyCli::ROOT)
+          .returns(@status_mock[:"#{status}"])
+      end
+    end
+
+    def stub_heroku_installed(status:)
+      File.stubs(:exist?)
+        .with(@heroku_path)
+        .returns(status)
+
+      @context.stubs(:capture2e)
+        .with(@heroku_path, '--version')
+        .returns(['', @status_mock[:"#{status}"]])
+
+      @context.stubs(:capture2e)
+        .with('heroku', '--version')
+        .returns(['', @status_mock[:"#{status}"]])
+    end
+
+    def stub_tar(status:)
+      if status.nil?
+        @context.stubs(:system)
+          .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
+          .never
+      else
+        @context.stubs(:system)
+          .with('tar', '-xf', @download_path, chdir: ShopifyCli::ROOT)
+          .returns(@status_mock[:"#{status}"])
+      end
+
+      if status
+        @context.stubs(:rm).with(@download_path).returns(status)
+      else
+        @context.stubs(:rm).with(@download_path).never
+      end
+    end
+
+    def stub_heroku_select_app(status:)
+      File.stubs(:exist?).returns(true)
+
+      @context.stubs(:system)
+        .with(@heroku_path, 'git:remote', '-a', 'app-name')
+        .returns(@status_mock[:"#{status}"])
+    end
+
+    def stub_heroku_whoami(status:)
+      output = status ? 'username' : nil
+
+      @context.stubs(:capture2e)
+        .with(@heroku_command, 'whoami')
+        .returns([output, @status_mock[:"#{status}"]])
+
+      @context.stubs(:capture2e)
+        .with('heroku', 'whoami')
+        .returns([output, @status_mock[:"#{status}"]])
+    end
+
+    def stub_os(os:)
+      ShopifyCli::Context.any_instance.stubs(:os).returns(os)
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

I wanted to group all the Heroku-related methods together at the top-level so they can be used by any project type.

I also realized I previously added the wrong `pry`, I actually need `pry-byebug` so I added that as well and removed `pry`.
 
### WHAT is this pull request doing?

Moving the code out of `lib/shopify-cli/commands/deploy/heroku.rb` and move it into `lib/shopify-cli/heroku.rb`. 
And then in the future/next PR break out `lib/shopify-cli/commands/deploy/heroku.rb`
into `lib/project_types/node/commands/deploy/heroku.rb` and `lib/project_types/rails/commands/deploy/heroku.rb`