### PR TITLE
Print auth url instead of auto-opening

### DIFF
--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -144,17 +144,16 @@ module ShopifyCli
       FileUtils.mkdir_p(path)
     end
 
-    # will open a url in a browser if that functionality is available, otherwise
-    # it will simply output to the console a link for the user to either copy/paste
+    # will output to the console a link for the user to either copy/paste
     # or click on.
     #
     # #### Parameters
     # * `uri` - a http URI to open in a browser
     #
     def open_url!(uri)
-      return system("open '#{uri}'") if mac?
       help = <<~OPEN
-        Please open {{green:#{uri}}} in your browser
+        Please open this URL in your browser:
+        {{green:#{uri}}}
       OPEN
       puts(help)
     end

--- a/lib/shopify-cli/oauth.rb
+++ b/lib/shopify-cli/oauth.rb
@@ -76,13 +76,21 @@ module ShopifyCli
       params.merge!(challange_params) if secret.nil?
       uri = URI.parse("#{url}#{auth_path}")
       uri.query = URI.encode_www_form(params.merge(options))
+      output_authentication_info(uri)
+    end
+
+    def output_authentication_info(uri)
+      login_location = service == 'admin' ? 'development store' : 'Shopify Partners account'
+      ctx.puts(
+        "{{i}} Authentication required. Login to the URL below with your #{login_location} credentials to continue."
+      )
       ctx.open_url!(uri)
     end
 
     def receive_access_code
       @access_code ||= begin
         @server_thread.join(240)
-        raise Error, 'Timed out while waiting for response from shopify' if response_query.nil?
+        raise Error, 'Timed out while waiting for response from Shopify' if response_query.nil?
         raise Error, response_query['error_description'] unless response_query['error'].nil?
         response_query['code']
       end

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -30,10 +30,10 @@ module ShopifyCli
       refute(@ctx.mac?)
     end
 
-    def test_open_url_formats_command_correctly
+    def test_open_url_outputs_url_to_open
       url = 'http://cutekitties.com'
       @ctx.stubs(:mac?).returns(true)
-      @ctx.expects(:system).with("open '#{url}'")
+      @ctx.expects(:puts).with("Please open this URL in your browser:\n{{green:#{url}}}\n")
       @ctx.open_url!(url)
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/shopify-app-cli/issues/509

When we call the OAuth code to authenticate with either Partners or Admin, we are auto-opening a browser window if on a Mac. Users find this a bit annoying as they may have certain sessions in certain browsers and would like a bit more control over where/when to open. 

### WHAT is this pull request doing?

Since we're only auto-opening on a Mac, I've removed this behaviour in favour of printing out the url to open for all OS. 

![image](https://user-images.githubusercontent.com/30087610/81315131-e793d080-9057-11ea-92b7-6f0874f129a9.png)

![image](https://user-images.githubusercontent.com/30087610/81315149-ec588480-9057-11ea-979f-f8f55dd7b930.png)

There was also an ask to identify the reason for authentication, but this is difficult as there are a variety of reasons we are querying Partners/Admin GraphQL. And since these are being called from all over the codebase, it would get a bit messy to pass strings with each query to say why a particular auth was being done. Especially since if you are already logged in once, we would never print the subsequent query/auth attempts as we don't need you to login again. 

I did add an alternating string to say which type of account you should log into, (dev store vs Partners) to make it a bit clearer, so hopefully that's helpful.