### PR TITLE
Change ToC to optional via frontmatter, but default to on

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,3 +8,9 @@ exclude: [
   'Gemfile',
   'Gemfile.lock'
 ]
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      toc: true

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -55,9 +55,11 @@
 
                 <h1>{{ page.title }}</h1>
 
-                <h2 class="heading--4">On this page</h2>
+                {% if page.toc %}
+                  <h2 class="heading--4">On this page</h2>
 
-                {% include toc.html html=content h_max=2 %}
+                  {% include toc.html html=content h_max=2 %}
+                {% endif %}
 
                 {{ content }}
               </article>

--- a/docs/app/node/index.md
+++ b/docs/app/node/index.md
@@ -1,6 +1,7 @@
 ---
 title: Node app projects
 section: node
+toc: false
 ---
 
 ## Getting started

--- a/docs/app/rails/index.md
+++ b/docs/app/rails/index.md
@@ -1,6 +1,7 @@
 ---
 title: Rails app projects
 section: rails
+toc: false
 ---
 
 ## Getting started

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 section: intro
+toc: false
 ---
 
 Shopify App CLI helps you build Shopify apps faster. It automates many common tasks in the development process and lets you quickly add popular features, such as billing and webhooks.


### PR DESCRIPTION
Changes the table of contents on each page of the user-facing docs to optional — it can be turned off by setting `toc: false` on the front matter YAML.

I've turned it off on the 3 pages where there's no good reason to have a table of contents.