### PR TITLE
Hide implementation of Command::Registry from ProjectType

### DIFF
--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -8,23 +8,23 @@ module ShopifyCli
     )
     @core_commands = []
 
-    def self.register(const, cmd, path = nil)
+    def self.register(const, cmd, path = nil, is_core = false)
       autoload(const, path) if path
       Registry.add(->() { const_get(const) }, cmd)
-      @core_commands.push(cmd)
+      @core_commands.push(cmd) if is_core
     end
 
     def self.core_command?(cmd)
       @core_commands.include?(cmd)
     end
 
-    register :Connect, 'connect', 'shopify-cli/commands/connect'
-    register :Create, 'create', 'shopify-cli/commands/create'
-    register :Help, 'help', 'shopify-cli/commands/help'
-    register :LoadDev, 'load-dev', 'shopify-cli/commands/load_dev'
-    register :LoadSystem, 'load-system', 'shopify-cli/commands/load_system'
-    register :Logout, 'logout', 'shopify-cli/commands/logout'
-    register :System, 'system', 'shopify-cli/commands/system'
-    register :Update, 'update', 'shopify-cli/commands/update'
+    register :Connect, 'connect', 'shopify-cli/commands/connect', true
+    register :Create, 'create', 'shopify-cli/commands/create', true
+    register :Help, 'help', 'shopify-cli/commands/help', true
+    register :LoadDev, 'load-dev', 'shopify-cli/commands/load_dev', true
+    register :LoadSystem, 'load-system', 'shopify-cli/commands/load_system', true
+    register :Logout, 'logout', 'shopify-cli/commands/logout', true
+    register :System, 'system', 'shopify-cli/commands/system', true
+    register :Update, 'update', 'shopify-cli/commands/update', true
   end
 end

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -55,7 +55,7 @@ module ShopifyCli
 
       def register_command(const, cmd)
         Context.new.abort("Can't register duplicate core command '#{cmd}' from #{const}") if Commands.core_command?(cmd)
-        Commands::Registry.add(->() { const_get(const) }, cmd)
+        Commands.register(const, cmd)
       end
 
       def register_task(task, name)


### PR DESCRIPTION
### WHY are these changes introduced?

`ProjectType.register_command()` uses `add()` method of `Registry` directly, instead of using `Commands.register()` that hides command registry implementation.

### WHAT is this pull request doing?

- Add flag to `Command.register()` to indicate a core command (default to `false`, only `true` for calls within `lib/shopify-cli/commands.rb`)
- Use `Command.register()` instead of `Command::Registry.add()` in `ProjectType.register_command()`
