### PR TITLE
Remove hardcoded EP names in CLI

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -30,7 +30,7 @@ module Script
       end
 
       def self.help
-        allowed_values = Script::Layers::Application::ExtensionPoints.types.map {|type| "{{cyan:#{type}}}"}
+        allowed_values = Script::Layers::Application::ExtensionPoints.types.map { |type| "{{cyan:#{type}}}" }
         ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME, allowed_values.join(', '))
       end
     end

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -30,8 +30,8 @@ module Script
       end
 
       def self.help
-        allowed_values = "{{cyan:discount}} and {{cyan:unit_limit_per_order}}"
-        ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME, allowed_values)
+        allowed_values = Script::Layers::Application::ExtensionPoints.types.map {|type| "{{cyan:#{type}}}"}
+        ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME, allowed_values.join(', '))
       end
     end
   end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -32,7 +32,7 @@ module Script
           project_exists_help: "Use different script name and try again.",
 
           invalid_extension_cause: "Invalid extension point %s",
-          invalid_extension_help: "Allowed values: discount and unit_limit_per_order.",
+          invalid_extension_help: "Allowed values: %s.",
 
           script_not_found_cause: "Couldn't find script %s for extension point %s",
 

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -70,7 +70,8 @@ module Script
         when Layers::Domain::Errors::InvalidExtensionPointError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.invalid_extension_cause', e.type),
-            help_suggestion: ShopifyCli::Context.message('script.error.invalid_extension_help'),
+            help_suggestion: ShopifyCli::Context.message('script.error.invalid_extension_help',
+             Script::Layers::Application::ExtensionPoints.types.join(', ')),
           }
         when Layers::Domain::Errors::ScriptNotFoundError
           {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -70,8 +70,10 @@ module Script
         when Layers::Domain::Errors::InvalidExtensionPointError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.invalid_extension_cause', e.type),
-            help_suggestion: ShopifyCli::Context.message('script.error.invalid_extension_help',
-             Script::Layers::Application::ExtensionPoints.types.join(', ')),
+            help_suggestion: ShopifyCli::Context.message(
+              'script.error.invalid_extension_help',
+             Script::Layers::Application::ExtensionPoints.types.join(', ')
+            )
           }
         when Layers::Domain::Errors::ScriptNotFoundError
           {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -73,7 +73,7 @@ module Script
             help_suggestion: ShopifyCli::Context.message(
               'script.error.invalid_extension_help',
              Script::Layers::Application::ExtensionPoints.types.join(', ')
-            )
+            ),
           }
         when Layers::Domain::Errors::ScriptNotFoundError
           {

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -40,7 +40,8 @@ module Script
 
       def test_help
         Script::Layers::Application::ExtensionPoints.expects(:types).returns(%w(ep1 ep2))
-        ShopifyCli::Context.expects(:message).with('script.create.help', ShopifyCli::TOOL_NAME, '{{cyan:ep1}}, {{cyan:ep2}}')
+        ShopifyCli::Context.expects(:message).with('script.create.help', ShopifyCli::TOOL_NAME,
+           '{{cyan:ep1}}, {{cyan:ep2}}')
         Script::Commands::Create.help
       end
 

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -38,6 +38,12 @@ module Script
         perform_command
       end
 
+      def test_help
+        Script::Layers::Application::ExtensionPoints.expects(:types).returns(%w(ep1 ep2))
+        ShopifyCli::Context.expects(:message).with('script.create.help', ShopifyCli::TOOL_NAME, '{{cyan:ep1}}, {{cyan:ep2}}')
+        Script::Commands::Create.help
+      end
+
       private
 
       def perform_command

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -40,8 +40,9 @@ module Script
 
       def test_help
         Script::Layers::Application::ExtensionPoints.expects(:types).returns(%w(ep1 ep2))
-        ShopifyCli::Context.expects(:message).with('script.create.help', ShopifyCli::TOOL_NAME,
-           '{{cyan:ep1}}, {{cyan:ep2}}')
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.create.help', ShopifyCli::TOOL_NAME, '{{cyan:ep1}}, {{cyan:ep2}}')
         Script::Commands::Create.help
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Corresponds to [this issue](https://github.com/Shopify/script-service/issues/1187)

### WHAT is this pull request doing?

Replaces hardcoded EP names for `discount` and `unit_limit_per_order` in the UI messages shown to the user.

**Original:**
<img width="691" alt="Screen Shot 2020-05-20 at 12 20 20 PM" src="https://user-images.githubusercontent.com/64974039/82488218-621b1200-9a94-11ea-8284-0911456543d7.png">
and
<img width="683" alt="Screen Shot 2020-05-20 at 12 19 42 PM" src="https://user-images.githubusercontent.com/64974039/82488217-61827b80-9a94-11ea-86a6-182793c11f97.png">

**New:**
<img width="782" alt="Screen Shot 2020-05-20 at 12 18 08 PM" src="https://user-images.githubusercontent.com/64974039/82488202-5e878b00-9a94-11ea-9dd2-383ac17d4c37.png">
and
<img width="780" alt="Screen Shot 2020-05-20 at 12 17 21 PM" src="https://user-images.githubusercontent.com/64974039/82488188-59c2d700-9a94-11ea-9696-1e7e9e929c30.png">



