### PR TITLE
Make oauth more battle worthy

### DIFF
--- a/lib/shopify-cli/oauth.rb
+++ b/lib/shopify-cli/oauth.rb
@@ -5,39 +5,20 @@ require 'net/http'
 require 'securerandom'
 require 'openssl'
 require 'shopify_cli'
-require 'socket'
 require 'uri'
+require 'webrick'
 
 module ShopifyCli
   class OAuth
     include SmartProperties
 
+    autoload :Servlet, 'shopify-cli/oauth/servlet'
+
     class Error < StandardError; end
     LocalRequest = Struct.new(:method, :path, :query, :protocol)
 
     DEFAULT_PORT = 3456
-    REDIRECT_HOST = "http://app-cli-loopback.shopifyapps.com:#{DEFAULT_PORT}"
-    TEMPLATE = %{HTTP/1.1 200
-      Content-Type: text/html
-
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <title>%{title}</title>
-      </head>
-      <body>
-        <h1 style="color: #%{color};">%{message}</h1>
-        %{autoclose}
-      </body>
-      </html>
-    }
-    AUTOCLOSE_TEMPLATE = %{
-      <script>
-        setTimeout(function() { window.close(); }, 3000)
-      </script>
-    }
-    SUCCESS_RESP = 'Authenticated Successfully, this page will close shortly.'
-    INVALID_STATE_RESP = 'Anti-forgery state token does not match the initial request.'
+    REDIRECT_HOST = "http://127.0.0.1:#{DEFAULT_PORT}"
 
     property! :ctx
     property! :service, accepts: String
@@ -51,6 +32,8 @@ module ShopifyCli
     property :token_path, default: "/token", accepts: ->(path) { path.is_a?(String) && path.start_with?("/") }
     property :state_token, accepts: String, default: SecureRandom.hex(30)
     property :code_verifier, accepts: String, default: SecureRandom.hex(30)
+
+    attr_accessor :response_query
 
     def authenticate(url)
       return if refresh_exchange_token(url)
@@ -67,10 +50,22 @@ module ShopifyCli
       )
     end
 
+    def server
+      @server ||= begin
+        server = WEBrick::HTTPServer.new(
+          Port: DEFAULT_PORT,
+          Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
+          AccessLog: [],
+        )
+        server.mount('/', Servlet, self, state_token)
+        server
+      end
+    end
+
     private
 
     def initiate_authentication(url)
-      listen_local
+      @server_thread = Thread.new { server.start }
       params = {
         client_id: client_id,
         scope: scopes,
@@ -84,54 +79,12 @@ module ShopifyCli
       ctx.open_url!(uri)
     end
 
-    def listen_local
-      server = TCPServer.new('127.0.0.1', DEFAULT_PORT)
-      @server_thread ||= Thread.new do
-        Thread.current.abort_on_exception = true
-        begin
-          socket = server.accept
-          req = decode_request(socket.gets)
-          if !req.query['error'].nil?
-            respond_with(socket, 400, "Invalid Request: #{req.query['error_description']}")
-          elsif req.query['state'] != state_token
-            req.query.merge!('error' => 'invalid_state', 'error_description' => INVALID_STATE_RESP)
-            respond_with(socket, 403, INVALID_STATE_RESP)
-          else
-            respond_with(socket, 200, SUCCESS_RESP)
-          end
-          req.query
-        ensure
-          socket.close_write
-          server.close
-        end
-      end
-    end
-
-    def decode_request(req)
-      data = LocalRequest.new
-      data.method, path, data.protocol = req.split(' ')
-      data.path, _sep, query = path.partition("?")
-      data.query = decode_request_params(query)
-      data
-    end
-
-    def decode_request_params(str)
-      str.b.split('&').each_with_object({}) do |string, params|
-        key, _sep, val = string.partition('=')
-        key = URI.decode_www_form_component(key)
-        val = URI.decode_www_form_component(val)
-        params[key] = val
-        params
-      end
-    end
-
     def receive_access_code
       @access_code ||= begin
-        server = @server_thread.join(60)
-        raise Error, 'Timed out while waiting for response from shopify' if server.nil?
-        query = server.value
-        raise Error, query['error_description'] unless query['error'].nil?
-        query['code']
+        @server_thread.join(240)
+        raise Error, 'Timed out while waiting for response from shopify' if response_query.nil?
+        raise Error, response_query['error_description'] unless response_query['error'].nil?
+        response_query['code']
       end
     end
 
@@ -209,18 +162,6 @@ module ShopifyCli
       res = https.request(request)
       raise Error, JSON.parse(res.body)['error_description'] unless res.is_a?(Net::HTTPSuccess)
       JSON.parse(res.body)
-    end
-
-    def respond_with(resp, status, message)
-      successful = status == 200
-      locals = {
-        status: status,
-        message: message,
-        color: successful ? 'black' : 'red',
-        title: successful ? 'Authenticate Successfully' : 'Failed to Authenticate',
-        autoclose: successful ? AUTOCLOSE_TEMPLATE : '',
-      }
-      resp.print(format(TEMPLATE, locals))
     end
 
     def challange_params

--- a/lib/shopify-cli/oauth/servlet.rb
+++ b/lib/shopify-cli/oauth/servlet.rb
@@ -1,0 +1,57 @@
+module ShopifyCli
+  class OAuth
+    class Servlet < WEBrick::HTTPServlet::AbstractServlet
+      TEMPLATE = %{<!DOCTYPE html>
+        <html>
+        <head>
+          <title>%{title}</title>
+        </head>
+        <body>
+          <h1 style="color: #%{color};">%{message}</h1>
+          %{autoclose}
+        </body>
+        </html>
+      }
+      AUTOCLOSE_TEMPLATE = %{
+        <script>
+          setTimeout(function() { window.close(); }, 3000)
+        </script>
+      }
+      SUCCESS_RESP = 'Authenticated Successfully, this page will close shortly.'
+      INVALID_STATE_RESP = 'Anti-forgery state token does not match the initial request.'
+
+      def initialize(server, oauth, token)
+        super
+        @server = server
+        @oauth = oauth
+        @state_token = token
+      end
+
+      def do_GET(req, res) # rubocop:disable Naming/MethodName
+        if !req.query['error'].nil?
+          respond_with(res, 400, "Invalid Request: #{req.query['error_description']}")
+        elsif req.query['state'] != @state_token
+          req.query.merge!('error' => 'invalid_state', 'error_description' => INVALID_STATE_RESP)
+          respond_with(res, 403, INVALID_STATE_RESP)
+        else
+          respond_with(res, 200, SUCCESS_RESP)
+        end
+        @oauth.response_query = req.query
+        @server.shutdown
+      end
+
+      def respond_with(response, status, message)
+        successful = status == 200
+        locals = {
+          status: status,
+          message: message,
+          color: successful ? 'black' : 'red',
+          title: successful ? 'Authenticate Successfully' : 'Failed to Authenticate',
+          autoclose: successful ? AUTOCLOSE_TEMPLATE : '',
+        }
+        response.status = status
+        response.body = format(TEMPLATE, locals)
+      end
+    end
+  end
+end

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -134,7 +134,7 @@ module Node
             title: 'test-app',
             type: 'public',
             app_url: 'https://shopify.github.io/shopify-app-cli/getting-started',
-            redir: ["http://app-cli-loopback.shopifyapps.com:3456"],
+            redir: ["http://127.0.0.1:3456"],
           },
           resp: {
             'data': {
@@ -195,7 +195,7 @@ module Node
             title: 'test-app',
             type: 'public',
             app_url: 'https://shopify.github.io/shopify-app-cli/getting-started',
-            redir: ["http://app-cli-loopback.shopifyapps.com:3456"],
+            redir: ["http://127.0.0.1:3456"],
           },
           resp: {
             'data': {

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -64,7 +64,7 @@ module Rails
             title: 'test-app',
             type: 'public',
             app_url: 'https://shopify.github.io/shopify-app-cli/getting-started',
-            redir: ["http://app-cli-loopback.shopifyapps.com:3456"],
+            redir: ["http://127.0.0.1:3456"],
           },
           resp: {
             'data': {

--- a/test/shopify-cli/oauth/servlet_test.rb
+++ b/test/shopify-cli/oauth/servlet_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+require 'ostruct'
+require 'webrick'
+
+module ShopifyCli
+  module OAuthTests
+    class ServletTest < MiniTest::Test
+      Request = Struct.new(:query)
+      Response = Struct.new(:status, :body)
+
+      def test_do_get
+        server = new_server
+        oauth = OpenStruct.new
+        servlet = OAuth::Servlet.new(server, oauth, 'state_token')
+        resp = Response.new
+        servlet.do_GET(Request.new({ 'state' => 'state_token' }), resp)
+        assert_equal(oauth.response_query, { 'state' => 'state_token' })
+        assert_equal(resp.status, 200)
+        assert_match('Authenticate Successfully', resp.body)
+      end
+
+      def test_oauth_error
+        server = new_server
+        oauth = OpenStruct.new
+        servlet = OAuth::Servlet.new(server, oauth, 'state_token')
+        data = {
+          "error" => "bad_request",
+          "error_description" => "bad url callback",
+        }
+        resp = Response.new
+        servlet.do_GET(Request.new(data), resp)
+        assert_equal(oauth.response_query, data)
+        assert_equal(resp.status, 400)
+        assert_match('Failed to Authenticate', resp.body)
+      end
+
+      def test_invalid_state
+        server = new_server
+        oauth = OpenStruct.new
+        servlet = OAuth::Servlet.new(server, oauth, 'state_token')
+        resp = Response.new
+        servlet.do_GET(Request.new({ 'state' => 'nope' }), resp)
+        assert_equal(oauth.response_query, {
+          "state" => "nope",
+          "error" => "invalid_state",
+          "error_description" => OAuth::Servlet::INVALID_STATE_RESP,
+        })
+        assert_equal(resp.status, 403)
+        assert_match('Failed to Authenticate', resp.body)
+      end
+
+      private
+
+      def new_server
+        server = Object.new
+        server.stubs(:[])
+        server.expects(:shutdown)
+        server
+      end
+    end
+  end
+end

--- a/test/shopify-cli/oauth_test.rb
+++ b/test/shopify-cli/oauth_test.rb
@@ -20,9 +20,8 @@ module ShopifyCli
     def test_authenticate_with_secret
       endpoint = "https://example.com/auth"
       client = oauth(secret: 'secret')
-      @context.expects(:open_url!).with do |param|
-        auth_response(client, endpoint, param)
-      end
+      @context.expects(:open_url!)
+      stub_auth_response(client)
 
       authorize_query = {
         client_id: client.client_id,
@@ -52,9 +51,8 @@ module ShopifyCli
     def test_authenticate_without_secret
       endpoint = "https://example.com/auth"
       client = oauth
-      @context.expects(:open_url!).with do |param|
-        auth_response(client, endpoint, param)
-      end
+      @context.expects(:open_url!)
+      stub_auth_response(client)
 
       authorize_query = {
         client_id: client.client_id,
@@ -84,9 +82,8 @@ module ShopifyCli
     def test_request_exchange_token
       endpoint = "https://example.com/auth"
       client = oauth(request_exchange: '123')
-      @context.expects(:open_url!).with do |param|
-        auth_response(client, endpoint, param)
-      end
+      @context.expects(:open_url!)
+      stub_auth_response(client)
 
       authorize_query = {
         client_id: client.client_id,
@@ -214,31 +211,11 @@ module ShopifyCli
     def test_authenticate_with_invalid_request
       endpoint = "https://example.com/auth"
       client = oauth
-      @context.expects(:open_url!).with do |_param|
-        WebMock.disable!
-        https = Net::HTTP.new('localhost', 3456)
-        request = Net::HTTP::Get.new("/?error=err&error_description=error")
-        https.request(request)
-        WebMock.enable!
-        true
-      end
-      stub_request(:post, "#{endpoint}/authorize")
-      assert_raises OAuth::Error do
-        client.authenticate(endpoint)
-      end
-    end
-
-    def test_authenticate_with_invalid_state
-      endpoint = "https://example.com/auth"
-      client = oauth
-      @context.expects(:open_url!).with do |_param|
-        WebMock.disable!
-        https = Net::HTTP.new('localhost', 3456)
-        request = Net::HTTP::Get.new("/?code=mycode&state=notyourstate")
-        https.request(request)
-        WebMock.enable!
-        true
-      end
+      @context.expects(:open_url!)
+      stub_server(client, {
+        error: 'err',
+        error_description: 'error',
+      })
       stub_request(:post, "#{endpoint}/authorize")
       assert_raises OAuth::Error do
         client.authenticate(endpoint)
@@ -248,9 +225,8 @@ module ShopifyCli
     def test_authenticate_with_invalid_code
       endpoint = "https://example.com/auth"
       client = oauth(secret: 'secret')
-      @context.expects(:open_url!).with do |param|
-        auth_response(client, endpoint, param)
-      end
+      @context.expects(:open_url!)
+      stub_auth_response(client)
 
       authorize_query = {
         client_id: client.client_id,
@@ -295,29 +271,18 @@ module ShopifyCli
       }.merge(args))
     end
 
-    def auth_response(client, endpoint, param)
-      query = {
-        client_id: client.client_id,
-        scope: client.scopes,
-        redirect_uri: OAuth::REDIRECT_HOST,
+    def stub_auth_response(client)
+      stub_server(client, {
+        code: 'mycode',
         state: client.state_token,
-        response_type: :code,
-      }
-      if client.secret.nil?
-        query.merge!(
-          code_challenge: client.code_challenge,
-          code_challenge_method: 'S256',
-        )
-      end
-      command = "#{endpoint}/authorize?#{URI.encode_www_form(query)}"
-      if command == param.to_s
-        WebMock.disable!
-        https = Net::HTTP.new('localhost', 3456)
-        request = Net::HTTP::Get.new("/?code=mycode&state=#{client.state_token}")
-        https.request(request)
-        WebMock.enable!
-      end
-      command == param.to_s
+      })
+    end
+
+    def stub_server(client, resp)
+      server = Object.new
+      client.stubs(:server).returns(server)
+      server.expects(:start)
+      client.response_query = resp.transform_keys(&:to_s)
     end
 
     def token_resp

--- a/test/shopify-cli/oauth_test.rb
+++ b/test/shopify-cli/oauth_test.rb
@@ -213,8 +213,8 @@ module ShopifyCli
       client = oauth
       @context.expects(:open_url!)
       stub_server(client, {
-        error: 'err',
-        error_description: 'error',
+        'error' => 'err',
+        'error_description' => 'error',
       })
       stub_request(:post, "#{endpoint}/authorize")
       assert_raises OAuth::Error do
@@ -273,8 +273,8 @@ module ShopifyCli
 
     def stub_auth_response(client)
       stub_server(client, {
-        code: 'mycode',
-        state: client.state_token,
+        'code' => 'mycode',
+        'state' => client.state_token,
       })
     end
 
@@ -282,7 +282,7 @@ module ShopifyCli
       server = Object.new
       client.stubs(:server).returns(server)
       server.expects(:start)
-      client.response_query = resp.transform_keys(&:to_s)
+      client.response_query = resp
     end
 
     def token_resp

--- a/test/shopify-cli/task/create_api_client_test.rb
+++ b/test/shopify-cli/task/create_api_client_test.rb
@@ -13,7 +13,7 @@ module ShopifyCli
             title: 'Test app',
             type: 'public',
             app_url: 'http://app.com',
-            redir: ["http://app-cli-loopback.shopifyapps.com:3456"],
+            redir: ["http://127.0.0.1:3456"],
           },
           resp: {
             'data': {
@@ -47,7 +47,7 @@ module ShopifyCli
             title: 'Test app',
             type: 'public',
             app_url: 'http://app.com',
-            redir: ["http://app-cli-loopback.shopifyapps.com:3456"],
+            redir: ["http://127.0.0.1:3456"],
           },
           resp: {
             'data': {

--- a/test/shopify-cli/task/ensure_loopback_url_test.rb
+++ b/test/shopify-cli/task/ensure_loopback_url_test.rb
@@ -18,7 +18,7 @@ module ShopifyCli
               app: {
                 redirectUrlWhitelist: [
                   'https://123abc.ngrok.io',
-                  'http://app-cli-loopback.shopifyapps.com:3456',
+                  'http://127.0.0.1:3456',
                 ],
               },
             },
@@ -52,7 +52,7 @@ module ShopifyCli
             input: {
               redirectUrlWhitelist: [
                 'https://123abc.ngrok.io',
-                'http://app-cli-loopback.shopifyapps.com:3456',
+                'http://127.0.0.1:3456',
               ],
               apiKey: api_key,
             },


### PR DESCRIPTION
### WHY are these changes introduced?

fixes #469
fixes #432
fixes #484

Currently there are a couple of problems with our Auth
- `app-cli-loopback.shopifyapps.com` has DNS issues
- `app-cli-loopback.shopifyapps.com` is often redirected to https in firefox which our local server can't handle
- `request bodies are longer than expected`

We previously were using a domain to avoid DNS rebinding with `localhost` but I don't *think* this should be an issue with 127. Also, 127 should not be redirected to https ever. 

### WHAT is this pull request doing?

- Changes the redirect URL to `http://127.0.0.1:3456` from `http://app-cli-loopback.shopifyapps.com:3456`
- Changes from TScocket to use Webrick to be more stable and make webrick parse requests for us.
