### PR TITLE
Fix relative paths for docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,10 @@
 title: Shopify App CLI
 markdown: kramdown
+url: https://shopify.github.io
+baseurl: /shopify-app-cli
+
 exclude: [
   'heroku/',
+  'Gemfile',
+  'Gemfile.lock'
 ]

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -16,4 +16,4 @@
 
 <link rel="shortcut icon" type="image/png" href="https://cdn.shopify.com/shopify-marketing_assets/static/shopify-favicon.png" />
 <link href="https://cdn.shopify.com/shopify-marketing_assets/builds/88.3.2/marketing_assets.css" rel="stylesheet" type="text/css">
-<link href="{{ site.url }}/css/docs.css" rel="stylesheet" type="text/css">
+<link href="{{ '/css/docs.css' | relative_url }}" rel="stylesheet" type="text/css">

--- a/docs/_includes/sidebar_nav.html
+++ b/docs/_includes/sidebar_nav.html
@@ -1,11 +1,11 @@
 <ul class="in-page-menu in-page-menu--vertical">
   {% for item in site.data.nav.sidebar %}
     <li>
-      <a class="{% if item.url == page.url %}is-active{% endif %}" href="{{ item.url }}">{{ item.title }}</a>
+      <a class="{% if item.url == page.url %}is-active{% endif %}" href="{{ item.url | relative_url }}">{{ item.title }}</a>
       {% if item.section == page.section %}
         <ul>
           {% for subitem in item.subnav %}
-            <li><a class="{% if subitem.url == page.url %}is-active{% endif %}" href="{{ subitem.url }}">{{ subitem.title }}</a></li>
+            <li><a class="{% if subitem.url == page.url %}is-active{% endif %}" href="{{ subitem.url | relative_url  }}">{{ subitem.title }}</a></li>
           {% endfor %}
         </ul>
       {% endif %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,7 +21,7 @@
         <nav class="marketing-nav--skin-dark marketing-nav marketing-nav--primary" id="ShopifyMainNav" itemscope="itemscope" itemtype="https://schema.org/SiteNavigationElement" aria-label="Main Navigation">
 
           <div class="marketing-nav__logo color-white">
-            <a href="{{ site.url }}" class="marketing-nav__logo__shopify">
+            <a href="{{ '/' | relative_url }}" class="marketing-nav__logo__shopify">
               <svg class="icon" aria-labelledby="icon-shopify-developers-logo-5-title" role="img"><title id="icon-shopify-developers-logo-5-title">Home</title> <use xlink:href="#shopify-developers-logo"></use> </svg>
             </a>
           </div>

--- a/docs/app/node/index.md
+++ b/docs/app/node/index.md
@@ -30,4 +30,4 @@ install it on a development store.
     $ shopify open
     ```
 
-For more information, look at the [command reference]({% link app/node/commands/index.md %}).
+For more information, look at the [command reference]({{ site.baseurl }}{% link app/node/commands/index.md %}).

--- a/docs/app/rails/index.md
+++ b/docs/app/rails/index.md
@@ -30,5 +30,5 @@ install it on a development store.
     $ shopify open
     ```
 
-For more information, look at the [command reference]({% link app/node/commands/index.md %}).
+For more information, look at the [command reference]({{ site.baseurl }}{% link app/node/commands/index.md %}).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,4 +23,4 @@ $ shopify create
 
 Each project type has its own set of commands to speed up your development process.
 
-To get started, look at the [requirements and installation instructions]({% link getting-started/index.md %}).
+To get started, look at the [requirements and installation instructions]({{ site.baseurl }}{% link getting-started/index.md %}).


### PR DESCRIPTION
In #550, I neglected to consider that the docs site is published in a directory (`http://shopify.github.io/shopify-app-cli/`), and GitHubPages/Jekyll don't deal with that gracefully.

This PR fixes all the links in the docs.