### PR TITLE
Abort when rescuing 404 from parters in authenticated_req

### DIFF
--- a/lib/shopify-cli/helpers/partners_api.rb
+++ b/lib/shopify-cli/helpers/partners_api.rb
@@ -44,7 +44,7 @@ module ShopifyCli
           Tasks::AuthenticateIdentity.call(ctx)
           retry
         rescue API::APIRequestNotFoundError
-          ctx.puts("{{x}} error: Your account was not found. Please sign up at https://partners.shopify.com/signup")
+          ctx.error("error: Your account was not found. Please sign up at https://partners.shopify.com/signup")
         end
 
         def api_client(ctx)

--- a/test/shopify-cli/helpers/partners_api_test.rb
+++ b/test/shopify-cli/helpers/partners_api_test.rb
@@ -62,7 +62,7 @@ module ShopifyCli
         PartnersAPI.query(@context, 'query')
       end
 
-      def test_query_fails_gracefully_without_partners_account
+      def test_query_aborts_without_partners_account
         api_stub = Object.new
         PartnersAPI.expects(:new).with(
           ctx: @context,
@@ -70,10 +70,13 @@ module ShopifyCli
           url: "#{PartnersAPI.endpoint}/api/cli/graphql",
         ).returns(api_stub)
         api_stub.expects(:query).raises(API::APIRequestNotFoundError)
-        @context.expects(:puts).with(
-          "{{x}} error: Your account was not found. Please sign up at https://partners.shopify.com/signup",
+        e = assert_raises ShopifyCli::Abort do
+          PartnersAPI.query(@context, 'query')
+        end
+        assert_match(
+          'error: Your account was not found. Please sign up at https://partners.shopify.com/signup',
+          e.message
         )
-        PartnersAPI.query(@context, 'query')
       end
 
       def test_query


### PR DESCRIPTION
### WHY are these changes introduced?

Currently  we just call `ctx.puts(msg)` so execution continues and the method returns nil. This is a problem because for most authenticated requests, we check the response hash like [this](https://github.com/Shopify/shopify-app-cli/blob/7cdb93fea746edbe84b7e485cd2d64c941fffc5e/lib/shopify-cli/helpers/organizations.rb#L23). This then causes an undefined method exception, so the actual error message gets hidden behind a stack trace so its hard to figure out what actually went wrong.

### WHAT is this pull request doing?

Aborts rather than printing the error and letting execution continue. 