### PR TITLE
Started catching 'file not found' errors thrown when we check for nod…

### DIFF
--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -64,21 +64,19 @@ module Node
       private
 
       def check_node
-        version, stat = @ctx.capture2e('node', '-v')
-        @ctx.done("node #{version}")
+        output, stat = @ctx.capture2e('which', 'node')
         @ctx.abort(NODE_REQUIRED_NOTICE) unless stat.success?
-      rescue Errno::ENOENT
-        # We can run into this error if we attempt to touch a non-existing file
-        @ctx.abort(NODE_REQUIRED_NOTICE)
+
+        version, = @ctx.capture2e('node', '-v')
+        @ctx.done("node #{version}")
       end
 
       def check_npm
-        version, stat = @ctx.capture2e('npm', '-v')
-        @ctx.done("npm #{version}")
+        output, stat = @ctx.capture2e('which', 'npm')
         @ctx.abort(NPM_REQUIRED_NOTICE) unless stat.success?
-      rescue Errno::ENOENT
-        # We can run into this error if we attempt to touch a non-existing file
-        @ctx.abort(NPM_REQUIRED_NOTICE)
+
+        version, = @ctx.capture2e('npm', '-v')
+        @ctx.done("npm #{version}")
       end
 
       def set_npm_config

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -3,7 +3,11 @@ module Node
   module Commands
     class Create < ShopifyCli::SubCommand
       NODE_REQUIRED_NOTICE = "node is required to create an app project. Download at https://nodejs.org/en/download."
+      NODE_VERSION_FAILURE_NOTICE = "Failed to get the current node version. Please make sure it is installed as per " \
+        "the instructions at https://nodejs.org/en."
       NPM_REQUIRED_NOTICE = "npm is required to create an app project. Download at https://www.npmjs.com/get-npm."
+      NPM_VERSION_FAILURE_NOTICE = "Failed to get the current npm version. Please make sure it is installed as per " \
+        "the instructions at https://www.npmjs.com/get-npm."
 
       options do |parser, flags|
         # backwards compatibility allow 'title' for now
@@ -64,18 +68,22 @@ module Node
       private
 
       def check_node
-        output, stat = @ctx.capture2e('which', 'node')
+        _, stat = @ctx.capture2e('which', 'node')
         @ctx.abort(NODE_REQUIRED_NOTICE) unless stat.success?
 
-        version, = @ctx.capture2e('node', '-v')
+        version, stat = @ctx.capture2e('node', '-v')
+        @ctx.abort(NODE_VERSION_FAILURE_NOTICE) unless stat.success?
+
         @ctx.done("node #{version}")
       end
 
       def check_npm
-        output, stat = @ctx.capture2e('which', 'npm')
+        _, stat = @ctx.capture2e('which', 'npm')
         @ctx.abort(NPM_REQUIRED_NOTICE) unless stat.success?
 
-        version, = @ctx.capture2e('npm', '-v')
+        version, stat = @ctx.capture2e('npm', '-v')
+        @ctx.abort(NPM_VERSION_FAILURE_NOTICE) unless stat.success?
+
         @ctx.done("npm #{version}")
       end
 

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -67,12 +67,18 @@ module Node
         version, stat = @ctx.capture2e('node', '-v')
         @ctx.done("node #{version}")
         @ctx.abort(NODE_REQUIRED_NOTICE) unless stat.success?
+      rescue Errno::ENOENT
+        # We can run into this error if we attempt to touch a non-existing file
+        @ctx.abort(NODE_REQUIRED_NOTICE)
       end
 
       def check_npm
         version, stat = @ctx.capture2e('npm', '-v')
         @ctx.done("npm #{version}")
         @ctx.abort(NPM_REQUIRED_NOTICE) unless stat.success?
+      rescue Errno::ENOENT
+        # We can run into this error if we attempt to touch a non-existing file
+        @ctx.abort(NPM_REQUIRED_NOTICE)
       end
 
       def set_npm_config

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -45,7 +45,8 @@ module Node
       end
 
       def test_check_npm_installed
-        Create.any_instance.stubs(:check_node)
+        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
+        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2e).with('which', 'npm').returns([nil, mock(success?: false)])
         assert_raises ShopifyCli::Abort, Create::NPM_REQUIRED_NOTICE do
           perform_command
@@ -53,7 +54,8 @@ module Node
       end
 
       def test_check_get_npm_version
-        Create.any_instance.stubs(:check_node)
+        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
+        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
         @context.expects(:capture2e).with('npm', '-v').returns([nil, mock(success?: false)])
         assert_raises ShopifyCli::Abort, Create::NPM_VERSION_FAILURE_NOTICE do
@@ -69,10 +71,7 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.js')
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
-        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
-        @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
-        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
-        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
+        expect_node_npm_check_commands
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(
           ['https://registry.yarnpkg.com', nil]
         )
@@ -99,10 +98,7 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.js')
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
-        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
-        @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
-        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
-        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
+        expect_node_npm_check_commands
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(
           ['https://badregistry.com', nil]
         )
@@ -140,10 +136,7 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
         @context.stubs(:uname).returns('Mac')
-        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
-        @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
-        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
-        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
+        expect_node_npm_check_commands
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(
           ['https://registry.yarnpkg.com', nil]
         )
@@ -193,10 +186,7 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
         @context.stubs(:uname).returns('Mac')
-        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
-        @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
-        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
-        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
+        expect_node_npm_check_commands
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(
           ['https://badregistry.com', nil]
         )
@@ -258,6 +248,13 @@ module Node
           --type=public \
           --organization_id=42 \
           --shop_domain=testshop.myshopify.com")
+      end
+
+      def expect_node_npm_check_commands
+        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
+        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
+        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
+        @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
       end
     end
   end

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -30,16 +30,33 @@ module Node
       end
 
       def test_check_node_installed
-        @context.expects(:capture2e).with('node', '-v').returns([nil, mock(success?: false)])
+        @context.expects(:capture2e).with('which', 'node').returns([nil, mock(success?: false)])
         assert_raises ShopifyCli::Abort, Create::NODE_REQUIRED_NOTICE do
+          perform_command
+        end
+      end
+
+      def test_check_get_node_version
+        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
+        @context.expects(:capture2e).with('node', '-v').returns([nil, mock(success?: false)])
+        assert_raises ShopifyCli::Abort, Create::NODE_VERSION_FAILURE_NOTICE do
           perform_command
         end
       end
 
       def test_check_npm_installed
         Create.any_instance.stubs(:check_node)
-        @context.expects(:capture2e).with('npm', '-v').returns([nil, mock(success?: false)])
+        @context.expects(:capture2e).with('which', 'npm').returns([nil, mock(success?: false)])
         assert_raises ShopifyCli::Abort, Create::NPM_REQUIRED_NOTICE do
+          perform_command
+        end
+      end
+
+      def test_check_get_npm_version
+        Create.any_instance.stubs(:check_node)
+        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
+        @context.expects(:capture2e).with('npm', '-v').returns([nil, mock(success?: false)])
+        assert_raises ShopifyCli::Abort, Create::NPM_VERSION_FAILURE_NOTICE do
           perform_command
         end
       end
@@ -52,7 +69,9 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.js')
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
+        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
         @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
+        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(
           ['https://registry.yarnpkg.com', nil]
@@ -80,7 +99,9 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.js')
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
+        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
         @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
+        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(
           ['https://badregistry.com', nil]
@@ -119,7 +140,9 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
         @context.stubs(:uname).returns('Mac')
+        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
         @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
+        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(
           ['https://registry.yarnpkg.com', nil]
@@ -170,7 +193,9 @@ module Node
         FileUtils.touch('test-app/server/handlers/client.cli.js')
 
         @context.stubs(:uname).returns('Mac')
+        @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
         @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
+        @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2).with('npm config get @shopify:registry').returns(
           ['https://badregistry.com', nil]


### PR DESCRIPTION
Started catching 'file not found' errors thrown when we check for node / npme / npm and they are not installed

### WHY are these changes introduced?

The CLI was raising an error when checking for node / npm installations when they were not present.

Fixes #552  <!-- link to issue if one exists -->

### WHAT is this pull request doing?

Adding a rescue block specifically for the 'file not found' error thrown in this scenario. The previous behaviour of aborting the current command still applies, but we return a proper error message instead of an exception now.