### PR TITLE
Update create command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Developers should have some prior knowledge of the Shopify app ecosystem. Curren
 The `create` command will scaffold a new Shopify app in your current active directory and generate all the necessary starter files.
 
 ```sh
-$ shopify create project APP_NAME
+$ shopify create
 ```
 
 The CLI will ask what type of app you want to create. Two languages are currently supported:

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Developers should have some prior knowledge of the Shopify app ecosystem. Curren
 The `create` command will scaffold a new Shopify app in your current active directory and generate all the necessary starter files.
 
 ```sh
-$ shopify create project APP_NAME
+$ shopify create
 ```
 
 The CLI will ask what type of app you want to create. Two languages are currently supported:

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -30,7 +30,7 @@ module ShopifyCli
       def message
         <<~MESSAGE
           {{x}} You are not in a Shopify app project
-          {{yellow:{{*}}}}{{reset: Run}}{{cyan: shopify create project}}{{reset: to create your app}}
+          {{yellow:{{*}}}}{{reset: Run}}{{cyan: shopify create}}{{reset: to create your app}}
         MESSAGE
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?
Our create command was different before v2

### WHAT is this pull request doing?
Changes all references of `shopify create project` to `shopify create`


This is a small change, but a bigger change will eventually need to be made because all of our documentation seems like rails/node project are the only function of the Shopify command so we need to document how they work in a project context.