### PR TITLE
Update Generate and ProjectType

### DIFF
--- a/lib/project_types/node/commands/generate.rb
+++ b/lib/project_types/node/commands/generate.rb
@@ -21,25 +21,30 @@ module Node
 
       def self.extended_help
         <<~HELP
-          help
+          {{bold:Subcommands:}}
+            {{cyan:webhook}}: Generate and register a new webhook that listens for the specified Shopify store event.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate webhook [type]}}
+          {{bold:Examples:}}
+            {{cyan:#{ShopifyCli::TOOL_NAME} generate webhook PRODUCTS_CREATE}}
+              Generate and register a new webhook that will be called every time a new product is created on your store.
         HELP
       end
 
       def self.run_generate(script, name, ctx)
         stat = ctx.system(script)
         unless stat.success?
-          raise(ShopifyCli::Abort, CLI::UI.fmt(response(stat.exitstatus, name)))
+          ctx.abort(response(stat.exitstatus, name))
         end
       end
 
       def self.response(code, name)
         case code
         when 1
-          "{{x}} Error generating #{name}"
+          "Error generating #{name}"
         when 2
-          "{{x}} #{name} already exists!"
+          "#{name} already exists!"
         else
-          '{{x}} Error'
+          'Error'
         end
       end
     end

--- a/lib/project_types/rails/commands/generate.rb
+++ b/lib/project_types/rails/commands/generate.rb
@@ -23,7 +23,7 @@ module Rails
             {{cyan:webhook}}: Generate and register a new webhook that listens for the specified Shopify store event.
               Usage: {{command:#{ShopifyCli::TOOL_NAME} generate webhook [type]}}
           {{bold:Examples:}}
-            {{cyan:shopify generate webhook PRODUCTS_CREATE}}
+            {{cyan:#{ShopifyCli::TOOL_NAME} generate webhook PRODUCTS_CREATE}}
               Generate and register a new webhook that will be called every time a new product is created on your store.
         HELP
       end
@@ -31,7 +31,18 @@ module Rails
       def self.run_generate(script, name, ctx)
         stat = ctx.system(script)
         unless stat.success?
-          raise(ShopifyCli::Abort, CLI::UI.fmt(response(stat.exitstatus, name)))
+          ctx.abort(response(stat.exitstatus, name))
+        end
+      end
+
+      def self.response(code, name)
+        case code
+        when 1
+          "Error generating #{name}"
+        when 2
+          "#{name} already exists!"
+        else
+          'Error'
         end
       end
     end

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -49,7 +49,7 @@ module ShopifyCli
           output += "\n"
           output += klass.extended_help
         end
-        @ctx.page(output)
+        @ctx.puts(output)
       end
     end
   end

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -17,7 +17,7 @@ module ShopifyCli
       end
 
       def load_type(current_type)
-        filepath = File.join(ROOT, 'lib', 'project_types', current_type.to_s, 'cli.rb')
+        filepath = File.join(ShopifyCli::ROOT, 'lib', 'project_types', current_type.to_s, 'cli.rb')
         return unless File.exist?(filepath)
         @current_type = current_type
         load(filepath)
@@ -26,7 +26,7 @@ module ShopifyCli
       end
 
       def load_all
-        Dir.glob(File.join(ROOT, 'lib', 'project_types', '*', 'cli.rb')).map do |filepath|
+        Dir.glob(File.join(ShopifyCli::ROOT, 'lib', 'project_types', '*', 'cli.rb')).map do |filepath|
           load_type(filepath.split(File::Separator)[-2])
         end
       end

--- a/test/project_types/node/commands/generate/webhook_test.rb
+++ b/test/project_types/node/commands/generate/webhook_test.rb
@@ -9,21 +9,16 @@ module Node
         def setup
           super
           ShopifyCli::ProjectType.load_type(:node)
+          ShopifyCli::Tasks::Schema.expects(:call).returns(schema_json)
         end
 
         def test_with_existing_param
-          ShopifyCli::Tasks::Schema.expects(:call).returns(
-            JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
-          )
           @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook APP_UNINSTALLED')
             .returns(mock(success?: true))
           run_cmd('generate webhook APP_UNINSTALLED')
         end
 
         def test_with_incorrect_param_expects_ask
-          ShopifyCli::Tasks::Schema.expects(:call).returns(
-            JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
-          )
           CLI::UI::Prompt.expects(:ask).returns('APP_UNINSTALLED')
           @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook APP_UNINSTALLED')
             .returns(mock(success?: true))
@@ -31,13 +26,16 @@ module Node
         end
 
         def test_with_selection
-          ShopifyCli::Tasks::Schema.expects(:call).returns(
-            JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json"))),
-          )
           CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
           @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook PRODUCT_CREATE')
             .returns(mock(success?: true))
           run_cmd('generate webhook')
+        end
+
+        private
+
+        def schema_json
+          @schema_json ||= JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
         end
       end
     end

--- a/test/project_types/node/commands/generate_test.rb
+++ b/test/project_types/node/commands/generate_test.rb
@@ -13,7 +13,12 @@ module Node
         run_cmd('generate')
       end
 
-      def test_for_failure
+      def test_help_argument_calls_extended_help
+        @context.expects(:puts).with(Node::Commands::Generate.help + "\n" + Node::Commands::Generate.extended_help)
+        run_cmd('help generate')
+      end
+
+      def test_run_generate_raises_abort_when_not_successful
         m = mock
         m.stubs(:success?).returns(false)
         m.stubs(:exitstatus).returns(1)
@@ -26,6 +31,7 @@ module Node
             '--silent',
           ]
         ).returns(m)
+
         assert_raises(ShopifyCli::Abort) do
           Node::Commands::Generate.run_generate(
             [

--- a/test/project_types/rails/commands/generate_test.rb
+++ b/test/project_types/rails/commands/generate_test.rb
@@ -12,6 +12,22 @@ module Rails
         @context.expects(:puts).with(Rails::Commands::Generate.help)
         run_cmd('generate')
       end
+
+      def test_help_argument_calls_extended_help
+        @context.expects(:puts).with(Rails::Commands::Generate.help + "\n" + Rails::Commands::Generate.extended_help)
+        run_cmd('help generate')
+      end
+
+      def test_run_generate_raises_abort_when_not_successful
+        failure = mock
+        failure.stubs(:success?).returns(false)
+        failure.stubs(:exitstatus).returns(1)
+        ShopifyCli::Context.any_instance.expects(:system).returns(failure)
+
+        assert_raises(ShopifyCli::Abort) do
+          Rails::Commands::Generate.run_generate(['script'], 'test-name', @context)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## WHAT is this pull request doing?

I noticed that the `extended_help` in `Node::Commands::Generate` was missing, and I added tests for `extended_help` in both Node/Rails. 

I also added `ShopifyCli::ROOT` to `ShopifyCli::ProjectType.load_type`, as I think we're talking about the CLI Root, and just to make sure we namespace stuff so we don't get into any weird `root` issues.