### PR TITLE
Add enable and disable script commands

### DIFF
--- a/lib/graphql/shop_script_delete.graphql
+++ b/lib/graphql/shop_script_delete.graphql
@@ -1,0 +1,15 @@
+mutation ShopScriptDelete($extensionPointName: ExtensionPointName!) {
+  shopScriptDelete(extensionPointName: $extensionPointName) {
+    userErrors {
+      field
+      message
+      tag
+    }
+    shopScript {
+      extensionPointName
+      shopId
+      title
+      configuration
+    }
+  }
+}

--- a/lib/graphql/shop_script_update_or_create.graphql
+++ b/lib/graphql/shop_script_update_or_create.graphql
@@ -1,0 +1,23 @@
+mutation ShopScriptUpdateOrCreate(
+  $extensionPointName: ExtensionPointName!,
+  $configuration: String,
+  $title: String
+) {
+  shopScriptUpdateOrCreate(
+    extensionPointName: $extensionPointName,
+    configuration: $configuration,
+    title: $title
+) {
+    userErrors {
+      field
+      message
+      tag
+    }
+    shopScript {
+      extensionPointName
+      shopId
+      title
+      configuration
+    }
+  }
+}

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -6,6 +6,7 @@ module Script
     creator 'Script', 'Script::Commands::Create'
 
     register_command('Script::Commands::Deploy', 'deploy')
+    register_command('Script::Commands::Disable', 'disable')
     register_command('Script::Commands::Enable', 'enable')
     register_command('Script::Commands::Test', 'test')
 
@@ -17,6 +18,7 @@ module Script
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')
+    autoload :Disable, Project.project_filepath('commands/disable')
     autoload :Enable, Project.project_filepath('commands/enable')
     autoload :Test, Project.project_filepath('commands/test')
   end
@@ -34,6 +36,7 @@ module Script
       autoload :BuildScript, Project.project_filepath('layers/application/build_script')
       autoload :CreateScript, Project.project_filepath('layers/application/create_script')
       autoload :DeployScript, Project.project_filepath('layers/application/deploy_script')
+      autoload :DisableScript, Project.project_filepath('layers/application/disable_script')
       autoload :EnableScript, Project.project_filepath('layers/application/enable_script')
       autoload :ExtensionPoints, Project.project_filepath('layers/application/extension_points')
       autoload :ProjectDependencies, Project.project_filepath('layers/application/project_dependencies')

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -6,6 +6,7 @@ module Script
     creator 'Script', 'Script::Commands::Create'
 
     register_command('Script::Commands::Deploy', 'deploy')
+    register_command('Script::Commands::Enable', 'enable')
     register_command('Script::Commands::Test', 'test')
 
     require Project.project_filepath('messages/messages')
@@ -16,6 +17,7 @@ module Script
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')
+    autoload :Enable, Project.project_filepath('commands/enable')
     autoload :Test, Project.project_filepath('commands/test')
   end
 
@@ -23,6 +25,7 @@ module Script
   module Forms
     autoload :Create, Project.project_filepath('forms/create')
     autoload :Deploy, Project.project_filepath('forms/deploy')
+    autoload :Enable, Project.project_filepath('forms/enable')
     autoload :ScriptForm, Project.project_filepath('forms/script_form')
   end
 
@@ -31,6 +34,7 @@ module Script
       autoload :BuildScript, Project.project_filepath('layers/application/build_script')
       autoload :CreateScript, Project.project_filepath('layers/application/create_script')
       autoload :DeployScript, Project.project_filepath('layers/application/deploy_script')
+      autoload :EnableScript, Project.project_filepath('layers/application/enable_script')
       autoload :ExtensionPoints, Project.project_filepath('layers/application/extension_points')
       autoload :ProjectDependencies, Project.project_filepath('layers/application/project_dependencies')
       autoload :TestScript, Project.project_filepath('layers/application/test_script')

--- a/lib/project_types/script/commands/disable.rb
+++ b/lib/project_types/script/commands/disable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Script
+  module Commands
+    class Disable < ShopifyCli::Command
+      OPERATION_FAILED_MESSAGE = "Can't disable script."
+      OPERATION_SUCCESS_MESSAGE = "{{v}} Script disabled. Script is turned off in development store."
+
+      options do |parser, flags|
+        parser.on('--api_key=APIKEY') { |t| flags[:api_key] = t }
+        parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |t| flags[:shop_domain] = t }
+      end
+
+      def call(args, _name)
+        form = Forms::Enable.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) unless form
+
+        project = ScriptProject.current
+        Layers::Application::DisableScript.call(
+          ctx: @ctx,
+          api_key: form.api_key,
+          shop_domain: form.shop_domain,
+          extension_point_type: project.extension_point_type
+        )
+        @ctx.puts(OPERATION_SUCCESS_MESSAGE)
+      rescue StandardError => e
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: OPERATION_FAILED_MESSAGE)
+      end
+
+      def self.help
+        <<~HELP
+        Turn on script in development store.
+          Usage: {{command:#{ShopifyCli::TOOL_NAME} disable --API_key=<API_key> --shop_domain=<my_store.myshopify.com>}}
+        HELP
+      end
+    end
+  end
+end

--- a/lib/project_types/script/commands/disable.rb
+++ b/lib/project_types/script/commands/disable.rb
@@ -3,9 +3,6 @@
 module Script
   module Commands
     class Disable < ShopifyCli::Command
-      OPERATION_FAILED_MESSAGE = "Can't disable script."
-      OPERATION_SUCCESS_MESSAGE = "{{v}} Script disabled. Script is turned off in development store."
-
       options do |parser, flags|
         parser.on('--api_key=APIKEY') { |t| flags[:api_key] = t }
         parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |t| flags[:shop_domain] = t }
@@ -22,16 +19,13 @@ module Script
           shop_domain: form.shop_domain,
           extension_point_type: project.extension_point_type
         )
-        @ctx.puts(OPERATION_SUCCESS_MESSAGE)
+        @ctx.puts(@ctx.message('script.disable.script_disabled'))
       rescue StandardError => e
-        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: OPERATION_FAILED_MESSAGE)
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.disable.error.operation_failed'))
       end
 
       def self.help
-        <<~HELP
-        Turn on script in development store.
-          Usage: {{command:#{ShopifyCli::TOOL_NAME} disable --API_key=<API_key> --shop_domain=<my_store.myshopify.com>}}
-        HELP
+        ShopifyCli::Context.message('script.disable.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/commands/enable.rb
+++ b/lib/project_types/script/commands/enable.rb
@@ -3,10 +3,6 @@
 module Script
   module Commands
     class Enable < ShopifyCli::Command
-      OPERATION_FAILED_MESSAGE = "Can't enable script."
-      OPERATION_SUCCESS_MESSAGE = "{{v}} Script enabled. %{type} script %{title} in app (API key: %{api_key}) "\
-                                  "is turned on in development store {{green:%{shop_domain}}}"
-
       options do |parser, flags|
         parser.on('--api_key=APIKEY') { |t| flags[:api_key] = t }
         parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |t| flags[:shop_domain] = t }
@@ -26,22 +22,19 @@ module Script
           extension_point_type: project.extension_point_type,
           title: project.script_name
         )
-        @ctx.puts(format(
-                    OPERATION_SUCCESS_MESSAGE,
-                    api_key: form.api_key,
-                    shop_domain: form.shop_domain,
-                    type: project.extension_point_type.capitalize,
-                    title: project.script_name
-                  ))
+        @ctx.puts(@ctx.message(
+          'script.enable.script_enabled',
+          api_key: form.api_key,
+          shop_domain: form.shop_domain,
+          type: project.extension_point_type.capitalize,
+          title: project.script_name
+        ))
       rescue StandardError => e
-        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: OPERATION_FAILED_MESSAGE)
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.enable.error.operation_failed'))
       end
 
       def self.help
-        <<~HELP
-        Turn on script in development store.
-          Usage: {{command:#{ShopifyCli::TOOL_NAME} enable --API_key=<API_key> --shop_domain=<my_store.myshopify.com>}}
-        HELP
+        ShopifyCli::Context.message('script.enable.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/commands/enable.rb
+++ b/lib/project_types/script/commands/enable.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Script
+  module Commands
+    class Enable < ShopifyCli::Command
+      OPERATION_FAILED_MESSAGE = "Can't enable script."
+      OPERATION_SUCCESS_MESSAGE = "{{v}} Script enabled. %{type} script %{title} in app (API key: %{api_key}) "\
+                                  "is turned on in development store {{green:%{shop_domain}}}"
+
+      options do |parser, flags|
+        parser.on('--api_key=APIKEY') { |t| flags[:api_key] = t }
+        parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |t| flags[:shop_domain] = t }
+      end
+
+      def call(args, _name)
+        form = Forms::Enable.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) unless form
+
+        project = ScriptProject.current
+
+        Layers::Application::EnableScript.call(
+          ctx: @ctx,
+          api_key: form.api_key,
+          shop_domain: form.shop_domain,
+          configuration: '{}',
+          extension_point_type: project.extension_point_type,
+          title: project.script_name
+        )
+        @ctx.puts(format(
+                    OPERATION_SUCCESS_MESSAGE,
+                    api_key: form.api_key,
+                    shop_domain: form.shop_domain,
+                    type: project.extension_point_type.capitalize,
+                    title: project.script_name
+                  ))
+      rescue StandardError => e
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: OPERATION_FAILED_MESSAGE)
+      end
+
+      def self.help
+        <<~HELP
+        Turn on script in development store.
+          Usage: {{command:#{ShopifyCli::TOOL_NAME} enable --API_key=<API_key> --shop_domain=<my_store.myshopify.com>}}
+        HELP
+      end
+    end
+  end
+end

--- a/lib/project_types/script/forms/enable.rb
+++ b/lib/project_types/script/forms/enable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Script
+  module Forms
+    class Enable < ScriptForm
+      flag_arguments :api_key, :shop_domain
+
+      def ask
+        self.api_key ||= ask_api_key
+        self.shop_domain ||= ask_shop_domain
+      end
+
+      private
+
+      def ask_api_key
+        ask_app_api_key(ctx, organization['apps'], message: 'Which app is the script deployed to?')
+      end
+
+      def ask_shop_domain
+        super(ctx, organization, message: 'Which development store is the app installed on?')
+      end
+    end
+  end
+end

--- a/lib/project_types/script/forms/enable.rb
+++ b/lib/project_types/script/forms/enable.rb
@@ -13,11 +13,11 @@ module Script
       private
 
       def ask_api_key
-        ask_app_api_key(ctx, organization['apps'], message: 'Which app is the script deployed to?')
+        ask_app_api_key(organization['apps'], message: ctx.message('script.forms.enable.ask_app_api_key'))
       end
 
       def ask_shop_domain
-        super(ctx, organization, message: 'Which development store is the app installed on?')
+        super(organization, message: ctx.message('script.forms.enable.ask_shop_domain'))
       end
     end
   end

--- a/lib/project_types/script/forms/script_form.rb
+++ b/lib/project_types/script/forms/script_form.rb
@@ -48,6 +48,18 @@ module Script
           organizations.find { |o| o['id'] == org_id }
         end
       end
+
+      def ask_shop_domain(ctx, organization, message: 'Select a development store')
+        if organization['stores'].count == 0
+          raise Errors::NoExistingStoresError, organization['id']
+        elsif organization['stores'].count == 1
+          domain = organization['stores'].first['shopDomain']
+          ctx.puts("Using development store {{green:#{domain}}}")
+          domain
+        else
+          CLI::UI::Prompt.ask(message, options: organization["stores"].map { |s| s["shopDomain"] })
+        end
+      end
     end
   end
 end

--- a/lib/project_types/script/forms/script_form.rb
+++ b/lib/project_types/script/forms/script_form.rb
@@ -49,12 +49,12 @@ module Script
         end
       end
 
-      def ask_shop_domain(ctx, organization, message: 'Select a development store')
+      def ask_shop_domain(organization, message: ctx.message('script.forms.script_form.ask_shop_domain_default'))
         if organization['stores'].count == 0
           raise Errors::NoExistingStoresError, organization['id']
         elsif organization['stores'].count == 1
           domain = organization['stores'].first['shopDomain']
-          ctx.puts("Using development store {{green:#{domain}}}")
+          ctx.message('script.forms.script_form.using_development_store', domain: domain)
           domain
         else
           CLI::UI::Prompt.ask(message, options: organization["stores"].map { |s| s["shopDomain"] })

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -6,11 +6,11 @@ module Script
       class BuildScript
         class << self
           def call(ctx:, script:)
-            return if CLI::UI::Frame.open(ctx.message('script.application.build_script.building')) do
+            return if CLI::UI::Frame.open(ctx.message('script.application.building')) do
               begin
-                UI::StrictSpinner.spin(ctx.message('script.application.build_script.building_script')) do |spinner|
+                UI::StrictSpinner.spin(ctx.message('script.application.building_script')) do |spinner|
                   build(script)
-                  spinner.update_title(ctx.message('script.application.build_script.built'))
+                  spinner.update_title(ctx.message('script.application.built'))
                 end
                 true
               rescue StandardError => e

--- a/lib/project_types/script/layers/application/deploy_script.rb
+++ b/lib/project_types/script/layers/application/deploy_script.rb
@@ -17,12 +17,12 @@ module Script
           private
 
           def deploy_script(ctx, script, api_key, force)
-            UI::StrictSpinner.spin(ctx.message('script.application.deploy_script.deploying')) do |spinner|
+            UI::StrictSpinner.spin(ctx.message('script.application.deploying')) do |spinner|
               compiled_type = Infrastructure::ScriptBuilder.for(script).compiled_type
               Infrastructure::DeployPackageRepository.new
                 .get_deploy_package(script, compiled_type)
                 .deploy(Infrastructure::ScriptService.new(ctx: ctx), api_key, force)
-              spinner.update_title(ctx.message('script.application.deploy_script.deployed'))
+              spinner.update_title(ctx.message('script.application.deployed'))
             end
           end
         end

--- a/lib/project_types/script/layers/application/disable_script.rb
+++ b/lib/project_types/script/layers/application/disable_script.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Application
+      class DisableScript
+        DISABLING_MSG = "Disabling"
+        DISABLED_MSG = "Disabled"
+
+        def self.call(ctx:, api_key:, shop_domain:, extension_point_type:)
+          UI::StrictSpinner.spin(DISABLING_MSG) do |spinner|
+            script_service = Infrastructure::ScriptService.new(ctx: ctx)
+            script_service.disable(
+              api_key: api_key,
+              shop_domain: shop_domain,
+              extension_point_type: extension_point_type,
+            )
+            spinner.update_title(DISABLED_MSG)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/application/disable_script.rb
+++ b/lib/project_types/script/layers/application/disable_script.rb
@@ -4,18 +4,15 @@ module Script
   module Layers
     module Application
       class DisableScript
-        DISABLING_MSG = "Disabling"
-        DISABLED_MSG = "Disabled"
-
         def self.call(ctx:, api_key:, shop_domain:, extension_point_type:)
-          UI::StrictSpinner.spin(DISABLING_MSG) do |spinner|
+          UI::StrictSpinner.spin(ctx.message('script.application.disable_script.disabling')) do |spinner|
             script_service = Infrastructure::ScriptService.new(ctx: ctx)
             script_service.disable(
               api_key: api_key,
               shop_domain: shop_domain,
               extension_point_type: extension_point_type,
             )
-            spinner.update_title(DISABLED_MSG)
+            spinner.update_title(ctx.message('script.application.disable_script.disabled'))
           end
         end
       end

--- a/lib/project_types/script/layers/application/disable_script.rb
+++ b/lib/project_types/script/layers/application/disable_script.rb
@@ -5,14 +5,14 @@ module Script
     module Application
       class DisableScript
         def self.call(ctx:, api_key:, shop_domain:, extension_point_type:)
-          UI::StrictSpinner.spin(ctx.message('script.application.disable_script.disabling')) do |spinner|
+          UI::StrictSpinner.spin(ctx.message('script.application.disabling')) do |spinner|
             script_service = Infrastructure::ScriptService.new(ctx: ctx)
             script_service.disable(
               api_key: api_key,
               shop_domain: shop_domain,
               extension_point_type: extension_point_type,
             )
-            spinner.update_title(ctx.message('script.application.disable_script.disabled'))
+            spinner.update_title(ctx.message('script.application.disabled'))
           end
         end
       end

--- a/lib/project_types/script/layers/application/enable_script.rb
+++ b/lib/project_types/script/layers/application/enable_script.rb
@@ -4,11 +4,8 @@ module Script
   module Layers
     module Application
       class EnableScript
-        ENABLING_MSG = "Enabling"
-        ENABLED_MSG = "Enabled"
-
         def self.call(ctx:, api_key:, shop_domain:, configuration:, extension_point_type:, title:)
-          UI::StrictSpinner.spin(ENABLING_MSG) do |spinner|
+          UI::StrictSpinner.spin(ctx.message('script.application.enable_script.enabling')) do |spinner|
             script_service = Infrastructure::ScriptService.new(ctx: ctx)
             script_service.enable(
               api_key: api_key,
@@ -17,7 +14,7 @@ module Script
               extension_point_type: extension_point_type,
               title: title
             )
-            spinner.update_title(ENABLED_MSG)
+            spinner.update_title(ctx.message('script.application.enable_script.enabled'))
           end
         end
       end

--- a/lib/project_types/script/layers/application/enable_script.rb
+++ b/lib/project_types/script/layers/application/enable_script.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Application
+      class EnableScript
+        ENABLING_MSG = "Enabling"
+        ENABLED_MSG = "Enabled"
+
+        def self.call(ctx:, api_key:, shop_domain:, configuration:, extension_point_type:, title:)
+          UI::StrictSpinner.spin(ENABLING_MSG) do |spinner|
+            script_service = Infrastructure::ScriptService.new(ctx: ctx)
+            script_service.enable(
+              api_key: api_key,
+              shop_domain: shop_domain,
+              configuration: configuration,
+              extension_point_type: extension_point_type,
+              title: title
+            )
+            spinner.update_title(ENABLED_MSG)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/application/enable_script.rb
+++ b/lib/project_types/script/layers/application/enable_script.rb
@@ -5,7 +5,7 @@ module Script
     module Application
       class EnableScript
         def self.call(ctx:, api_key:, shop_domain:, configuration:, extension_point_type:, title:)
-          UI::StrictSpinner.spin(ctx.message('script.application.enable_script.enabling')) do |spinner|
+          UI::StrictSpinner.spin(ctx.message('script.application.enabling')) do |spinner|
             script_service = Infrastructure::ScriptService.new(ctx: ctx)
             script_service.enable(
               api_key: api_key,
@@ -14,7 +14,7 @@ module Script
               extension_point_type: extension_point_type,
               title: title
             )
-            spinner.update_title(ctx.message('script.application.enable_script.enabled'))
+            spinner.update_title(ctx.message('script.application.enabled'))
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -5,6 +5,7 @@ module Script
     module Infrastructure
       module Errors
         class AppNotInstalledError < ScriptProjectError; end
+        class AppScriptUndefinedError < ScriptProjectError; end
         class BuilderNotFoundError < ScriptProjectError; end
         class BuildError < ScriptProjectError; end
         class DependencyError < ScriptProjectError; end
@@ -29,6 +30,7 @@ module Script
           end
         end
         class ShopAuthenticationError < ScriptProjectError; end
+        class ShopScriptConflictError < ScriptProjectError; end
         class TestError < ScriptProjectError; end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -31,6 +31,7 @@ module Script
         end
         class ShopAuthenticationError < ScriptProjectError; end
         class ShopScriptConflictError < ScriptProjectError; end
+        class ShopScriptUndefinedError < ScriptProjectError; end
         class TestError < ScriptProjectError; end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -40,6 +40,33 @@ module Script
           end
         end
 
+        def enable(api_key:, shop_domain:, configuration:, extension_point_type:, title:)
+          query_name = "shop_script_update_or_create"
+          variables = {
+            extensionPointName: extension_point_type.upcase,
+            configuration: configuration,
+            title: title,
+          }
+
+          resp_hash = script_service_request(
+            query_name: query_name,
+            api_key: api_key,
+            shop_domain: shop_domain,
+            variables: variables,
+          )
+          user_errors = resp_hash["data"]["shopScriptUpdateOrCreate"]["userErrors"]
+
+          return resp_hash if user_errors.empty?
+
+          if user_errors.any? { |e| e['tag'] == 'app_script_not_found' }
+            raise Errors::AppScriptUndefinedError, api_key
+          elsif user_errors.any? { |e| e['tag'] == 'shop_script_conflict' }
+            raise Errors::ShopScriptConflictError
+          else
+            raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
+          end
+        end
+
         private
 
         class ScriptServiceAPI < ShopifyCli::API

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -67,6 +67,28 @@ module Script
           end
         end
 
+        def disable(api_key:, shop_domain:, extension_point_type:)
+          query_name = "shop_script_delete"
+          variables = {
+            extensionPointName: extension_point_type.upcase,
+          }
+
+          resp_hash = script_service_request(
+            query_name: query_name,
+            api_key: api_key,
+            shop_domain: shop_domain,
+            variables: variables,
+          )
+          user_errors = resp_hash["data"]["shopScriptDelete"]["userErrors"]
+          return resp_hash if user_errors.empty?
+
+          if user_errors.any? { |e| e['tag'] == 'shop_script_not_found' }
+            raise Errors::ShopScriptUndefinedError, api_key
+          else
+            raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
+          end
+        end
+
         private
 
         class ScriptServiceAPI < ShopifyCli::API

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -38,6 +38,8 @@ module Script
 
           app_not_installed_cause: "App not installed on development store.",
 
+          app_script_undefined_help: "Deploy script to app.",
+
           build_error_cause: "Something went wrong while building the script.",
           build_error_help: "Correct the errors and try again.",
 
@@ -54,6 +56,12 @@ module Script
 
           shop_auth_cause: "Unable to authenticate with the store.",
           shop_auth_help: "Try again.",
+
+          shop_script_conflict_cause: "Another app in this store has already enabled a script "\
+                                      "on this extension point.",
+          shop_script_conflict_help: "Disable that script or uninstall that app and try again.",
+
+          shop_script_undefined_cause: "Script is already turned off in development store.",
 
           test_help: "Correct the errors and try again.",
         },
@@ -90,6 +98,33 @@ module Script
           script_deployed: "{{v}} Script deployed to app (API key: %{api_key}).",
         },
 
+        disable: {
+          help: <<~HELP,
+          Turn off script in development store.
+            Usage: {{command:%s disable --API_key=<API_key> --shop_domain=<my_store.myshopify.com>}}
+          HELP
+
+          error: {
+            operation_failed: "Can't disable script.",
+          },
+
+          script_disabled: "{{v}} Script disabled. Script is turned off in development store.",
+        },
+
+        enable: {
+          help: <<~HELP,
+          Turn on script in development store.
+            Usage: {{command:%s enable --API_key=<API_key> --shop_domain=<my_store.myshopify.com>}}
+          HELP
+
+          error: {
+            operation_failed: "Can't enable script.",
+          },
+
+          script_enabled: "{{v}} Script enabled. %{type} script %{title} in app (API key: %{api_key}) "\
+                          "is turned on in development store {{green:%{shop_domain}}}",
+        },
+
         project_deps: {
           deps_are_installed: "{{v}} Dependencies installed",
           installing_with_npm: "Installing dependencies with npm",
@@ -118,11 +153,17 @@ module Script
           },
           script_form: {
             ask_app_api_key_default: "Which app do you want this script to belong to?",
+            ask_shop_domain_default: "Select a development store",
             fetching_organizations: "Fetching organizations",
             fetched_organizations: "Fetched organizations",
             select_organization: "Select organization.",
             using_app: "Using app {{green:%{title} (%{api_key})}}.",
+            using_development_store: "Using development store {{green:%{domain}}}",
             using_organization: "Organization {{green:%s}}.",
+          },
+          enable: {
+            ask_app_api_key: "Which app is the script deployed to?",
+            ask_shop_domain: "Which development store is the app installed on?",
           },
         },
 
@@ -135,6 +176,14 @@ module Script
           deploy_script: {
             deploying: "Deploying",
             deployed: "Deployed",
+          },
+          disable_script: {
+            disabling: "Disabling",
+            disabled: "Disabled",
+          },
+          enable_script: {
+            enabling: "Enabling",
+            enabled: "Enabled",
           },
         },
       },

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -168,23 +168,15 @@ module Script
         },
 
         application: {
-          build_script: {
-            building: "Building",
-            building_script: "Building script",
-            built: "Built",
-          },
-          deploy_script: {
-            deploying: "Deploying",
-            deployed: "Deployed",
-          },
-          disable_script: {
-            disabling: "Disabling",
-            disabled: "Disabled",
-          },
-          enable_script: {
-            enabling: "Enabling",
-            enabled: "Enabled",
-          },
+          building: "Building",
+          building_script: "Building script",
+          built: "Built",
+          deploying: "Deploying",
+          deployed: "Deployed",
+          disabling: "Disabling",
+          disabled: "Disabled",
+          enabling: "Enabling",
+          enabled: "Enabled",
         },
       },
     }.freeze

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -86,7 +86,7 @@ module Script
           }
         when Layers::Infrastructure::Errors::AppScriptUndefinedError
           {
-            help_suggestion: "Deploy script to app.",
+            help_suggestion: ShopifyCli::Context.message('script.error.app_script_undefined_help'),
           }
         when Layers::Infrastructure::Errors::BuildError
           {
@@ -119,12 +119,12 @@ module Script
           }
         when Layers::Infrastructure::Errors::ShopScriptConflictError
           {
-            cause_of_error: "Another app in this store has already enabled a script on this extension point.",
-            help_suggestion: "Disable that script or uninstall that app and try again.",
+            cause_of_error: ShopifyCli::Context.message('script.error.shop_script_conflict_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.shop_script_conflict_help'),
           }
         when Layers::Infrastructure::Errors::ShopScriptUndefinedError
           {
-            cause_of_error: "Script is already turned off in development store.",
+            cause_of_error: ShopifyCli::Context.message('script.error.shop_script_undefined_cause'),
           }
         when Layers::Infrastructure::Errors::TestError
           {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -122,7 +122,10 @@ module Script
             cause_of_error: "Another app in this store has already enabled a script on this extension point.",
             help_suggestion: "Disable that script or uninstall that app and try again.",
           }
-
+        when Layers::Infrastructure::Errors::ShopScriptUndefinedError
+          {
+            cause_of_error: "Script is already turned off in development store.",
+          }
         when Layers::Infrastructure::Errors::TestError
           {
             help_suggestion: ShopifyCli::Context.message('script.error.test_help'),

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -84,6 +84,10 @@ module Script
           {
             cause_of_error: ShopifyCli::Context.message('script.error.app_not_installed_cause'),
           }
+        when Layers::Infrastructure::Errors::AppScriptUndefinedError
+          {
+            help_suggestion: "Deploy script to app.",
+          }
         when Layers::Infrastructure::Errors::BuildError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.build_error_cause'),
@@ -113,6 +117,12 @@ module Script
             cause_of_error: ShopifyCli::Context.message('script.error.shop_auth_cause'),
             help_suggestion: ShopifyCli::Context.message('script.error.shop_auth_help'),
           }
+        when Layers::Infrastructure::Errors::ShopScriptConflictError
+          {
+            cause_of_error: "Another app in this store has already enabled a script on this extension point.",
+            help_suggestion: "Disable that script or uninstall that app and try again.",
+          }
+
         when Layers::Infrastructure::Errors::TestError
           {
             help_suggestion: ShopifyCli::Context.message('script.error.test_help'),

--- a/test/project_types/script/commands/disable_test.rb
+++ b/test/project_types/script/commands/disable_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+module Script
+  module Commands
+    class DisableTest < MiniTest::Test
+      def setup
+        super
+        @cmd = Disable
+        @cmd.ctx = @context
+        @ep_type = 'discount'
+        @script_name = 'script'
+        @api_key = 'key'
+        @shop_domain = 'shop.myshopify.com'
+        @script_project = TestHelpers::FakeScriptProject.new(
+          language: @language,
+          extension_point_type: @ep_type,
+          script_name: @script_name
+        )
+        ScriptProject.stubs(:current).returns(@script_project)
+      end
+
+      def test_calls_application_enable
+        Script::Layers::Application::DisableScript.expects(:call).with(
+          ctx: @context,
+          api_key: @api_key,
+          shop_domain: @shop_domain,
+          extension_point_type: @ep_type,
+        )
+        capture_io do
+          perform_command
+        end
+      end
+
+      private
+
+      def perform_command
+        run_cmd("disable --api_key=#{@api_key} --shop_domain=#{@shop_domain}")
+      end
+    end
+  end
+end

--- a/test/project_types/script/commands/enable_test.rb
+++ b/test/project_types/script/commands/enable_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'project_types/script/test_helper'
+
+module Script
+  module Commands
+    class EnableTest < MiniTest::Test
+      def setup
+        super
+        @cmd = Enable
+        @cmd.ctx = @context
+        @configuration = '{}'
+        @ep_type = 'discount'
+        @script_name = 'script'
+        @api_key = 'key'
+        @shop_domain = 'shop.myshopify.com'
+        @script_project = TestHelpers::FakeScriptProject.new(
+          language: @language,
+          extension_point_type: @ep_type,
+          script_name: @script_name
+        )
+        ScriptProject.stubs(:current).returns(@script_project)
+      end
+
+      def test_calls_application_enable
+        Script::Layers::Application::EnableScript.expects(:call).with(
+          ctx: @context,
+          api_key: @api_key,
+          shop_domain: @shop_domain,
+          configuration: @configuration,
+          extension_point_type: @ep_type,
+          title: @script_name
+        )
+        capture_io do
+          perform_command
+        end
+      end
+
+      private
+
+      def perform_command
+        run_cmd("enable --api_key=#{@api_key} --shop_domain=#{@shop_domain}")
+      end
+    end
+  end
+end

--- a/test/project_types/script/forms/deploy_test.rb
+++ b/test/project_types/script/forms/deploy_test.rb
@@ -16,7 +16,7 @@ module Script
       def test_ask_calls_form_ask_app_api_key_when_no_flag
         apps = [{ "apiKey" => 1234 }]
         Deploy.any_instance.expects(:ask_app_api_key).with(apps)
-        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).with(@context).returns([{ "apps" => apps }])
+        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns([{ "apps" => apps }])
         ask
       end
 

--- a/test/project_types/script/forms/enable_test.rb
+++ b/test/project_types/script/forms/enable_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+module Script
+  module Forms
+    class EnableTest < MiniTest::Test
+      include TestHelpers::Partners
+      include TestHelpers::FakeUI
+
+      def test_use_provided_flags
+        form = ask
+        assert_equal(form.api_key, 'fakekey')
+        assert_equal(form.shop_domain, 'shop.myshopify.com')
+      end
+
+      def test_raises_when_no_apps_available
+        stub_organization
+        assert_raises Errors::NoExistingAppsError do
+          ask(api_key: nil)
+        end
+      end
+
+      def test_organizations_fetch_once
+        UI::StrictSpinner.expects(:spin).with('Fetching organizations').yields(FakeSpinner.new).returns(true).once
+        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).returns(true).once
+        form = Enable.new(@context, [], [])
+        2.times { form.send(:organizations) }
+      end
+
+      def test_pick_singular_app
+        stub_organization(apps: [{ "apiKey" => 1234 }])
+        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_apps).returns([{ "apiKey" => 1234 }])
+        form = ask(api_key: nil)
+        assert_equal 1234, form.api_key
+      end
+
+      def test_display_selection_for_apps
+        stub_organization(apps: [{ "apiKey" => 1234 }, { "apiKey" => 1267 }])
+        CLI::UI::Prompt.expects(:ask)
+          .with('Which app is the script deployed to?')
+          .returns(1267)
+        form = ask(api_key: nil)
+        assert_equal(form.api_key, 1267)
+      end
+
+      def test_raises_when_no_shops_available
+        stub_organization
+        assert_raises Errors::NoExistingStoresError do
+          ask(shop_domain: nil)
+        end
+      end
+
+      def test_pick_singular_shop
+        stub_organization(stores: [{ 'shopId' => 1234, 'shopDomain' => 'domain' }])
+        form = ask(shop_domain: nil)
+        assert_equal 'domain', form.shop_domain
+      end
+
+      def test_display_selection_for_shops
+        stub_organization(stores: [{ 'shopId' => 1, 'shopDomain' => 'a' }, { 'shopId' => 2, 'shopDomain' => 'b' }])
+        CLI::UI::Prompt.expects(:ask)
+          .with('Which development store is the app installed on?', options: %w(a b))
+          .returns('a')
+        form = ask(shop_domain: nil)
+        assert_equal(form.shop_domain, 'a')
+      end
+
+      private
+
+      def stub_organization(apps: [], stores: [])
+        Enable.any_instance.stubs(:organization).returns({ 'apps' => apps, 'stores' => stores })
+      end
+
+      def ask(api_key: 'fakekey', shop_domain: 'shop.myshopify.com')
+        Enable.ask(
+          @context,
+          [],
+          api_key: api_key,
+          shop_domain: shop_domain
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/script/forms/enable_test.rb
+++ b/test/project_types/script/forms/enable_test.rb
@@ -21,16 +21,8 @@ module Script
         end
       end
 
-      def test_organizations_fetch_once
-        UI::StrictSpinner.expects(:spin).with('Fetching organizations').yields(FakeSpinner.new).returns(true).once
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).returns(true).once
-        form = Enable.new(@context, [], [])
-        2.times { form.send(:organizations) }
-      end
-
       def test_pick_singular_app
         stub_organization(apps: [{ "apiKey" => 1234 }])
-        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_apps).returns([{ "apiKey" => 1234 }])
         form = ask(api_key: nil)
         assert_equal 1234, form.api_key
       end

--- a/test/project_types/script/forms/script_form_test.rb
+++ b/test/project_types/script/forms/script_form_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+module Script
+  module Forms
+    class ScriptFormTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def test_organizations_fetch_once
+        UI::StrictSpinner.expects(:spin).with('Fetching organizations').yields(FakeSpinner.new).returns(true).once
+        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).returns(true).once
+        form = ScriptForm.new(@context, [], [])
+        2.times { form.send(:organizations) }
+      end
+    end
+  end
+end

--- a/test/project_types/script/layers/application/disable_script_test.rb
+++ b/test/project_types/script/layers/application/disable_script_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+describe Script::Layers::Application::DisableScript do
+  describe '.call' do
+    let(:api_key) { 'api_key' }
+    let(:shop_domain) { 'shop_domain' }
+    let(:extension_point_type) { 'extension_point_type' }
+
+    subject do
+      Script::Layers::Application::DisableScript
+        .call(ctx: @context, api_key: api_key, shop_domain: shop_domain, extension_point_type: extension_point_type)
+    end
+
+    it 'should authenticate and make disable request' do
+      Script::Layers::Infrastructure::ScriptService
+        .any_instance
+        .expects(:disable)
+        .with(api_key: api_key, shop_domain: shop_domain, extension_point_type: extension_point_type)
+      capture_io { subject }
+    end
+  end
+end

--- a/test/project_types/script/layers/application/enable_script_test.rb
+++ b/test/project_types/script/layers/application/enable_script_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+describe Script::Layers::Application::EnableScript do
+  describe '.call' do
+    let(:api_key) { 'api_key' }
+    let(:shop_domain) { 'shop_domain' }
+    let(:configuration) { '{}' }
+    let(:extension_point_type) { 'extension_point_type' }
+    let(:title) { 'title' }
+
+    subject do
+      Script::Layers::Application::EnableScript.call(
+        ctx: @context,
+        api_key: api_key,
+        shop_domain: shop_domain,
+        configuration: configuration,
+        extension_point_type: extension_point_type,
+        title: title
+      )
+    end
+
+    it 'should authenticate and make enable request' do
+      Script::Layers::Infrastructure::ScriptService.any_instance.expects(:enable).with(
+        api_key: api_key,
+        shop_domain: shop_domain,
+        configuration: configuration,
+        extension_point_type: extension_point_type,
+        title: title
+      )
+      capture_io { subject }
+    end
+  end
+end

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -209,6 +209,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when ShopScriptUndefinedError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ShopScriptUndefinedError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when TestError" do
         let(:err) { Script::Layers::Infrastructure::Errors::TestError.new }
         it "should call display_and_raise" do

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -153,6 +153,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when AppScriptUndefinedError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::AppScriptUndefinedError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when BuildError" do
         let(:err) { Script::Layers::Infrastructure::Errors::BuildError.new }
         it "should call display_and_raise" do
@@ -190,6 +197,13 @@ describe Script::UI::ErrorHandler do
 
       describe "when ShopAuthenticationError" do
         let(:err) { Script::Layers::Infrastructure::Errors::ShopAuthenticationError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when ShopScriptConflictError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ShopScriptConflictError.new }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end


### PR DESCRIPTION
### WHY are these changes introduced? 
These commands allow users to activate (enable) or deactivate (disable) a script on your store.

### WHAT is this pull request doing? 
- Adds an `enable` and a `disable` script project command.
- Finishes importing Scripts code 🎉 