### PR TITLE
Extract project_name method

### DIFF
--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -35,7 +35,7 @@ module ShopifyCli
 
         return unless inside_supported_project?
 
-        @ctx.puts("{{bold:Project: #{File.basename(Dir.pwd)} (#{project_type_name})}}")
+        @ctx.puts("{{bold:Project: #{Project.project_name} (#{project_type_name})}}")
         @ctx.puts("{{bold:Available commands for #{project_type_name} projects:}}\n\n")
 
         local_commands.each do |name, klass|

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -80,6 +80,10 @@ module ShopifyCli
         ctx.write('.shopify-cli.yml', YAML.dump(content))
       end
 
+      def project_name
+        File.basename(Dir.pwd)
+      end
+
       private
 
       def directory(dir)

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -70,7 +70,7 @@ module ShopifyCli
       end
 
       def test_shows_current_project_path_and_type
-        Dir.stubs(:pwd).returns("/Users/john/my_app")
+        Project.stubs(:project_name).returns("my_app")
         Project.stubs(:current_project_type).returns('rails')
         ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
 

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -40,5 +40,11 @@ module ShopifyCli
       ShopifyCli::Project.write(@context, :node, { 'other_option' => true })
       assert Project.current.config['other_option']
     end
+
+    def test_project_name_returns_last_entry_in_working_directory
+      Dir.stubs(:pwd).returns("/Users/john/my_app")
+      project_name = Project.project_name
+      assert_equal "my_app", project_name
+    end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Extracting out this method better conveys the intention of the code.

Closes #591

### WHAT is this pull request doing?

Moving the project name behaviour out of `Help` and into `Project`

There is no change to the observable behaviour.