### PR TITLE
Added a doc index for all the generated docs

### DIFF
--- a/lib/docgen/index_template.md.erb
+++ b/lib/docgen/index_template.md.erb
@@ -1,0 +1,7 @@
+We provide a base set of core APIs to help enable you to not have to write as much
+code and so that every developer can access resources in a consistent way.
+
+<%- classes.each do |method| -%>
+- [<%= method.title %>](#<%= method.filename %>)
+<%- end -%>
+

--- a/lib/docgen/index_template.md.erb
+++ b/lib/docgen/index_template.md.erb
@@ -1,7 +1,5 @@
-We provide a base set of core APIs to help enable you to not have to write as much
-code and so that every developer can access resources in a consistent way.
+The Shopify App CLI has a set of core APIs that simplify the process of extending its functionality.
 
 <%- classes.each do |method| -%>
 - [<%= method.title %>](#<%= method.filename %>)
 <%- end -%>
-

--- a/lib/docgen/markdown.rb
+++ b/lib/docgen/markdown.rb
@@ -8,7 +8,7 @@ module RDoc
 
       DocClass = Struct.new(
         :title, :kind, :comment, :class_methods, :instance_methods, :attributes,
-        :constants, :extended, :included,
+        :constants, :extended, :included, :filename,
         keyword_init: true,
       )
       ClassMember = Struct.new(:title, :comment, :signature, :source_code, keyword_init: true)
@@ -17,8 +17,6 @@ module RDoc
         @options = options
         @store = store
         @converter = ::RDoc::Markup::ToMarkdown.new
-        template_path = File.join(File.dirname(__FILE__), 'class_template.md.erb')
-        @renderer = ERB.new(File.read(template_path), nil, '-')
       end
 
       def generate
@@ -28,20 +26,24 @@ module RDoc
       private
 
       def render(data)
+        class_template_path = File.join(File.dirname(__FILE__), 'class_template.md.erb')
+        class_renderer = ERB.new(File.read(class_template_path), nil, '-')
         data.each do |cls|
-          File.write(
-            "#{cls.kind}-#{cls.title}.md",
-            @renderer.result(cls.instance_eval { binding }),
-          )
+          File.write("#{cls.filename}.md", class_renderer.result(cls.instance_eval { binding }))
         end
+        index_template_path = File.join(File.dirname(__FILE__), 'index_template.md.erb')
+        index_renderer = ERB.new(File.read(index_template_path), nil, '-')
+        File.write("Core-APIs.md", index_renderer.result(OpenStruct.new(classes: data).instance_eval { binding }))
       end
 
       def build_classes
         classes = @store.all_classes_and_modules.map do |klass|
           is_class = @store.all_modules.find { |m| m.full_name == klass.full_name }.nil?
+          kind = is_class ? :class : :module
           DocClass.new(
+            filename: "#{kind}-#{klass.full_name}.md",
             title: klass.full_name,
-            kind: is_class ? :class : :module,
+            kind: kind,
             comment: @converter.convert(klass.comment.parse),
             constants: build_members(klass.constants),
             class_methods: build_members(klass.method_list.select { |m| m.type == 'class' }),


### PR DESCRIPTION
### WHY are these changes introduced?
We need a way of having a index for the classes that we are documenting so that we can keep them separate from our more Tutorial-like content.

### WHAT is this pull request doing?
Adds a template and generation of a list of all the classes that we document.

I am going to hold off on merging and running this until I merge #536 and #537