### PR TITLE
Create test script command

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -47,18 +47,17 @@ module Script
   autoload :ScriptProject, Project.project_filepath('script_project')
 
   class ScriptProjectError < StandardError; end
-  class InvalidContextError < ScriptProjectError; end
-  class ScriptProjectAlreadyExistsError < ScriptProjectError; end
-  class ServiceFailureError < ScriptProjectError; end
-  class TestSuiteNotFoundError < ScriptProjectError; end
   class DependencyError < ScriptProjectError; end
   class DependencyInstallError < ScriptProjectError; end
+  class InvalidContextError < ScriptProjectError; end
   class InvalidExtensionPointError < ScriptProjectError
     attr_reader :type
     def initialize(type)
       @type = type
     end
   end
+  class ServiceFailureError < ScriptProjectError; end
+  class ScriptProjectAlreadyExistsError < ScriptProjectError; end
   class ScriptNotFoundError < ScriptProjectError
     attr_reader :script_name, :extension_point_type
     def initialize(extension_point_type, script_name)
@@ -66,4 +65,5 @@ module Script
       @extension_point_type = extension_point_type
     end
   end
+  class TestSuiteNotFoundError < ScriptProjectError; end
 end

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -4,11 +4,14 @@ module Script
   class Project < ShopifyCli::ProjectType
     hidden_project_type
     creator 'Script', 'Script::Commands::Create'
+
+    register_command('Script::Commands::Test', 'test')
   end
 
   # define/autoload project specific Commads
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
+    autoload :Test, Project.project_filepath('commands/test')
   end
 
   # define/autoload project specific Forms
@@ -21,6 +24,7 @@ module Script
       autoload :CreateScript, Project.project_filepath('layers/application/create_script')
       autoload :ExtensionPoints, Project.project_filepath('layers/application/extension_points')
       autoload :ProjectDependencies, Project.project_filepath('layers/application/project_dependencies')
+      autoload :TestScript, Project.project_filepath('layers/application/test_script')
     end
 
     module Domain
@@ -32,6 +36,8 @@ module Script
       autoload :AssemblyScriptTsConfig, Project.project_filepath('layers/infrastructure/assemblyscript_tsconfig')
       autoload :AssemblyScriptDependencyManager,
                Project.project_filepath('layers/infrastructure/assemblyscript_dependency_manager')
+      autoload :AssemblyScriptTestRunner,
+               Project.project_filepath('layers/infrastructure/assemblyscript_test_runner')
       autoload :DependencyManager, Project.project_filepath('layers/infrastructure/dependency_manager')
       autoload :ExtensionPointRepository, Project.project_filepath('layers/infrastructure/extension_point_repository')
       autoload :ScriptRepository, Project.project_filepath('layers/infrastructure/script_repository')
@@ -65,5 +71,6 @@ module Script
       @extension_point_type = extension_point_type
     end
   end
+  class TestError < ScriptProjectError; end
   class TestSuiteNotFoundError < ScriptProjectError; end
 end

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -28,11 +28,13 @@ module Script
     end
 
     module Domain
+      autoload :Errors, Project.project_filepath('layers/domain/errors')
       autoload :ExtensionPoint, Project.project_filepath('layers/domain/extension_point')
       autoload :Script, Project.project_filepath('layers/domain/script')
     end
 
     module Infrastructure
+      autoload :Errors, Project.project_filepath('layers/infrastructure/errors')
       autoload :AssemblyScriptTsConfig, Project.project_filepath('layers/infrastructure/assemblyscript_tsconfig')
       autoload :AssemblyScriptDependencyManager,
                Project.project_filepath('layers/infrastructure/assemblyscript_dependency_manager')
@@ -51,26 +53,7 @@ module Script
   end
 
   autoload :ScriptProject, Project.project_filepath('script_project')
+  autoload :Errors, Project.project_filepath('errors')
 
   class ScriptProjectError < StandardError; end
-  class DependencyError < ScriptProjectError; end
-  class DependencyInstallError < ScriptProjectError; end
-  class InvalidContextError < ScriptProjectError; end
-  class InvalidExtensionPointError < ScriptProjectError
-    attr_reader :type
-    def initialize(type)
-      @type = type
-    end
-  end
-  class ServiceFailureError < ScriptProjectError; end
-  class ScriptProjectAlreadyExistsError < ScriptProjectError; end
-  class ScriptNotFoundError < ScriptProjectError
-    attr_reader :script_name, :extension_point_type
-    def initialize(extension_point_type, script_name)
-      @script_name = script_name
-      @extension_point_type = extension_point_type
-    end
-  end
-  class TestError < ScriptProjectError; end
-  class TestSuiteNotFoundError < ScriptProjectError; end
 end

--- a/lib/project_types/script/commands/test.rb
+++ b/lib/project_types/script/commands/test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Script
+  module Commands
+    class Test < ShopifyCli::Command
+      OPERATION_FAILED_MESSAGE = "Tests didn't run or they ran with failures."
+      OPERATION_SUCCESS_MESSAGE = "{{v}} Tests finished."
+
+      def call(_args, _name)
+        project = Script::ScriptProject.current
+        Layers::Application::TestScript.call(
+          ctx: @ctx,
+          language: project.language,
+          extension_point_type: project.extension_point_type,
+          script_name: project.script_name
+        )
+        @ctx.puts(OPERATION_SUCCESS_MESSAGE)
+      rescue StandardError => e
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: OPERATION_FAILED_MESSAGE)
+      end
+
+      def self.help
+        <<~HELP
+        Runs unit tests on your script.
+          Usage: {{command:#{ShopifyCli::TOOL_NAME} test}}
+        HELP
+      end
+    end
+  end
+end

--- a/lib/project_types/script/errors.rb
+++ b/lib/project_types/script/errors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Script
+  module Errors
+    class InvalidContextError < ScriptProjectError; end
+    class ScriptProjectAlreadyExistsError < ScriptProjectError; end
+  end
+end

--- a/lib/project_types/script/layers/application/project_dependencies.rb
+++ b/lib/project_types/script/layers/application/project_dependencies.rb
@@ -18,14 +18,14 @@ module Script
                 spinner.update_title('Dependencies installed')
               end
               true
-            rescue DependencyInstallError => e
+            rescue Infrastructure::Errors::DependencyInstallError => e
               CLI::UI::Frame.with_frame_color_override(:red) do
                 ctx.puts("\n#{e.message}")
               end
               false
             end
           end
-            raise DependencyInstallError
+            raise Infrastructure::Errors::DependencyInstallError
           end
         end
       end

--- a/lib/project_types/script/layers/application/test_script.rb
+++ b/lib/project_types/script/layers/application/test_script.rb
@@ -22,9 +22,10 @@ module Script
           def run_tests(ctx, language, extension_point_type, script_name)
             ensure_valid_test_suite(language, extension_point_type, script_name)
 
-            raise TestError unless Infrastructure::TestSuiteRepository.new.with_test_suite_context do
+            success = Infrastructure::TestSuiteRepository.new.with_test_suite_context do
               Infrastructure::AssemblyScriptTestRunner.new(ctx: ctx).run_tests
             end
+            raise Infrastructure::Errors::TestError unless success
           end
 
           def ensure_valid_test_suite(language, extension_point_type, script_name)

--- a/lib/project_types/script/layers/application/test_script.rb
+++ b/lib/project_types/script/layers/application/test_script.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Application
+      class TestScript
+        RUNNING_MSG = "Running tests"
+
+        class << self
+          def call(ctx:, language:, extension_point_type:, script_name:)
+            extension_point = ExtensionPoints.get(type: extension_point_type)
+            ProjectDependencies
+              .install(ctx: ctx, language: language, extension_point: extension_point, script_name: script_name)
+
+            CLI::UI::Frame.open(RUNNING_MSG) do
+              run_tests(ctx, language, extension_point_type, script_name)
+            end
+          end
+
+          private
+
+          def run_tests(ctx, language, extension_point_type, script_name)
+            ensure_valid_test_suite(language, extension_point_type, script_name)
+
+            raise TestError unless Infrastructure::TestSuiteRepository.new.with_test_suite_context do
+              Infrastructure::AssemblyScriptTestRunner.new(ctx: ctx).run_tests
+            end
+          end
+
+          def ensure_valid_test_suite(language, extension_point_type, script_name)
+            Infrastructure::TestSuiteRepository.new.get_test_suite(language, extension_point_type, script_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/domain/errors.rb
+++ b/lib/project_types/script/layers/domain/errors.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Domain
+      module Errors
+        class InvalidExtensionPointError < ScriptProjectError
+          attr_reader :type
+          def initialize(type)
+            @type = type
+          end
+        end
+        class ScriptNotFoundError < ScriptProjectError
+          attr_reader :script_name, :extension_point_type
+          def initialize(extension_point_type, script_name)
+            @script_name = script_name
+            @extension_point_type = extension_point_type
+          end
+        end
+        class ServiceFailureError < ScriptProjectError; end
+        class TestSuiteNotFoundError < ScriptProjectError; end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
@@ -23,7 +23,7 @@ module Script
 
         def install
           output, status = @ctx.capture2e("npm", "install", "--no-audit", "--no-optional", "--loglevel error")
-          raise DependencyInstallError, output unless status.success?
+          raise Errors::DependencyInstallError, output unless status.success?
         end
 
         private

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_test_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_test_runner.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Infrastructure
+      class AssemblyScriptTestRunner
+        include SmartProperties
+        property! :ctx, accepts: ShopifyCli::Context
+
+        RUN_TEST_COMMAND = "npm test"
+
+        def run_tests
+          ctx.setenv("FORCE_COLOR", "1") # force aspect output to have colour
+          ctx.system(RUN_TEST_COMMAND)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/infrastructure/dependency_manager.rb
+++ b/lib/project_types/script/layers/infrastructure/dependency_manager.rb
@@ -27,7 +27,7 @@ module Script
         }
 
         def self.for(ctx, language, extension_point, script_name)
-          raise DependencyError, language unless DEP_MANAGER[language]
+          raise Errors::DependencyError, language unless DEP_MANAGER[language]
           DEP_MANAGER[language].new(ctx, language, extension_point, script_name)
         end
       end

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Infrastructure
+      module Errors
+        class DependencyError < ScriptProjectError; end
+        class DependencyInstallError < ScriptProjectError; end
+        class TestError < ScriptProjectError; end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
@@ -15,7 +15,7 @@ module Script
         private
 
         def fetch_extension_point(type)
-          raise InvalidExtensionPointError, type unless extension_points[type]
+          raise Domain::Errors::InvalidExtensionPointError, type unless extension_points[type]
           extension_points[type]
         end
 

--- a/lib/project_types/script/layers/infrastructure/script_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_repository.rb
@@ -9,7 +9,7 @@ module Script
         def create_script(language, extension_point, script_name)
           FileUtils.mkdir_p(src_base)
           out, status = CLI::Kit::System.capture2e(format(BOOTSTRAP_SRC, src_base: src_base))
-          raise ServiceFailureError, out unless status.success?
+          raise Domain::Errors::ServiceFailureError, out unless status.success?
 
           write_tsconfig if language == "ts"
 
@@ -24,7 +24,7 @@ module Script
         def get_script(language, extension_point_type, script_name)
           source_file_path = src_code_file(language)
           unless File.exist?(source_file_path)
-            raise ScriptNotFoundError.new(extension_point_type, source_file_path)
+            raise Domain::Errors::ScriptNotFoundError.new(extension_point_type, source_file_path)
           end
 
           Domain::Script.new(script_id(language), script_name, extension_point_type, language)

--- a/lib/project_types/script/layers/infrastructure/test_suite_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/test_suite_repository.rb
@@ -17,7 +17,7 @@ module Script
           FileUtils.mkdir_p(test_base)
           FileUtils.copy(aspect_config_template(script.language), "#{test_base}/as-pect.config.js")
           out, status = CLI::Kit::System.capture2e(format(BOOTSTRAP_TEST, test_base: test_base))
-          raise ServiceFailureError, out unless status.success?
+          raise Domain::Errors::ServiceFailureError, out unless status.success?
 
           write_tsconfig_file
           write_aspect_type_definitions_file
@@ -26,7 +26,7 @@ module Script
         def get_test_suite(language, extension_point_type, script_name)
           ScriptRepository.new.get_script(language, extension_point_type, script_name)
           source = "#{test_base}/script.spec.#{language}"
-          raise TestSuiteNotFoundError unless File.exist?(source)
+          raise Domain::Errors::TestSuiteNotFoundError unless File.exist?(source)
         end
 
         def with_test_suite_context

--- a/lib/project_types/script/script_project.rb
+++ b/lib/project_types/script/script_project.rb
@@ -16,13 +16,13 @@ module Script
     private
 
     def lookup_config(key)
-      raise InvalidContextError, key unless config.key?(key)
+      raise Errors::InvalidContextError, key unless config.key?(key)
       config[key]
     end
 
     class << self
       def create(dir)
-        raise ScriptProjectAlreadyExistsError, dir if Dir.exist?(dir)
+        raise Errors::ScriptProjectAlreadyExistsError, dir if Dir.exist?(dir)
 
         FileUtils.mkdir_p(dir)
         Dir.chdir(dir)

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -63,6 +63,10 @@ module Script
             cause_of_error: "Directory with the same name as the script already exists.",
             help_suggestion: "Use different script name and try again.",
           }
+        when TestError
+          {
+            help_suggestion: "Correct the errors and try again.",
+          }
         end
       end
     end

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -39,31 +39,31 @@ module Script
             cause_of_error: "Something went wrong while authenticating your account with the Partner Dashboard.",
             help_suggestion: "Try again.",
           }
-        when DependencyInstallError
-          {
-            cause_of_error: "Something went wrong while installing the dependencies that are needed.",
-            help_suggestion: "See https://help.shopify.com/en/",
-          }
-        when InvalidContextError
+        when Errors::InvalidContextError
           {
             cause_of_error: "Your .shopify-cli.yml file is not correct.",
             help_suggestion: "See https://help.shopify.com/en/",
           }
-        when InvalidExtensionPointError
-          {
-            cause_of_error: "Invalid extension point #{e.type}",
-            help_suggestion: "Allowed values: discount and unit_limit_per_order.",
-          }
-        when ScriptNotFoundError
-          {
-            cause_of_error: "Couldn't find script #{e.script_name} for extension point #{e.extension_point_type}",
-          }
-        when ScriptProjectAlreadyExistsError
+        when Errors::ScriptProjectAlreadyExistsError
           {
             cause_of_error: "Directory with the same name as the script already exists.",
             help_suggestion: "Use different script name and try again.",
           }
-        when TestError
+        when Layers::Domain::Errors::InvalidExtensionPointError
+          {
+            cause_of_error: "Invalid extension point #{e.type}",
+            help_suggestion: "Allowed values: discount and unit_limit_per_order.",
+          }
+        when Layers::Domain::Errors::ScriptNotFoundError
+          {
+            cause_of_error: "Couldn't find script #{e.script_name} for extension point #{e.extension_point_type}",
+          }
+        when Layers::Infrastructure::Errors::DependencyInstallError
+          {
+            cause_of_error: "Something went wrong while installing the dependencies that are needed.",
+            help_suggestion: "See https://help.shopify.com/en/",
+          }
+        when Layers::Infrastructure::Errors::TestError
           {
             help_suggestion: "Correct the errors and try again.",
           }

--- a/test/project_types/script/commands/test_test.rb
+++ b/test/project_types/script/commands/test_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'project_types/script/test_helper'
+
+module Script
+  module Commands
+    class TestTest < MiniTest::Test
+      def setup
+        @context = TestHelpers::FakeContext.new
+        @language = 'ts'
+        @script_name = 'name'
+        @ep_type = 'discount'
+        @script_project = TestHelpers::FakeScriptProject.new(
+          language: @language,
+          extension_point_type: @ep_type,
+          script_name: @script_name
+        )
+        Script::ScriptProject.stubs(:current).returns(@script_project)
+      end
+
+      def test_calls_test_service
+        Script::Layers::Application::TestScript
+          .expects(:call)
+          .with(ctx: @context, language: @language, script_name: @script_name, extension_point_type: @ep_type)
+
+        @context
+          .expects(:puts)
+          .with(Script::Commands::Test::OPERATION_SUCCESS_MESSAGE)
+        perform_command
+      end
+
+      private
+
+      def perform_command
+        run_cmd('test')
+      end
+    end
+  end
+end

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -32,7 +32,7 @@ describe Script::Layers::Application::ExtensionPoints do
 
     describe 'when extension point exists' do
       it 'should return a valid extension point' do
-        assert_raises(Script::InvalidExtensionPointError) do
+        assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) do
           Script::Layers::Application::ExtensionPoints.get(type: 'invalid')
         end
       end

--- a/test/project_types/script/layers/application/project_dependencies_test.rb
+++ b/test/project_types/script/layers/application/project_dependencies_test.rb
@@ -65,12 +65,12 @@ describe Script::Layers::Application::ProjectDependencies do
         let(:error_message) { 'some message' }
         before do
           dependency_manager.stubs(:install)
-            .raises(Script::DependencyInstallError, error_message)
+            .raises(Script::Layers::Infrastructure::Errors::DependencyInstallError, error_message)
         end
 
         it "should display error message" do
           @context.expects(:puts).with("\n#{error_message}")
-          assert_raises(Script::DependencyInstallError) do
+          assert_raises(Script::Layers::Infrastructure::Errors::DependencyInstallError) do
             subject
           end
         end

--- a/test/project_types/script/layers/application/test_script_test.rb
+++ b/test/project_types/script/layers/application/test_script_test.rb
@@ -56,7 +56,7 @@ describe Script::Layers::Application::TestScript do
         Script::Layers::Infrastructure::AssemblyScriptTestRunner
           .any_instance.expects(:run_tests)
           .returns(false)
-        assert_raises(Script::TestError) do
+        assert_raises(Script::Layers::Infrastructure::Errors::TestError) do
           capture_io { subject }
         end
       end

--- a/test/project_types/script/layers/application/test_script_test.rb
+++ b/test/project_types/script/layers/application/test_script_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'project_types/script/test_helper'
+require "project_types/script/layers/infrastructure/fake_extension_point_repository"
+
+describe Script::Layers::Application::TestScript do
+  include TestHelpers::FakeFS
+
+  let(:language) { 'ts' }
+  let(:extension_point_type) { 'extension_point_type' }
+  let(:script_name) { 'script_name' }
+  let(:project) do
+    TestHelpers::FakeScriptProject
+      .new(language: language, extension_point_type: extension_point_type, script_name: script_name)
+  end
+  let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
+  let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
+
+  before do
+    Script::ScriptProject.stubs(:current).returns(project)
+    Script::Layers::Infrastructure::ExtensionPointRepository.stubs(:new).returns(extension_point_repository)
+    extension_point_repository.create_extension_point(extension_point_type)
+    FileUtils.mkdir("/test")
+  end
+
+  describe '.call' do
+    subject do
+      Script::Layers::Application::TestScript.call(
+        ctx: @context,
+        language: language,
+        extension_point_type: extension_point_type,
+        script_name: script_name
+      )
+    end
+
+    before do
+      Script::Layers::Application::ProjectDependencies
+        .expects(:install)
+        .with(ctx: @context, language: language, extension_point: ep, script_name: script_name)
+      Script::Layers::Application::TestScript
+        .expects(:ensure_valid_test_suite)
+        .returns(true)
+    end
+
+    describe 'when tests are run successfully' do
+      it 'should succeed' do
+        Script::Layers::Infrastructure::AssemblyScriptTestRunner
+          .any_instance.expects(:run_tests)
+          .returns(true)
+        capture_io { subject }
+      end
+    end
+
+    describe 'when a test fails' do
+      it 'should raise TestError' do
+        Script::Layers::Infrastructure::AssemblyScriptTestRunner
+          .any_instance.expects(:run_tests)
+          .returns(false)
+        assert_raises(Script::TestError) do
+          capture_io { subject }
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/script/layers/infrastructure/assemblyscript_dependency_manager_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_dependency_manager_test.rb
@@ -65,7 +65,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptDependencyManager do
     it "should raise error on failure" do
       msg = 'error message'
       @context.expects(:capture2e).returns([msg, mock(success?: false)])
-      assert_raises Script::DependencyInstallError, msg do
+      assert_raises Script::Layers::Infrastructure::Errors::DependencyInstallError, msg do
         subject
       end
     end

--- a/test/project_types/script/layers/infrastructure/assemblyscript_wasm_test_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_wasm_test_runner_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'project_types/script/test_helper'
+
+describe Script::Layers::Infrastructure::AssemblyScriptTestRunner do
+  let(:ctx) { TestHelpers::FakeContext.new }
+  let(:assemblyscript_wasm_test_runner) do
+    Script::Layers::Infrastructure::AssemblyScriptTestRunner.new(ctx: ctx)
+  end
+  let(:npm_test_command) { "npm test" }
+
+  describe ".run_tests" do
+    subject { assemblyscript_wasm_test_runner.run_tests }
+
+    it "should execute the test script defined in package.json" do
+      ctx.expects(:system).with(npm_test_command).returns(true)
+      subject
+    end
+  end
+end

--- a/test/project_types/script/layers/infrastructure/dependency_manager_test.rb
+++ b/test/project_types/script/layers/infrastructure/dependency_manager_test.rb
@@ -37,7 +37,7 @@ describe Script::Layers::Infrastructure::DependencyManager do
 
       it "should raise dependency not supported error" do
         assert_raises(
-          Script::DependencyError,
+          Script::Layers::Infrastructure::Errors::DependencyError,
           "{{x}} No dependency support for #{language}"
         ) { subject }
       end

--- a/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
@@ -24,7 +24,7 @@ describe Script::Layers::Infrastructure::ExtensionPointRepository do
       let(:bogus_extension) { "bogus" }
 
       it "should raise InvalidExtensionPointError" do
-        assert_raises(Script::InvalidExtensionPointError) do
+        assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) do
           subject.get_extension_point(bogus_extension)
         end
       end

--- a/test/project_types/script/layers/infrastructure/fake_extension_point_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_extension_point_repository.rb
@@ -18,7 +18,7 @@ module Script
           if @cache.key?(type)
             @cache[type]
           else
-            raise InvalidExtensionPointError, type
+            raise Domain::Errors::InvalidExtensionPointError, type
           end
         end
 

--- a/test/project_types/script/layers/infrastructure/fake_script_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_script_repository.rb
@@ -21,7 +21,7 @@ module Script
           if @cache.key?(id)
             @cache[id]
           else
-            raise ScriptNotFoundError.new(extension_point_type, script_name)
+            raise Domain::Errors::ScriptNotFoundError.new(extension_point_type, script_name)
           end
         end
 

--- a/test/project_types/script/layers/infrastructure/script_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_repository_test.rb
@@ -68,7 +68,7 @@ describe Script::Layers::Infrastructure::ScriptRepository do
 
       it "should raise ScriptNotFoundError when script source file does not exist" do
         FileUtils.mkdir_p(script_source_base)
-        e = assert_raises(Script::ScriptNotFoundError) { subject }
+        e = assert_raises(Script::Layers::Domain::Errors::ScriptNotFoundError) { subject }
         assert_equal script_source_file, e.script_name
       end
     end

--- a/test/project_types/script/layers/infrastructure/test_suite_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/test_suite_repository_test.rb
@@ -87,7 +87,7 @@ describe Script::Layers::Infrastructure::TestSuiteRepository do
       end
 
       it "should raise TestSuiteNotFoundError if test spec file does not exist" do
-        assert_raises(Script::TestSuiteNotFoundError) { subject }
+        assert_raises(Script::Layers::Domain::Errors::TestSuiteNotFoundError) { subject }
       end
     end
   end

--- a/test/project_types/script/test_helper.rb
+++ b/test/project_types/script/test_helper.rb
@@ -1,2 +1,4 @@
 require "test_helper"
+require_relative "test_helpers"
+
 ShopifyCli::ProjectType.load_type(:script)

--- a/test/project_types/script/test_helpers.rb
+++ b/test/project_types/script/test_helpers.rb
@@ -1,0 +1,3 @@
+module TestHelpers
+  autoload :FakeScriptProject, 'project_types/script/test_helpers/fake_script_project'
+end

--- a/test/project_types/script/test_helpers/fake_script_project.rb
+++ b/test/project_types/script/test_helpers/fake_script_project.rb
@@ -1,0 +1,7 @@
+module TestHelpers
+  class FakeScriptProject < FakeProject
+    property :extension_point_type
+    property :script_name
+    property :language
+  end
+end

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -131,6 +131,13 @@ describe Script::UI::ErrorHandler do
           should_call_display_and_raise
         end
       end
+
+      describe "when TestError" do
+        let(:err) { Script::TestError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
     end
   end
 end

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -98,42 +98,42 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when InvalidContextError" do
-        let(:err) { Script::InvalidContextError.new('') }
+        let(:err) { Script::Errors::InvalidContextError.new('') }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when ScriptProjectAlreadyExistsError" do
-        let(:err) { Script::ScriptProjectAlreadyExistsError.new('/') }
+        let(:err) { Script::Errors::ScriptProjectAlreadyExistsError.new('/') }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when InvalidExtensionPointError" do
-        let(:err) { Script::InvalidExtensionPointError.new('') }
+        let(:err) { Script::Layers::Domain::Errors::InvalidExtensionPointError.new('') }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when ScriptNotFoundError" do
-        let(:err) { Script::ScriptNotFoundError.new('ep type', 'name') }
+        let(:err) { Script::Layers::Domain::Errors::ScriptNotFoundError.new('ep type', 'name') }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when DependencyInstallError" do
-        let(:err) { Script::DependencyInstallError.new }
+        let(:err) { Script::Layers::Infrastructure::Errors::DependencyInstallError.new }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when TestError" do
-        let(:err) { Script::TestError.new }
+        let(:err) { Script::Layers::Infrastructure::Errors::TestError.new }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end


### PR DESCRIPTION
### WHY are these changes introduced?

To continue to import script commands from our fork.

### WHAT is this pull request doing?

Creates a `test` script command. Right now, scripts only support AssemblyScript. Testing a script project that uses AssemblyScript just requires calling `npm test` in the script context. 

This command is imported exactly how its implemented in our fork. Once we merge all our commands, our plan is to refactor our language abstraction technique. That will hopefully change our approach to language specific classes, so we can avoid loading small classes like the [AssemblyScriptTestRunner](https://github.com/Shopify/shopify-app-cli/blob/69ac548b3b34d6aa4bad7e98ba6642617b8a5e54/lib/project_types/script/layers/infrastructure/assemblyscript_test_runner.rb).