### PR TITLE
Removing calls to uname

### DIFF
--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -82,7 +82,7 @@ module ShopifyCli
 
     def default_headers
       {
-        'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} #{current_sha} | #{ctx.uname(flag: 'v')}",
+        'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} #{current_sha} | #{ctx.uname}",
       }.merge(auth_headers(token))
     end
 

--- a/lib/shopify-cli/context/system.rb
+++ b/lib/shopify-cli/context/system.rb
@@ -11,16 +11,17 @@ module ShopifyCli
       }
 
       def os
-        return :mac if mac?
-        return :linux if linux?
+        host = uname
+        return :mac if /darwin/.match(host)
+        return :linux if /linux/.match(host)
       end
 
       def mac?
-        /Darwin/.match(uname)
+        os == :mac
       end
 
       def linux?
-        /Linux/.match(uname)
+        os == :linux
       end
 
       def system?
@@ -39,8 +40,8 @@ module ShopifyCli
         ENV['CI']
       end
 
-      def uname(flag: 'a')
-        @uname ||= capture2("uname -#{flag}")[0].strip
+      def uname
+        @uname ||= RbConfig::CONFIG["host"]
       end
 
       def spawn(*args, **kwargs)

--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -73,16 +73,12 @@ module ShopifyCli
         def monorail_payload(args:, duration:, result:)
           {
             cli_sha: ShopifyCli::Git.sha(dir: ShopifyCli::ROOT),
-            uname: uname,
+            uname: RbConfig::CONFIG["host"],
             args: args,
             timestamp: Time.now.utc.iso8601(MICROSECOND_PRECISION),
             duration: duration,
             result: result,
           }
-        end
-
-        def uname
-          @uname ||= %x{uname -a}
         end
 
         def ruby_version

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -63,7 +63,7 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.js')
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
-        @context.stubs(:uname).with(flag: 'v').returns('Mac')
+        @context.stubs(:uname).returns('Mac')
         @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(

--- a/test/shopify-cli/api_test.rb
+++ b/test/shopify-cli/api_test.rb
@@ -20,7 +20,7 @@ module ShopifyCli
         url: "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json",
       )
       Git.stubs(:sha).returns('abcde')
-      @context.stubs(:uname).with(flag: 'v').returns('Mac')
+      @context.stubs(:uname).returns('Mac')
     end
 
     def test_mutation_makes_request_to_shopify

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -17,18 +17,14 @@ module ShopifyCli
     end
 
     def test_mac_matches
-      @ctx.expects(:capture2).with('uname -a').returns(
-        ['Darwin hostname.local 18.6.0 Darwin Kernel Version 18.6.0', nil]
-      )
+      @ctx.expects(:uname).returns('x86_64-apple-darwin19.3.0').times(3)
       assert(@ctx.mac?)
       assert_equal(:mac, @ctx.os)
       refute(@ctx.linux?)
     end
 
     def test_linux_matches
-      @ctx.expects(:capture2).with('uname -a').returns(
-        ['Linux hostname 4.15.0-50-generic #54-Ubuntu SMP', nil]
-      )
+      @ctx.expects(:uname).returns('x86_64-pc-linux-gnu').times(3)
       assert(@ctx.linux?)
       assert_equal(:linux, @ctx.os)
       refute(@ctx.mac?)


### PR DESCRIPTION
### WHY are these changes introduced?
We need less system-dependent system calls. 

### WHAT is this pull request doing?
Removes calls to uname and replacing them with Ruby internals that are already available `RbConfig::Config['host']`
