### PR TITLE
Fix handling of project name when called from inside subdirectory

### DIFF
--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -35,7 +35,7 @@ module ShopifyCli
 
         return unless inside_supported_project?
 
-        @ctx.puts("{{bold:Project: #{File.basename(Dir.pwd)} (#{project_type_name})}}")
+        @ctx.puts("{{bold:Project: #{Project.project_name} (#{project_type_name})}}")
         @ctx.puts("{{bold:Available commands for #{project_type_name} projects:}}\n\n")
 
         local_commands.each do |name, klass|

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -81,7 +81,7 @@ module ShopifyCli
       end
 
       def project_name
-        File.basename(Dir.pwd)
+        File.basename(current.directory)
       end
 
       private

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -80,6 +80,10 @@ module ShopifyCli
         ctx.write('.shopify-cli.yml', YAML.dump(content))
       end
 
+      def project_name
+        File.basename(Dir.pwd)
+      end
+
       private
 
       def directory(dir)

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -47,6 +47,7 @@ module ShopifyCli
 
       def test_local_commands_available_within_a_project
         Project.stubs(:current_project_type).returns('rails')
+        Project.stubs(:project_name).returns('myapp')
         ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
 
         io = capture_io do
@@ -70,8 +71,8 @@ module ShopifyCli
       end
 
       def test_shows_current_project_path_and_type
-        Project.stubs(:project_name).returns("my_app")
         Project.stubs(:current_project_type).returns('rails')
+        Project.stubs(:project_name).returns("my_app")
         ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
 
         io = capture_io do

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -70,7 +70,7 @@ module ShopifyCli
       end
 
       def test_shows_current_project_path_and_type
-        Dir.stubs(:pwd).returns("/Users/john/my_app")
+        Project.stubs(:project_name).returns("my_app")
         Project.stubs(:current_project_type).returns('rails')
         ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
 

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -40,5 +40,11 @@ module ShopifyCli
       ShopifyCli::Project.write(@context, :node, { 'other_option' => true })
       assert Project.current.config['other_option']
     end
+
+    def test_project_name_returns_last_entry_in_working_directory
+      Dir.stubs(:pwd).returns("/Users/john/my_app")
+      project_name = Project.project_name
+      assert_equal "my_app", project_name
+    end
   end
 end

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -41,10 +41,24 @@ module ShopifyCli
       assert Project.current.config['other_option']
     end
 
-    def test_project_name_returns_last_entry_in_working_directory
-      Dir.stubs(:pwd).returns("/Users/john/my_app")
-      project_name = Project.project_name
-      assert_equal "my_app", project_name
+    def test_project_name_returns_name
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p("#{dir}/myapp")
+        FileUtils.touch("#{dir}/myapp/.shopify-cli.yml")
+        FileUtils.cd("#{dir}/myapp")
+        project_name = Project.project_name
+        assert_equal "myapp", project_name
+      end
+    end
+
+    def test_project_name_returns_name_even_if_called_from_subdirectory
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p("#{dir}/myapp/lib")
+        FileUtils.touch("#{dir}/myapp/.shopify-cli.yml")
+        FileUtils.cd("#{dir}/myapp/lib")
+        project_name = Project.project_name
+        assert_equal "myapp", project_name
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #591 and #598

### WHAT is this pull request doing?

* Extracts out the `project_name` method.
* Changes the behaviour so that the correct project name is shown, even if run from within a nested directory.
