### PR TITLE
Bump scripts SDK + EP versions

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,15 +1,15 @@
 discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    version: "~0.0.20"
-    sdk-version: "^3.0.0"
+    version: "~0.0.21"
+    sdk-version: "^4.0.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
-    version: "~0.0.20"
-    sdk-version: "^3.0.0"
+    version: "~0.0.21"
+    sdk-version: "^4.0.0"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
-    version: "~0.0.2"
-    sdk-version: "^3.0.0"
+    version: "~0.0.5"
+    sdk-version: "^4.0.0"


### PR DESCRIPTION
### WHY are these changes introduced?

The Scripts SDK has a new `Money` type and was bumped to version 4.0.0. Related EP versions were also bumped.

Related issue: https://github.com/Shopify/script-service/issues/1170

### WHAT is this pull request doing?

This PR updates the package versions so that new scripts have the latest version.
