### PR TITLE
Add --name flag for create

### DIFF
--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -11,7 +11,9 @@ module Node
       NPM_REQUIRED_NOTICE = "node is required to create an app project. Download at https://www.npmjs.com/get-npm."
 
       options do |parser, flags|
+        # backwards compatibility allow 'title' for now
         parser.on('--title=TITLE') { |t| flags[:title] = t }
+        parser.on('--name=NAME') { |t| flags[:title] = t }
         parser.on('--organization_id=ID') { |url| flags[:organization_id] = url }
         parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
         parser.on('--type=APPTYPE') { |url| flags[:type] = url }
@@ -57,9 +59,9 @@ module Node
         {{command:#{ShopifyCli::TOOL_NAME} create node}}: Creates an embedded nodejs app.
           Usage: {{command:#{ShopifyCli::TOOL_NAME} create node}}
           Options:
-            {{command:--title=TITLE}} App project title. Any string.
-            {{command:--app_url=APPURL}} App project URL. Must be valid URL.
-            {{command:--organization_id=ID}} App project Org ID. Must be existing org ID.
+            {{command:--name=NAME}} App name. Any string.
+            {{command:--app_url=APPURL}} App URL. Must be valid URL.
+            {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
             {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
         HELP
       end

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -17,7 +17,9 @@ module Rails
       MSG
 
       options do |parser, flags|
+        # backwards compatibility allow 'title' for now
         parser.on('--title=TITLE') { |t| flags[:title] = t }
+        parser.on('--name=NAME') { |t| flags[:title] = t }
         parser.on('--organization_id=ID') { |url| flags[:organization_id] = url }
         parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
         parser.on('--type=APPTYPE') { |url| flags[:type] = url }
@@ -65,9 +67,9 @@ module Rails
         {{command:#{ShopifyCli::TOOL_NAME} create rails}}: Creates a ruby on rails app.
           Usage: {{command:#{ShopifyCli::TOOL_NAME} create rails}}
           Options:
-            {{command:--title=TITLE}} App project title. Any string.
-            {{command:--app_url=APPURL}} App project URL. Must be valid URL.
-            {{command:--organization_id=ID}} App project Org ID. Must be existing org ID.
+            {{command:--name=NAME}} App name. Any string.
+            {{command:--app_url=APPURL}} App URL. Must be valid URL.
+            {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
             {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
         HELP
       end

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -113,7 +113,7 @@ module Node
 
       def perform_command
         run_cmd("create node \
-          --title=test-app \
+          --name=test-app \
           --type=public \
           --organization_id=42 \
           --shop_domain=testshop.myshopify.com")

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -96,7 +96,7 @@ module Rails
       def perform_command
         run_cmd("create rails \
           --type=public \
-          --title=test-app \
+          --name=test-app \
           --organization_id=42 \
           --shop_domain=testshop.myshopify.com")
       end


### PR DESCRIPTION
### WHAT is this pull request doing?
Fixes https://github.com/Shopify/shopify-app-cli/issues/534

In the Shopify ecosystem, we refer to "app name" when we talk about apps, not "title". The --title option used when creating an app project should therefore be --name instead. I kept --title around for backwards compatibility but no longer suggest it as a valid option.

<img width="605" alt="Screen Shot 2020-04-23 at 2 59 23 PM" src="https://user-images.githubusercontent.com/30087610/80138668-24010000-8573-11ea-9601-cb376a9bfecb.png">

