### PR TITLE
Abort when a project type attempts to register a CLI core command

### DIFF
--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -6,10 +6,16 @@ module ShopifyCli
       default: 'help',
       contextual_resolver: nil,
     )
+    @core_commands = []
 
     def self.register(const, cmd, path = nil)
       autoload(const, path) if path
       Registry.add(->() { const_get(const) }, cmd)
+      @core_commands.push(cmd)
+    end
+
+    def self.core_command?(cmd)
+      @core_commands.include?(cmd)
     end
 
     register :Connect, 'connect', 'shopify-cli/commands/connect'

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -54,6 +54,7 @@ module ShopifyCli
       end
 
       def register_command(const, cmd)
+        Context.new.abort("Can't register duplicate core command '#{cmd}' from #{const}") if Commands.core_command?(cmd)
         Commands::Registry.add(->() { const_get(const) }, cmd)
       end
 

--- a/test/shopify-cli/project_type_test.rb
+++ b/test/shopify-cli/project_type_test.rb
@@ -32,5 +32,11 @@ module ShopifyCli
         File.join(ShopifyCli::PROJECT_TYPES_DIR, 'rails', 'myfile')
       )
     end
+
+    def test_duplicate_command
+      assert_raises ShopifyCli::Abort, "Can't register duplicate core command" do
+        ProjectType.register_command('Nonsense::Module::Help', 'help')
+      end
+    end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

If a project type attempts to register a command of the same name as a CLI core command (e.g., `help`, `logout`, `connect`, `load-dev`, etc.), the CLI will silent replace the current command with the projects command.  Now the CLI aborts when a project type attempts to re-register a CLI core command.

### WHAT is this pull request doing?

- Add reference list and `core_command?` method to `ShopifyCli::Commands`
- `register_command` method in `ShopifyCli::ProjectType` (and anything inheriting from it) checks if the command is a core command and aborts if it is.