### PR TITLE
Add central tooling for CLI messages and prompts

### DIFF
--- a/lib/project_types/node/cli.rb
+++ b/lib/project_types/node/cli.rb
@@ -11,7 +11,8 @@ module Node
     register_command('Node::Commands::Tunnel', "tunnel")
     # register_task('Node::Tasks::NodeTask', 'node_task')
 
-    register_messages_file(Project.project_filepath('messages/messages.yml'))
+    require Project.project_filepath('messages/messages')
+    register_messages(Node::Messages::MESSAGES)
   end
 
   # define/autoload project specific Commands

--- a/lib/project_types/node/cli.rb
+++ b/lib/project_types/node/cli.rb
@@ -10,9 +10,11 @@ module Node
     register_command('Node::Commands::Serve', "serve")
     register_command('Node::Commands::Tunnel', "tunnel")
     # register_task('Node::Tasks::NodeTask', 'node_task')
+
+    register_messages_file(Project.project_filepath('messages/messages.yml'))
   end
 
-  # define/autoload project specific Commads
+  # define/autoload project specific Commands
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -38,44 +38,33 @@ module Node
 
         partners_url = "https://partners.shopify.com/#{form.organization_id}/apps/#{api_client['id']}"
 
-        @ctx.puts("{{v}} {{green:#{form.title}}} was created in your Partner" \
-                  " Dashboard " \
-                  "{{underline:#{partners_url}}}")
-        @ctx.puts("{{*}} Run {{command:#{ShopifyCli::TOOL_NAME} serve}} to start a local server")
-        @ctx.puts("{{*}} Then, visit {{underline:#{partners_url}/test}} to install" \
-                  " {{green:#{form.title}}} on your Dev Store")
+        @ctx.puts(@ctx.message('node.create.info.created', form.title, partners_url))
+        @ctx.puts(@ctx.message('node.create.info.serve', ShopifyCli::TOOL_NAME))
+        @ctx.puts(@ctx.message('node.create.info.install', partners_url, form.title))
       end
 
       def self.help
-        <<~HELP
-        {{command:#{ShopifyCli::TOOL_NAME} create node}}: Creates an embedded nodejs app.
-          Usage: {{command:#{ShopifyCli::TOOL_NAME} create node}}
-          Options:
-            {{command:--name=NAME}} App name. Any string.
-            {{command:--app_url=APPURL}} App URL. Must be valid URL.
-            {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
-            {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
-        HELP
+        ShopifyCli::Context.message('node.create.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
       end
 
       private
 
       def check_node
         _, stat = @ctx.capture2e('which', 'node')
-        @ctx.abort(@ctx.message('node.node_required_notice')) unless stat.success?
+        @ctx.abort(@ctx.message('node.create.error.node_required')) unless stat.success?
 
         version, stat = @ctx.capture2e('node', '-v')
-        @ctx.abort(@ctx.message('node.node_version_failure_notice')) unless stat.success?
+        @ctx.abort(@ctx.message('node.create.error.node_version_failure')) unless stat.success?
 
         @ctx.done("node #{version}")
       end
 
       def check_npm
         _, stat = @ctx.capture2e('which', 'npm')
-        @ctx.abort(@ctx.message('node.npm_required_notice')) unless stat.success?
+        @ctx.abort(@ctx.message('node.create.error.npm_required')) unless stat.success?
 
         version, stat = @ctx.capture2e('npm', '-v')
-        @ctx.abort(@ctx.message('node.npm_version_failure_notice')) unless stat.success?
+        @ctx.abort(@ctx.message('node.create.error.npm_version_failure')) unless stat.success?
 
         @ctx.done("npm #{version}")
       end

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -56,7 +56,7 @@ module Node
         version, stat = @ctx.capture2e('node', '-v')
         @ctx.abort(@ctx.message('node.create.error.node_version_failure')) unless stat.success?
 
-        @ctx.done("node #{version}")
+        @ctx.done(@ctx.message('node.create.node_version', version))
       end
 
       def check_npm
@@ -66,7 +66,7 @@ module Node
         version, stat = @ctx.capture2e('npm', '-v')
         @ctx.abort(@ctx.message('node.create.error.npm_version_failure')) unless stat.success?
 
-        @ctx.done("npm #{version}")
+        @ctx.done(@ctx.message('node.create.npm_version', version))
       end
 
       def set_npm_config

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -2,13 +2,6 @@
 module Node
   module Commands
     class Create < ShopifyCli::SubCommand
-      NODE_REQUIRED_NOTICE = "node is required to create an app project. Download at https://nodejs.org/en/download."
-      NODE_VERSION_FAILURE_NOTICE = "Failed to get the current node version. Please make sure it is installed as per " \
-        "the instructions at https://nodejs.org/en."
-      NPM_REQUIRED_NOTICE = "npm is required to create an app project. Download at https://www.npmjs.com/get-npm."
-      NPM_VERSION_FAILURE_NOTICE = "Failed to get the current npm version. Please make sure it is installed as per " \
-        "the instructions at https://www.npmjs.com/get-npm."
-
       options do |parser, flags|
         # backwards compatibility allow 'title' for now
         parser.on('--title=TITLE') { |t| flags[:title] = t }
@@ -69,20 +62,20 @@ module Node
 
       def check_node
         _, stat = @ctx.capture2e('which', 'node')
-        @ctx.abort(NODE_REQUIRED_NOTICE) unless stat.success?
+        @ctx.abort(@ctx.message('node.node_required_notice')) unless stat.success?
 
         version, stat = @ctx.capture2e('node', '-v')
-        @ctx.abort(NODE_VERSION_FAILURE_NOTICE) unless stat.success?
+        @ctx.abort(@ctx.message('node.node_version_failure_notice')) unless stat.success?
 
         @ctx.done("node #{version}")
       end
 
       def check_npm
         _, stat = @ctx.capture2e('which', 'npm')
-        @ctx.abort(NPM_REQUIRED_NOTICE) unless stat.success?
+        @ctx.abort(@ctx.message('node.npm_required_notice')) unless stat.success?
 
         version, stat = @ctx.capture2e('npm', '-v')
-        @ctx.abort(NPM_VERSION_FAILURE_NOTICE) unless stat.success?
+        @ctx.abort(@ctx.message('node.npm_version_failure_notice')) unless stat.success?
 
         @ctx.done("npm #{version}")
       end

--- a/lib/project_types/node/commands/deploy.rb
+++ b/lib/project_types/node/commands/deploy.rb
@@ -11,18 +11,11 @@ module Node
       end
 
       def self.help
-        <<~HELP
-          Deploy the current Node project to a hosting service. Heroku ({{underline:https://www.heroku.com}}) is currently the only option, but more will be added in the future.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy [ heroku ]}}
-        HELP
+        ShopifyCli::Context.message('node.deploy.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        <<~HELP
-        {{bold:Subcommands:}}
-          {{cyan:heroku}}: Deploys the current Node project to Heroku.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy heroku}}
-        HELP
+        ShopifyCli::Context.message('node.deploy.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/deploy/heroku.rb
+++ b/lib/project_types/node/commands/deploy/heroku.rb
@@ -30,7 +30,7 @@ module Node
           spin_group.wait
 
           if (account = heroku_service.whoami)
-            @ctx.puts(@ctx.message('node.deploy.heroku.git.authenticated', account))
+            @ctx.puts(@ctx.message('node.deploy.heroku.authenticated_with_account', account))
           else
             CLI::UI::Frame.open(
               @ctx.message('node.deploy.heroku.authenticating'),

--- a/lib/project_types/node/commands/deploy/heroku.rb
+++ b/lib/project_types/node/commands/deploy/heroku.rb
@@ -6,58 +6,61 @@ module Node
     class Deploy
       class Heroku < ShopifyCli::SubCommand
         def self.help
-          <<~HELP
-            Deploy the current Node project to Heroku
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy heroku}}
-          HELP
+          ShopifyCli::Context.message('node.deploy.heroku.help', ShopifyCli::TOOL_NAME)
         end
 
         def call(_args, _name)
           spin_group = CLI::UI::SpinGroup.new
           heroku_service = ShopifyCli::Heroku.new(@ctx)
 
-          spin_group.add('Downloading Heroku CLI…') do |spinner|
+          spin_group.add(@ctx.message('node.deploy.heroku.downloading')) do |spinner|
             heroku_service.download
-            spinner.update_title('Downloaded Heroku CLI')
+            spinner.update_title(@ctx.message('node.deploy.heroku.downloaded'))
           end
           spin_group.wait
 
-          spin_group.add('Installing Heroku CLI…') do |spinner|
+          spin_group.add(@ctx.message('node.deploy.heroku.installing')) do |spinner|
             heroku_service.install
-            spinner.update_title('Installed Heroku CLI')
+            spinner.update_title(@ctx.message('node.deploy.heroku.installed'))
           end
-          spin_group.add('Checking git repo…') do |spinner|
+          spin_group.add(@ctx.message('node.deploy.heroku.git.checking')) do |spinner|
             ShopifyCli::Git.init(@ctx)
-            spinner.update_title('Git repo initialized')
+            spinner.update_title(@ctx.message('node.deploy.heroku.git.initialized'))
           end
           spin_group.wait
 
           if (account = heroku_service.whoami)
-            @ctx.puts("{{v}} Authenticated with Heroku as `#{account}`")
+            @ctx.puts(@ctx.message('node.deploy.heroku.git.authenticated', account))
           else
-            CLI::UI::Frame.open("Authenticating with Heroku…", success_text: '{{v}} Authenticated with Heroku') do
+            CLI::UI::Frame.open(
+              @ctx.message('node.deploy.heroku.authenticating'),
+              success_text: @ctx.message('node.deploy.heroku.authenticated')
+            ) do
               heroku_service.authenticate
             end
           end
 
           if (app_name = heroku_service.app)
-            @ctx.puts("{{v}} Heroku app `#{app_name}` selected")
+            @ctx.puts(@ctx.message('node.deploy.heroku.app.selected', app_name))
           else
-            app_type = CLI::UI::Prompt.ask('No existing Heroku app found. What would you like to do?') do |handler|
-              handler.option('Create a new Heroku app') { :new }
-              handler.option('Specify an existing Heroku app') { :existing }
+            app_type = CLI::UI::Prompt.ask(@ctx.message('node.deploy.heroku.app.no_apps_found')) do |handler|
+              handler.option(@ctx.message('node.deploy.heroku.app.create')) { :new }
+              handler.option(@ctx.message('node.deploy.heroku.app.select')) { :existing }
             end
 
             if app_type == :existing
-              app_name = CLI::UI::Prompt.ask('What is your Heroku app’s name?')
+              app_name = CLI::UI::Prompt.ask(@ctx.message('node.deploy.heroku.app.name'))
               CLI::UI::Frame.open(
-                "Selecting Heroku app `#{app_name}`…",
-                success_text: "{{v}} Heroku app `#{app_name}` selected"
+                @ctx.message('node.deploy.heroku.app.selecting', app_name),
+                success_text: @ctx.message('node.deploy.heroku.app.selected', app_name)
               ) do
                 heroku_service.select_existing_app(app_name)
               end
             elsif app_type == :new
-              CLI::UI::Frame.open('Creating new Heroku app…', success_text: '{{v}} New Heroku app created') do
+              CLI::UI::Frame.open(
+                @ctx.message('node.deploy.heroku.app.creating'),
+                success_text: @ctx.message('node.deploy.heroku.app.created')
+              ) do
                 heroku_service.create_new_app
               end
             end
@@ -66,16 +69,19 @@ module Node
           branches = ShopifyCli::Git.branches(@ctx)
           if branches.length == 1
             branch_to_deploy = branches[0]
-            @ctx.puts("{{v}} Git branch `#{branch_to_deploy}` selected for deploy")
+            @ctx.puts(@ctx.message('node.deploy.heroku.git.branch_selected', branch_to_deploy))
           else
-            branch_to_deploy = CLI::UI::Prompt.ask('What branch would you like to deploy?') do |handler|
+            branch_to_deploy = CLI::UI::Prompt.ask(@ctx.message('node.deploy.heroku.git.what_branch')) do |handler|
               branches.each do |branch|
                 handler.option(branch) { branch }
               end
             end
           end
 
-          CLI::UI::Frame.open('Deploying to Heroku…', success_text: '{{v}} Deployed to Heroku') do
+          CLI::UI::Frame.open(
+            @ctx.message('node.deploy.heroku.deploying'),
+            success_text: @ctx.message('node.deploy.heroku.deployed')
+          ) do
             heroku_service.deploy(branch_to_deploy)
           end
         end

--- a/lib/project_types/node/commands/generate.rb
+++ b/lib/project_types/node/commands/generate.rb
@@ -13,10 +13,7 @@ module Node
       end
 
       def self.help
-        <<~HELP
-          Generate code in your Node project. Supports generating new billing API calls, new pages, or new webhooks.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} generate [ billing | page | webhook ]}}
-        HELP
+        ShopifyCli::Context.message('node.generate.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
@@ -29,28 +26,24 @@ module Node
           end
           extended_help += "\n"
         end
-        extended_help += <<~EXAMPLES
-          {{bold:Examples:}}
-            {{cyan:#{ShopifyCli::TOOL_NAME} generate webhook PRODUCTS_CREATE}}
-              Generate and register a new webhook that will be called every time a new product is created on your store.
-        EXAMPLES
+        extended_help += ShopifyCli::Context.message('node.generate.extended_help', ShopifyCli::TOOL_NAME)
       end
 
       def self.run_generate(script, name, ctx)
         stat = ctx.system(script)
         unless stat.success?
-          ctx.abort(response(stat.exitstatus, name))
+          ctx.abort(response(stat.exitstatus, name, ctx))
         end
       end
 
-      def self.response(code, name)
+      def self.response(code, name, ctx)
         case code
         when 1
-          "Error generating #{name}"
+          ctx.message('node.generate.error.generic', name)
         when 2
-          "#{name} already exists!"
+          ctx.message('node.generate.error.name_exists', name)
         else
-          'Error'
+          ctx.message('node.error.generic')
         end
       end
     end

--- a/lib/project_types/node/commands/generate/billing.rb
+++ b/lib/project_types/node/commands/generate/billing.rb
@@ -11,7 +11,7 @@ module Node
         def call(args, _name)
           selected_type = BILLING_TYPES[args[1]]
           unless selected_type
-            selected_type = CLI::UI::Prompt.ask('How would you like to charge for your app?') do |handler|
+            selected_type = CLI::UI::Prompt.ask(@ctx.message('node.generate.billing.type_select')) do |handler|
               BILLING_TYPES.each do |key, value|
                 handler.option(key) { value }
               end
@@ -19,22 +19,17 @@ module Node
           end
           billing_type_name = BILLING_TYPES.key(selected_type)
           spin_group = CLI::UI::SpinGroup.new
-          spin_group.add("Generating #{billing_type_name} code ...") do |spinner|
+          spin_group.add(@ctx.message('node.generate.billing.generating', billing_type_name)) do |spinner|
             Node::Commands::Generate.run_generate(
               selected_type, billing_type_name, @ctx
             )
-            spinner.update_title(
-              "{{green:#{billing_type_name} generated in server/server.js"
-            )
+            spinner.update_title(@ctx.message('node.generate.billing.generated', billing_type_name))
           end
           spin_group.wait
         end
 
         def self.help
-          <<~HELP
-            Enable charging for your app. This command generates the necessary code to call Shopify’s billing API.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate billing [ one-time-billing | recurring-billing ]}}
-          HELP
+          ShopifyCli::Context.message('node.generate.billing.help', ShopifyCli::TOOL_NAME)
         end
       end
     end

--- a/lib/project_types/node/commands/generate/page.rb
+++ b/lib/project_types/node/commands/generate/page.rb
@@ -27,11 +27,11 @@ module Node
 
           selected_type = if flag
             unless PAGE_TYPES.key?(flag)
-              @ctx.abort("Invalid page type.")
+              @ctx.abort(@ctx.message('node.generate.page.error.invalid_page_type'))
             end
             PAGE_TYPES[flag]
           else
-            CLI::UI::Prompt.ask("Which template would you like to use?") do |handler|
+            CLI::UI::Prompt.ask(@ctx.message('node.generate.page.type_select')) do |handler|
               PAGE_TYPES.each do |key, value|
                 handler.option(key) { value }
               end
@@ -39,20 +39,15 @@ module Node
           end
 
           spin_group = CLI::UI::SpinGroup.new
-          spin_group.add("Generating #{selected_type} page...") do |spinner|
-            Node::Commands::Generate.run_generate(
-              "#{selected_type} #{name}", name, @ctx
-            )
-            spinner.update_title("{{green: #{name}}} generated in pages/#{name}")
+          spin_group.add(@ctx.message('node.generate.page.generating', selected_type)) do |spinner|
+            Node::Commands::Generate.run_generate("#{selected_type} #{name}", name, @ctx)
+            spinner.update_title(@ctx.message('node.generate.page.generated', name, name))
           end
           spin_group.wait
         end
 
         def self.help
-          <<~HELP
-            Generate a new page in your app with the specified name. New files are generated inside the project’s “/pages” directory.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate page <pagename>}}
-          HELP
+          ShopifyCli::Context.message('node.generate.page.help', ShopifyCli::TOOL_NAME)
         end
       end
     end

--- a/lib/project_types/node/commands/generate/webhook.rb
+++ b/lib/project_types/node/commands/generate/webhook.rb
@@ -9,26 +9,23 @@ module Node
           schema = ShopifyCli::AdminAPI::Schema.get(@ctx)
           webhooks = schema.get_names_from_type('WebhookSubscriptionTopic')
           unless selected_type && webhooks.include?(selected_type)
-            selected_type = CLI::UI::Prompt.ask('What type of webhook would you like to create?') do |handler|
+            selected_type = CLI::UI::Prompt.ask(@ctx.message('node.generate.webhook.type_select')) do |handler|
               webhooks.each do |type|
                 handler.option(type) { type }
               end
             end
           end
           spin_group = CLI::UI::SpinGroup.new
-          spin_group.add("Generating webhook: #{selected_type}") do |spinner|
+          spin_group.add(@ctx.message('node.generate.webhook.generating', selected_type)) do |spinner|
             Node::Commands::Generate.run_generate("./node_modules/.bin/generate-node-app webhook #{selected_type}",
               selected_type, @ctx)
-            spinner.update_title("{{green:#{selected_type}}} generated in server/server.js")
+            spinner.update_title(@ctx.message('node.generate.webhook.generated', selected_type))
           end
           spin_group.wait
         end
 
         def self.help
-          <<~HELP
-            Generate and register a new webhook that listens for the specified Shopify store event.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate webhook <type>}}
-          HELP
+          ShopifyCli::Context.message('node.generate.webhook.help', ShopifyCli::TOOL_NAME)
         end
       end
     end

--- a/lib/project_types/node/commands/open.rb
+++ b/lib/project_types/node/commands/open.rb
@@ -9,10 +9,7 @@ module Node
       end
 
       def self.help
-        <<~HELP
-          Open your local development app in the default browser.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} open}}
-        HELP
+        ShopifyCli::Context.message('node.open.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/populate.rb
+++ b/lib/project_types/node/commands/populate.rb
@@ -12,46 +12,11 @@ module Node
       end
 
       def self.help
-        <<~HELP
-          Populate your Shopify development store with example customers, orders, or products.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} populate [ customers | draftorders | products ]}}
-        HELP
+        ShopifyCli::Context.message('node.populate.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        <<~HELP
-          {{bold:Subcommands:}}
-
-            {{cyan:customers [options]}}: Add dummy customers to the specified development store.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} populate customers}}
-
-            {{cyan:draftorders [options]}}: Add dummy orders to the specified development store.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} populate draftorders}}
-
-            {{cyan:products [options]}}: Add dummy products to the specified development store.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} populate products}}
-
-          {{bold:Options:}}
-
-            {{cyan:--count [integer]}}: The number of dummy items to populate. Defaults to 5.
-            {{cyan:--silent}}: Silence the populate output.
-            {{cyan:--help}}: Display more options specific to each subcommand.
-
-          {{bold:Examples:}}
-
-            {{command:#{ShopifyCli::TOOL_NAME} populate products}}
-              Populate your development store with 5 additional products.
-
-            {{command:#{ShopifyCli::TOOL_NAME} populate customers --count 30}}
-              Populate your development store with 30 additional customers.
-
-            {{command:#{ShopifyCli::TOOL_NAME} populate draftorders}}
-              Populate your development store with 5 additional orders.
-
-            {{command:#{ShopifyCli::TOOL_NAME} populate products --help}}
-              Display the list of options available to customize the
-              {{command:#{ShopifyCli::TOOL_NAME} populate products}} command.
-        HELP
+        ShopifyCli::Context.message('node.populate.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/populate/customer.rb
+++ b/lib/project_types/node/commands/populate/customer.rb
@@ -17,8 +17,9 @@ module Node
         def message(data)
           ret = data['customerCreate']['customer']
           id = ShopifyCli::API.gid_to_id(ret['id'])
-          "#{ret['displayName']} added to {{green:#{ShopifyCli::Project.current.env.shop}}} "\
-          "at {{underline:#{admin_url}customers/#{id}}}"
+          @ctx.message(
+            'node.populate.customer.added', ret['displayName'], ShopifyCli::Project.current.env.shop, admin_url, id
+          )
         end
       end
     end

--- a/lib/project_types/node/commands/populate/customer.rb
+++ b/lib/project_types/node/commands/populate/customer.rb
@@ -18,7 +18,11 @@ module Node
           ret = data['customerCreate']['customer']
           id = ShopifyCli::API.gid_to_id(ret['id'])
           @ctx.message(
-            'node.populate.customer.added', ret['displayName'], ShopifyCli::Project.current.env.shop, admin_url, id
+            'node.populate.customer.added',
+            ret['displayName'],
+            ShopifyCli::Project.current.env.shop,
+            admin_url,
+            id
           )
         end
       end

--- a/lib/project_types/node/commands/populate/draft_order.rb
+++ b/lib/project_types/node/commands/populate/draft_order.rb
@@ -20,8 +20,7 @@ module Node
         def message(data)
           ret = data['draftOrderCreate']['draftOrder']
           id = ShopifyCli::API.gid_to_id(ret['id'])
-          "DraftOrder added to {{green:#{ShopifyCli::Project.current.env.shop}}} "\
-          "at {{underline:#{admin_url}draft_orders/#{id}}}"
+          @ctx.message('node.populate.draft_order.added', ShopifyCli::Project.current.env.shop, admin_url, id)
         end
       end
     end

--- a/lib/project_types/node/commands/populate/product.rb
+++ b/lib/project_types/node/commands/populate/product.rb
@@ -16,8 +16,7 @@ module Node
         def message(data)
           ret = data['productCreate']['product']
           id = ShopifyCli::API.gid_to_id(ret['id'])
-          "#{ret['title']} added to {{green:#{ShopifyCli::Project.current.env.shop}}} "\
-          "at {{underline:#{admin_url}products/#{id}}}"
+          @ctx.message('node.populate.product.added', ret['title'], ShopifyCli::Project.current.env.shop, admin_url, id)
         end
       end
     end

--- a/lib/project_types/node/commands/populate/product.rb
+++ b/lib/project_types/node/commands/populate/product.rb
@@ -16,7 +16,13 @@ module Node
         def message(data)
           ret = data['productCreate']['product']
           id = ShopifyCli::API.gid_to_id(ret['id'])
-          @ctx.message('node.populate.product.added', ret['title'], ShopifyCli::Project.current.env.shop, admin_url, id)
+          @ctx.message(
+            'node.populate.product.added',
+            ret['title'],
+            ShopifyCli::Project.current.env.shop,
+            admin_url,
+            id
+          )
         end
       end
     end

--- a/lib/project_types/node/commands/serve.rb
+++ b/lib/project_types/node/commands/serve.rb
@@ -13,7 +13,7 @@ module Node
       def call(*)
         project = ShopifyCli::Project.current
         url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx)
-        @ctx.abort("{{red:HOST must be a HTTPS url.}}") if url.match(/^https/i).nil?
+        @ctx.abort(@ctx.message('node.serve.error.must_be_https')) if url.match(/^https/i).nil?
         project.env.update(@ctx, :host, url)
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @ctx,
@@ -21,12 +21,12 @@ module Node
           callback_url: "/auth/callback",
         )
         if @ctx.mac? && project.env.shop
-          @ctx.puts("{{*}} Press {{yellow: Control-T}} to open this project in {{green:#{project.env.shop}}} ")
+          @ctx.puts(@ctx.message('node.serve.open_info', project.env.shop))
           @ctx.on_siginfo do
             @ctx.open_url!("#{project.env.host}/auth?shop=#{project.env.shop}")
           end
         end
-        CLI::UI::Frame.open('Running server...') do
+        CLI::UI::Frame.open(@ctx.message('node.serve.running')) do
           env = project.env.to_h
           env['PORT'] = ShopifyCli::Tunnel::PORT.to_s
           @ctx.system('npm run dev', env: env)
@@ -34,17 +34,11 @@ module Node
       end
 
       def self.help
-        <<~HELP
-          Start a local development node server for your project, as well as a public ngrok tunnel to your localhost.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} serve}}
-        HELP
+        ShopifyCli::Context.message('node.serve.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        <<~HELP
-          {{bold:Options:}}
-            {{cyan:--host=HOST}}: Bypass running tunnel and use custom host. HOST must be HTTPS url.
-        HELP
+        ShopifyCli::Context.message('node.serve.extended_help')
       end
     end
   end

--- a/lib/project_types/node/commands/serve.rb
+++ b/lib/project_types/node/commands/serve.rb
@@ -13,7 +13,7 @@ module Node
       def call(*)
         project = ShopifyCli::Project.current
         url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx)
-        @ctx.abort(@ctx.message('node.serve.error.must_be_https')) if url.match(/^https/i).nil?
+        @ctx.abort(@ctx.message('node.serve.error.host_must_be_https')) if url.match(/^https/i).nil?
         project.env.update(@ctx, :host, url)
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @ctx,

--- a/lib/project_types/node/commands/serve.rb
+++ b/lib/project_types/node/commands/serve.rb
@@ -26,7 +26,7 @@ module Node
             @ctx.open_url!("#{project.env.host}/auth?shop=#{project.env.shop}")
           end
         end
-        CLI::UI::Frame.open(@ctx.message('node.serve.running')) do
+        CLI::UI::Frame.open(@ctx.message('node.serve.running_server')) do
           env = project.env.to_h
           env['PORT'] = ShopifyCli::Tunnel::PORT.to_s
           @ctx.system('npm run dev', env: env)

--- a/lib/project_types/node/commands/tunnel.rb
+++ b/lib/project_types/node/commands/tunnel.rb
@@ -13,7 +13,7 @@ module Node
         when 'auth'
           token = args.shift
           if token.nil?
-            @ctx.puts("{{x}} {{red:auth requires a token argument}}\n\n")
+            @ctx.puts(@ctx.message('node.tunnel.error.token_argument_missing'))
             @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
           else
             ShopifyCli::Tunnel.auth(@ctx, token)
@@ -28,26 +28,11 @@ module Node
       end
 
       def self.help
-        <<~HELP
-          Start or stop an http tunnel to your local development app using ngrok.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel [ auth | start | stop ]}}
-        HELP
+        ShopifyCli::Context.message('node.tunnel.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        <<~HELP
-          {{bold:Subcommands:}}
-
-            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel auth <token>}}
-
-            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel start}}
-
-            {{cyan:stop}}: Stops the ngrok tunnel.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel stop}}
-
-        HELP
+        ShopifyCli::Context.message('node.tunnel.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/js_deps.rb
+++ b/lib/project_types/node/js_deps.rb
@@ -15,10 +15,10 @@ module Node
     end
 
     def install
-      CLI::UI::Frame.open("Installing dependencies with #{yarn? ? 'yarn' : 'npm'}...") do
+      CLI::UI::Frame.open(ctx.message('node.js_deps.installing', yarn? ? 'yarn' : 'npm')) do
         yarn? ? yarn : npm
       end
-      ctx.done("Dependencies installed")
+      ctx.done(ctx.message('node.js_deps.installed'))
     end
 
     def yarn
@@ -37,19 +37,19 @@ module Node
       pkg = begin
               JSON.parse(File.read(package_json))
             rescue Errno::ENOENT, Errno::ENOTDIR
-              ctx.abort("expected to have a file at: #{package_json}")
+              ctx.abort(ctx.message('node.js_deps.error.missing_package', package_json))
             end
 
       deps = %w(dependencies devDependencies).map do |key|
         pkg.fetch(key, []).keys
       end.flatten
-      CLI::UI::Spinner.spin("Installing #{deps.size} dependencies...") do |spinner|
+      CLI::UI::Spinner.spin(ctx.message('node.js_deps.npm_installing_deps', deps.size)) do |spinner|
         ctx.system('npm', 'install', '--no-audit', '--no-optional', '--silent', chdir: ctx.root)
-        spinner.update_title("#{deps.size} npm dependencies installed")
+        spinner.update_title(ctx.message('node.js_deps.npm_installed_deps', deps.size))
       end
     rescue JSON::ParserError
       ctx.puts(
-        "{{info:#{File.read(File.join(path, 'package.json'))}}} was not valid JSON. Fix this then try again",
+        ctx.message('node.js_deps.error.invalid_package', File.read(File.join(path, 'package.json'))),
         error: true
       )
       raise ShopifyCli::AbortSilent

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -43,6 +43,8 @@ module Node
             serve: "{{*}} Run {{command:%s serve}} to start a local server",
             install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
           },
+          node_version: "node %s",
+          npm_version: "npm %s",
         },
 
         deploy: {
@@ -211,7 +213,7 @@ module Node
           },
 
           open_info: "{{*}} Press {{yellow: Control-T}} to open this project in {{green:%s}} ",
-          running: "Running server...",
+          running_server: "Running server...",
         },
 
         tunnel: {

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Node
+  module Messages
+    MESSAGES = {
+      node: {
+        node_required_notice: "node is required to create an app project. Download at https://nodejs.org/en/download.",
+        node_version_failure_notice: "Failed to get the current node version. Please make sure it is installed as " \
+          "per the instructions at https://nodejs.org/en.",
+        npm_required_notice: "npm is required to create an app project. Download at https://www.npmjs.com/get-npm.",
+        npm_version_failure_notice: "Failed to get the current npm version. Please make sure it is installed as per " \
+          "the instructions at https://www.npmjs.com/get-npm.",
+      },
+    }.freeze
+  end
+end

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -180,8 +180,7 @@ module Node
               Populate your development store with 5 additional orders.
 
             {{command:%1$s populate products --help}}
-              Display the list of options available to customize the
-              {{command:%1$s populate products}} command.
+              Display the list of options available to customize the {{command:%1$s populate products}} command.
           HELP
 
           customer: {

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -4,12 +4,266 @@ module Node
   module Messages
     MESSAGES = {
       node: {
-        node_required_notice: "node is required to create an app project. Download at https://nodejs.org/en/download.",
-        node_version_failure_notice: "Failed to get the current node version. Please make sure it is installed as " \
-          "per the instructions at https://nodejs.org/en.",
-        npm_required_notice: "npm is required to create an app project. Download at https://www.npmjs.com/get-npm.",
-        npm_version_failure_notice: "Failed to get the current npm version. Please make sure it is installed as per " \
-          "the instructions at https://www.npmjs.com/get-npm.",
+        error: {
+          generic: "Error",
+        },
+
+        js_deps: {
+          error: {
+            missing_package: "expected to have a file at: %s",
+            invalid_package: "{{info:%s}} was not valid JSON. Fix this then try again",
+          },
+
+          installing: "Installing dependencies with %s...",
+          installed: "Dependencies installed",
+          npm_installing_deps: "Installing %d dependencies...",
+          npm_installed_deps: "%d npm dependencies installed",
+        },
+
+        create: {
+          help: <<~HELP,
+          {{command:%s create node}}: Creates an embedded nodejs app.
+            Usage: {{command:%s create node}}
+            Options:
+              {{command:--name=NAME}} App name. Any string.
+              {{command:--app_url=APPURL}} App URL. Must be valid URL.
+              {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
+              {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
+          HELP
+          error: {
+            node_required: "node is required to create an app project. Download at https://nodejs.org/en/download.",
+            node_version_failure: "Failed to get the current node version. Please make sure it is installed as " \
+              "per the instructions at https://nodejs.org/en.",
+            npm_required: "npm is required to create an app project. Download at https://www.npmjs.com/get-npm.",
+            npm_version_failure: "Failed to get the current npm version. Please make sure it is installed as per " \
+              "the instructions at https://www.npmjs.com/get-npm.",
+          },
+          info: {
+            created: "{{v}} {{green:%s}} was created in your Partner Dashboard {{underline:%s}}",
+            serve: "{{*}} Run {{command:%s serve}} to start a local server",
+            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
+          },
+        },
+
+        deploy: {
+          help: <<~HELP,
+          Deploy the current Node project to a hosting service. Heroku ({{underline:https://www.heroku.com}}) is currently the only option, but more will be added in the future.
+            Usage: {{command:%s deploy [ heroku ]}}
+          HELP
+          extended_help: <<~HELP,
+          {{bold:Subcommands:}}
+            {{cyan:heroku}}: Deploys the current Node project to Heroku.
+              Usage: {{command:%s deploy heroku}}
+          HELP
+          heroku: {
+            help: <<~HELP,
+            Deploy the current Node project to Heroku
+              Usage: {{command:%s deploy heroku}}
+            HELP
+            downloading: "Downloading Heroku CLI…",
+            downloaded: "Downloaded Heroku CLI",
+            installing: "Installing Heroku CLI…",
+            installed: "Installed Heroku CLI",
+            authenticating: "Authenticating with Heroku…",
+            authenticated: "{{v}} Authenticated with Heroku",
+            deploying: "Deploying to Heroku…",
+            deployed: "{{v}} Deployed to Heroku",
+            git: {
+              checking: "Checking git repo…",
+              initialized: "Git repo initialized",
+              authenticated: "{{v}} Authenticated with Heroku as `%s`",
+              what_branch: "What branch would you like to deploy?",
+              branch_selected: "{{v}} Git branch `%s` selected for deploy",
+            },
+            app: {
+              no_apps_found: "No existing Heroku app found. What would you like to do?",
+              name: "What is your Heroku app’s name?",
+              select: "Specify an existing Heroku app",
+              selecting: "Selecting Heroku app `%s`…",
+              selected: "{{v}} Heroku app `%s` selected",
+              create: "Create a new Heroku app",
+              creating: "Creating new Heroku app…",
+              created: "{{v}} New Heroku app created",
+            },
+          },
+        },
+
+        generate: {
+          help: <<~HELP,
+          Generate code in your Node project. Supports generating new billing API calls, new pages, or new webhooks.
+            Usage: {{command:%s generate [ billing | page | webhook ]}}
+          HELP
+          extended_help: <<~EXAMPLES,
+          {{bold:Examples:}}
+            {{cyan:%s generate webhook PRODUCTS_CREATE}}
+              Generate and register a new webhook that will be called every time a new product is created on your store.
+          EXAMPLES
+
+          error: {
+            name_exists: "%s already exists!",
+            generic: "Error generating %s",
+          },
+
+          billing: {
+            help: <<~HELP,
+            Enable charging for your app. This command generates the necessary code to call Shopify’s billing API.
+              Usage: {{command:%s generate billing [ one-time-billing | recurring-billing ]}}
+            HELP
+            type_select: "How would you like to charge for your app?",
+            generating: "Generating %s code ...",
+            generated: "{{green:%s generated in server/server.js",
+          },
+
+          page: {
+            help: <<~HELP,
+            Generate a new page in your app with the specified name. New files are generated inside the project’s “/pages” directory.
+              Usage: {{command:%s generate page <pagename>}}
+            HELP
+            error: {
+              invalid_page_type: "Invalid page type.",
+            },
+            type_select: "Which template would you like to use?",
+            generating: "Generating %s page...",
+            generated: "{{green: %s}} generated in pages/%s",
+          },
+
+          webhook: {
+            help: <<~HELP,
+            Generate and register a new webhook that listens for the specified Shopify store event.
+              Usage: {{command:%s generate webhook <type>}}
+            HELP
+            type_select: "What type of webhook would you like to create?",
+            generating: "Generating webhook: %s",
+            generated: "{{green:%s}} generated in server/server.js",
+          },
+        },
+
+        open: {
+          help: <<~HELP,
+          Open your local development app in the default browser.
+            Usage: {{command:%s open}}
+          HELP
+        },
+
+        populate: {
+          help: <<~HELP,
+          Populate your Shopify development store with example customers, orders, or products.
+            Usage: {{command:%s populate [ customers | draftorders | products ]}}
+          HELP
+          extended_help: <<~HELP,
+          {{bold:Subcommands:}}
+
+            {{cyan:customers [options]}}: Add dummy customers to the specified development store.
+              Usage: {{command:%1$s populate customers}}
+
+            {{cyan:draftorders [options]}}: Add dummy orders to the specified development store.
+              Usage: {{command:%1$s populate draftorders}}
+
+            {{cyan:products [options]}}: Add dummy products to the specified development store.
+              Usage: {{command:%1$s populate products}}
+
+          {{bold:Options:}}
+
+            {{cyan:--count [integer]}}: The number of dummy items to populate. Defaults to 5.
+            {{cyan:--silent}}: Silence the populate output.
+            {{cyan:--help}}: Display more options specific to each subcommand.
+
+          {{bold:Examples:}}
+
+            {{command:%1$s populate products}}
+              Populate your development store with 5 additional products.
+
+            {{command:%1$s populate customers --count 30}}
+              Populate your development store with 30 additional customers.
+
+            {{command:%1$s populate draftorders}}
+              Populate your development store with 5 additional orders.
+
+            {{command:%1$s populate products --help}}
+              Display the list of options available to customize the
+              {{command:%1$s populate products}} command.
+          HELP
+
+          customer: {
+            added: "%s added to {{green:%s}} at {{underline:%scustomers/%d}}",
+          },
+
+          draft_order: {
+            added: "DraftOrder added to {{green:%s}} at {{underline:%sdraft_orders/%d}}",
+          },
+
+          product: {
+            added: "%s added to {{green:%s}} at {{underline:%sproducts/%d}}",
+          },
+        },
+
+        serve: {
+          help: <<~HELP,
+          Start a local development node server for your project, as well as a public ngrok tunnel to your localhost.
+            Usage: {{command:%s serve}}
+          HELP
+          extended_help: <<~HELP,
+          {{bold:Options:}}
+            {{cyan:--host=HOST}}: Bypass running tunnel and use custom host. HOST must be HTTPS url.
+          HELP
+
+          error: {
+            must_be_https: "HOST must be a HTTPS url.",
+          },
+
+          open_info: "{{*}} Press {{yellow: Control-T}} to open this project in {{green:%s}} ",
+          running: "Running server...",
+        },
+
+        tunnel: {
+          help: <<~HELP,
+          Start or stop an http tunnel to your local development app using ngrok.
+            Usage: {{command:%s tunnel [ auth | start | stop ]}}
+          HELP
+          extended_help: <<~HELP,
+          {{bold:Subcommands:}}
+
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
+              Usage: {{command:%1$s tunnel auth <token>}}
+
+            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
+              Usage: {{command:%1$s tunnel start}}
+
+            {{cyan:stop}}: Stops the ngrok tunnel.
+              Usage: {{command:%1$s tunnel stop}}
+
+          HELP
+
+          error: {
+            token_argument_missing: "{{x}} {{red:auth requires a token argument}}\n\n",
+          },
+        },
+
+        forms: {
+          create: {
+            error: {
+              invalid_app_type: "Invalid App Type %s",
+              organization_not_found: "Cannot find an organization with that ID",
+              no_organizations: "No organizations available.",
+            },
+
+            authentication_issue: "For authentication issues, run {{command:%s logout}} to clear invalid credentials",
+            partners_notice: "Please visit https://partners.shopify.com/ to create a partners account",
+            no_development_stores: "{{x}} No Development Stores available.",
+            create_store: "Visit {{underline:https://partners.shopify.com/%s/stores}} to create one",
+            app_name: "App Name",
+            app_type: {
+              select: "What type of app are you building?",
+              select_public: "Public: An app built for a wide merchant audience.",
+              select_custom: "Custom: An app custom built for a single client.",
+              selected: "App Type {{green:%s}}",
+            },
+            organization_select: "Select organization",
+            organization: "Organization {{green:%s}}",
+            development_store_select: "Select a Development Store",
+            development_store: "Using Development Store {{green:%s}}",
+          },
+        },
       },
     }.freeze
   end

--- a/lib/project_types/node/messages/messages.yml
+++ b/lib/project_types/node/messages/messages.yml
@@ -1,5 +1,0 @@
-node:
-  node_required_notice: "node is required to create an app project. Download at https://nodejs.org/en/download."
-  node_version_failure_notice: "Failed to get the current node version. Please make sure it is installed as per the instructions at https://nodejs.org/en."
-  npm_required_notice: "npm is required to create an app project. Download at https://www.npmjs.com/get-npm."
-  npm_version_failure_notice: "Failed to get the current npm version. Please make sure it is installed as per the instructions at https://www.npmjs.com/get-npm."

--- a/lib/project_types/node/messages/messages.yml
+++ b/lib/project_types/node/messages/messages.yml
@@ -1,0 +1,5 @@
+node:
+  node_required_notice: "node is required to create an app project. Download at https://nodejs.org/en/download."
+  node_version_failure_notice: "Failed to get the current node version. Please make sure it is installed as per the instructions at https://nodejs.org/en."
+  npm_required_notice: "npm is required to create an app project. Download at https://www.npmjs.com/get-npm."
+  npm_version_failure_notice: "Failed to get the current npm version. Please make sure it is installed as per the instructions at https://www.npmjs.com/get-npm."

--- a/lib/project_types/rails/cli.rb
+++ b/lib/project_types/rails/cli.rb
@@ -11,6 +11,9 @@ module Rails
     register_command('Rails::Commands::Serve', "serve")
     register_command('Rails::Commands::Tunnel', "tunnel")
     # register_task('Rails::Tasks::RailsTask', 'rails_task')
+
+    require Project.project_filepath('messages/messages')
+    register_messages(Rails::Messages::MESSAGES)
   end
 
   # define/autoload project specific Commads

--- a/lib/project_types/rails/commands/deploy.rb
+++ b/lib/project_types/rails/commands/deploy.rb
@@ -11,18 +11,11 @@ module Rails
       end
 
       def self.help
-        <<~HELP
-          Deploy the current Rails project to a hosting service. Heroku ({{underline:https://www.heroku.com}}) is currently the only option, but more will be added in the future.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy [ heroku ]}}
-        HELP
+        ShopifyCli::Context.message('rails.deploy.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        <<~HELP
-        {{bold:Subcommands:}}
-          {{cyan:heroku}}: Deploys the current Rails project to Heroku.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} deploy heroku}}
-        HELP
+        ShopifyCli::Context.message('rails.deploy.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/generate.rb
+++ b/lib/project_types/rails/commands/generate.rb
@@ -11,10 +11,7 @@ module Rails
       end
 
       def self.help
-        <<~HELP
-          Generate code in your Rails project. Currently supports generating new webhooks.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} generate [ webhook ]}}
-        HELP
+        ShopifyCli::Context.message('rails.generate.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
@@ -27,28 +24,24 @@ module Rails
           end
           extended_help += "\n"
         end
-        extended_help += <<~EXAMPLES
-          {{bold:Examples:}}
-            {{cyan:#{ShopifyCli::TOOL_NAME} generate webhook PRODUCTS_CREATE}}
-              Generate and register a new webhook that will be called every time a new product is created on your store.
-        EXAMPLES
+        extended_help += ShopifyCli::Context.message('rails.generate.extended_help', ShopifyCli::TOOL_NAME)
       end
 
       def self.run_generate(script, name, ctx)
         stat = ctx.system(script)
         unless stat.success?
-          ctx.abort(response(stat.exitstatus, name))
+          ctx.abort(response(stat.exitstatus, name, ctx))
         end
       end
 
-      def self.response(code, name)
+      def self.response(code, name, ctx)
         case code
         when 1
-          "Error generating #{name}"
+          ctx.message('rails.generate.error.generic', name)
         when 2
-          "#{name} already exists!"
+          ctx.message('rails.generate.error.name_exists', name)
         else
-          'Error'
+          ctx.message('rails.error.generic')
         end
       end
     end

--- a/lib/project_types/rails/commands/generate/webhook.rb
+++ b/lib/project_types/rails/commands/generate/webhook.rb
@@ -9,14 +9,14 @@ module Rails
           schema = ShopifyCli::AdminAPI::Schema.get(@ctx)
           webhooks = schema.get_names_from_type('WebhookSubscriptionTopic')
           unless selected_type && webhooks.include?(selected_type)
-            selected_type = CLI::UI::Prompt.ask('What type of webhook would you like to create?') do |handler|
+            selected_type = CLI::UI::Prompt.ask(@ctx.message('rails.generate.webhook.select')) do |handler|
               webhooks.each do |type|
                 handler.option(type) { type }
               end
             end
           end
           spin_group = CLI::UI::SpinGroup.new
-          spin_group.add("Generating webhook: #{selected_type}") do |spinner|
+          spin_group.add(@ctx.message('rails.generate.webhook.selected', selected_type)) do |spinner|
             Rails::Commands::Generate.run_generate(generate_command(selected_type), selected_type, @ctx)
             spinner.update_title("{{green:#{selected_type}}} config/initializers/shopify_app.rb")
           end
@@ -24,10 +24,7 @@ module Rails
         end
 
         def self.help
-          <<~HELP
-            Generate and register a new webhook that listens for the specified Shopify store event.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate webhook <type>}}
-          HELP
+          ShopifyCli::Context.message('rails.generate.webhook.help', ShopifyCli::TOOL_NAME)
         end
 
         def generate_command(selected_type)

--- a/lib/project_types/rails/commands/open.rb
+++ b/lib/project_types/rails/commands/open.rb
@@ -9,10 +9,7 @@ module Rails
       end
 
       def self.help
-        <<~HELP
-          Open your local development app in the default browser.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} open}}
-        HELP
+        ShopifyCli::Context.message('rails.open.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/populate.rb
+++ b/lib/project_types/rails/commands/populate.rb
@@ -12,46 +12,11 @@ module Rails
       end
 
       def self.help
-        <<~HELP
-          Populate your Shopify development store with example customers, orders, or products.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} populate [ customers | draftorders | products ]}}
-        HELP
+        ShopifyCli::Context.message('rails.populate.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        <<~HELP
-          {{bold:Subcommands:}}
-
-            {{cyan:customers [options]}}: Add dummy customers to the specified development store.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} populate customers}}
-
-            {{cyan:draftorders [options]}}: Add dummy orders to the specified development store.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} populate draftorders}}
-
-            {{cyan:products [options]}}: Add dummy products to the specified development store.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} populate products}}
-
-          {{bold:Options:}}
-
-            {{cyan:--count [integer]}}: The number of dummy items to populate. Defaults to 5.
-            {{cyan:--silent}}: Silence the populate output.
-            {{cyan:--help}}: Display more options specific to each subcommand.
-
-          {{bold:Examples:}}
-
-            {{command:#{ShopifyCli::TOOL_NAME} populate products}}
-              Populate your development store with 5 additional products.
-
-            {{command:#{ShopifyCli::TOOL_NAME} populate customers --count 30}}
-              Populate your development store with 30 additional customers.
-
-            {{command:#{ShopifyCli::TOOL_NAME} populate draftorders}}
-              Populate your development store with 5 additional orders.
-
-            {{command:#{ShopifyCli::TOOL_NAME} populate products --help}}
-              Display the list of options available to customize the
-              {{command:#{ShopifyCli::TOOL_NAME} populate products}} command.
-        HELP
+        ShopifyCli::Context.message('rails.populate.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/populate/customer.rb
+++ b/lib/project_types/rails/commands/populate/customer.rb
@@ -18,7 +18,11 @@ module Rails
           ret = data['customerCreate']['customer']
           id = ShopifyCli::API.gid_to_id(ret['id'])
           @ctx.message(
-            'rails.populate.customer.added', ret['displayName'], ShopifyCli::Project.current.env.shop, admin_url, id
+            'rails.populate.customer.added',
+            ret['displayName'],
+            ShopifyCli::Project.current.env.shop,
+            admin_url,
+            id
           )
         end
       end

--- a/lib/project_types/rails/commands/populate/customer.rb
+++ b/lib/project_types/rails/commands/populate/customer.rb
@@ -17,8 +17,9 @@ module Rails
         def message(data)
           ret = data['customerCreate']['customer']
           id = ShopifyCli::API.gid_to_id(ret['id'])
-          "#{ret['displayName']} added to {{green:#{ShopifyCli::Project.current.env.shop}}} "\
-          "at {{underline:#{admin_url}customers/#{id}}}"
+          @ctx.message(
+            'rails.populate.customer.added', ret['displayName'], ShopifyCli::Project.current.env.shop, admin_url, id
+          )
         end
       end
     end

--- a/lib/project_types/rails/commands/populate/draft_order.rb
+++ b/lib/project_types/rails/commands/populate/draft_order.rb
@@ -20,8 +20,7 @@ module Rails
         def message(data)
           ret = data['draftOrderCreate']['draftOrder']
           id = ShopifyCli::API.gid_to_id(ret['id'])
-          "DraftOrder added to {{green:#{ShopifyCli::Project.current.env.shop}}} "\
-          "at {{underline:#{admin_url}draft_orders/#{id}}}"
+          @ctx.message('rails.populate.draft_order.added', ShopifyCli::Project.current.env.shop, admin_url, id)
         end
       end
     end

--- a/lib/project_types/rails/commands/populate/product.rb
+++ b/lib/project_types/rails/commands/populate/product.rb
@@ -16,8 +16,9 @@ module Rails
         def message(data)
           ret = data['productCreate']['product']
           id = ShopifyCli::API.gid_to_id(ret['id'])
-          "#{ret['title']} added to {{green:#{ShopifyCli::Project.current.env.shop}}} "\
-          "at {{underline:#{admin_url}products/#{id}}}"
+          @ctx.message(
+            'rails.populate.product.added', ret['title'], ShopifyCli::Project.current.env.shop, admin_url, id
+          )
         end
       end
     end

--- a/lib/project_types/rails/commands/populate/product.rb
+++ b/lib/project_types/rails/commands/populate/product.rb
@@ -17,7 +17,11 @@ module Rails
           ret = data['productCreate']['product']
           id = ShopifyCli::API.gid_to_id(ret['id'])
           @ctx.message(
-            'rails.populate.product.added', ret['title'], ShopifyCli::Project.current.env.shop, admin_url, id
+            'rails.populate.product.added',
+            ret['title'],
+            ShopifyCli::Project.current.env.shop,
+            admin_url,
+            id
           )
         end
       end

--- a/lib/project_types/rails/commands/serve.rb
+++ b/lib/project_types/rails/commands/serve.rb
@@ -27,7 +27,7 @@ module Rails
           end
         end
         Gem.gem_home(@ctx)
-        CLI::UI::Frame.open(@ctx.message('rails.serve.running')) do
+        CLI::UI::Frame.open(@ctx.message('rails.serve.running_server')) do
           env = ShopifyCli::Project.current.env.to_h
           env.delete('HOST')
           env['PORT'] = ShopifyCli::Tunnel::PORT.to_s

--- a/lib/project_types/rails/commands/serve.rb
+++ b/lib/project_types/rails/commands/serve.rb
@@ -13,7 +13,7 @@ module Rails
       def call(*)
         project = ShopifyCli::Project.current
         url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx)
-        @ctx.abort("{{red:HOST must be a HTTPS url.}}") if url.match(/^https/i).nil?
+        @ctx.abort(@ctx.message('rails.serve.error.host_must_be_https')) if url.match(/^https/i).nil?
         project.env.update(@ctx, :host, url)
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @ctx,
@@ -21,13 +21,13 @@ module Rails
           callback_url: "/auth/shopify/callback",
         )
         if @ctx.mac? && project.env.shop
-          @ctx.puts("{{*}} Press {{yellow: Control-T}} to open this project in {{green:#{project.env.shop}}} ")
+          @ctx.puts(@ctx.message('rails.serve.open_info', project.env.shop))
           @ctx.on_siginfo do
             @ctx.open_url!("#{project.env.host}/login?shop=#{project.env.shop}")
           end
         end
         Gem.gem_home(@ctx)
-        CLI::UI::Frame.open('Running server...') do
+        CLI::UI::Frame.open(@ctx.message('rails.serve.running')) do
           env = ShopifyCli::Project.current.env.to_h
           env.delete('HOST')
           env['PORT'] = ShopifyCli::Tunnel::PORT.to_s
@@ -36,17 +36,11 @@ module Rails
       end
 
       def self.help
-        <<~HELP
-          Start a local development rails server for your project, as well as a public ngrok tunnel to your localhost.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} serve}}
-        HELP
+        ShopifyCli::Context.message('rails.serve.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        <<~HELP
-          {{bold:Options:}}
-            {{cyan:--host=HOST}}: Bypass running tunnel and use custom host. HOST must be HTTPS url.
-        HELP
+        ShopifyCli::Context.message('rails.serve.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/tunnel.rb
+++ b/lib/project_types/rails/commands/tunnel.rb
@@ -13,7 +13,7 @@ module Rails
         when 'auth'
           token = args.shift
           if token.nil?
-            @ctx.puts("{{x}} {{red:auth requires a token argument}}\n\n")
+            @ctx.puts(@ctx.message('rails.tunnel.error.token_argument_missing'))
             @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
           else
             ShopifyCli::Tunnel.auth(@ctx, token)
@@ -28,26 +28,11 @@ module Rails
       end
 
       def self.help
-        <<~HELP
-          Start or stop an http tunnel to your local development app using ngrok.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel [ auth | start | stop ]}}
-        HELP
+        ShopifyCli::Context.message('rails.tunnel.help', ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        <<~HELP
-          {{bold:Subcommands:}}
-
-            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel auth <token>}}
-
-            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel start}}
-
-            {{cyan:stop}}: Stops the ngrok tunnel.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel stop}}
-
-        HELP
+        ShopifyCli::Context.message('rails.tunnel.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/forms/create.rb
+++ b/lib/project_types/rails/forms/create.rb
@@ -7,7 +7,7 @@ module Rails
       flag_arguments :title, :organization_id, :shop_domain, :type
 
       def ask
-        self.title ||= CLI::UI::Prompt.ask('App Name')
+        self.title ||= CLI::UI::Prompt.ask(ctx.message('rails.forms.create.app_name'))
         self.type = ask_type
         self.name = self.title.downcase.split(" ").join("_")
         self.organization_id ||= organization["id"].to_i
@@ -18,16 +18,16 @@ module Rails
 
       def ask_type
         if type.nil?
-          return CLI::UI::Prompt.ask('What type of app are you building?') do |handler|
-            handler.option('Public: An app built for a wide merchant audience.') { 'public' }
-            handler.option('Custom: An app custom built for a single client.') { 'custom' }
+          return CLI::UI::Prompt.ask(ctx.message('rails.forms.create.app_type.select')) do |handler|
+            handler.option(ctx.message('rails.forms.create.app_type.select_public')) { 'public' }
+            handler.option(ctx.message('rails.forms.create.app_type.select_custom')) { 'custom' }
           end
         end
 
         unless ShopifyCli::Tasks::CreateApiClient::VALID_APP_TYPES.include?(type)
-          ctx.abort("Invalid App Type #{type}")
+          ctx.abort(ctx.message('rails.forms.create.error.invalid_app_type', type))
         end
-        ctx.puts("App Type {{green:#{type}}}")
+        ctx.puts(ctx.message('rails.forms.create.app_type.selected', type))
         type
       end
 
@@ -39,23 +39,19 @@ module Rails
         @organization ||= if !organization_id.nil?
           org = ShopifyCli::PartnersAPI::Organizations.fetch(ctx, id: organization_id)
           if org.nil?
-            ctx.puts(
-              "For authentication issues, run {{command:#{ShopifyCli::TOOL_NAME} logout}} to clear invalid credentials"
-            )
-            ctx.abort("Cannot find an organization with that ID")
+            ctx.puts(ctx.message('rails.forms.create.authentication_issue', ShopifyCli::TOOL_NAME))
+            ctx.abort(ctx.message('rails.forms.create.error.organization_not_found'))
           end
           org
         elsif organizations.count == 0
-          ctx.puts('Please visit https://partners.shopify.com/ to create a partners account')
-          ctx.puts(
-            "For authentication issues, run {{command:#{ShopifyCli::TOOL_NAME} logout}} to clear invalid credentials"
-          )
-          ctx.abort('No organizations available.')
+          ctx.puts(ctx.message('rails.forms.create.partners_notice'))
+          ctx.puts(ctx.message('rails.forms.create.authentication_issue', ShopifyCli::TOOL_NAME))
+          ctx.abort(ctx.message('rails.forms.create.error.no_organizations'))
         elsif organizations.count == 1
-          ctx.puts("Organization {{green:#{organizations.first['businessName']}}}")
+          ctx.puts(ctx.message('rails.forms.create.organization', organizations.first['businessName']))
           organizations.first
         else
-          org_id = CLI::UI::Prompt.ask('Select organization') do |handler|
+          org_id = CLI::UI::Prompt.ask(ctx.message('rails.forms.create.organization_select')) do |handler|
             organizations.each { |o| handler.option(o['businessName']) { o['id'] } }
           end
           organizations.find { |o| o['id'] == org_id }
@@ -68,18 +64,16 @@ module Rails
         end
 
         if valid_stores.count == 0
-          ctx.puts('{{x}} No Development Stores available.')
-          ctx.puts("Visit {{underline:https://partners.shopify.com/#{organization['id']}/stores}} to create one")
-          ctx.puts(
-            "For authentication issues, run {{command:#{ShopifyCli::TOOL_NAME} logout}} to clear invalid credentials"
-          )
+          ctx.puts(ctx.message('rails.forms.create.no_development_stores'))
+          ctx.puts(ctx.message('rails.forms.create.create_store', organization['id']))
+          ctx.puts(ctx.message('rails.forms.create.authentication_issue', ShopifyCli::TOOL_NAME))
         elsif valid_stores.count == 1
           domain = valid_stores.first['shopDomain']
-          ctx.puts("Using Development Store {{green:#{domain}}}")
+          ctx.puts(ctx.message('rails.forms.create.development_store', domain))
           domain
         else
           CLI::UI::Prompt.ask(
-            'Select a Development Store',
+            ctx.message('rails.forms.create.development_store_select'),
             options: valid_stores.map { |s| s['shopDomain'] }
           )
         end

--- a/lib/project_types/rails/gem.rb
+++ b/lib/project_types/rails/gem.rb
@@ -14,7 +14,7 @@ module Rails
         name = args.shift
         version = args.shift
         gem = new(ctx: ctx, name: name, version: version)
-        ctx.debug("#{name} installed: #{gem.installed?}")
+        ctx.debug(ctx.message('rails.gem.installed_debug', name, gem.installed?))
         gem.install! unless gem.installed?
       end
 
@@ -43,12 +43,12 @@ module Rails
 
     def install!
       spin = CLI::UI::SpinGroup.new
-      spin.add("Installing #{name} gem...") do |spinner|
+      spin.add(ctx.message('rails.gem.installing', name)) do |spinner|
         args = %w(gem install)
         args.push(name)
         args.push('-v', version) unless version.nil?
         ctx.system(*args)
-        spinner.update_title("Installed #{name} gem")
+        spinner.update_title(ctx.message('rails.gem.installed', name))
       end
       spin.wait
     end

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -1,72 +1,74 @@
 # frozen_string_literal: true
 
-module Node
+module Rails
   module Messages
     MESSAGES = {
-      node: {
+      rails: {
         error: {
           generic: "Error",
         },
 
-        js_deps: {
-          error: {
-            missing_package: "expected to have a file at: %s",
-            invalid_package: "{{info:%s}} was not valid JSON. Fix this then try again",
-          },
-
-          installing: "Installing dependencies with %s...",
-          installed: "Dependencies installed",
-          npm_installing_deps: "Installing %d dependencies...",
-          npm_installed_deps: "%d npm dependencies installed",
+        gem: {
+          installed_debug: "%s installed: %s",
+          installing: "Installing %s gem...",
+          installed: "Installed %s gem",
         },
 
         create: {
           help: <<~HELP,
-          {{command:%s create node}}: Creates an embedded nodejs app.
-            Usage: {{command:%s create node}}
+          {{command:%s create rails}}: Creates a ruby on rails app.
+            Usage: {{command:%s create rails}}
             Options:
               {{command:--name=NAME}} App name. Any string.
               {{command:--app_url=APPURL}} App URL. Must be valid URL.
               {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
               {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
           HELP
+
           error: {
-            node_required: "node is required to create an app project. Download at https://nodejs.org/en/download.",
-            node_version_failure: "Failed to get the current node version. Please make sure it is installed as " \
-              "per the instructions at https://nodejs.org/en.",
-            npm_required: "npm is required to create an app project. Download at https://www.npmjs.com/get-npm.",
-            npm_version_failure: "Failed to get the current npm version. Please make sure it is installed as per " \
-              "the instructions at https://www.npmjs.com/get-npm.",
+            invalid_ruby_version: <<~MSG,
+            This project requires a ruby version ~> 2.4.
+            See {{underline:https://github.com/Shopify/shopify-app-cli/blob/master/docs/installing-ruby.md}}
+            for our recommended method of installing ruby.
+            MSG
           },
+
           info: {
             created: "{{v}} {{green:%s}} was created in your Partner Dashboard {{underline:%s}}",
             serve: "{{*}} Run {{command:%s serve}} to start a local server",
             install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
           },
+          installing_bundler: "Installing bundler…",
+          generating_app: "Generating new rails app project in %s...",
+          adding_shopify_gem: "{{v}} Adding shopify_app gem…",
+          running_bundle_install: "Running bundle install...",
+          running_generator: "Running shopfiy_app generator...",
+          running_migrations: "Running migrations…",
         },
 
         deploy: {
           help: <<~HELP,
-          Deploy the current Node project to a hosting service. Heroku ({{underline:https://www.heroku.com}}) is currently the only option, but more will be added in the future.
+          Deploy the current Rails project to a hosting service. Heroku ({{underline:https://www.heroku.com}}) is currently the only option, but more will be added in the future.
             Usage: {{command:%s deploy [ heroku ]}}
           HELP
           extended_help: <<~HELP,
           {{bold:Subcommands:}}
-            {{cyan:heroku}}: Deploys the current Node project to Heroku.
+            {{cyan:heroku}}: Deploys the current Rails project to Heroku.
               Usage: {{command:%s deploy heroku}}
           HELP
+
           heroku: {
             help: <<~HELP,
-            Deploy the current Node project to Heroku
-              Usage: {{command:%s deploy heroku}}
+            Deploy the current Rails project to Heroku
+            Usage: {{command:%s deploy heroku}}
             HELP
             downloading: "Downloading Heroku CLI…",
             downloaded: "Downloaded Heroku CLI",
             installing: "Installing Heroku CLI…",
             installed: "Installed Heroku CLI",
+            authenticated_with_account: "{{v}} Authenticated with Heroku as `%s`",
             authenticating: "Authenticating with Heroku…",
             authenticated: "{{v}} Authenticated with Heroku",
-            authenticated_with_account: "{{v}} Authenticated with Heroku as `%s`",
             deploying: "Deploying to Heroku…",
             deployed: "{{v}} Deployed to Heroku",
             git: {
@@ -90,8 +92,8 @@ module Node
 
         generate: {
           help: <<~HELP,
-          Generate code in your Node project. Supports generating new billing API calls, new pages, or new webhooks.
-            Usage: {{command:%s generate [ billing | page | webhook ]}}
+          Generate code in your Rails project. Currently supports generating new webhooks.
+            Usage: {{command:%s generate [ webhook ]}}
           HELP
           extended_help: <<~EXAMPLES,
           {{bold:Examples:}}
@@ -104,37 +106,14 @@ module Node
             generic: "Error generating %s",
           },
 
-          billing: {
-            help: <<~HELP,
-            Enable charging for your app. This command generates the necessary code to call Shopify’s billing API.
-              Usage: {{command:%s generate billing [ one-time-billing | recurring-billing ]}}
-            HELP
-            type_select: "How would you like to charge for your app?",
-            generating: "Generating %s code ...",
-            generated: "{{green:%s generated in server/server.js",
-          },
-
-          page: {
-            help: <<~HELP,
-            Generate a new page in your app with the specified name. New files are generated inside the project’s “/pages” directory.
-              Usage: {{command:%s generate page <pagename>}}
-            HELP
-            error: {
-              invalid_page_type: "Invalid page type.",
-            },
-            type_select: "Which template would you like to use?",
-            generating: "Generating %s page...",
-            generated: "{{green: %s}} generated in pages/%s",
-          },
-
           webhook: {
             help: <<~HELP,
             Generate and register a new webhook that listens for the specified Shopify store event.
               Usage: {{command:%s generate webhook <type>}}
             HELP
-            type_select: "What type of webhook would you like to create?",
-            generating: "Generating webhook: %s",
-            generated: "{{green:%s}} generated in server/server.js",
+
+            select: "What type of webhook would you like to create?",
+            selected: "Generating webhook: %s",
           },
         },
 
@@ -199,7 +178,7 @@ module Node
 
         serve: {
           help: <<~HELP,
-          Start a local development node server for your project, as well as a public ngrok tunnel to your localhost.
+          Start a local development rails server for your project, as well as a public ngrok tunnel to your localhost.
             Usage: {{command:%s serve}}
           HELP
           extended_help: <<~HELP,
@@ -208,7 +187,7 @@ module Node
           HELP
 
           error: {
-            host_must_be_https: "HOST must be a HTTPS url.",
+            host_must_be_https: "{{red:HOST must be a HTTPS url.}}",
           },
 
           open_info: "{{*}} Press {{yellow: Control-T}} to open this project in {{green:%s}} ",

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -190,7 +190,7 @@ module Rails
           },
 
           open_info: "{{*}} Press {{yellow: Control-T}} to open this project in {{green:%s}} ",
-          running: "Running server...",
+          running_server: "Running server...",
         },
 
         tunnel: {

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -159,8 +159,7 @@ module Rails
               Populate your development store with 5 additional orders.
 
             {{command:%1$s populate products --help}}
-              Display the list of options available to customize the
-              {{command:%1$s populate products}} command.
+              Display the list of options available to customize the {{command:%1$s populate products}} command.
           HELP
 
           customer: {

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -6,6 +6,9 @@ module Script
     creator 'Script', 'Script::Commands::Create'
 
     register_command('Script::Commands::Test', 'test')
+
+    require Project.project_filepath('messages/messages')
+    register_messages(Script::Messages::MESSAGES)
   end
 
   # define/autoload project specific Commads

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -3,10 +3,6 @@
 module Script
   module Commands
     class Create < ShopifyCli::SubCommand
-      DIRECTORY_CHANGED_MSG = "{{v}} Changed to project directory: {{green:%{folder}}}"
-      OPERATION_FAILED_MESSAGE = "Script not created."
-      OPERATION_SUCCESS_MESSAGE = "{{v}} Script created: {{green:%{script_id}}}"
-
       options do |parser, flags|
         parser.on('--name=NAME') { |name| flags[:name] = name }
         parser.on('--extension_point=EP_NAME') { |ep_name| flags[:extension_point] = ep_name }
@@ -27,21 +23,15 @@ module Script
           script_name: form.name,
           extension_point_type: form.extension_point
         )
-        @ctx.puts(format(DIRECTORY_CHANGED_MSG, folder: script.name))
-        @ctx.puts(format(OPERATION_SUCCESS_MESSAGE, script_id: script.id))
+        @ctx.puts(@ctx.message('script.create.changed_dir', folder: script.name))
+        @ctx.puts(@ctx.message('script.create.created', script_id: script.id))
       rescue StandardError => e
-        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: OPERATION_FAILED_MESSAGE)
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.create.error.operation_failed'))
       end
 
       def self.help
         allowed_values = "{{cyan:discount}} and {{cyan:unit_limit_per_order}}"
-        <<~HELP
-        {{command:#{ShopifyCli::TOOL_NAME} create script}}: Creates a script project.
-          Usage: {{command:#{ShopifyCli::TOOL_NAME} create script}}
-          Options:
-            {{command:--name=NAME}} Script project name. Any string.
-            {{command:--extension_point=TYPE}} Extension point name. Allowed values: #{allowed_values}.
-        HELP
+        ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME, allowed_values)
       end
     end
   end

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -24,7 +24,7 @@ module Script
           extension_point_type: form.extension_point
         )
         @ctx.puts(@ctx.message('script.create.changed_dir', folder: script.name))
-        @ctx.puts(@ctx.message('script.create.created', script_id: script.id))
+        @ctx.puts(@ctx.message('script.create.script_created', script_id: script.id))
       rescue StandardError => e
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.create.error.operation_failed'))
       end

--- a/lib/project_types/script/commands/test.rb
+++ b/lib/project_types/script/commands/test.rb
@@ -3,9 +3,6 @@
 module Script
   module Commands
     class Test < ShopifyCli::Command
-      OPERATION_FAILED_MESSAGE = "Tests didn't run or they ran with failures."
-      OPERATION_SUCCESS_MESSAGE = "{{v}} Tests finished."
-
       def call(_args, _name)
         project = Script::ScriptProject.current
         Layers::Application::TestScript.call(
@@ -14,16 +11,13 @@ module Script
           extension_point_type: project.extension_point_type,
           script_name: project.script_name
         )
-        @ctx.puts(OPERATION_SUCCESS_MESSAGE)
+        @ctx.puts(@ctx.message('script.test.success'))
       rescue StandardError => e
-        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: OPERATION_FAILED_MESSAGE)
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.test.error.operation_failed'))
       end
 
       def self.help
-        <<~HELP
-        Runs unit tests on your script.
-          Usage: {{command:#{ShopifyCli::TOOL_NAME} test}}
-        HELP
+        ShopifyCli::Context.message('script.test.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -14,13 +14,13 @@ module Script
 
       def ask_extension_point
         CLI::UI::Prompt.ask(
-          'Which extension point do you want to use?',
+          @ctx.message('script.create.select_extension_point'),
           options: Script::Layers::Application::ExtensionPoints.types
         )
       end
 
       def ask_name
-        CLI::UI::Prompt.ask('Script Name')
+        CLI::UI::Prompt.ask(@ctx.message('script.create.name'))
       end
     end
   end

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -14,13 +14,13 @@ module Script
 
       def ask_extension_point
         CLI::UI::Prompt.ask(
-          @ctx.message('script.create.select_extension_point'),
+          @ctx.message('script.forms.create.select_extension_point'),
           options: Script::Layers::Application::ExtensionPoints.types
         )
       end
 
       def ask_name
-        CLI::UI::Prompt.ask(@ctx.message('script.create.name'))
+        CLI::UI::Prompt.ask(@ctx.message('script.forms.create.script_name'))
       end
     end
   end

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -34,10 +34,10 @@ module Script
 
           def create_definition(ctx, language, extension_point, script_name)
             script = nil
-            UI::StrictSpinner.spin(ctx.message('script.create.spinner_creating')) do |spinner|
+            UI::StrictSpinner.spin(ctx.message('script.create.creating')) do |spinner|
               script = Infrastructure::ScriptRepository.new.create_script(language, extension_point, script_name)
               Infrastructure::TestSuiteRepository.new.create_test_suite(script)
-              spinner.update_title(ctx.message('script.create.spinner_created'))
+              spinner.update_title(ctx.message('script.create.created'))
             end
             script
           end

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -10,7 +10,7 @@ module Script
           def call(ctx:, language:, script_name:, extension_point_type:)
             extension_point = ExtensionPoints.get(type: extension_point_type)
             create_project(ctx, language, script_name, extension_point)
-            script = create_definition(language, extension_point, script_name)
+            script = create_definition(ctx, language, extension_point, script_name)
             ShopifyCli::Core::Finalize.request_cd(script_name)
             script
           end
@@ -32,12 +32,12 @@ module Script
               .install(ctx: ctx, language: language, extension_point: extension_point, script_name: script_name)
           end
 
-          def create_definition(language, extension_point, script_name)
+          def create_definition(ctx, language, extension_point, script_name)
             script = nil
-            UI::StrictSpinner.spin('Creating script') do |spinner|
+            UI::StrictSpinner.spin(ctx.message('script.create.spinner_creating')) do |spinner|
               script = Infrastructure::ScriptRepository.new.create_script(language, extension_point, script_name)
               Infrastructure::TestSuiteRepository.new.create_test_suite(script)
-              spinner.update_title('Created script')
+              spinner.update_title(ctx.message('script.create.spinner_created'))
             end
             script
           end

--- a/lib/project_types/script/layers/application/project_dependencies.rb
+++ b/lib/project_types/script/layers/application/project_dependencies.rb
@@ -9,13 +9,13 @@ module Script
 
         def self.install(ctx:, language:, extension_point:, script_name:)
           dep_manager = Infrastructure::DependencyManager.for(ctx, language, extension_point, script_name)
-          return ctx.puts("{{v}} Dependencies installed") if dep_manager.installed?
+          return ctx.puts(ctx.message('script.project_deps.deps_are_installed')) if dep_manager.installed?
 
-          unless CLI::UI::Frame.open("Installing dependencies with npm") do
+          unless CLI::UI::Frame.open(ctx.message('script.project_deps.installing_with_npm')) do
             begin
-              UI::StrictSpinner.spin('Dependencies installing') do |spinner|
+              UI::StrictSpinner.spin(ctx.message('script.project_deps.installing')) do |spinner|
                 dep_manager.install
-                spinner.update_title('Dependencies installed')
+                spinner.update_title(ctx.message('script.project_deps.installed'))
               end
               true
             rescue Infrastructure::Errors::DependencyInstallError => e

--- a/lib/project_types/script/layers/application/test_script.rb
+++ b/lib/project_types/script/layers/application/test_script.rb
@@ -4,15 +4,13 @@ module Script
   module Layers
     module Application
       class TestScript
-        RUNNING_MSG = "Running tests"
-
         class << self
           def call(ctx:, language:, extension_point_type:, script_name:)
             extension_point = ExtensionPoints.get(type: extension_point_type)
             ProjectDependencies
               .install(ctx: ctx, language: language, extension_point: extension_point, script_name: script_name)
 
-            CLI::UI::Frame.open(RUNNING_MSG) do
+            CLI::UI::Frame.open(ctx.message('script.test.running')) do
               run_tests(ctx, language, extension_point_type, script_name)
             end
           end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -46,11 +46,9 @@ module Script
           },
 
           changed_dir: "{{v}} Changed to project directory: {{green:%{folder}}}",
-          created: "{{v}} Script created: {{green:%{script_id}}}",
-          select_extension_point: "Which extension point do you want to use?",
-          name: "Script Name",
-          spinner_creating: "Creating script",
-          spinner_created: "Created script",
+          script_created: "{{v}} Script created: {{green:%{script_id}}}",
+          creating: "Creating script",
+          created: "Created script",
         },
 
         project_deps: {
@@ -72,6 +70,13 @@ module Script
 
           running: "Running tests",
           success: "{{v}} Tests finished.",
+        },
+
+        forms: {
+          create: {
+            select_extension_point: "Which extension point do you want to use?",
+            script_name: "Script Name",
+          },
         },
       },
     }.freeze

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -16,7 +16,7 @@ module Script
           oauth_help: "Try again.",
 
           invalid_context_cause: "Your .shopify-cli.yml file is not correct.",
-          invalid_context_help: "See https://help.shopify.com/en/",
+          invalid_context_help: "See https://help.shopify.com",
 
           project_exists_cause: "Directory with the same name as the script already exists.",
           project_exists_help: "Use different script name and try again.",
@@ -27,7 +27,7 @@ module Script
           script_not_found_cause: "Couldn't find script %s for extension point %s",
 
           dependency_install_cause: "Something went wrong while installing the dependencies that are needed.",
-          dependency_install_help: "See https://help.shopify.com/en/",
+          dependency_install_help: "See https://help.shopify.com",
 
           test_help: "Correct the errors and try again.",
         },

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Script
+  module Messages
+    MESSAGES = {
+      script: {
+        error: {
+          generic: "{{red:{{x}} Error}}",
+          eacces_cause: "You don't have permission to write to this directory.",
+          eacces_help: "Change your directory permissions and try again.",
+
+          enospc_cause: "You don't have enough disk space to perform this action.",
+          enospc_help: "Free up some space and try again.",
+
+          oauth_cause: "Something went wrong while authenticating your account with the Partner Dashboard.",
+          oauth_help: "Try again.",
+
+          invalid_context_cause: "Your .shopify-cli.yml file is not correct.",
+          invalid_context_help: "See https://help.shopify.com/en/",
+
+          project_exists_cause: "Directory with the same name as the script already exists.",
+          project_exists_help: "Use different script name and try again.",
+
+          invalid_extension_cause: "Invalid extension point %s",
+          invalid_extension_help: "Allowed values: discount and unit_limit_per_order.",
+
+          script_not_found_cause: "Couldn't find script %s for extension point %s",
+
+          dependency_install_cause: "Something went wrong while installing the dependencies that are needed.",
+          dependency_install_help: "See https://help.shopify.com/en/",
+
+          test_help: "Correct the errors and try again.",
+        },
+
+        create: {
+          help: <<~HELP,
+          {{command:%1$s create script}}: Creates a script project.
+            Usage: {{command:%1$s create script}}
+            Options:
+              {{command:--name=NAME}} Script project name. Any string.
+              {{command:--extension_point=TYPE}} Extension point name. Allowed values: %2$s.
+          HELP
+
+          error: {
+            operation_failed: "Script not created.",
+          },
+
+          changed_dir: "{{v}} Changed to project directory: {{green:%{folder}}}",
+          created: "{{v}} Script created: {{green:%{script_id}}}",
+          select_extension_point: "Which extension point do you want to use?",
+          name: "Script Name",
+          spinner_creating: "Creating script",
+          spinner_created: "Created script",
+        },
+
+        project_deps: {
+          deps_are_installed: "{{v}} Dependencies installed",
+          installing_with_npm: "Installing dependencies with npm",
+          installing: "Dependencies installing",
+          installed: "Dependencies installed",
+        },
+
+        test: {
+          help: <<~HELP,
+          Runs unit tests on your script.
+            Usage: {{command:%s test}}
+          HELP
+
+          error: {
+            operation_failed: "Tests didn't run or they ran with failures.",
+          },
+
+          running: "Running tests",
+          success: "{{v}} Tests finished.",
+        },
+      },
+    }.freeze
+  end
+end

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -4,7 +4,7 @@ module Script
   module UI
     module ErrorHandler
       def self.display(failed_op:, cause_of_error:, help_suggestion:)
-        $stderr.puts(CLI::UI.fmt("{{red:{{x}} Error}}"))
+        $stderr.puts(CLI::UI.fmt(ShopifyCli::Context.message('script.error.generic')))
         full_msg = failed_op ? failed_op.dup : ""
         full_msg << " #{cause_of_error}" if cause_of_error
         full_msg << " #{help_suggestion}" if help_suggestion
@@ -26,46 +26,48 @@ module Script
         case e
         when Errno::EACCES
           {
-            cause_of_error: "You don't have permission to write to this directory.",
-            help_suggestion: "Change your directory permissions and try again.",
+            cause_of_error: ShopifyCli::Context.message('script.error.eacces_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.eacces_help'),
           }
         when Errno::ENOSPC
           {
-            cause_of_error: "You don't have enough disk space to perform this action.",
-            help_suggestion: "Free up some space and try again.",
+            cause_of_error: ShopifyCli::Context.message('script.error.enospc_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.enospc_help'),
           }
         when ShopifyCli::OAuth::Error
           {
-            cause_of_error: "Something went wrong while authenticating your account with the Partner Dashboard.",
-            help_suggestion: "Try again.",
+            cause_of_error: ShopifyCli::Context.message('script.error.oauth_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.oauth_help'),
           }
         when Errors::InvalidContextError
           {
-            cause_of_error: "Your .shopify-cli.yml file is not correct.",
-            help_suggestion: "See https://help.shopify.com/en/",
+            cause_of_error: ShopifyCli::Context.message('script.error.invalid_context_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.invalid_context_help'),
           }
         when Errors::ScriptProjectAlreadyExistsError
           {
-            cause_of_error: "Directory with the same name as the script already exists.",
-            help_suggestion: "Use different script name and try again.",
+            cause_of_error: ShopifyCli::Context.message('script.error.project_exists_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.project_exists_help'),
           }
         when Layers::Domain::Errors::InvalidExtensionPointError
           {
-            cause_of_error: "Invalid extension point #{e.type}",
-            help_suggestion: "Allowed values: discount and unit_limit_per_order.",
+            cause_of_error: ShopifyCli::Context.message('script.error.invalid_extension_cause', e.type),
+            help_suggestion: ShopifyCli::Context.message('script.error.invalid_extension_help'),
           }
         when Layers::Domain::Errors::ScriptNotFoundError
           {
-            cause_of_error: "Couldn't find script #{e.script_name} for extension point #{e.extension_point_type}",
+            cause_of_error: ShopifyCli::Context.message(
+              'script.error.script_not_found_cause', e.script_name, e.extension_point_type
+            ),
           }
         when Layers::Infrastructure::Errors::DependencyInstallError
           {
-            cause_of_error: "Something went wrong while installing the dependencies that are needed.",
-            help_suggestion: "See https://help.shopify.com/en/",
+            cause_of_error: ShopifyCli::Context.message('script.error.dependency_install_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.dependency_install_help'),
           }
         when Layers::Infrastructure::Errors::TestError
           {
-            help_suggestion: "Correct the errors and try again.",
+            help_suggestion: ShopifyCli::Context.message('script.error.test_help'),
           }
         end
       end

--- a/lib/shopify-cli/admin_api/populate_resource_command.rb
+++ b/lib/shopify-cli/admin_api/populate_resource_command.rb
@@ -36,14 +36,14 @@ module ShopifyCli
 
         if @help
           output = display_parent_extended_help
-          output += "\n{{bold:{{cyan:#{camel_case_resource_type}}} options:}}\n"
+          output += "\n#{@ctx.message('core.populate.options.header', camel_case_resource_type)}\n"
           output += resource_options.help
           return @ctx.puts(output)
         end
 
         if @silent
           spin_group = CLI::UI::SpinGroup.new
-          spin_group.add("Populating #{@count} #{camel_case_resource_type}s...") do |spinner|
+          spin_group.add(@ctx.message('core.populate.populating', @count, camel_case_resource_type)) do |spinner|
             populate
             spinner.update_title(completion_message)
           end
@@ -73,7 +73,11 @@ module ShopifyCli
       def resource_options
         @resource_options ||= OptionParser.new do |opts|
           opts.banner = ""
-          opts.on("-c #{DEFAULT_COUNT}", "--count=#{DEFAULT_COUNT}", 'Number of resources to generate') do |value|
+          opts.on(
+            "-c #{DEFAULT_COUNT}",
+            "--count=#{DEFAULT_COUNT}",
+            @ctx.message('core.populate.options.count_help')
+          ) do |value|
             @count = value.to_i
           end
 
@@ -120,10 +124,15 @@ module ShopifyCli
 
       def completion_message
         plural = @count > 1 ? "s" : ""
-        <<~COMPLETION_MESSAGE
-          Successfully added #{@count} #{camel_case_resource_type}#{plural} to {{green:#{Project.current.env.shop}}}
-          {{*}} View all #{camel_case_resource_type}s at {{underline:#{admin_url}#{snake_case_resource_type}s}}
-        COMPLETION_MESSAGE
+        @ctx.message(
+          'core.populate.completion_message',
+          @count,
+          "#{camel_case_resource_type}#{plural}",
+          Project.current.env.shop,
+          camel_case_resource_type,
+          admin_url,
+          snake_case_resource_type
+        )
       end
 
       def admin_url

--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -5,14 +5,14 @@ module ShopifyCli
     class Connect < ShopifyCli::Command
       def call(*)
         if Project.current
-          @ctx.puts "{{yellow:! Don't use}} {{cyan:connect}} {{yellow:for production apps}}"
+          @ctx.puts @ctx.message('core.connect.production_warning')
           org = fetch_org
           id = org['id']
           app = get_app(org['apps'])
           shop = get_shop(org['stores'], id)
           write_env(app, shop)
-          @ctx.puts "{{v}} Project now connected to {{green:#{app.first['title']}}}"
-          @ctx.puts "{{*}} Run {{command:#{ShopifyCli::TOOL_NAME} serve}} to start a local development server"
+          @ctx.puts(@ctx.message('core.connect.connected', app.first['title']))
+          @ctx.puts(@ctx.message('core.connect.serve', ShopifyCli::TOOL_NAME))
         end
       end
 
@@ -21,7 +21,7 @@ module ShopifyCli
         org_id = if orgs.count == 1
           orgs.first["id"]
         else
-          CLI::UI::Prompt.ask('To which organization does this project belong?') do |handler|
+          CLI::UI::Prompt.ask(@ctx.message('core.connect.organization_select')) do |handler|
             orgs.each { |org| handler.option(org["businessName"]) { org["id"] } }
           end
         end
@@ -33,7 +33,7 @@ module ShopifyCli
         app_id = if apps.count == 1
           apps.first["id"]
         else
-          CLI::UI::Prompt.ask('To which app does this project belong?') do |handler|
+          CLI::UI::Prompt.ask(@ctx.message('core.connect.app_select')) do |handler|
             apps.each { |app| handler.option(app["title"]) { app["id"] } }
           end
         end
@@ -44,10 +44,9 @@ module ShopifyCli
         if shops.count == 1
           shop = shops.first["shopDomain"]
         elsif shops.count == 0
-          @ctx.puts('No development stores available.')
-          @ctx.puts("Visit {{underline:https://partners.shopify.com/#{id}/stores}} to create one")
+          @ctx.puts(@ctx.message('core.connect.no_development_stores', id))
         else
-          shop = CLI::UI::Prompt.ask('Which development store would you like to use?') do |handler|
+          shop = CLI::UI::Prompt.ask(@ctx.message('core.connect.development_store_select')) do |handler|
             shops.each { |s| handler.option(s["shopName"]) { s["shopDomain"] } }
           end
         end
@@ -64,10 +63,7 @@ module ShopifyCli
       end
 
       def self.help
-        <<~HELP
-          Connect a Shopify App CLI project. Restores the ENV file.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} connect}}
-        HELP
+        ShopifyCli::Context.message('core.connect.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -10,11 +10,11 @@ module ShopifyCli
 
       def call(args, command_name)
         unless args.empty?
-          @ctx.puts("{{red:Error}}: invalid app type {{bold:#{args[0]}}}")
+          @ctx.puts(@ctx.message('core.create.error.invalid_app_type', args[0]))
           return @ctx.puts(self.class.help)
         end
 
-        type_name = CLI::UI::Prompt.ask('What type of project would you like to create?') do |handler|
+        type_name = CLI::UI::Prompt.ask(@ctx.message('core.create.app_type_select')) do |handler|
           self.class.all_visible_type.each do |type|
             handler.option(type.project_name) { type.project_type }
           end
@@ -33,10 +33,7 @@ module ShopifyCli
 
       def self.help
         project_types = all_visible_type.map(&:project_type).join(" | ")
-        <<~HELP
-          Create a new project.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} create [ #{project_types} ]}}
-        HELP
+        ShopifyCli::Context.message('core.create.help', ShopifyCli::TOOL_NAME, project_types)
       end
 
       def self.extended_help

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -14,7 +14,7 @@ module ShopifyCli
           return @ctx.puts(self.class.help)
         end
 
-        type_name = CLI::UI::Prompt.ask(@ctx.message('core.create.app_type_select')) do |handler|
+        type_name = CLI::UI::Prompt.ask(@ctx.message('core.create.project_type_select')) do |handler|
           self.class.all_visible_type.each do |type|
             handler.option(type.project_name) { type.project_type }
           end

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -16,17 +16,11 @@ module ShopifyCli
             end
             return
           else
-            @ctx.puts("Command #{command} not found.")
+            @ctx.puts(@ctx.message('core.help.error.command_not_found', command))
           end
         end
 
-        preamble = <<~MESSAGE
-          CLI to help build Shopify apps faster.
-
-          Use {{command:#{ShopifyCli::TOOL_NAME} help <command>}} to display detailed information about a specific command.
-
-          {{bold:Available commands}}
-        MESSAGE
+        preamble = @ctx.message('core.help.preamble', ShopifyCli::TOOL_NAME)
         @ctx.puts(preamble)
 
         visible_commands = ShopifyCli::Commands::Registry

--- a/lib/shopify-cli/commands/load_dev.rb
+++ b/lib/shopify-cli/commands/load_dev.rb
@@ -8,17 +8,14 @@ module ShopifyCli
       def call(args, _name)
         project_dir = File.expand_path(args.shift || Dir.pwd)
         unless File.exist?(project_dir)
-          raise(ShopifyCli::AbortSilent, "{{x}} #{project_dir} does not exist")
+          raise(ShopifyCli::AbortSilent, @ctx.message('core.load_dev.error.project_dir_not_found', project_dir))
         end
-        @ctx.done("Reloading #{TOOL_FULL_NAME} from #{project_dir}")
+        @ctx.done(@ctx.message('core.load_dev.reloading', TOOL_FULL_NAME, project_dir))
         ShopifyCli::Core::Finalize.reload_shopify_from(project_dir)
       end
 
       def self.help
-        <<~HELP
-          Load a development instance of Shopify App CLI from the given path. This command is intended for development work on the CLI itself.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} load-dev `/absolute/path/to/cli/instance`}}
-        HELP
+        ShopifyCli::Context.message('core.load_dev.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify-cli/commands/load_system.rb
+++ b/lib/shopify-cli/commands/load_system.rb
@@ -6,15 +6,12 @@ module ShopifyCli
       hidden_command
 
       def call(_args, _name)
-        @ctx.done("Reloading #{TOOL_FULL_NAME} from #{ShopifyCli::INSTALL_DIR}")
+        @ctx.done(@ctx.message('core.load_system.reloading', TOOL_FULL_NAME, ShopifyCli::INSTALL_DIR))
         ShopifyCli::Core::Finalize.reload_shopify_from(ShopifyCli::INSTALL_DIR)
       end
 
       def self.help
-        <<~HELP
-          Reload the installed instance of Shopify App CLI. This command is intended for development work on the CLI itself.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} load-system}}
-        HELP
+        ShopifyCli::Context.message('core.load_system.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify-cli/commands/logout.rb
+++ b/lib/shopify-cli/commands/logout.rb
@@ -12,14 +12,11 @@ module ShopifyCli
         LOGIN_TOKENS.each do |token|
           ShopifyCli::DB.del(token) if ShopifyCli::DB.exists?(token)
         end
-        @ctx.puts "Logged out of Organization and Shop"
+        @ctx.puts(@ctx.message('core.logout.success'))
       end
 
       def self.help
-        <<~HELP
-          Log out of a currently authenticated Organization and Shop, or clear invalid credentials
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} logout}}
-        HELP
+        ShopifyCli::Context.message('core.logout.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify-cli/commands/system.rb
+++ b/lib/shopify-cli/commands/system.rb
@@ -68,7 +68,7 @@ module ShopifyCli
           if status.success?
             @ctx.puts("  " + @ctx.message('core.system.command_with_path', s, output))
           else
-            @ctx.puts("  " + @ctx.message('core.system.command', s))
+            @ctx.puts("  " + @ctx.message('core.system.command_not_found', s))
           end
         end
       end
@@ -100,7 +100,7 @@ module ShopifyCli
             version = version_output.match(/(\d+\.[^\s]+)/)[0]
             @ctx.puts("  " + @ctx.message('core.system.project.command_with_path', s, output.strip, version.strip))
           else
-            @ctx.puts("  " + @ctx.message('core.system.project.command', s))
+            @ctx.puts("  " + @ctx.message('core.system.project.command_not_found', s))
           end
         end
         display_ngrok

--- a/lib/shopify-cli/commands/system.rb
+++ b/lib/shopify-cli/commands/system.rb
@@ -9,7 +9,7 @@ module ShopifyCli
         show_all_details = false
         flag = args.shift
         if flag && flag != 'all'
-          @ctx.puts("{{x}} {{red:unknown option '#{flag}'}}")
+          @ctx.puts(@ctx.message('core.system.error.unknown_option', flag))
           @ctx.puts("\n" + self.class.help)
           return
         end
@@ -25,13 +25,7 @@ module ShopifyCli
       end
 
       def self.help
-        <<~HELP
-          Print details about the development system.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} system [all]}}
-
-          {{cyan:all}}: displays more details about development system and environment
-
-        HELP
+        ShopifyCli::Context.message('core.system.help', ShopifyCli::TOOL_NAME)
       end
 
       private
@@ -50,32 +44,31 @@ module ShopifyCli
 
         cli_constants += cli_constants_extra if show_all_details
 
-        @ctx.puts("{{bold:Shopify App CLI}}")
+        @ctx.puts(@ctx.message('core.system.header'))
         cli_constants.each do |s|
-          @ctx.puts(format("  %17s = #{ShopifyCli.const_get(s.to_sym)}\n", s))
+          @ctx.puts("  " + @ctx.message('core.system.const', s, ShopifyCli.const_get(s.to_sym)) + "\n")
         end
       end
 
       def display_cli_ruby(_show_all_details)
         rbconfig_constants = %w(host RUBY_VERSION_NAME)
 
-        @ctx.puts("\n{{bold:Ruby (via RbConfig)}}")
-        @ctx.puts("  #{RbConfig.ruby}")
+        @ctx.puts("\n" + @ctx.message('core.system.ruby_header', RbConfig.ruby))
         rbconfig_constants.each do |s|
-          @ctx.puts(format("  %-25s - RbConfig[\"#{s}\"]", RbConfig::CONFIG[s]))
+          @ctx.puts("  " + @ctx.message('core.system.rb_config', RbConfig::CONFIG[s], s))
         end
       end
 
       def display_utility_commands(_show_all_details)
         commands = %w(git curl tar unzip)
 
-        @ctx.puts("\n{{bold:Commands}}")
+        @ctx.puts("\n" + @ctx.message('core.system.command_header'))
         commands.each do |s|
           output, status = @ctx.capture2e('which', s)
           if status.success?
-            @ctx.puts("  {{v}} #{s}, #{output}")
+            @ctx.puts("  " + @ctx.message('core.system.command_with_path', s, output))
           else
-            @ctx.puts("  {{x}} #{s}")
+            @ctx.puts("  " + @ctx.message('core.system.command', s))
           end
         end
       end
@@ -83,9 +76,9 @@ module ShopifyCli
       def display_ngrok
         ngrok_location = File.join(ShopifyCli::ROOT, 'ngrok')
         if File.exist?(ngrok_location)
-          @ctx.puts("  {{v}} ngrok, #{ngrok_location}")
+          @ctx.puts("  " + @ctx.message('core.system.ngrok_available', ngrok_location))
         else
-          @ctx.puts("  {{x}} ngrok NOT available")
+          @ctx.puts("  " + @ctx.message('core.system.ngrok_not_available'))
         end
       end
 
@@ -99,15 +92,15 @@ module ShopifyCli
       end
 
       def display_project(project_type, commands)
-        @ctx.puts("\n{{bold:In a {{cyan:#{project_type}}} project directory}}")
+        @ctx.puts("\n" + @ctx.message('core.system.project.header', project_type))
         commands.each do |s|
           output, status = @ctx.capture2e('which', s)
           if status.success?
             version_output, _ = @ctx.capture2e(s, '--version')
             version = version_output.match(/(\d+\.[^\s]+)/)[0]
-            @ctx.puts("  {{v}} #{s}, #{output.strip}, version #{version.strip}")
+            @ctx.puts("  " + @ctx.message('core.system.project.command_with_path', s, output.strip, version.strip))
           else
-            @ctx.puts("  {{x}} #{s}")
+            @ctx.puts("  " + @ctx.message('core.system.project.command', s))
           end
         end
         display_ngrok
@@ -115,25 +108,25 @@ module ShopifyCli
       end
 
       def display_project_environment
-        @ctx.puts("\n  {{bold:Project environment}}")
+        @ctx.puts("\n  " + @ctx.message('core.system.project.env_header'))
         if File.exist?('./.env')
           Project.current.env.to_h.each do |k, v|
             display_value = if v.nil? || v.strip == ''
-              "not set"
+              @ctx.message('core.system.project.env_not_set')
             else
               k.match(/^SHOPIFY_API/) ? "********" : v
             end
-            @ctx.puts(format("  %-18s = %s", k, display_value))
+            @ctx.puts("  " + @ctx.message('core.system.project.env', k, display_value))
           end
         else
-          @ctx.puts("  {{x}} .env file not present")
+          @ctx.puts("  " + @ctx.message('core.system.project.no_env'))
         end
       end
 
       def display_environment
-        @ctx.puts("{{bold:Environment}}")
+        @ctx.puts(@ctx.message('core.system.environment_header'))
         %w(TERM SHELL PATH USING_SHOPIFY_CLI LANG).each do |k|
-          @ctx.puts(format("  %-17s = %s", k, ENV[k])) unless ENV[k].nil?
+          @ctx.puts("  " + @ctx.message('core.system.env', k, ENV[k])) unless ENV[k].nil?
         end
         @ctx.puts("")
       end

--- a/lib/shopify-cli/commands/update.rb
+++ b/lib/shopify-cli/commands/update.rb
@@ -4,10 +4,7 @@ module ShopifyCli
   module Commands
     class Update < ShopifyCli::Command
       def self.help
-        <<~HELP
-          Update Shopify App CLI.
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} update}}
-        HELP
+        ShopifyCli::Context.message('core.update.help', ShopifyCli::TOOL_NAME)
       end
 
       def call(_args, _name)

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -179,10 +179,7 @@ module ShopifyCli
     # * `uri` - a http URI to open in a browser
     #
     def open_url!(uri)
-      help = <<~OPEN
-        Please open this URL in your browser:
-        {{green:#{uri}}}
-      OPEN
+      help = message('core.context.open_url', uri)
       puts(help)
     end
 

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -20,9 +20,9 @@ module ShopifyCli
       # #### Parameters
       # * `messages` - Hash containing the new keys to register
       def load_messages(messages)
-        @messages = {} if @messages.nil?
+        @messages ||= {}
         @messages = @messages.merge(messages) do |key|
-          abort("Message key '#{key}' already exists and cannot be registered") if @messages.key?(key)
+          Context.new.abort("Message key '#{key}' already exists and cannot be registered") if @messages.key?(key)
         end
       end
 

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -25,6 +25,17 @@ module ShopifyCli
           abort("Message key '#{key}' already exists and cannot be registered") if @messages.key?(key)
         end
       end
+
+      # returns the user-facing messages for the given key. Returns the key if no message is available.
+      #
+      # #### Parameters
+      # * `key` - a symbol representing the message
+      # * `params` - the parameters to format the string with
+      def message(key, *params)
+        key_parts = key.split('.').map(&:to_sym)
+        str = Context.messages.dig(*key_parts)
+        str ? str % params : key
+      end
     end
 
     # is the directory root that the current command is running in. If you want to
@@ -224,15 +235,13 @@ module ShopifyCli
       puts("{{red:DEBUG}} #{text}") if getenv('DEBUG')
     end
 
-    # returns the user-facing messages for the given key. Returns the key if no message is available.
+    # proxy call to Context.message.
     #
     # #### Parameters
     # * `key` - a symbol representing the message
     # * `params` - the parameters to format the string with
     def message(key, *params)
-      key_parts = key.split('.').map(&:to_sym)
-      str = Context.messages.dig(*key_parts)
-      str ? str % params : key
+      Context.message(key, *params)
     end
 
     # will grab the host info of the computer running the cli. This indicates the

--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -61,11 +61,7 @@ module ShopifyCli
         def prompt_for_consent
           return unless enabled?
           return if ShopifyCli::Config.get_section('analytics').key?('enabled')
-          msg = <<~MSG
-            Would you like to enable anonymous usage reporting?
-            If you select “Yes”, we’ll collect data about which commands you use and which errors you encounter.
-            Sharing this anonymous data helps Shopify improve this tool.
-          MSG
+          msg = Context.message('core.monorail.consent_prompt')
           opt = CLI::UI::Prompt.confirm(msg)
           ShopifyCli::Config.set('analytics', 'enabled', opt)
         end

--- a/lib/shopify-cli/core/update.rb
+++ b/lib/shopify-cli/core/update.rb
@@ -28,27 +28,18 @@ module ShopifyCli
             if restart_command_after_update
               return # just skip
             else
-              err("Development version of {{command:#{ShopifyCli::TOOL_NAME}}} in use. "\
-                "Run {{command:#{ShopifyCli::TOOL_NAME} load-system}} first.")
+              err(Context.message('core.update.error.development_version', ShopifyCli::TOOL_NAME))
               raise(ShopifyCli::AbortSilent)
             end
           end
 
           if File.exist?(File.expand_path('.git/HEAD.lock', ShopifyCli::ROOT))
-            err("failed!")
-            err("It looks like another git operation is in progress on {{blue:#{ShopifyCli::ROOT}}}.")
-            err("Try running {{command:#{ShopifyCli::TOOL_NAME} update}}.")
-            err("If that fails, you must run {{green: rm #{ShopifyCli::ROOT}/.git/HEAD.lock}} to continue.")
+            err(Context.message('core.update.error.git_head_locked', ShopifyCli::ROOT, ShopifyCli::TOOL_NAME))
             raise(ShopifyCli::AbortSilent)
           end
 
           if File.exist?(File.expand_path(".git/refs/heads/master.lock", ShopifyCli::ROOT))
-            err("failed!")
-            err("It looks like another git operation is in progress on {{blue:#{ShopifyCli::ROOT}}}.")
-            err("Try running {{command:#{ShopifyCli::TOOL_NAME} update}}.")
-            err(
-              "If that fails, you must run {{green: rm #{ShopifyCli::ROOT}/.git/refs/heads/master.lock}} to continue."
-            )
+            err(Context.message('core.update.error.git_master_locked', ShopifyCli::ROOT, ShopifyCli::TOOL_NAME))
             raise(ShopifyCli::AbortSilent)
           end
 
@@ -63,13 +54,13 @@ module ShopifyCli
             ['checkout', '-f', '-B', 'master'],
             ['reset', '--hard', 'FETCH_HEAD'],
           ]
-          Kernel.print('Updating shopify-cli...')
+          Kernel.print(Context.message('core.update.updating'))
           commands.each do |args|
             _, stat = ctx.capture2e('git', '-C', ShopifyCli::ROOT, *args)
-            ctx.abort("command failed: #{args.join(' ')}") unless stat.success?
+            ctx.abort(Context.message('core.update.error.git_command_failure', args.join(' '))) unless stat.success?
           end
 
-          ctx.puts("done!")
+          ctx.puts(Context.message('core.update.updated'))
 
           if restart_command_after_update
             ENV.replace($original_env)
@@ -85,7 +76,7 @@ module ShopifyCli
 
         def prompt_for_updates
           return if ShopifyCli::Config.get_section('autoupdate').key?('enabled')
-          opt = CLI::UI::Prompt.confirm('Would you like to enable auto updates for Shopify App CLI?')
+          opt = CLI::UI::Prompt.confirm(Context.message('core.update.auto_update_prompt'))
           ShopifyCli::Config.set('autoupdate', 'enabled', opt)
           auto_update
         end

--- a/lib/shopify-cli/git.rb
+++ b/lib/shopify-cli/git.rb
@@ -44,12 +44,12 @@ module ShopifyCli
       #
       def clone(repository, dest, ctx: Context.new)
         if Dir.exist?(dest)
-          ctx.abort("Project directory already exists. Please create a project with a new name.")
+          ctx.abort(ctx.message('core.git.error.directory_exists'))
         else
-          CLI::UI::Frame.open("Cloning into #{dest}...") do
+          CLI::UI::Frame.open(ctx.message('core.git.cloning', dest)) do
             clone_progress('clone', '--single-branch', repository, dest, ctx: ctx)
           end
-          ctx.done("Cloned into #{dest}")
+          ctx.done(ctx.message('core.git.cloned', dest))
         end
       end
 
@@ -70,7 +70,7 @@ module ShopifyCli
       #
       def branches(ctx)
         output, status = ctx.capture2e('git', 'branch', '--list', '--format=%(refname:short)')
-        ctx.abort("Could not find any git branches") unless status.success?
+        ctx.abort(ctx.message('core.git.error.no_branches_found')) unless status.success?
 
         branches = if output == ''
           ['master']
@@ -97,12 +97,11 @@ module ShopifyCli
         output, status = ctx.capture2e('git', 'status')
 
         unless status.success?
-          msg = "Git repo is not initiated. Please run `git init` and make at least one commit."
-          ctx.abort(msg)
+          ctx.abort(ctx.message('core.git.error.repo_not_initiated'))
         end
 
         if output.include?('No commits yet')
-          ctx.abort("No git commits have been made. Please make at least one commit.")
+          ctx.abort(ctx.message('core.git.error.no_commits_made'))
         end
       end
 

--- a/lib/shopify-cli/heroku.rb
+++ b/lib/shopify-cli/heroku.rb
@@ -19,33 +19,33 @@ module ShopifyCli
 
     def authenticate
       result = @ctx.system(heroku_command, 'login')
-      @ctx.abort("Could not authenticate with Heroku") unless result.success?
+      @ctx.abort(@ctx.message('core.heroku.error.authentication')) unless result.success?
     end
 
     def create_new_app
       output, status = @ctx.capture2e(heroku_command, 'create')
-      @ctx.abort('Heroku app could not be created') unless status.success?
+      @ctx.abort(@ctx.message('core.heroku.error.creation')) unless status.success?
       @ctx.puts(output)
     end
 
     def deploy(branch_to_deploy)
       result = @ctx.system('git', 'push', '-u', 'heroku', "#{branch_to_deploy}:master")
-      @ctx.abort("Could not deploy to Heroku") unless result.success?
+      @ctx.abort(@ctx.message('core.heroku.error.deploy')) unless result.success?
     end
 
     def download
       return if installed?
 
       result = @ctx.system('curl', '-o', download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCli::ROOT)
-      @ctx.abort("Heroku CLI could not be downloaded") unless result.success?
-      @ctx.abort("Heroku CLI could not be downloaded") unless File.exist?(download_path)
+      @ctx.abort(@ctx.message('core.heroku.error.download')) unless result.success?
+      @ctx.abort(@ctx.message('core.heroku.error.download')) unless File.exist?(download_path)
     end
 
     def install
       return if installed?
 
       result = @ctx.system('tar', '-xf', download_path, chdir: ShopifyCli::ROOT)
-      @ctx.abort("Could not install Heroku CLI") unless result.success?
+      @ctx.abort(@ctx.message('core.heroku.error.install')) unless result.success?
 
       @ctx.rm(download_path)
     end
@@ -53,7 +53,7 @@ module ShopifyCli
     def select_existing_app(app_name)
       result = @ctx.system(heroku_command, 'git:remote', '-a', app_name)
 
-      msg = "Heroku app `#{app_name}` could not be selected"
+      msg = @ctx.message('core.heroku.error.could_not_select_app', app_name)
       @ctx.abort(msg) unless result.success?
     end
 

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -3,6 +3,140 @@
 module ShopifyCli
   module Messages
     MESSAGES = {
+      core: {
+        connect: {
+          help: <<~HELP,
+          Connect a Shopify App CLI project. Restores the ENV file.
+            Usage: {{command:%s connect}}
+          HELP
+
+          production_warning: "{{yellow:! Don't use}} {{cyan:connect}} {{yellow:for production apps}}",
+          connected: "{{v}} Project now connected to {{green:%s}}",
+          serve: "{{*}} Run {{command:%s serve}} to start a local development server",
+          organization_select: "To which organization does this project belong?",
+          app_select: "To which app does this project belong?",
+          no_development_stores: <<~MESSAGE,
+          No development stores available.
+          Visit {{underline:https://partners.shopify.com/%d/stores}} to create one
+          MESSAGE
+          development_store_select: "Which development store would you like to use?",
+        },
+
+        create: {
+          help: <<~HELP,
+          Create a new project.
+            Usage: {{command:%s create [ %s ]}}
+          HELP
+
+          error: {
+            invalid_app_type: "{{red:Error}}: invalid app type {{bold:%s}}",
+          },
+
+          app_type_select: "What type of project would you like to create?",
+        },
+
+        help: {
+          error: {
+            command_not_found: "Command %s not found.",
+          },
+
+          preamble: <<~MESSAGE,
+          CLI to help build Shopify apps faster.
+
+          Use {{command:%s help <command>}} to display detailed information about a specific command.
+
+          {{bold:Available commands}}
+          MESSAGE
+        },
+
+        load_dev: {
+          help: <<~HELP,
+          Load a development instance of Shopify App CLI from the given path. This command is intended for development work on the CLI itself.
+            Usage: {{command:%s load-dev `/absolute/path/to/cli/instance`}}
+          HELP
+
+          error: {
+            project_dir_not_found: "{{x}} %s does not exist",
+          },
+
+          reloading: "Reloading %s from %s",
+        },
+
+        load_system: {
+          help: <<~HELP,
+          Reload the installed instance of Shopify App CLI. This command is intended for development work on the CLI itself.
+            Usage: {{command:%s load-system}}
+          HELP
+
+          reloading: "Reloading %s from %s",
+        },
+
+        logout: {
+          help: <<~HELP,
+          Log out of a currently authenticated Organization and Shop, or clear invalid credentials
+            Usage: {{command:%s logout}}
+          HELP
+
+          success: "Logged out of Organization and Shop",
+        },
+
+        populate: {
+          options: {
+            header: "{{bold:{{cyan:%s}} options:}}",
+            count_help: "Number of resources to generate",
+          },
+          populating: "Populating %d %ss...",
+          completion_message: <<~COMPLETION_MESSAGE,
+          Successfully added %d %s to {{green:%s}}
+          {{*}} View all %ss at {{underline:%s%ss}}
+          COMPLETION_MESSAGE
+        },
+
+        system: {
+          help: <<~HELP,
+          Print details about the development system.
+            Usage: {{command:%s system [all]}}
+
+          {{cyan:all}}: displays more details about development system and environment
+
+          HELP
+
+          error: {
+            unknown_option: "{{x}} {{red:unknown option '%s'}}",
+          },
+
+          header: "{{bold:Shopify App CLI}}",
+          const: "%17s = %s",
+          ruby_header: <<~RUBY_MESSAGE,
+          {{bold:Ruby (via RbConfig)}}
+            %s
+          RUBY_MESSAGE
+          rb_config: "%-25s - RbConfig[\"%s\"]",
+          command_header: "{{bold:Commands}}",
+          command_with_path: "{{v}} %s, %s",
+          command: "{{x}} %s",
+          ngrok_available: "{{v}} ngrok, %s",
+          ngrok_not_available: "{{x}} ngrok NOT available",
+          project: {
+            header: "{{bold:In a {{cyan:%s}} project directory}}",
+            command_with_path: "{{v}} %s, %s, version %s",
+            command: "{{x}} %s",
+            env_header: "{{bold:Project environment}}",
+            env_not_set: "not set",
+            env: "%-18s = %s",
+            no_env: "{{x}} .env file not present",
+          },
+          environment_header: "{{bold:Environment}}",
+          env: "%-17s = %s",
+        },
+
+        update: {
+          help: <<~HELP,
+          Update Shopify App CLI.
+            Usage: {{command:%s update}}
+          HELP
+        },
+      },
     }.freeze
   end
 end

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ShopifyCli
+  module Messages
+    MESSAGES = {
+    }.freeze
+  end
+end

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -22,6 +22,13 @@ module ShopifyCli
           development_store_select: "Which development store would you like to use?",
         },
 
+        context: {
+          open_url: <<~OPEN,
+          Please open this URL in your browser:
+          {{green:%s}}
+          OPEN
+        },
+
         create: {
           help: <<~HELP,
           Create a new project.
@@ -33,6 +40,24 @@ module ShopifyCli
           },
 
           app_type_select: "What type of project would you like to create?",
+        },
+
+        env_file: {
+          saving_header: "writing %s file...",
+          saving: "writing %s file",
+          saved: "%s saved to project root",
+        },
+
+        git: {
+          error: {
+            directory_exists: "Project directory already exists. Please create a project with a new name.",
+            no_branches_found: "Could not find any git branches",
+            repo_not_initiated: "Git repo is not initiated. Please run `git init` and make at least one commit.",
+            no_commits_made: "No git commits have been made. Please make at least one commit.",
+          },
+
+          cloning: "Cloning into %s...",
+          cloned: "Cloned into %s",
         },
 
         help: {
@@ -47,6 +72,17 @@ module ShopifyCli
 
           {{bold:Available commands}}
           MESSAGE
+        },
+
+        heroku: {
+          error: {
+            authentication: "Could not authenticate with Heroku",
+            creation: "Heroku app could not be created",
+            deploy: "Could not deploy to Heroku",
+            download: "Heroku CLI could not be downloaded",
+            install: "Could not install Heroku CLI",
+            could_not_select_app: "Heroku app `%s` could not be selected",
+          },
         },
 
         load_dev: {
@@ -80,6 +116,48 @@ module ShopifyCli
           success: "Logged out of Organization and Shop",
         },
 
+        monorail: {
+          consent_prompt: <<~MSG,
+            Would you like to enable anonymous usage reporting?
+            If you select “Yes”, we’ll collect data about which commands you use and which errors you encounter.
+            Sharing this anonymous data helps Shopify improve this tool.
+          MSG
+        },
+
+        oauth: {
+          error: {
+            timeout: "Timed out while waiting for response from Shopify",
+          },
+
+          location: {
+            admin: "development store",
+            partner: "Shopify Partners account",
+          },
+          authentication_required:
+            "{{i}} Authentication required. Login to the URL below with your %s credentials to continue.",
+
+          servlet: {
+            success_response: "Authenticated Successfully, this page will close shortly.",
+            invalid_request_response: "Invalid Request: %s",
+            invalid_state_response: "Anti-forgery state token does not match the initial request.",
+            authenticated: "Authenticate Successfully",
+            not_authenticated: "Failed to Authenticate",
+          },
+        },
+
+        options: {
+          help_text: "Print help for command",
+        },
+
+        partners_api: {
+          error: {
+            account_not_found: <<~MESSAGE,
+            {{x}} error: Your account was not found. Please sign up at https://partners.shopify.com/signup
+            For authentication issues, run {{command:%s logout}} to clear invalid credentials
+            MESSAGE
+          },
+        },
+
         populate: {
           options: {
             header: "{{bold:{{cyan:%s}} options:}}",
@@ -90,6 +168,26 @@ module ShopifyCli
           Successfully added %d %s to {{green:%s}}
           {{*}} View all %ss at {{underline:%s%ss}}
           COMPLETION_MESSAGE
+        },
+
+        project: {
+          error: {
+            not_in_project: <<~MESSAGE,
+            {{x}} You are not in a Shopify app project
+            {{yellow:{{*}}}}{{reset: Run}}{{cyan: shopify create}}{{reset: to create your app}}
+            MESSAGE
+            cli_yaml: {
+              not_hash: "{{x}} .shopify-cli.yml was not a proper YAML file. Expecting a hash.",
+              invalid: "{{x}} %s contains invalid YAML: %s",
+              not_found: "{{x}} %s not found",
+            },
+          },
+        },
+
+        project_type: {
+          error: {
+            cannot_override_core: "Can't register duplicate core command '%s' from %s",
+          },
         },
 
         system: {
@@ -130,11 +228,65 @@ module ShopifyCli
           env: "%-17s = %s",
         },
 
+        tasks: {
+          ensure_env: {
+            api_key_question: "What is your Shopify API key?",
+            api_secret_key_question: "What is your Shopify API secret key?",
+            development_store_question: "What is your development store URL? (e.g. my-test-shop.myshopify.com)",
+          },
+          ensure_test_shop: {
+            could_not_verify_shop: "Couldn't verify your shop %s",
+            convert_dev_to_test_store:
+              "Do you want to convert %s to a test shop? This will enable you to install your app on this store.",
+            transfer_disabled: "{{v}} Transfer has been disabled on %s.",
+          },
+          update_dashboard_urls: {
+            updated: "{{v}} Whitelist URLS updated in Partners Dashboard}}",
+            update_error:
+              "{{x}} error: For authentication issues, run {{command:%s logout}} to clear invalid credentials",
+            update_prompt: "Do you want to update your application url?",
+          },
+        },
+
+        tunnel: {
+          error: {
+            stop: "ngrok tunnel could not be stopped. Try running {{command:killall -9 ngrok}}",
+            url_fetch_failure: "Unable to fetch external url",
+          },
+
+          stopped: "{{green:x}} ngrok tunnel stopped",
+          not_running: "{{green:x}} ngrok tunnel not running",
+          start_with_account: "{{v}} ngrok tunnel running at {{underline:%s}}, with account %s",
+          start: "{{v}} ngrok tunnel running at {{underline:%s}}",
+        },
+
         update: {
           help: <<~HELP,
           Update Shopify App CLI.
             Usage: {{command:%s update}}
           HELP
+
+          error: {
+            development_version:
+              "Development version of {{command:%1$s}} in use. Run {{command:%1$s load-system}} first.",
+            git_head_locked: <<~MESSAGE,
+            failed!
+            It looks like another git operation is in progress on {{blue:%1$s}}.
+            Try running {{command:%2$s update}}.
+            If that fails, you must run {{green: rm %1$s/.git/HEAD.lock}} to continue.
+            MESSAGE
+            git_master_locked: <<~MESSAGE,
+            failed!
+            It looks like another git operation is in progress on {{blue:%1$s}}.
+            Try running {{command:%2$s update}}.
+            If that fails, you must run {{green: rm %1$s/.git/refs/heads/master.lock}} to continue.
+            MESSAGE
+            git_command_error: "command failed: %s",
+          },
+
+          updating: "Updating shopify-cli... ",
+          updated: "done!",
+          auto_update_prompt: "Would you like to enable auto updates for Shopify App CLI?",
         },
       },
     }.freeze

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -66,11 +66,10 @@ module ShopifyCli
           },
 
           preamble: <<~MESSAGE,
-          CLI to help build Shopify apps faster.
-
           Use {{command:%s help <command>}} to display detailed information about a specific command.
 
-          {{bold:Available commands}}
+          {{bold:Available core commands:}}
+
           MESSAGE
         },
 

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -39,7 +39,7 @@ module ShopifyCli
             invalid_app_type: "{{red:Error}}: invalid app type {{bold:%s}}",
           },
 
-          app_type_select: "What type of project would you like to create?",
+          project_type_select: "What type of project would you like to create?",
         },
 
         env_file: {
@@ -212,13 +212,13 @@ module ShopifyCli
           rb_config: "%-25s - RbConfig[\"%s\"]",
           command_header: "{{bold:Commands}}",
           command_with_path: "{{v}} %s, %s",
-          command: "{{x}} %s",
+          command_not_found: "{{x}} %s",
           ngrok_available: "{{v}} ngrok, %s",
           ngrok_not_available: "{{x}} ngrok NOT available",
           project: {
             header: "{{bold:In a {{cyan:%s}} project directory}}",
             command_with_path: "{{v}} %s, %s, version %s",
-            command: "{{x}} %s",
+            command_not_found: "{{x}} %s",
             env_header: "{{bold:Project environment}}",
             env_not_set: "not set",
             env: "%-18s = %s",

--- a/lib/shopify-cli/oauth.rb
+++ b/lib/shopify-cli/oauth.rb
@@ -80,17 +80,15 @@ module ShopifyCli
     end
 
     def output_authentication_info(uri)
-      login_location = service == 'admin' ? 'development store' : 'Shopify Partners account'
-      ctx.puts(
-        "{{i}} Authentication required. Login to the URL below with your #{login_location} credentials to continue."
-      )
+      login_location = ctx.message(service == 'admin' ? 'core.oauth.location.admin' : 'core.oauth.location.partner')
+      ctx.puts(ctx.message('core.oauth.authentication_required', login_location))
       ctx.open_url!(uri)
     end
 
     def receive_access_code
       @access_code ||= begin
         @server_thread.join(240)
-        raise Error, 'Timed out while waiting for response from Shopify' if response_query.nil?
+        raise Error, ctx.message('core.oauth.error.timeout') if response_query.nil?
         raise Error, response_query['error_description'] unless response_query['error'].nil?
         response_query['code']
       end

--- a/lib/shopify-cli/oauth/servlet.rb
+++ b/lib/shopify-cli/oauth/servlet.rb
@@ -17,8 +17,6 @@ module ShopifyCli
           setTimeout(function() { window.close(); }, 3000)
         </script>
       }
-      SUCCESS_RESP = 'Authenticated Successfully, this page will close shortly.'
-      INVALID_STATE_RESP = 'Anti-forgery state token does not match the initial request.'
 
       def initialize(server, oauth, token)
         super
@@ -29,12 +27,15 @@ module ShopifyCli
 
       def do_GET(req, res) # rubocop:disable Naming/MethodName
         if !req.query['error'].nil?
-          respond_with(res, 400, "Invalid Request: #{req.query['error_description']}")
+          respond_with(
+            res, 400, Context.message('core.oauth.servlet.invalid_request_response', req.query['error_description'])
+          )
         elsif req.query['state'] != @state_token
-          req.query.merge!('error' => 'invalid_state', 'error_description' => INVALID_STATE_RESP)
-          respond_with(res, 403, INVALID_STATE_RESP)
+          response_message = Context.message('core.oauth.servlet.invalid_state_response')
+          req.query.merge!('error' => 'invalid_state', 'error_description' => response_message)
+          respond_with(res, 403, response_message)
         else
-          respond_with(res, 200, SUCCESS_RESP)
+          respond_with(res, 200, Context.message('core.oauth.servlet.success_response'))
         end
         @oauth.response_query = req.query
         @server.shutdown
@@ -46,7 +47,8 @@ module ShopifyCli
           status: status,
           message: message,
           color: successful ? 'black' : 'red',
-          title: successful ? 'Authenticate Successfully' : 'Failed to Authenticate',
+          title:
+            Context.message(successful ? 'core.oauth.servlet.authenticated' : 'core.oauth.servlet.not_authenticated'),
           autoclose: successful ? AUTOCLOSE_TEMPLATE : '',
         }
         response.status = status

--- a/lib/shopify-cli/oauth/servlet.rb
+++ b/lib/shopify-cli/oauth/servlet.rb
@@ -28,7 +28,9 @@ module ShopifyCli
       def do_GET(req, res) # rubocop:disable Naming/MethodName
         if !req.query['error'].nil?
           respond_with(
-            res, 400, Context.message('core.oauth.servlet.invalid_request_response', req.query['error_description'])
+            res,
+            400,
+            Context.message('core.oauth.servlet.invalid_request_response', req.query['error_description'])
           )
         elsif req.query['state'] != @state_token
           response_message = Context.message('core.oauth.servlet.invalid_state_response')

--- a/lib/shopify-cli/options.rb
+++ b/lib/shopify-cli/options.rb
@@ -31,7 +31,7 @@ module ShopifyCli
     def parser
       @parser ||= begin
         opt = OptionParser.new
-        opt.on('--help', '-h', 'Print help for command') do |v|
+        opt.on('--help', '-h', Context.message('core.options.help_text')) do |v|
           @help = v
         end
       end

--- a/lib/shopify-cli/partners_api.rb
+++ b/lib/shopify-cli/partners_api.rb
@@ -58,10 +58,7 @@ module ShopifyCli
         authenticate(ctx)
         retry
       rescue API::APIRequestNotFoundError
-        ctx.puts("{{x}} error: Your account was not found. Please sign up at https://partners.shopify.com/signup")
-        ctx.puts(
-          "For authentication issues, run {{command:#{ShopifyCli::TOOL_NAME} logout}} to clear invalid credentials"
-        )
+        ctx.puts(ctx.message('core.partners_api.error.account_not_found', ShopifyCli::TOOL_NAME))
       end
 
       def api_client(ctx)

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -9,11 +9,6 @@ module ShopifyCli
   #
   class Project
     include SmartProperties
-    NOT_IN_PROJECT = <<~MESSAGE
-      {{x}} You are not in a Shopify app project
-      {{yellow:{{*}}}}{{reset: Run}}{{cyan: shopify create}}{{reset: to create your app}}
-    MESSAGE
-    private_constant :NOT_IN_PROJECT
 
     class << self
       ##
@@ -90,7 +85,7 @@ module ShopifyCli
       def at(dir)
         proj_dir = directory(dir)
         unless proj_dir
-          raise(ShopifyCli::Abort, NOT_IN_PROJECT)
+          raise(ShopifyCli::Abort, Context.message('core.project.error.not_in_project'))
         end
         @at ||= Hash.new { |h, k| h[k] = new(directory: k) }
         @at[proj_dir]
@@ -143,7 +138,7 @@ module ShopifyCli
       @config ||= begin
         config = load_yaml_file('.shopify-cli.yml')
         unless config.is_a?(Hash)
-          raise ShopifyCli::Abort, '{{x}} .shopify-cli.yml was not a proper YAML file. Expecting a hash.'
+          raise ShopifyCli::Abort, Context.message('core.project.error.cli_yaml.not_hash')
         end
         config
       end
@@ -157,12 +152,12 @@ module ShopifyCli
       begin
         YAML.load_file(f)
       rescue Psych::SyntaxError => e
-        raise(ShopifyCli::Abort, "{{x}} #{relative_path} contains invalid YAML: #{e.message}")
+        raise(ShopifyCli::Abort, Context.message('core.project.error.cli_yaml.invalid', relative_path, e.message))
       # rescue Errno::EACCES => e
       # TODO
       #   Dev::Helpers::EaccesHandler.diagnose_and_raise(f, e, mode: :read)
       rescue Errno::ENOENT
-        raise ShopifyCli::Abort, "{{x}} #{f} not found"
+        raise ShopifyCli::Abort, Context.message('core.project.error.cli_yaml.not_found', f)
       end
     end
   end

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -54,7 +54,9 @@ module ShopifyCli
       end
 
       def register_command(const, cmd)
-        Context.new.abort("Can't register duplicate core command '#{cmd}' from #{const}") if Commands.core_command?(cmd)
+        Context.new.abort(
+          Context.message('core.project_type.error.cannot_override_core', cmd, const)
+        ) if Commands.core_command?(cmd)
         Commands.register(const, cmd)
       end
 

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -66,7 +66,7 @@ module ShopifyCli
 
       def register_messages(messages)
         # Make sure we don't attempt to register a file more than once as that will fail
-        @registered_message_files = {} if @registered_message_files.nil?
+        @registered_message_files ||= {}
         return if @registered_message_files.key?(@project_type)
         @registered_message_files[@project_type] = true
 

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -62,13 +62,13 @@ module ShopifyCli
         Task::Registry.add(const_get(task), name)
       end
 
-      def register_messages_file(messages_file_path)
+      def register_messages(messages)
         # Make sure we don't attempt to register a file more than once as that will fail
         @registered_message_files = {} if @registered_message_files.nil?
-        return if @registered_message_files.key?(messages_file_path)
-        @registered_message_files[messages_file_path] = true
+        return if @registered_message_files.key?(@project_type)
+        @registered_message_files[@project_type] = true
 
-        Context.load_messages_file(messages_file_path)
+        Context.load_messages(messages)
       end
     end
   end

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -61,6 +61,15 @@ module ShopifyCli
       def register_task(task, name)
         Task::Registry.add(const_get(task), name)
       end
+
+      def register_messages_file(messages_file_path)
+        # Make sure we don't attempt to register a file more than once as that will fail
+        @registered_message_files = {} if @registered_message_files.nil?
+        return if @registered_message_files.key?(messages_file_path)
+        @registered_message_files[messages_file_path] = true
+
+        Context.load_messages_file(messages_file_path)
+      end
     end
   end
 end

--- a/lib/shopify-cli/resources/env_file.rb
+++ b/lib/shopify-cli/resources/env_file.rb
@@ -67,7 +67,7 @@ module ShopifyCli
 
       def write(ctx)
         spin_group = CLI::UI::SpinGroup.new
-        spin_group.add("writing #{FILENAME} file...") do |spinner|
+        spin_group.add(ctx.message('core.env_file.saving_header', FILENAME)) do |spinner|
           output = []
           KEY_MAP.each do |key, value|
             output << "#{key}=#{send(value)}" if send(value)
@@ -75,9 +75,9 @@ module ShopifyCli
           extra.each do |key, value|
             output << "#{key}=#{value}"
           end
-          ctx.print_task("writing #{FILENAME} file")
+          ctx.print_task(ctx.message('core.env_file.saving', FILENAME))
           ctx.write(FILENAME, output.join("\n") + "\n")
-          spinner.update_title("#{FILENAME} saved to project root")
+          spinner.update_title(ctx.message('core.env_file.saved', FILENAME))
         end
         spin_group.wait
       end

--- a/lib/shopify-cli/tasks/ensure_env.rb
+++ b/lib/shopify-cli/tasks/ensure_env.rb
@@ -11,9 +11,9 @@ module ShopifyCli
       end
 
       def ask
-        api_key = CLI::UI.ask('What is your Shopify API key?')
-        api_secret = CLI::UI.ask('What is your Shopify API secret key?')
-        shop = CLI::UI.ask('What is your development store URL? (e.g. my-test-shop.myshopify.com)')
+        api_key = CLI::UI.ask(@ctx.message('core.tasks.ensure_env.api_key_question'))
+        api_secret = CLI::UI.ask(@ctx.message('core.tasks.ensure_env.api_secret_key_question'))
+        shop = CLI::UI.ask(@ctx.message('core.tasks.ensure_env.development_store_question'))
 
         shop.gsub!(/https?\:\/\//, '')
 

--- a/lib/shopify-cli/tasks/ensure_test_shop.rb
+++ b/lib/shopify-cli/tasks/ensure_test_shop.rb
@@ -5,15 +5,16 @@ module ShopifyCli
     class EnsureTestShop < ShopifyCli::Task
       def call(ctx)
         @ctx = ctx
-        return ctx.puts("Couldn't verify your shop #{project.env.shop}") if shop.nil?
+        return ctx.puts(ctx.message('core.tasks.ensure_test_shop.could_not_verify_shop', project.env.shop)) if shop.nil?
         return if shop['transferDisabled'] == true
-        return unless CLI::UI::Prompt.confirm("Do you want to convert #{project.env.shop} to a test shop."\
-                                " This will enable you to install your app on this store.")
+        return unless CLI::UI::Prompt.confirm(
+          ctx.message('core.tasks.ensure_test_shop.convert_dev_to_test_store', project.env.shop)
+        )
         ShopifyCli::PartnersAPI.query(ctx, 'convert_dev_to_test_store', input: {
           organizationID: shop['orgID'].to_i,
           shopId: shop['shopId'],
         })
-        ctx.puts("{{v}} Transfer has been disabled on #{project.env.shop}.")
+        ctx.puts(ctx.message('core.tasks.ensure_test_shop.transfer_disabled', project.env.shop))
       end
 
       private

--- a/lib/shopify-cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify-cli/tasks/update_dashboard_urls.rb
@@ -16,16 +16,15 @@ module ShopifyCli
           applicationUrl: consent ? url : app['applicationUrl'],
           redirectUrlWhitelist: constructed_urls, apiKey: api_key
         })
-        @ctx.puts("{{v}} Whitelist URLS updated in Partners Dashboard}}")
+        @ctx.puts(@ctx.message('core.tasks.update_dashboard_urls.updated'))
       rescue
-        @ctx.puts("{{x}} error: For authentication issues, run {{command:#{ShopifyCli::TOOL_NAME} logout}} "\
-          "to clear invalid credentials")
+        @ctx.puts(@ctx.message('core.tasks.update_dashboard_urls.update_error', ShopifyCli::TOOL_NAME))
         raise
       end
 
       def check_application_url(application_url, new_url)
         return false if application_url.match(new_url)
-        CLI::UI::Prompt.confirm('Do you want to update your application url?')
+        CLI::UI::Prompt.confirm(@ctx.message('core.tasks.update_dashboard_urls.update_prompt'))
       end
 
       def construct_redirect_urls(urls, new_url, callback_url)

--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -34,12 +34,12 @@ module ShopifyCli
     def stop(ctx)
       if ShopifyCli::ProcessSupervision.running?(:ngrok)
         if ShopifyCli::ProcessSupervision.stop(:ngrok)
-          ctx.puts('{{green:x}} ngrok tunnel stopped')
+          ctx.puts(ctx.message('core.tunnel.stopped'))
         else
-          ctx.abort('ngrok tunnel could not be stopped. Try running {{command:killall -9 ngrok}}')
+          ctx.abort(ctx.message('core.tunnel.error.stop'))
         end
       else
-        ctx.puts("{{green:x}} ngrok tunnel not running")
+        ctx.puts(ctx.message('core.tunnel.not_running'))
       end
     end
 
@@ -60,9 +60,9 @@ module ShopifyCli
       process = ShopifyCli::ProcessSupervision.start(:ngrok, ngrok_command)
       log = fetch_url(ctx, process.log_path)
       if log.account
-        ctx.puts("{{v}} ngrok tunnel running at {{underline:#{log.url}}}, with account #{log.account}")
+        ctx.puts(ctx.message('core.tunnel.start_with_account', log.url, log.account))
       else
-        ctx.puts("{{v}} ngrok tunnel running at {{underline:#{log.url}}}")
+        ctx.puts(ctx.message('core.tunnel.start', log.url))
       end
       log.url
     end
@@ -123,7 +123,7 @@ module ShopifyCli
           sleep(1)
         end
 
-        raise FetchUrlError, "Unable to fetch external url" unless url
+        raise FetchUrlError, Context.message('core.tunnel.error.url_fetch_failure') unless url
       end
 
       def parse

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -122,5 +122,6 @@ module ShopifyCli
   autoload :Tasks, 'shopify-cli/tasks'
   autoload :Tunnel, 'shopify-cli/tunnel'
 
-  Context.load_messages_file(File.join(ROOT, 'lib', 'shopify-cli', 'messages/messages.yml'))
+  require 'shopify-cli/messages/messages'
+  Context.load_messages(ShopifyCli::Messages::MESSAGES)
 end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -121,4 +121,6 @@ module ShopifyCli
   autoload :Task, 'shopify-cli/task'
   autoload :Tasks, 'shopify-cli/tasks'
   autoload :Tunnel, 'shopify-cli/tunnel'
+
+  Context.load_messages_file(File.join(ROOT, 'lib', 'shopify-cli', 'messages/messages.yml'))
 end

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -31,7 +31,7 @@ module Node
 
       def test_check_node_installed
         @context.expects(:capture2e).with('which', 'node').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, 'node.node_required_notice' do
+        assert_raises ShopifyCli::Abort, 'node.create.error.node_required' do
           perform_command
         end
       end
@@ -39,7 +39,7 @@ module Node
       def test_check_get_node_version
         @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, 'node.node_version_failure_notice' do
+        assert_raises ShopifyCli::Abort, 'node.create.error.node_version_failure' do
           perform_command
         end
       end
@@ -48,7 +48,7 @@ module Node
         @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2e).with('which', 'npm').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, 'node.npm_required_notice' do
+        assert_raises ShopifyCli::Abort, 'node.create.error.npm_required' do
           perform_command
         end
       end
@@ -58,7 +58,7 @@ module Node
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
         @context.expects(:capture2e).with('npm', '-v').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, 'node.npm_version_failure_notice' do
+        assert_raises ShopifyCli::Abort, 'node.create.error.npm_version_failure' do
           perform_command
         end
       end

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -31,7 +31,7 @@ module Node
 
       def test_check_node_installed
         @context.expects(:capture2e).with('which', 'node').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, Create::NODE_REQUIRED_NOTICE do
+        assert_raises ShopifyCli::Abort, 'node.node_required_notice' do
           perform_command
         end
       end
@@ -39,7 +39,7 @@ module Node
       def test_check_get_node_version
         @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, Create::NODE_VERSION_FAILURE_NOTICE do
+        assert_raises ShopifyCli::Abort, 'node.node_version_failure_notice' do
           perform_command
         end
       end
@@ -48,7 +48,7 @@ module Node
         @context.expects(:capture2e).with('which', 'node').returns(['/usr/bin/node', mock(success?: true)])
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2e).with('which', 'npm').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, Create::NPM_REQUIRED_NOTICE do
+        assert_raises ShopifyCli::Abort, 'node.npm_required_notice' do
           perform_command
         end
       end
@@ -58,7 +58,7 @@ module Node
         @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
         @context.expects(:capture2e).with('which', 'npm').returns(['/usr/bin/npm', mock(success?: true)])
         @context.expects(:capture2e).with('npm', '-v').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, Create::NPM_VERSION_FAILURE_NOTICE do
+        assert_raises ShopifyCli::Abort, 'node.npm_version_failure_notice' do
           perform_command
         end
       end

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -31,10 +31,10 @@ module Script
 
         @context
           .expects(:puts)
-          .with(format(Script::Commands::Create::DIRECTORY_CHANGED_MSG, folder: fake_script.name))
+          .with(@context.message('script.create.changed_dir', folder: fake_script.name))
         @context
           .expects(:puts)
-          .with(format(Script::Commands::Create::OPERATION_SUCCESS_MESSAGE, script_id: fake_script.id))
+          .with(@context.message('script.create.created', script_id: fake_script.id))
         perform_command
       end
 

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -34,7 +34,7 @@ module Script
           .with(@context.message('script.create.changed_dir', folder: fake_script.name))
         @context
           .expects(:puts)
-          .with(@context.message('script.create.created', script_id: fake_script.id))
+          .with(@context.message('script.create.script_created', script_id: fake_script.id))
         perform_command
       end
 

--- a/test/project_types/script/commands/test_test.rb
+++ b/test/project_types/script/commands/test_test.rb
@@ -25,7 +25,7 @@ module Script
 
         @context
           .expects(:puts)
-          .with(Script::Commands::Test::OPERATION_SUCCESS_MESSAGE)
+          .with(@context.message('script.test.success'))
         perform_command
       end
 

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -56,7 +56,7 @@ describe Script::Layers::Application::CreateScript do
 
     describe 'create_definition' do
       subject do
-        Script::Layers::Application::CreateScript.send(:create_definition, language, ep, script_name)
+        Script::Layers::Application::CreateScript.send(:create_definition, @context, language, ep, script_name)
       end
 
       it 'should return new script' do

--- a/test/shopify-cli/oauth/servlet_test.rb
+++ b/test/shopify-cli/oauth/servlet_test.rb
@@ -16,7 +16,7 @@ module ShopifyCli
         servlet.do_GET(Request.new({ 'state' => 'state_token' }), resp)
         assert_equal(oauth.response_query, { 'state' => 'state_token' })
         assert_equal(resp.status, 200)
-        assert_match('Authenticate Successfully', resp.body)
+        assert_match(Context.message('core.oauth.servlet.authenticated'), resp.body)
       end
 
       def test_oauth_error
@@ -31,7 +31,7 @@ module ShopifyCli
         servlet.do_GET(Request.new(data), resp)
         assert_equal(oauth.response_query, data)
         assert_equal(resp.status, 400)
-        assert_match('Failed to Authenticate', resp.body)
+        assert_match(Context.message('core.oauth.servlet.not_authenticated'), resp.body)
       end
 
       def test_invalid_state
@@ -43,10 +43,10 @@ module ShopifyCli
         assert_equal(oauth.response_query, {
           "state" => "nope",
           "error" => "invalid_state",
-          "error_description" => OAuth::Servlet::INVALID_STATE_RESP,
+          "error_description" => Context.message('core.oauth.servlet.invalid_state_response'),
         })
         assert_equal(resp.status, 403)
-        assert_match('Failed to Authenticate', resp.body)
+        assert_match(Context.message('core.oauth.servlet.not_authenticated'), resp.body)
       end
 
       private

--- a/test/shopify-cli/partners_api_test.rb
+++ b/test/shopify-cli/partners_api_test.rb
@@ -54,11 +54,7 @@ module ShopifyCli
         url: "https://partners.shopify.com/api/cli/graphql",
       ).returns(api_stub)
       api_stub.expects(:query).raises(API::APIRequestNotFoundError)
-      @context.expects(:puts).with(
-        "{{x}} error: Your account was not found. Please sign up at https://partners.shopify.com/signup",
-      )
-      @context.expects(:puts).with("For authentication issues, run "\
-        "{{command:#{ShopifyCli::TOOL_NAME} logout}} to clear invalid credentials")
+      @context.expects(:puts).with(@context.message('core.partners_api.error.account_not_found', ShopifyCli::TOOL_NAME))
       PartnersAPI.query(@context, 'query')
     end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #555 once completed <!-- link to issue if one exists -->

In order to make it easier to find and maintain the CLI messages / prompts, it was decided that we should have a central location in the code where all messages are available. They are accessed by a central method (`Context::message`) which allows us to run any necessary steps on the messages in the future, if we need to.

In addition, this gives us an easy place to plug in translations in the future if we decide to do i18n by simply replacing the set of loaded messages, without requiring any code changes.

### WHAT is this pull request doing?

Messages can now be pre-loaded by project types (and the core CLI code) into the `Context` class, which handles parsing the YAML files. These messages are available as a class variable of `Context` so they can be set at any point in the code.

The `Context` class also provides a method to fetch a string based on its key that can also format parameters into it, similarly to printf. If a key is missing `Context::message` will return the key itself so missing keys don't trigger errors.

A few sample messages were replaced to the new format to help us validate that the solution is acceptable, but to complete this work I'll still have to go over all messages and move them to the new format.

Before:
```ruby
@ctx.abort(NODE_REQUIRED_NOTICE) unless stat.success?
```
After:
```ruby
@ctx.abort(@ctx.message('node.node_required_notice')) unless stat.success?
```