### PR TITLE
Fix flaky tests in populate_resource_command_test.rb

### DIFF
--- a/test/shopify-cli/admin_api/populate_resource_command_test.rb
+++ b/test/shopify-cli/admin_api/populate_resource_command_test.rb
@@ -8,6 +8,7 @@ module ShopifyCli
 
       def setup
         super
+        ShopifyCli::ProjectType.load_type(:rails)
         @resource = Rails::Commands::Populate::Product.new(@context)
         ShopifyCli::AdminAPI.stubs(:new).returns(Object.new)
       end


### PR DESCRIPTION
### WHY are these changes introduced?

These tests periodically fail if they are run before any other rails project type test. This is because the rails project type hasn't been loaded when we try to access it. Simply loading the project type will fix it. 