### PR TITLE
Convert tunnel command to Project Type-based system

### DIFF
--- a/lib/project_types/node/cli.rb
+++ b/lib/project_types/node/cli.rb
@@ -6,6 +6,7 @@ module Node
     register_command('Node::Commands::Generate', "generate")
     register_command('Node::Commands::Open', "open")
     register_command('Node::Commands::Serve', "serve")
+    register_command('Node::Commands::Tunnel', "tunnel")
     # register_task('Node::Tasks::NodeTask', 'node_task')
   end
 
@@ -15,6 +16,7 @@ module Node
     autoload :Generate, Project.project_filepath('commands/generate')
     autoload :Open, Project.project_filepath('commands/open')
     autoload :Serve, Project.project_filepath('commands/serve')
+    autoload :Tunnel, Project.project_filepath('commands/tunnel')
   end
 
   # define/autoload project specific Tasks

--- a/lib/project_types/node/commands/tunnel.rb
+++ b/lib/project_types/node/commands/tunnel.rb
@@ -2,22 +2,22 @@
 
 require 'shopify_cli'
 
-module ShopifyCli
+module Node
   module Commands
     class Tunnel < ShopifyCli::Command
-      # subcommands :start, :stop
+      # subcommands :auth, :start, :stop
 
       def call(args, _name)
         subcommand = args.shift
         task = ShopifyCli::Tasks::Tunnel.new
         case subcommand
+        when 'auth'
+          token = args.shift
+          task.auth(@ctx, token)
         when 'start'
           task.call(@ctx)
         when 'stop'
           task.stop(@ctx)
-        when 'auth'
-          token = args.shift
-          task.auth(@ctx, token)
         else
           @ctx.puts(self.class.help)
         end
@@ -35,7 +35,7 @@ module ShopifyCli
           {{bold:Subcommands:}}
 
             {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to allow connecting with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} auth <token>}}
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel auth <token>}}
 
             {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
               Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel start}}

--- a/lib/project_types/rails/cli.rb
+++ b/lib/project_types/rails/cli.rb
@@ -4,18 +4,20 @@ module Rails
     # hidden_project_type
     creator 'Ruby on Rails App', 'Rails::Commands::Create'
 
+    register_command('Rails::Commands::Generate', "generate")
     register_command('Rails::Commands::Open', "open")
     register_command('Rails::Commands::Serve', "serve")
-    register_command('Rails::Commands::Generate', "generate")
+    register_command('Rails::Commands::Tunnel', "tunnel")
     # register_task('Rails::Tasks::RailsTask', 'rails_task')
   end
 
   # define/autoload project specific Commads
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
-    autoload :Open, Project.project_filepath('commands/open')
     autoload :Generate, Project.project_filepath('commands/generate')
+    autoload :Open, Project.project_filepath('commands/open')
     autoload :Serve, Project.project_filepath('commands/serve')
+    autoload :Tunnel, Project.project_filepath('commands/tunnel')
   end
 
   # define/autoload project specific Tasks

--- a/lib/project_types/rails/commands/tunnel.rb
+++ b/lib/project_types/rails/commands/tunnel.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'shopify_cli'
+
+module Rails
+  module Commands
+    class Tunnel < ShopifyCli::Command
+      # subcommands :auth, :start, :stop
+
+      def call(args, _name)
+        subcommand = args.shift
+        task = ShopifyCli::Tasks::Tunnel.new
+        case subcommand
+        when 'auth'
+          token = args.shift
+          task.auth(@ctx, token)
+        when 'start'
+          task.call(@ctx)
+        when 'stop'
+          task.stop(@ctx)
+        else
+          @ctx.puts(self.class.help)
+        end
+      end
+
+      def self.help
+        <<~HELP
+          Start or stop an http tunnel to your local development app using ngrok.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel [ auth | start | stop ]}}
+        HELP
+      end
+
+      def self.extended_help
+        <<~HELP
+          {{bold:Subcommands:}}
+
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to allow connecting with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel auth <token>}}
+
+            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel start}}
+
+            {{cyan:stop}}: Stops the ngrok tunnel.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel stop}}
+
+        HELP
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -20,7 +20,6 @@ module ShopifyCli
     register :LoadDev, 'load-dev', 'shopify-cli/commands/load_dev'
     register :LoadSystem, 'load-system', 'shopify-cli/commands/load_system'
     register :Populate, 'populate', 'shopify-cli/commands/populate'
-    register :Tunnel, 'tunnel', 'shopify-cli/commands/tunnel'
     register :Update, 'update', 'shopify-cli/commands/update'
   end
 end

--- a/test/project_types/node/commands/tunnel_test.rb
+++ b/test/project_types/node/commands/tunnel_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module Node
+  module Commands
+    class TunnelTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:node)
+      end
+
+      def test_auth
+        ShopifyCli::Tasks::Tunnel.any_instance.expects(:auth)
+        run_cmd('tunnel auth')
+      end
+
+      def test_start
+        ShopifyCli::Tasks::Tunnel.any_instance.expects(:call)
+        run_cmd('tunnel start')
+      end
+
+      def test_stop
+        ShopifyCli::Tasks::Tunnel.any_instance.expects(:stop)
+        run_cmd('tunnel stop')
+      end
+    end
+  end
+end

--- a/test/project_types/rails/commands/tunnel_test.rb
+++ b/test/project_types/rails/commands/tunnel_test.rb
@@ -1,8 +1,13 @@
 require 'test_helper'
 
-module ShopifyCli
+module Rails
   module Commands
     class TunnelTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:rails)
+      end
+
       def test_auth
         ShopifyCli::Tasks::Tunnel.any_instance.expects(:auth)
         run_cmd('tunnel auth')


### PR DESCRIPTION
### WHY are these changes introduced?

Expands on #458 and #470 by adding **Tunnel** command to **Create**, **Serve**, **Open** (already converted), aligning with `project_type` structure for extensibility.

### WHAT is this pull request doing?

- adding `Tunnel` to `cli.rb` files under `{node,rails}` directories
- copying and modifying `tunnel.rb` to `{node,rails}/commands` directories
- copying and modifying `tunnel_test.rb` to `{nodes,rails}` test directories
- deleting `tunnel.rb` and `tunnel_test.rb` from respective directories under previous system
