### PR TITLE
Tidy up context usage

### DIFF
--- a/lib/shopify-cli/context/output.rb
+++ b/lib/shopify-cli/context/output.rb
@@ -2,7 +2,7 @@ module ShopifyCli
   class Context
     module Output
       def print_task(text)
-        puts CLI::UI.fmt("{{yellow:*}} #{text}")
+        puts "{{yellow:*}} #{text}"
       end
 
       def puts(*args)
@@ -27,7 +27,7 @@ module ShopifyCli
             pipe.puts CLI::UI.fmt(output)
           end
         else
-          puts(CLI::UI.fmt(output))
+          puts(output)
         end
       end
     end

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -86,7 +86,7 @@ module ShopifyCli
     end
 
     def test_clones_git_repo
-      CLI::Kit::System.expects(:system).with(
+      ShopifyCli::Context.any_instance.expects(:system).with(
         'git',
         'clone',
         '--single-branch',
@@ -101,7 +101,7 @@ module ShopifyCli
 
     def test_clone_failure
       assert_raises(ShopifyCli::Abort) do
-        CLI::Kit::System.expects(:system).with(
+        ShopifyCli::Context.any_instance.expects(:system).with(
           'git',
           'clone',
           '--single-branch',


### PR DESCRIPTION
### WHY are these changes introduced?
Tidy up some outstanding items from `consistent-context-usage` branch

### WHAT is this pull request doing?
- Removing unnecessary calls to `CLI::UI.fmt()` in `Context` (`output.rb`) - the underlying methods already call that `fmt()` method.
- `ShopifyCli::Git`: using `abort()`, `system()`, `done()` from `Context` instead of direct calls
- Changing associated test cases for `ShopifyCli::Git` as a result of previous point.
