### PR TITLE
Add system command to display system/env information

### DIFF
--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -18,6 +18,7 @@ module ShopifyCli
     register :LoadDev, 'load-dev', 'shopify-cli/commands/load_dev'
     register :LoadSystem, 'load-system', 'shopify-cli/commands/load_system'
     register :Logout, 'logout', 'shopify-cli/commands/logout'
+    register :System, 'system', 'shopify-cli/commands/system'
     register :Update, 'update', 'shopify-cli/commands/update'
   end
 end

--- a/lib/shopify-cli/commands/system.rb
+++ b/lib/shopify-cli/commands/system.rb
@@ -1,0 +1,142 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class System < ShopifyCli::Command
+      hidden_command
+
+      def call(args, _name)
+        show_all_details = false
+        flag = args.shift
+        if flag && flag != 'all'
+          @ctx.puts("{{x}} {{red:unknown option '#{flag}'}}")
+          @ctx.puts("\n" + self.class.help)
+          return
+        end
+
+        show_all_details = true if flag == 'all'
+
+        display_environment if show_all_details
+
+        display_cli_constants(show_all_details)
+        display_cli_ruby(show_all_details)
+        display_utility_commands(show_all_details)
+        display_project_commands(show_all_details)
+      end
+
+      def self.help
+        <<~HELP
+          Print details about the development system.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} system [all]}}
+
+          {{cyan:all}}: displays more details about development system and environment
+
+        HELP
+      end
+
+      private
+
+      def display_cli_constants(show_all_details)
+        cli_constants = %w(INSTALL_DIR)
+        cli_constants_extra = %w(
+          ROOT
+          PROJECT_TYPES_DIR
+          TEMP_DIR
+          CONFIG_HOME
+          TOOL_CONFIG_PATH
+          LOG_FILE
+          DEBUG_LOG_FILE
+        )
+
+        cli_constants += cli_constants_extra if show_all_details
+
+        @ctx.puts("{{bold:Shopify App CLI}}")
+        cli_constants.each do |s|
+          @ctx.puts(format("  %17s = #{ShopifyCli.const_get(s.to_sym)}\n", s))
+        end
+      end
+
+      def display_cli_ruby(_show_all_details)
+        rbconfig_constants = %w(host RUBY_VERSION_NAME)
+
+        @ctx.puts("\n{{bold:Ruby (via RbConfig)}}")
+        @ctx.puts("  #{RbConfig.ruby}")
+        rbconfig_constants.each do |s|
+          @ctx.puts(format("  %-25s - RbConfig[\"#{s}\"]", RbConfig::CONFIG[s]))
+        end
+      end
+
+      def display_utility_commands(_show_all_details)
+        commands = %w(git curl tar unzip)
+
+        @ctx.puts("\n{{bold:Commands}}")
+        commands.each do |s|
+          output, status = @ctx.capture2e('which', s)
+          if status.success?
+            @ctx.puts("  {{v}} #{s}, #{output}")
+          else
+            @ctx.puts("  {{x}} #{s}")
+          end
+        end
+      end
+
+      def display_ngrok
+        ngrok_location = File.join(ShopifyCli::ROOT, 'ngrok')
+        if File.exist?(ngrok_location)
+          @ctx.puts("  {{v}} ngrok, #{ngrok_location}")
+        else
+          @ctx.puts("  {{x}} ngrok NOT available")
+        end
+      end
+
+      def display_project_commands(_show_all_details)
+        case Project.current_project_type
+        when :node
+          display_project('Node.js', %w(npm node yarn))
+        when :rails
+          display_project('Rails', %w(gem rails rake ruby))
+        end
+      end
+
+      def display_project(project_type, commands)
+        @ctx.puts("\n{{bold:In a {{cyan:#{project_type}}} project directory}}")
+        commands.each do |s|
+          output, status = @ctx.capture2e('which', s)
+          if status.success?
+            version_output, _ = @ctx.capture2e(s, '--version')
+            version = version_output.match(/(\d+\.[^\s]+)/)[0]
+            @ctx.puts("  {{v}} #{s}, #{output.strip}, version #{version.strip}")
+          else
+            @ctx.puts("  {{x}} #{s}")
+          end
+        end
+        display_ngrok
+        display_project_environment
+      end
+
+      def display_project_environment
+        @ctx.puts("\n  {{bold:Project environment}}")
+        if File.exist?('./.env')
+          Project.current.env.to_h.each do |k, v|
+            display_value = if v.nil? || v.strip == ''
+              "not set"
+            else
+              k.match(/^SHOPIFY_API/) ? "********" : v
+            end
+            @ctx.puts(format("  %-18s = %s", k, display_value))
+          end
+        else
+          @ctx.puts("  {{x}} .env file not present")
+        end
+      end
+
+      def display_environment
+        @ctx.puts("{{bold:Environment}}")
+        %w(TERM SHELL PATH USING_SHOPIFY_CLI LANG).each do |k|
+          @ctx.puts(format("  %-17s = %s", k, ENV[k])) unless ENV[k].nil?
+        end
+        @ctx.puts("")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Adding hidden `system` command to help with debugging/troubleshooting CLI issues

### WHAT is this pull request doing?

Adding registration of `system` command to `lib/shopify-cli/commands.rb`
Adding implementation of `system` command, `lib/shopify-cli/commands/system.rb`

**Output of `shopify help system`**
```
% shopify help system
Print details about the development system.
  Usage: shopify system [all]

all: displays more details about development system and environment

%
```

### Sample output of `shopify system` in a non-project folder

<img width="908" alt="non-project" src="https://user-images.githubusercontent.com/56687600/80770422-45875c00-8b1e-11ea-9b89-4f5b14485b40.png">

### Sample output of `shopify system all` in a non-project folder

<img width="909" alt="non-project-all" src="https://user-images.githubusercontent.com/56687600/80770456-60f26700-8b1e-11ea-9a84-fa30e2f16aba.png">

### Sample output of `shopify system` in a Rails project folder

<img width="910" alt="Rails" src="https://user-images.githubusercontent.com/56687600/80770536-8da67e80-8b1e-11ea-82f0-ba1ae07e8a29.png">

### Sample output of `shopify system all` in a Rails project folder

<img width="912" alt="Rails-all" src="https://user-images.githubusercontent.com/56687600/80770557-9c8d3100-8b1e-11ea-9cbf-68424855921c.png">

### Sample output of `shopify system` in a Node.js project folder

<img width="909" alt="Node" src="https://user-images.githubusercontent.com/56687600/80770583-a9aa2000-8b1e-11ea-8ec1-f4680437e8c1.png">

### Sample output of `shopify system all` in a Node.js project folder

<img width="907" alt="Node-all" src="https://user-images.githubusercontent.com/56687600/80770592-b0389780-8b1e-11ea-90c5-3d32b9d82a3a.png">
