### PR TITLE
Add `rails new` flags

### DIFF
--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -10,6 +10,10 @@ module Rails
         end
       USERAGENT
 
+      DEFAULT_RAILS_FLAGS = %w(--skip-spring)
+
+      DEFAULT_RAILS_FLAGS = %w(--skip-spring)
+
       options do |parser, flags|
         # backwards compatibility allow 'title' for now
         parser.on('--title=TITLE') { |t| flags[:title] = t }
@@ -17,6 +21,9 @@ module Rails
         parser.on('--organization_id=ID') { |url| flags[:organization_id] = url }
         parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
         parser.on('--type=APPTYPE') { |url| flags[:type] = url }
+        parser.on('--db=DB') { |db| flags[:db] = db }
+        parser.on('--api') { flags[:api] = true }
+        parser.on('--rails_opts=RAILSOPTS') { |opts| flags[:rails_opts] = opts }
       end
 
       def call(args, _name)
@@ -72,7 +79,14 @@ module Rails
         end
 
         CLI::UI::Frame.open(@ctx.message('rails.create.generating_app', name)) do
-          syscall(%W(rails new --skip-spring #{name}))
+          new_command = %w(rails new)
+          new_command += DEFAULT_RAILS_FLAGS
+          new_command << "--database=#{options.flags[:db]}" unless options.flags[:db].nil?
+          new_command << "--api" unless options.flags[:api].nil?
+          new_command += options.flags[:rails_opts].split unless options.flags[:rails_opts].nil?
+          new_command << name
+
+          syscall(new_command)
         end
 
         @ctx.root = File.join(@ctx.root, name)

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -12,8 +12,6 @@ module Rails
 
       DEFAULT_RAILS_FLAGS = %w(--skip-spring)
 
-      DEFAULT_RAILS_FLAGS = %w(--skip-spring)
-
       options do |parser, flags|
         # backwards compatibility allow 'title' for now
         parser.on('--title=TITLE') { |t| flags[:title] = t }
@@ -22,7 +20,6 @@ module Rails
         parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
         parser.on('--type=APPTYPE') { |url| flags[:type] = url }
         parser.on('--db=DB') { |db| flags[:db] = db }
-        parser.on('--api') { flags[:api] = true }
         parser.on('--rails_opts=RAILSOPTS') { |opts| flags[:rails_opts] = opts }
       end
 
@@ -82,7 +79,6 @@ module Rails
           new_command = %w(rails new)
           new_command += DEFAULT_RAILS_FLAGS
           new_command << "--database=#{options.flags[:db]}" unless options.flags[:db].nil?
-          new_command << "--api" unless options.flags[:api].nil?
           new_command += options.flags[:rails_opts].split unless options.flags[:rails_opts].nil?
           new_command << name
 

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -23,6 +23,9 @@ module Rails
               {{command:--app_url=APPURL}} App URL. Must be valid URL.
               {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
               {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
+              {{command:--db=DB}} Database type. Must be one of: mysql, postgresql, sqlite3, oracle, frontbase, ibm_db, sqlserver, jdbcmysql, jdbcsqlite3, jdbcpostgresql, jdbc.
+            {{command:--api}} Scaffold an API-only Rails app.
+            {{command:--rails_opts=RAILSOPTS}} Additional options. Must be string containing one or more valid Rails options, separated by spaces.
           HELP
 
           error: {

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -24,8 +24,7 @@ module Rails
               {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
               {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
               {{command:--db=DB}} Database type. Must be one of: mysql, postgresql, sqlite3, oracle, frontbase, ibm_db, sqlserver, jdbcmysql, jdbcsqlite3, jdbcpostgresql, jdbc.
-            {{command:--api}} Scaffold an API-only Rails app.
-            {{command:--rails_opts=RAILSOPTS}} Additional options. Must be string containing one or more valid Rails options, separated by spaces.
+              {{command:--rails_opts=RAILSOPTS}} Additional options. Must be string containing one or more valid Rails options, separated by spaces.
           HELP
 
           error: {

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -15,10 +15,12 @@ module Minitest
       super
     end
 
-    def run_cmd(cmd)
+    def run_cmd(cmd, split_cmd = true)
       stub_prompt_for_cli_updates
       stub_monorail_log_git_sha
-      ShopifyCli::Core::EntryPoint.call(cmd.split(' '), @context)
+
+      new_cmd = split_cmd ? cmd.split : cmd
+      ShopifyCli::Core::EntryPoint.call(new_cmd, @context)
     end
 
     def capture_io(&block)

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -135,53 +135,6 @@ module Rails
         FileUtils.rm_r('test-app')
       end
 
-      def test_can_create_new_app_with_api_flag
-        FileUtils.mkdir_p('test-app')
-        FileUtils.mkdir_p('test-app/config/initializers')
-
-        gem_path = "/gem/path/"
-        Gem.stubs(:gem_home).returns(gem_path)
-
-        Ruby.expects(:version).returns(Semantic::Version.new('2.4.0'))
-        Gem.expects(:install).with(@context, 'rails', nil)
-        Gem.expects(:install).with(@context, 'bundler', '~>1.0')
-        Gem.expects(:install).with(@context, 'bundler', '~>2.0')
-        expect_command(%w(/gem/path/bin/rails new --skip-spring --api test-app))
-        expect_command(%w(/gem/path/bin/bundle install),
-                       chdir: File.join(@context.root, 'test-app'))
-        expect_command(%w(/gem/path/bin/spring stop),
-                       chdir: File.join(@context.root, 'test-app'))
-        expect_command(%w(/gem/path/bin/rails generate shopify_app),
-                       chdir: File.join(@context.root, 'test-app'))
-        expect_command(%w(/gem/path/bin/rails db:migrate RAILS_ENV=development),
-                       chdir: File.join(@context.root, 'test-app'))
-
-        stub_partner_req(
-          'create_app',
-          variables: {
-            org: 42,
-            title: 'test-app',
-            type: 'public',
-            app_url: 'https://shopify.github.io/shopify-app-cli/getting-started',
-            redir: ["http://127.0.0.1:3456"],
-          },
-          resp: {
-            'data': {
-              'appCreate': {
-                'app': {
-                  'apiKey': 'newapikey',
-                  'apiSecretKeys': [{ 'secret': 'secret' }],
-                },
-              },
-            },
-          }
-        )
-
-        perform_command('--api')
-
-        FileUtils.rm_r('test-app')
-      end
-
       def test_can_create_new_app_with_rails_opts_flag
         FileUtils.mkdir_p('test-app')
         FileUtils.mkdir_p('test-app/config/initializers')
@@ -232,11 +185,6 @@ module Rails
       private
 
       def default_new_cmd
-        "create rails \
-        --type=public \
-        --name=test-app \
-        --organization_id=42 \
-        --shop_domain=testshop.myshopify.com".split
       end
 
       def expect_command(command, chdir: @context.root)
@@ -244,6 +192,11 @@ module Rails
       end
 
       def perform_command(add_cmd = nil)
+        default_new_cmd = %w(create rails \
+                             --type=public \
+                             --name=test-app \
+                             --organization_id=42 \
+                             --shop_domain=testshop.myshopify.com)
         run_cmd(default_new_cmd << add_cmd, false)
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced? 🤔 
- Fixes #312 
- Adds ability to customize Rails scaffolding more efficiently, as users may not wish to use the defaults when scaffolding

### WHAT is this pull request doing? 📋 
- Adds flags to `rails new` command:
  - `--db=DB` changes the database being used
  - `--rails_opts=RAILSOPTS` takes a string of other possible flags
  - Removed `--api` flag added earlier as the CLI does not currently support API-only apps
- Adds help text for new flags
- Tests new flags

_Prompting for database choice will be done in a separate PR._