### PR TITLE
Drop Ruby 2.3 for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
- - 2.3.7
+ - 2.4.7
  - 2.5.1
 before_install:
 - gem install bundler -v '1.17.3'


### PR DESCRIPTION
### WHY are these changes introduced?

As mentioned in #595, testing on Ruby 2.3 prevents us from upgrading RuboCop.

The further we fall behind, the more warnings that will be generated.

### WHAT is this pull request doing?

Sets the minimum version we test against as 2.4 in Travis CI.

Ruby 2.3 was EOL in March 2019. This change doesn't prevent running the tool on Ruby 2.3, but it does mean there's a small risk that we could introduce a regression on 2.3 that isn't caught by the tests.