### PR TITLE
Remove git remote add call for heroku deploy

### DIFF
--- a/lib/project_types/node/commands/deploy/heroku.rb
+++ b/lib/project_types/node/commands/deploy/heroku.rb
@@ -33,8 +33,7 @@ module Node
           spin_group.wait
 
           if (account = heroku_service.whoami)
-            spin_group.add("Authenticated with Heroku as `#{account}`") { true }
-            spin_group.wait
+            @ctx.puts("{{v}} Authenticated with Heroku as `#{account}`")
           else
             CLI::UI::Frame.open("Authenticating with Heroku…", success_text: '{{v}} Authenticated with Heroku') do
               heroku_service.authenticate
@@ -42,8 +41,7 @@ module Node
           end
 
           if (app_name = heroku_service.app)
-            spin_group.add("Heroku app `#{app_name}` selected") { true }
-            spin_group.wait
+            @ctx.puts("{{v}} Heroku app `#{app_name}` selected")
           else
             app_type = CLI::UI::Prompt.ask('No existing Heroku app found. What would you like to do?') do |handler|
               handler.option('Create a new Heroku app') { :new }
@@ -68,8 +66,7 @@ module Node
           branches = ShopifyCli::Git.branches(@ctx)
           if branches.length == 1
             branch_to_deploy = branches[0]
-            spin_group.add("Git branch `#{branch_to_deploy}` selected for deploy") { true }
-            spin_group.wait
+            @ctx.puts("{{v}} Git branch `#{branch_to_deploy}` selected for deploy")
           else
             branch_to_deploy = CLI::UI::Prompt.ask('What branch would you like to deploy?') do |handler|
               branches.each do |branch|

--- a/lib/project_types/rails/commands/deploy/heroku.rb
+++ b/lib/project_types/rails/commands/deploy/heroku.rb
@@ -33,8 +33,7 @@ module Rails
           spin_group.wait
 
           if (account = heroku_service.whoami)
-            spin_group.add("Authenticated with Heroku as `#{account}`") { true }
-            spin_group.wait
+            @ctx.puts("{{v}} Authenticated with Heroku as `#{account}`")
           else
             CLI::UI::Frame.open("Authenticating with Heroku…", success_text: '{{v}} Authenticated with Heroku') do
               heroku_service.authenticate
@@ -42,8 +41,7 @@ module Rails
           end
 
           if (app_name = heroku_service.app)
-            spin_group.add("Heroku app `#{app_name}` selected") { true }
-            spin_group.wait
+            @ctx.puts("{{v}} Heroku app `#{app_name}` selected")
           else
             app_type = CLI::UI::Prompt.ask('No existing Heroku app found. What would you like to do?') do |handler|
               handler.option('Create a new Heroku app') { :new }
@@ -68,8 +66,7 @@ module Rails
           branches = ShopifyCli::Git.branches(@ctx)
           if branches.length == 1
             branch_to_deploy = branches[0]
-            spin_group.add("Git branch `#{branch_to_deploy}` selected for deploy") { true }
-            spin_group.wait
+            @ctx.puts("{{v}} Git branch `#{branch_to_deploy}` selected for deploy")
           else
             branch_to_deploy = CLI::UI::Prompt.ask('What branch would you like to deploy?') do |handler|
               branches.each do |branch|

--- a/lib/shopify-cli/heroku.rb
+++ b/lib/shopify-cli/heroku.rb
@@ -26,12 +26,6 @@ module ShopifyCli
       output, status = @ctx.capture2e(heroku_command, 'create')
       @ctx.abort('Heroku app could not be created') unless status.success?
       @ctx.puts(output)
-
-      new_remote = output.split("\n").last.split("|").last.strip
-      result = @ctx.system('git', 'remote', 'add', 'heroku', new_remote)
-
-      msg = "Heroku app created, but couldn’t be set as a git remote"
-      @ctx.abort(msg) unless result.success?
     end
 
     def deploy(branch_to_deploy)

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -16,7 +16,8 @@ module Minitest
     end
 
     def run_cmd(cmd)
-      stub_monorail_log_invocation
+      stub_prompt_for_cli_updates
+      stub_monorail_log_git_sha
       ShopifyCli::Core::EntryPoint.call(cmd.split(' '), @context)
     end
 
@@ -43,8 +44,12 @@ module Minitest
 
     private
 
-    def stub_monorail_log_invocation
+    def stub_monorail_log_git_sha
       ShopifyCli::Git.stubs(:sha).returns("bb6f42193239a248f054e5019e469bc75f3adf1b")
+    end
+
+    def stub_prompt_for_cli_updates
+      ShopifyCli::Config.stubs(:get_section).with("autoupdate").returns(stub("key?" => true))
     end
   end
 end

--- a/test/project_types/node/commands/deploy/heroku_test.rb
+++ b/test/project_types/node/commands/deploy/heroku_test.rb
@@ -101,8 +101,8 @@ module Node
         def test_call_uses_existing_heroku_auth_if_available
           expects_heroku_whoami(status: true)
 
-          CLI::UI::SpinGroup.any_instance.expects(:add).with(
-            'Authenticated with Heroku as `username`'
+          @context.expects(:puts).with(
+            '{{v}} Authenticated with Heroku as `username`'
           )
 
           run_cmd('deploy heroku')
@@ -127,8 +127,8 @@ module Node
         def test_call_uses_existing_heroku_app_if_available
           expects_git_remote_get_url_heroku(status: true, remote: 'heroku')
 
-          CLI::UI::SpinGroup.any_instance.expects(:add).with(
-            'Heroku app `app-name` selected'
+          @context.expects(:puts).with(
+            '{{v}} Heroku app `app-name` selected'
           )
 
           run_cmd('deploy heroku')
@@ -169,7 +169,6 @@ module Node
         def test_call_lets_you_create_new_heroku_app
           expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
           expects_heroku_create(status: true)
-          expects_git_remote_add_heroku(status: true)
 
           CLI::UI::Prompt.expects(:ask)
             .with('No existing Heroku app found. What would you like to do?')
@@ -181,21 +180,6 @@ module Node
         def test_call_raises_if_creating_new_heroku_app_fails
           expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
           expects_heroku_create(status: false)
-          expects_git_remote_add_heroku(status: nil)
-
-          CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
-            .returns(:new)
-
-          assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
-          end
-        end
-
-        def test_call_raises_if_setting_remote_heroku_fails
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
-          expects_heroku_create(status: true)
-          expects_git_remote_add_heroku(status: false)
 
           CLI::UI::Prompt.expects(:ask)
             .with('No existing Heroku app found. What would you like to do?')
@@ -209,8 +193,8 @@ module Node
         def test_call_doesnt_prompt_if_only_one_branch_exists
           expects_git_branch(status: true, multiple: false)
 
-          CLI::UI::SpinGroup.any_instance.expects(:add).with(
-            'Git branch `master` selected for deploy'
+          @context.expects(:puts).with(
+            '{{v}} Git branch `master` selected for deploy'
           )
 
           run_cmd('deploy heroku')

--- a/test/project_types/rails/commands/deploy/heroku_test.rb
+++ b/test/project_types/rails/commands/deploy/heroku_test.rb
@@ -101,8 +101,8 @@ module Rails
         def test_call_uses_existing_heroku_auth_if_available
           expects_heroku_whoami(status: true)
 
-          CLI::UI::SpinGroup.any_instance.expects(:add).with(
-            'Authenticated with Heroku as `username`'
+          @context.expects(:puts).with(
+            "{{v}} Authenticated with Heroku as `username`"
           )
 
           run_cmd('deploy heroku')
@@ -127,8 +127,8 @@ module Rails
         def test_call_uses_existing_heroku_app_if_available
           expects_git_remote_get_url_heroku(status: true, remote: 'heroku')
 
-          CLI::UI::SpinGroup.any_instance.expects(:add).with(
-            'Heroku app `app-name` selected'
+          @context.expects(:puts).with(
+            '{{v}} Heroku app `app-name` selected'
           )
 
           run_cmd('deploy heroku')
@@ -169,7 +169,6 @@ module Rails
         def test_call_lets_you_create_new_heroku_app
           expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
           expects_heroku_create(status: true)
-          expects_git_remote_add_heroku(status: true)
 
           CLI::UI::Prompt.expects(:ask)
             .with('No existing Heroku app found. What would you like to do?')
@@ -181,21 +180,6 @@ module Rails
         def test_call_raises_if_creating_new_heroku_app_fails
           expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
           expects_heroku_create(status: false)
-          expects_git_remote_add_heroku(status: nil)
-
-          CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
-            .returns(:new)
-
-          assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
-          end
-        end
-
-        def test_call_raises_if_setting_remote_heroku_fails
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
-          expects_heroku_create(status: true)
-          expects_git_remote_add_heroku(status: false)
 
           CLI::UI::Prompt.expects(:ask)
             .with('No existing Heroku app found. What would you like to do?')
@@ -209,8 +193,8 @@ module Rails
         def test_call_doesnt_prompt_if_only_one_branch_exists
           expects_git_branch(status: true, multiple: false)
 
-          CLI::UI::SpinGroup.any_instance.expects(:add).with(
-            'Git branch `master` selected for deploy'
+          @context.expects(:puts).with(
+            '{{v}} Git branch `master` selected for deploy'
           )
 
           run_cmd('deploy heroku')

--- a/test/shopify-cli/heroku_test.rb
+++ b/test/shopify-cli/heroku_test.rb
@@ -54,7 +54,6 @@ module ShopifyCli
 
     def test_create_new_app_using_full_path_heroku_to_create_new_heroku_app
       expects_heroku_create(status: true, full_path: true)
-      expects_git_remote_add_heroku(status: true)
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 
@@ -63,7 +62,6 @@ module ShopifyCli
 
     def test_create_new_app_using_non_full_path_heroku_to_create_new_heroku_app
       expects_heroku_create(status: true, full_path: false)
-      expects_git_remote_add_heroku(status: true)
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 
@@ -72,18 +70,6 @@ module ShopifyCli
 
     def test_create_new_app_raises_if_creating_new_heroku_app_fails
       expects_heroku_create(status: false)
-      expects_git_remote_add_heroku(status: nil)
-
-      heroku_service = ShopifyCli::Heroku.new(@context)
-
-      assert_raises ShopifyCli::Abort do
-        heroku_service.create_new_app
-      end
-    end
-
-    def test_create_new_app_raises_if_setting_remote_heroku_fails
-      expects_heroku_create(status: true)
-      expects_git_remote_add_heroku(status: false)
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 

--- a/test/test_helpers/heroku.rb
+++ b/test/test_helpers/heroku.rb
@@ -43,6 +43,9 @@ module TestHelpers
       @context.stubs(:system)
         .with('git', 'push', '-u', 'heroku', 'master:master')
         .returns(status_mock[:true])
+
+      # user outputs
+      @context.stubs(:puts)
     end
 
     def expects_tar_heroku(status:)
@@ -103,18 +106,6 @@ module TestHelpers
       @context.expects(:capture2e)
         .with('git', 'remote', 'get-url', remote)
         .returns([output, status_mock[:"#{status}"]])
-    end
-
-    def expects_git_remote_add_heroku(status:)
-      if status.nil?
-        @context.expects(:system)
-          .with('git', 'remote', 'add', 'heroku', heroku_remote)
-          .never
-      else
-        @context.expects(:system)
-          .with('git', 'remote', 'add', 'heroku', heroku_remote)
-          .returns(status_mock[:"#{status}"])
-      end
     end
 
     def expects_git_push_heroku(status:, branch:)


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes https://github.com/Shopify/shopify-app-cli/issues/495

The `shopify deploy heroku` command fails when creating a new app because we first call `heroku create` and then call `git remote add heroku new_remote`. If you run it a second time, it succeeds because the app is already created.

![image](https://user-images.githubusercontent.com/30087610/80133037-a2a56f80-856a-11ea-925b-6f43ed1a4b87.png)

As per the Heroku docs: `If you run the create command from your app’s root directory, the empty Heroku Git repository is automatically set as a remote for your local repository.` So our `remote add` call always fails because it's already being done by Heroku automatically.

I'm removing this call and tidying up some tests that used it. I needed to remove some of the `spin_group.add/wait` logic and replaced it with `@ctx.puts` as there are some weird `spin_group/Prompt` interaction issues that write over the printouts to the console.

I also noticed that sometimes when running my tests it first asks if i want to enable auto-updates, so I've stubbed that for all test runs in the future.