### PR TITLE
Bump scripts SDK and EP versions

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,10 +1,15 @@
 discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    version: "~0.0.19"
-    sdk-version: "^2.0.0"
+    version: "~0.0.20"
+    sdk-version: "^3.0.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
-    version: "~0.0.19"
-    sdk-version: "^2.0.0"
+    version: "~0.0.20"
+    sdk-version: "^3.0.0"
+payment_filter:
+  assemblyscript:
+    package: "@shopify/extension-point-as-payment-filter"
+    version: "~0.0.2"
+    sdk-version: "^3.0.0"


### PR DESCRIPTION
### WHY are these changes introduced?

As part of https://github.com/Shopify/scripts-sdk-as/pull/26, we need to bump the versions used in the CLI. We also need to add payment filter since that was added in the temp CLI.

**This can't be deployed until https://github.com/Shopify/extension-points/pull/49 is deployed**

Fixes https://github.com/Shopify/script-service/issues/1061

### WHAT is this pull request doing?

Just bumping the versions in the yml file and adding the payment filter EP.