### PR TITLE
Show current project context for help command

### DIFF
--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -35,6 +35,7 @@ module ShopifyCli
 
         return unless Project.current_project_type && ProjectType.load_type(Project.current_project_type)
 
+        @ctx.puts("{{bold:Project: #{File.basename(Dir.pwd)} (#{project_name})}}")
         @ctx.puts("{{bold:Available commands for #{project_name} projects:}}\n\n")
 
         local_commands.each do |name, klass|

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -53,12 +53,12 @@ module ShopifyCli
       def core_commands
         resolved_commands
           .select { |_name, c| !c.hidden }
-          .select { |_name, c| c.to_s.include?('ShopifyCli::Commands') }
+          .select { |name, _c| Commands.core_command?(name)}
       end
 
       def local_commands
         resolved_commands
-          .reject { |_name, c| c.to_s.include?('ShopifyCli::Commands') }
+          .reject { |name, _c| Commands.core_command?(name)}
       end
 
       def display_help(klass)

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -35,8 +35,8 @@ module ShopifyCli
 
         return unless inside_supported_project?
 
-        @ctx.puts("{{bold:Project: #{File.basename(Dir.pwd)} (#{project_name})}}")
-        @ctx.puts("{{bold:Available commands for #{project_name} projects:}}\n\n")
+        @ctx.puts("{{bold:Project: #{File.basename(Dir.pwd)} (#{project_type_name})}}")
+        @ctx.puts("{{bold:Available commands for #{project_type_name} projects:}}\n\n")
 
         local_commands.each do |name, klass|
           next if name == 'help'
@@ -46,7 +46,7 @@ module ShopifyCli
 
       private
 
-      def project_name
+      def project_type_name
         ProjectType.load_type(Project.current_project_type).project_name
       end
 

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -33,7 +33,7 @@ module ShopifyCli
           @ctx.puts("{{command:#{name}}}: #{klass.help}\n")
         end
 
-        return unless Project.current_project_type && ProjectType.load_type(Project.current_project_type)
+        return unless inside_supported_project?
 
         @ctx.puts("{{bold:Project: #{File.basename(Dir.pwd)} (#{project_name})}}")
         @ctx.puts("{{bold:Available commands for #{project_name} projects:}}\n\n")
@@ -74,6 +74,10 @@ module ShopifyCli
         ShopifyCli::Commands::Registry
           .resolved_commands
           .sort
+      end
+
+      def inside_supported_project?
+        Project.current_project_type && ProjectType.load_type(Project.current_project_type)
       end
     end
   end

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -53,12 +53,12 @@ module ShopifyCli
       def core_commands
         resolved_commands
           .select { |_name, c| !c.hidden }
-          .select { |name, _c| Commands.core_command?(name)}
+          .select { |name, _c| Commands.core_command?(name) }
       end
 
       def local_commands
         resolved_commands
-          .reject { |name, _c| Commands.core_command?(name)}
+          .reject { |name, _c| Commands.core_command?(name) }
       end
 
       def display_help(klass)

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -32,7 +32,7 @@ module ShopifyCli
 
     class HelpTest < MiniTest::Test
       def setup
-        ShopifyCli::Commands.register(:FakeCommand, 'fake')
+        ShopifyCli::Commands.register(:FakeCommand, 'fake', 'fake_path', true)
       end
 
       def test_default_behavior_lists_tasks
@@ -47,7 +47,7 @@ module ShopifyCli
 
       def test_local_commands_available_within_a_project
         Project.stubs(:current_project_type).returns('rails')
-        Registry.add(->() { Rails::Commands::Fake }, 'fake_rails')
+        ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
 
         io = capture_io do
           run_cmd('help')
@@ -59,7 +59,7 @@ module ShopifyCli
 
       def test_local_commands_not_available_outside_a_project
         Project.stubs(:current_project_type).returns(nil)
-        Registry.add(->() { Rails::Commands::Fake }, 'fake_rails')
+        ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
 
         io = capture_io do
           run_cmd('help')
@@ -72,7 +72,7 @@ module ShopifyCli
       def test_shows_current_project_path_and_type
         Dir.stubs(:pwd).returns("/Users/john/my_app")
         Project.stubs(:current_project_type).returns('rails')
-        Registry.add(->() { Rails::Commands::Fake }, 'fake_rails')
+        ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
 
         io = capture_io do
           run_cmd('help')

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -57,7 +57,7 @@ module ShopifyCli
 
       def test_local_commands_available_within_a_project
         Project.stubs(:current_project_type).returns('rails')
-        ShopifyCli::Commands.register("Rails::Commands::Fake", 'fake_rails')
+        Registry.add(->() { Rails::Commands::Fake }, 'fake_rails')
 
         io = capture_io do
           run_cmd('help')
@@ -70,7 +70,7 @@ module ShopifyCli
 
       def test_local_commands_not_available_outside_a_project
         Project.stubs(:current_project_type).returns(nil)
-        ShopifyCli::Commands.register("Rails::Commands::Fake", 'fake_rails')
+        Registry.add(->() { Rails::Commands::Fake }, 'fake_rails')
 
         io = capture_io do
           run_cmd('help')

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -72,7 +72,7 @@ module ShopifyCli
       def test_shows_current_project_path_and_type
         Dir.stubs(:pwd).returns("/Users/john/my_app")
         Project.stubs(:current_project_type).returns('rails')
-        ShopifyCli::Commands.register("Rails::Commands::Fake", 'fake_rails')
+        Registry.add(->() { Rails::Commands::Fake }, 'fake_rails')
 
         io = capture_io do
           run_cmd('help')

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -45,16 +45,6 @@ module ShopifyCli
         assert_match(/Usage: .*shopify/, output)
       end
 
-      def test_core_commands
-        io = capture_io do
-          run_cmd('help')
-        end
-        output = io.join
-
-        assert_match('Available core commands:', output)
-        assert_match(/Usage: .*shopify/, output)
-      end
-
       def test_local_commands_available_within_a_project
         Project.stubs(:current_project_type).returns('rails')
         Registry.add(->() { Rails::Commands::Fake }, 'fake_rails')

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -54,8 +54,7 @@ module ShopifyCli
         end
         output = io.join
 
-        assert_match(/Available commands.*Rails/, output)
-        assert_match(/fake_rails/, output)
+        assert_match(/Available commands for Ruby on Rails App projects.*fake_rails/m, output)
       end
 
       def test_local_commands_not_available_outside_a_project
@@ -67,8 +66,7 @@ module ShopifyCli
         end
         output = io.join
 
-        refute_match(/Available commands.*Rails/, output)
-        refute_match(/fake_rails/, output)
+        refute_match(/Available commands for Ruby on Rails App projects.*fake_rails/m, output)
       end
 
       def test_shows_current_project_path_and_type

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -1,5 +1,21 @@
 require 'test_helper'
 
+module Rails
+  module Commands
+    class Fake < ShopifyCli::Command
+      class << self
+        def help
+          "basic rails help"
+        end
+
+        def extended_help
+          "extended rails help"
+        end
+      end
+    end
+  end
+end
+
 module ShopifyCli
   module Commands
     class FakeCommand < ShopifyCli::Command
@@ -25,8 +41,44 @@ module ShopifyCli
         end
         output = io.join
 
-        assert_match('Available commands', output)
+        assert_match('Available core commands:', output)
         assert_match(/Usage: .*shopify/, output)
+      end
+
+      def test_core_commands
+        io = capture_io do
+          run_cmd('help')
+        end
+        output = io.join
+
+        assert_match('Available core commands:', output)
+        assert_match(/Usage: .*shopify/, output)
+      end
+
+      def test_local_commands_available_within_a_project
+        Project.stubs(:current_project_type).returns('rails')
+        ShopifyCli::Commands.register("Rails::Commands::Fake", 'fake_rails')
+
+        io = capture_io do
+          run_cmd('help')
+        end
+        output = io.join
+
+        assert_match(/Available commands.*Rails/, output)
+        assert_match(/fake_rails/, output)
+      end
+
+      def test_local_commands_not_available_outside_a_project
+        Project.stubs(:current_project_type).returns(nil)
+        ShopifyCli::Commands.register("Rails::Commands::Fake", 'fake_rails')
+
+        io = capture_io do
+          run_cmd('help')
+        end
+        output = io.join
+
+        refute_match(/Available commands.*Rails/, output)
+        refute_match(/fake_rails/, output)
       end
 
       def test_extended_help_for_individual_command

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -81,6 +81,19 @@ module ShopifyCli
         refute_match(/fake_rails/, output)
       end
 
+      def test_shows_current_project_path_and_type
+        Dir.stubs(:pwd).returns("/Users/john/my_app")
+        Project.stubs(:current_project_type).returns('rails')
+        ShopifyCli::Commands.register("Rails::Commands::Fake", 'fake_rails')
+
+        io = capture_io do
+          run_cmd('help')
+        end
+        output = io.join
+
+        assert_match("Project: my_app (Ruby on Rails App)", output)
+      end
+
       def test_extended_help_for_individual_command
         io = capture_io do
           run_cmd('help fake')


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #557

### WHAT is this pull request doing?

We're partitioning the command list into two categories, core and local. Core commands are available everywhere, local commands are only available when inside a supported app's directory, i.e. Node or Rails currerently.

Before:

<img width="597" alt="Screen Shot 2020-05-04 at 4 01 04 PM" src="https://user-images.githubusercontent.com/13400/81008192-89c97380-8e20-11ea-87c2-e8d63f44c5ae.png">

After:

<img width="596" alt="Screen Shot 2020-05-06 at 10 18 10 AM" src="https://user-images.githubusercontent.com/13400/81188106-efce0c00-8f82-11ea-92a0-be64cf0b3555.png">

- [x] Fix failing tests
- [x] Add 'after' screenshot
- [x] Add project indicator, e.g. `Project: my_project (Node app)`
- [x] Verify with a sample Rails app
- [x] Verify with a sample Node app
- [x] Verify with a sample unsupported app
- [x] Update screenshot to show latest output (including project path)
- [x] Update to use core check from #568
- [x] Update for changes in #574
- [ ] Squash before merging to master