### PR TITLE
[WIP] Fix flakey Project.at tests

### DIFF
--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -4,7 +4,7 @@ module ShopifyCli
   module Commands
     class Connect < ShopifyCli::Command
       def call(*)
-        if Project.at(Dir.pwd)
+        if Project.current
           @ctx.puts "{{yellow:! Don't use}} {{cyan:connect}} {{yellow:for production apps}}"
           org = fetch_org
           id = org['id']

--- a/lib/shopify-cli/commands/populate/resource.rb
+++ b/lib/shopify-cli/commands/populate/resource.rb
@@ -20,7 +20,7 @@ module ShopifyCli
         end
 
         def call(args, _)
-          return unless Project.at(Dir.pwd)
+          return unless Project.current
           Tasks::EnsureEnv.call(@ctx)
           @args = args
           @input = Hash.new

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -16,15 +16,6 @@ module ShopifyCli
         current.app_type_id
       end
 
-      def at(dir)
-        proj_dir = directory(dir)
-        unless proj_dir
-          raise(ShopifyCli::Abort, "{{x}} #{message}")
-        end
-        @at ||= Hash.new { |h, k| h[k] = new(directory: k) }
-        @at[proj_dir]
-      end
-
       # Returns the directory of the project you are current in
       # Traverses up directory hierarchy until it finds a `.shopify-cli.yml`, then returns the directory is it in
       #
@@ -52,6 +43,15 @@ module ShopifyCli
       end
 
       private
+
+      def at(dir)
+        proj_dir = directory(dir)
+        unless proj_dir
+          raise(ShopifyCli::Abort, "{{x}} #{message}")
+        end
+        @at ||= Hash.new { |h, k| h[k] = new(directory: k) }
+        @at[proj_dir]
+      end
 
       def __directory(curr)
         loop do

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -10,25 +10,28 @@ module ShopifyCli
 
     def test_directory_recurses
       Dir.mktmpdir do |dir|
+        Dir.stubs(:pwd).returns("#{dir}/a/b/c/d")
         FileUtils.mkdir_p("#{dir}/a/b/c/d")
         FileUtils.touch("#{dir}/.shopify-cli.yml")
-        assert_equal(dir, Project.at("#{dir}/a/b/c/d").directory)
+        assert_equal(dir, Project.current.directory)
       end
     end
 
     def test_current_fails_if_no_config
       Dir.mktmpdir do |dir|
+        Dir.stubs(:pwd).returns("#{dir}/a/b/c/d")
         assert_raises ShopifyCli::Abort do
           FileUtils.mkdir_p("#{dir}/a/b/c/d")
-          Project.at("#{dir}/a/b/c/d")
+          Project.current
         end
       end
     end
 
     def test_write_writes_yaml
+      Dir.stubs(:pwd).returns(@context.root)
       FileUtils.touch(".shopify-cli.yml")
       ShopifyCli::Project.write(@context, :node)
-      assert_equal :node, ShopifyCli::Project.at(@context.root).config['app_type']
+      assert_equal :node, Project.current.config['app_type']
     end
   end
 end


### PR DESCRIPTION
### WHAT is this pull request doing?
Occasionally my tests will fail on CI like this:
![image](https://user-images.githubusercontent.com/30087610/78387795-e7626a00-75ad-11ea-8392-4f85b0ffd76b.png)

It seems like most things are calling `Project.current` which then does a `Project.at(Dir.pwd)`. However some things are still calling `Project.at` instead, and it seems like only `Project.current` is using a fixtures directory in tests, which could be the cause for these flakey tests.

I've updated all the calls to `Project.at` to use `Project.current` and I also made `Project.at` a private method so nothing can accidentally call it in the future.