### PR TITLE
Use default minitest reporter

### DIFF
--- a/lib/shopify-cli/core/finalize.rb
+++ b/lib/shopify-cli/core/finalize.rb
@@ -45,7 +45,6 @@ module ShopifyCli
           begin
             finalizer_pipe.puts(message.join("\n"))
           rescue Errno::EBADF, IOError
-            $stderr.puts "Not running with shell integration. Finalizers: #{message.join("\n")}"
           ensure
             clear
           end

--- a/test/shopify-cli/core/finalize_test.rb
+++ b/test/shopify-cli/core/finalize_test.rb
@@ -37,14 +37,14 @@ module ShopifyCli
         assert_nil(Finalize.deliver!)
       end
 
-      def test_deliver_puts_error_if_io_error
+      def test_discard_error_if_io_error
         IO.expects(:new).raises(IOError.new)
 
         Finalize.request_cd('path/to/cd')
         output = capture_io do
           Finalize.deliver!
         end
-        assert output[1].include?("Not running with shell integration. Finalizers: cd:path/to/cd")
+        assert_equal "", output[1]
       end
 
       def test_deliver_raises_argument_error_if_io_not_found

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,5 +21,3 @@ require 'fakefs/safe'
 require 'webmock/minitest'
 
 require 'mocha/minitest'
-
-Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/shopify-app-cli/pull/44 the minitest reporter was changed. The SpecReporter emits a lot of output to the terminal which can cause us to miss useful output or warnings. It also means we need to scroll back a long way to grab the seed value for a particular run, for when we need to investigate an intermittent failure.

Here's how the output looks with this change:

```
# Running:

............................................Not running with shell integration. Finalizers: cd:test-app
..........................................Not running with shell integration. Finalizers: cd:test-app
.Not running with shell integration. Finalizers: cd:test-app
...Not running with shell integration. Finalizers: cd:test-app
..Not running with shell integration. Finalizers: cd:test-app
..............................................................
..............................................................
..............................................................
..............................................................
......................................

Finished in 3.581638s, 105.5383 runs/s, 273.8970 assertions/s.
```