### PR TITLE
Shallow Load Project Types when loading all

### DIFF
--- a/lib/project_types/node/commands/deploy/heroku.rb
+++ b/lib/project_types/node/commands/deploy/heroku.rb
@@ -9,7 +9,7 @@ module Node
           ShopifyCli::Context.message('node.deploy.heroku.help', ShopifyCli::TOOL_NAME)
         end
 
-        def call(_args, _name)
+        def call(*)
           spin_group = CLI::UI::SpinGroup.new
           heroku_service = ShopifyCli::Heroku.new(@ctx)
 

--- a/lib/project_types/rails/commands/deploy/heroku.rb
+++ b/lib/project_types/rails/commands/deploy/heroku.rb
@@ -9,7 +9,7 @@ module Rails
           ShopifyCli::Context.message('rails.deploy.heroku.help', ShopifyCli::TOOL_NAME)
         end
 
-        def call(_args, _name)
+        def call(*)
           spin_group = CLI::UI::SpinGroup.new
           heroku_service = ShopifyCli::Heroku.new(@ctx)
 

--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -16,9 +16,7 @@ module ShopifyCli
           subcommand.ctx = @ctx
           subcommand.call(args, resolved_name, command_name)
         else
-          cmd = new
-          cmd.ctx = @ctx
-          cmd.options = Options.new
+          cmd = new(@ctx)
           cmd.options.parse(@_options, args)
           return call_help(command_name) if cmd.options.help
           cmd.call(args, command_name)
@@ -63,6 +61,7 @@ module ShopifyCli
 
     def initialize(ctx = nil)
       @ctx = ctx || ShopifyCli::Context.new
+      self.options = Options.new
     end
   end
 end

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -18,7 +18,7 @@ module ShopifyCli
         klass.project_load_shallow = @shallow_load
       end
 
-      def load_type(current_type, shallow=false)
+      def load_type(current_type, shallow = false)
         filepath = File.join(ShopifyCli::ROOT, 'lib', 'project_types', current_type.to_s, 'cli.rb')
         return unless File.exist?(filepath)
         @shallow_load = shallow

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -3,7 +3,8 @@ module ShopifyCli
     class << self
       attr_accessor :project_type,
         :project_name,
-        :project_creator_command_class
+        :project_creator_command_class,
+        :project_load_shallow
       attr_reader :hidden
 
       def repository
@@ -14,20 +15,23 @@ module ShopifyCli
       def inherited(klass)
         repository << klass
         klass.project_type = @current_type
+        klass.project_load_shallow = @shallow_load
       end
 
-      def load_type(current_type)
+      def load_type(current_type, shallow=false)
         filepath = File.join(ShopifyCli::ROOT, 'lib', 'project_types', current_type.to_s, 'cli.rb')
         return unless File.exist?(filepath)
+        @shallow_load = shallow
         @current_type = current_type
         load(filepath)
         @current_type = nil
+        @shallow_load = false
         for_app_type(current_type)
       end
 
       def load_all
         Dir.glob(File.join(ShopifyCli::ROOT, 'lib', 'project_types', '*', 'cli.rb')).map do |filepath|
-          load_type(filepath.split(File::Separator)[-2])
+          load_type(filepath.split(File::Separator)[-2], true)
         end
       end
 
@@ -54,6 +58,7 @@ module ShopifyCli
       end
 
       def register_command(const, cmd)
+        return if project_load_shallow
         Context.new.abort(
           Context.message('core.project_type.error.cannot_override_core', cmd, const)
         ) if Commands.core_command?(cmd)
@@ -61,6 +66,7 @@ module ShopifyCli
       end
 
       def register_task(task, name)
+        return if project_load_shallow
         Task::Registry.add(const_get(task), name)
       end
 

--- a/lib/shopify-cli/sub_command.rb
+++ b/lib/shopify-cli/sub_command.rb
@@ -6,7 +6,6 @@ module ShopifyCli
     class << self
       def call(args, command_name, parent_command)
         cmd = new(@ctx)
-        cmd.options = Options.new
         args = cmd.options.parse(@_options, args[1..-1] || [])
         return call_help(parent_command, command_name) if cmd.options.help
         cmd.call(args, command_name)

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 require 'semantic/semantic'
 
 module Node
@@ -19,11 +20,6 @@ module Node
         app_type: node
         organization_id: 42
       APPTYPE
-
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:node)
-      end
 
       def test_prints_help_with_no_name_argument
         io = capture_io { run_cmd('create node --help') }

--- a/test/project_types/node/commands/deploy/heroku_test.rb
+++ b/test/project_types/node/commands/deploy/heroku_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
@@ -11,29 +12,21 @@ module Node
           super
           File.stubs(:exist?)
           File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, 'lib', 'project_types', 'node', 'cli.rb')).returns(true)
-          ShopifyCli::ProjectType.load_type(:node)
           ShopifyCli::Context.any_instance.stubs(:os).returns(:mac)
           stub_successful_heroku_flow
-        end
-
-        def test_help_argument_calls_help
-          @context.expects(:puts).with(Node::Commands::Deploy::Heroku.help)
-          run_cmd('help deploy heroku')
         end
 
         def test_call_doesnt_download_heroku_cli_if_it_is_installed
           expects_heroku_installed(status: true, twice: true)
           expects_heroku_download(status: nil)
-
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_downloads_heroku_cli_if_it_is_not_installed
           expects_heroku_installed(status: false)
           expects_heroku_download(status: true)
           expects_heroku_download_exists(status: true)
-
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_heroku_cli_download_fails
@@ -41,7 +34,7 @@ module Node
           expects_heroku_download(status: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -51,15 +44,14 @@ module Node
           expects_heroku_download(status: true)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
         def test_call_doesnt_install_heroku_cli_if_it_is_already_installed
           expects_heroku_installed(status: true, twice: true)
           expects_tar_heroku(status: nil)
-
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_installs_heroku_cli_if_it_is_downloaded
@@ -67,8 +59,7 @@ module Node
           expects_heroku_download_exists(status: true)
           expects_heroku_installed(status: false, twice: true)
           expects_tar_heroku(status: true)
-
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_heroku_cli_install_fails
@@ -78,7 +69,7 @@ module Node
           expects_tar_heroku(status: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -86,7 +77,7 @@ module Node
           expects_git_init_heroku(status: false, commits: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -94,7 +85,7 @@ module Node
           expects_git_init_heroku(status: true, commits: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -105,14 +96,14 @@ module Node
             '{{v}} Authenticated with Heroku as `username`'
           )
 
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_attempts_to_authenticate_with_heroku_if_not_already_authed
           expects_heroku_whoami(status: false)
           expects_heroku_login(status: true)
 
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_heroku_auth_fails
@@ -120,7 +111,7 @@ module Node
           expects_heroku_login(status: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -131,7 +122,7 @@ module Node
             '{{v}} Heroku app `app-name` selected'
           )
 
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_lets_you_choose_existing_heroku_app
@@ -146,7 +137,7 @@ module Node
             .with('What is your Heroku app’s name?')
             .returns('app-name')
 
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_choosing_existing_heroku_app_fails
@@ -162,7 +153,7 @@ module Node
             .returns('app-name')
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -174,7 +165,7 @@ module Node
             .with('No existing Heroku app found. What would you like to do?')
             .returns(:new)
 
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_creating_new_heroku_app_fails
@@ -186,7 +177,7 @@ module Node
             .returns(:new)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -197,7 +188,7 @@ module Node
             '{{v}} Git branch `master` selected for deploy'
           )
 
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_lets_you_specify_a_branch_if_multiple_exist
@@ -208,28 +199,28 @@ module Node
             .with('What branch would you like to deploy?')
             .returns('other_branch')
 
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_finding_branches_fails
           expects_git_branch(status: false, multiple: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
         def test_call_successfully_deploys_to_heroku
           expects_git_push_heroku(status: true, branch: "master:master")
 
-          run_cmd('deploy heroku')
+          Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_deploy_to_heroku_fails
           expects_git_push_heroku(status: false, branch: "master:master")
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Node::Commands::Deploy::Heroku.new(@context).call
           end
         end
       end

--- a/test/project_types/node/commands/deploy_test.rb
+++ b/test/project_types/node/commands/deploy_test.rb
@@ -1,27 +1,12 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
     class DeployTest < MiniTest::Test
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:node)
-        @command = Node::Commands::Deploy.new(@context)
-      end
-
-      def test_heroku_subcommand_calls_heroku
-        Node::Commands::Deploy::Heroku.expects(:call)
-        run_cmd('deploy heroku')
-      end
-
       def test_without_arguments_calls_help
         @context.expects(:puts).with(Node::Commands::Deploy.help)
-        run_cmd('deploy')
-      end
-
-      def test_help_argument_calls_extended_help
-        @context.expects(:puts).with(Node::Commands::Deploy.help + "\n" + Node::Commands::Deploy.extended_help)
-        run_cmd('help deploy')
+        Node::Commands::Deploy.new(@context).call
       end
     end
   end

--- a/test/project_types/node/commands/generate/billing_test.rb
+++ b/test/project_types/node/commands/generate/billing_test.rb
@@ -1,15 +1,11 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
     module GenerateTests
       class BillingTest < MiniTest::Test
         include TestHelpers::FakeUI
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:node)
-        end
 
         def test_recurring_billing
           CLI::UI::Prompt.expects(:ask).returns('recurring-billing')

--- a/test/project_types/node/commands/generate/billing_test.rb
+++ b/test/project_types/node/commands/generate/billing_test.rb
@@ -11,14 +11,14 @@ module Node
           CLI::UI::Prompt.expects(:ask).returns('recurring-billing')
           @context.expects(:system).with('recurring-billing')
             .returns(mock(success?: true))
-          run_cmd('generate billing')
+          Node::Commands::Generate::Billing.new(@context).call([], '')
         end
 
         def test_one_time_billing
           CLI::UI::Prompt.expects(:ask).returns('one-time-billing')
           @context.expects(:system).with('one-time-billing')
             .returns(mock(success?: true))
-          run_cmd('generate billing')
+          Node::Commands::Generate::Billing.new(@context).call([], '')
         end
       end
     end

--- a/test/project_types/node/commands/generate/page_test.rb
+++ b/test/project_types/node/commands/generate/page_test.rb
@@ -12,28 +12,31 @@ module Node
           CLI::UI::Prompt.expects(:ask).returns('empty-state')
           @context.expects(:system).with('empty-state name')
             .returns(mock(success?: true))
-          run_cmd('generate page name')
+          Node::Commands::Generate::Page.new(@context).call(['name'], '')
         end
 
         def test_with_type_argument
           CLI::UI::Prompt.expects(:ask).never
-          @context.expects(:system).with('./node_modules/.bin/generate-node-app list-page name')
+          @context
+            .expects(:system)
+            .with('./node_modules/.bin/generate-node-app list-page name')
             .returns(mock(success?: true))
-          run_cmd('generate page name --type=list')
+          command = Node::Commands::Generate::Page.new(@context)
+          command.options.flags[:type] = 'list'
+          command.call(['name'], '')
         end
 
         def test_raises_with_invalid_type
           assert_raises ShopifyCli::Abort do
-            run_cmd('generate page name --type=list_TYPE test-app')
+            command = Node::Commands::Generate::Page.new(@context)
+            command.options.flags[:type] = 'list_TYPE'
+            command.call(['name'], '')
           end
         end
 
         def test_no_name_calls_help
-          io = capture_io do
-            run_cmd('generate page')
-          end
-
-          assert_match(CLI::UI.fmt(Node::Commands::Generate::Page.help), io.join)
+          @context.expects(:puts).with(Node::Commands::Generate::Page.help)
+          Node::Commands::Generate::Page.new(@context).call([], '')
         end
       end
     end

--- a/test/project_types/node/commands/generate/page_test.rb
+++ b/test/project_types/node/commands/generate/page_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
@@ -6,11 +7,6 @@ module Node
       class PageTest < MiniTest::Test
         include TestHelpers::Project
         include TestHelpers::FakeUI
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:node)
-        end
 
         def test_with_selection
           CLI::UI::Prompt.expects(:ask).returns('empty-state')

--- a/test/project_types/node/commands/generate/webhook_test.rb
+++ b/test/project_types/node/commands/generate/webhook_test.rb
@@ -11,21 +11,21 @@ module Node
         def test_with_existing_param
           @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook APP_UNINSTALLED')
             .returns(mock(success?: true))
-          run_cmd('generate webhook APP_UNINSTALLED')
+          Node::Commands::Generate::Webhook.new(@context).call(['APP_UNINSTALLED'], '')
         end
 
         def test_with_incorrect_param_expects_ask
           CLI::UI::Prompt.expects(:ask).returns('APP_UNINSTALLED')
           @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook APP_UNINSTALLED')
             .returns(mock(success?: true))
-          run_cmd('generate webhook create_webhook_fake')
+          Node::Commands::Generate::Webhook.new(@context).call(['create_webhook_fake'], '')
         end
 
         def test_with_selection
           CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
           @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook PRODUCT_CREATE')
             .returns(mock(success?: true))
-          run_cmd('generate webhook')
+          Node::Commands::Generate::Webhook.new(@context).call([], '')
         end
       end
     end

--- a/test/project_types/node/commands/generate/webhook_test.rb
+++ b/test/project_types/node/commands/generate/webhook_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
@@ -6,11 +7,6 @@ module Node
       class WebhookTest < MiniTest::Test
         include TestHelpers::FakeUI
         include TestHelpers::Schema
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:node)
-        end
 
         def test_with_existing_param
           @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook APP_UNINSTALLED')

--- a/test/project_types/node/commands/generate_test.rb
+++ b/test/project_types/node/commands/generate_test.rb
@@ -6,12 +6,7 @@ module Node
     class GenerateTest < MiniTest::Test
       def test_without_arguments_calls_help
         @context.expects(:puts).with(Node::Commands::Generate.help)
-        run_cmd('generate')
-      end
-
-      def test_help_argument_calls_extended_help
-        @context.expects(:puts).with(Node::Commands::Generate.help + "\n" + Node::Commands::Generate.extended_help)
-        run_cmd('help generate')
+        Node::Commands::Generate.new(@context).call
       end
 
       def test_run_generate_raises_abort_when_not_successful

--- a/test/project_types/node/commands/generate_test.rb
+++ b/test/project_types/node/commands/generate_test.rb
@@ -1,13 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
     class GenerateTest < MiniTest::Test
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:node)
-      end
-
       def test_without_arguments_calls_help
         @context.expects(:puts).with(Node::Commands::Generate.help)
         run_cmd('generate')

--- a/test/project_types/node/commands/open_test.rb
+++ b/test/project_types/node/commands/open_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
@@ -6,7 +7,6 @@ module Node
       def setup
         super
         project_context('app_types', 'node')
-        ShopifyCli::ProjectType.load_type(:node)
         @context.stubs(:system)
       end
 

--- a/test/project_types/node/commands/open_test.rb
+++ b/test/project_types/node/commands/open_test.rb
@@ -12,7 +12,7 @@ module Node
 
       def test_run
         @context.expects(:open_url!).with('https://example.com/auth?shop=my-test-shop.myshopify.com')
-        run_cmd('open')
+        Node::Commands::Open.new(@context).call
       end
     end
   end

--- a/test/project_types/node/commands/populate/customer_test.rb
+++ b/test/project_types/node/commands/populate/customer_test.rb
@@ -1,15 +1,11 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
     module PopulateTests
       class CustomerTest < MiniTest::Test
         include TestHelpers::Schema
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:node)
-        end
 
         def test_populate_calls_api_with_mutation
           ShopifyCli::Helpers::Haikunator.stubs(:name).returns(['first', 'last'])

--- a/test/project_types/node/commands/populate/draft_order_test.rb
+++ b/test/project_types/node/commands/populate/draft_order_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
@@ -6,11 +7,6 @@ module Node
       class DraftOrderTest < MiniTest::Test
         include TestHelpers::Project
         include TestHelpers::Schema
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:node)
-        end
 
         def test_populate_calls_api_with_mutation
           ShopifyCli::Helpers::Haikunator.stubs(:title).returns('fake order')

--- a/test/project_types/node/commands/populate/product_test.rb
+++ b/test/project_types/node/commands/populate/product_test.rb
@@ -1,15 +1,11 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
     module PopulateTests
       class ProductTest < MiniTest::Test
         include TestHelpers::Schema
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:node)
-        end
 
         def test_populate_calls_api_with_mutation
           ShopifyCli::Helpers::Haikunator.expects(:title).returns('fake product')

--- a/test/project_types/node/commands/populate_test.rb
+++ b/test/project_types/node/commands/populate_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
@@ -7,7 +8,6 @@ module Node
         super
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
         project_context('app_types', 'node')
-        ShopifyCli::ProjectType.load_type(:node)
       end
 
       def test_without_arguments_calls_help

--- a/test/project_types/node/commands/serve_test.rb
+++ b/test/project_types/node/commands/serve_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
@@ -8,7 +9,6 @@ module Node
       def setup
         super
         project_context('app_types', 'node')
-        ShopifyCli::ProjectType.load_type(:node)
         ShopifyCli::Tasks::EnsureTestShop.stubs(:call)
         @context.stubs(:system)
       end

--- a/test/project_types/node/commands/tunnel_test.rb
+++ b/test/project_types/node/commands/tunnel_test.rb
@@ -1,13 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   module Commands
     class TunnelTest < MiniTest::Test
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:node)
-      end
-
       def test_auth
         ShopifyCli::Tunnel.any_instance.expects(:auth)
         run_cmd('tunnel auth adfhauf98q7rtqhfkajf')

--- a/test/project_types/node/forms/create_test.rb
+++ b/test/project_types/node/forms/create_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'project_types/rails/test_helper'
 
 module Node
   module Forms

--- a/test/project_types/node/js_deps_test.rb
+++ b/test/project_types/node/js_deps_test.rb
@@ -1,10 +1,10 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
 
 module Node
   class JsDepsTest < MiniTest::Test
     def setup
       project_context('app_types', 'node')
-      ShopifyCli::ProjectType.load_type(:node)
     end
 
     def test_installs_with_npm

--- a/test/project_types/node/test_helper.rb
+++ b/test/project_types/node/test_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+require "test_helper"
+
+ShopifyCli::ProjectType.load_type(:node)

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 require 'semantic/semantic'
 
 module Rails
@@ -19,11 +20,6 @@ module Rails
         app_type: rails
         organization_id: 42
       APPTYPE
-
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:rails)
-      end
 
       def test_prints_help_with_no_name_argument
         io = capture_io { run_cmd('create rails --help') }

--- a/test/project_types/rails/commands/deploy/heroku_test.rb
+++ b/test/project_types/rails/commands/deploy/heroku_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
@@ -11,21 +12,14 @@ module Rails
           super
           File.stubs(:exist?)
           File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, 'lib', 'project_types', 'rails', 'cli.rb')).returns(true)
-          ShopifyCli::ProjectType.load_type(:rails)
-          ShopifyCli::Context.any_instance.stubs(:os).returns(:mac)
+          @context.stubs(:os).returns(:mac)
           stub_successful_heroku_flow
-        end
-
-        def test_help_argument_calls_help
-          @context.expects(:puts).with(Rails::Commands::Deploy::Heroku.help)
-          run_cmd('help deploy heroku')
         end
 
         def test_call_doesnt_download_heroku_cli_if_it_is_installed
           expects_heroku_installed(status: true, twice: true)
           expects_heroku_download(status: nil)
-
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_downloads_heroku_cli_if_it_is_not_installed
@@ -33,7 +27,7 @@ module Rails
           expects_heroku_download(status: true)
           expects_heroku_download_exists(status: true)
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_heroku_cli_download_fails
@@ -41,7 +35,7 @@ module Rails
           expects_heroku_download(status: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -51,7 +45,7 @@ module Rails
           expects_heroku_download(status: true)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -59,7 +53,7 @@ module Rails
           expects_heroku_installed(status: true, twice: true)
           expects_tar_heroku(status: nil)
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_installs_heroku_cli_if_it_is_downloaded
@@ -68,7 +62,7 @@ module Rails
           expects_heroku_installed(status: false, twice: true)
           expects_tar_heroku(status: true)
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_heroku_cli_install_fails
@@ -78,7 +72,7 @@ module Rails
           expects_tar_heroku(status: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -86,7 +80,7 @@ module Rails
           expects_git_init_heroku(status: false, commits: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -94,7 +88,7 @@ module Rails
           expects_git_init_heroku(status: true, commits: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -105,14 +99,14 @@ module Rails
             "{{v}} Authenticated with Heroku as `username`"
           )
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_attempts_to_authenticate_with_heroku_if_not_already_authed
           expects_heroku_whoami(status: false)
           expects_heroku_login(status: true)
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_heroku_auth_fails
@@ -120,7 +114,7 @@ module Rails
           expects_heroku_login(status: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -131,7 +125,7 @@ module Rails
             '{{v}} Heroku app `app-name` selected'
           )
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_lets_you_choose_existing_heroku_app
@@ -146,7 +140,7 @@ module Rails
             .with('What is your Heroku app’s name?')
             .returns('app-name')
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_choosing_existing_heroku_app_fails
@@ -162,7 +156,7 @@ module Rails
             .returns('app-name')
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -174,7 +168,7 @@ module Rails
             .with('No existing Heroku app found. What would you like to do?')
             .returns(:new)
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_creating_new_heroku_app_fails
@@ -186,7 +180,7 @@ module Rails
             .returns(:new)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
@@ -197,7 +191,7 @@ module Rails
             '{{v}} Git branch `master` selected for deploy'
           )
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_lets_you_specify_a_branch_if_multiple_exist
@@ -208,28 +202,28 @@ module Rails
             .with('What branch would you like to deploy?')
             .returns('other_branch')
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_finding_branches_fails
           expects_git_branch(status: false, multiple: false)
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
 
         def test_call_successfully_deploys_to_heroku
           expects_git_push_heroku(status: true, branch: "master:master")
 
-          run_cmd('deploy heroku')
+          Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_deploy_to_heroku_fails
           expects_git_push_heroku(status: false, branch: "master:master")
 
           assert_raises ShopifyCli::Abort do
-            run_cmd('deploy heroku')
+            Rails::Commands::Deploy::Heroku.new(@context).call
           end
         end
       end

--- a/test/project_types/rails/commands/deploy_test.rb
+++ b/test/project_types/rails/commands/deploy_test.rb
@@ -1,27 +1,12 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
     class DeployTest < MiniTest::Test
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:rails)
-        @command = Rails::Commands::Deploy.new(@context)
-      end
-
-      def test_heroku_subcommand_calls_heroku
-        Rails::Commands::Deploy::Heroku.expects(:call)
-        run_cmd('deploy heroku')
-      end
-
       def test_without_arguments_calls_help
         @context.expects(:puts).with(Rails::Commands::Deploy.help)
-        run_cmd('deploy')
-      end
-
-      def test_help_argument_calls_extended_help
-        @context.expects(:puts).with(Rails::Commands::Deploy.help + "\n" + Rails::Commands::Deploy.extended_help)
-        run_cmd('help deploy')
+        Rails::Commands::Deploy.new(@context).call
       end
     end
   end

--- a/test/project_types/rails/commands/generate.rb/webhook_test.rb
+++ b/test/project_types/rails/commands/generate.rb/webhook_test.rb
@@ -1,4 +1,5 @@
-require('test_helper')
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
@@ -6,11 +7,6 @@ module Rails
       class WebhookTest < MiniTest::Test
         include TestHelpers::FakeUI
         include TestHelpers::Schema
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:rails)
-        end
 
         def test_with_existing_param
           @context.expects(:system).with('rails g shopify_app:add_webhook -t app/uninstalled -a https://example.com/webhooks/app/uninstalled')

--- a/test/project_types/rails/commands/generate.rb/webhook_test.rb
+++ b/test/project_types/rails/commands/generate.rb/webhook_test.rb
@@ -11,21 +11,21 @@ module Rails
         def test_with_existing_param
           @context.expects(:system).with('rails g shopify_app:add_webhook -t app/uninstalled -a https://example.com/webhooks/app/uninstalled')
             .returns(mock(success?: true))
-          run_cmd('generate webhook APP_UNINSTALLED')
+          Rails::Commands::Generate::Webhook.new(@context).call(['APP_UNINSTALLED'], '')
         end
 
         def test_with_incorrect_param_expects_ask
           CLI::UI::Prompt.expects(:ask).returns('APP_UNINSTALLED')
           @context.expects(:system).with('rails g shopify_app:add_webhook -t app/uninstalled -a https://example.com/webhooks/app/uninstalled')
             .returns(mock(success?: true))
-          run_cmd('generate webhook create_webhook_fake')
+          Rails::Commands::Generate::Webhook.new(@context).call(['create_webhook_fake'], '')
         end
 
         def test_with_selection
           CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
           @context.expects(:system).with('rails g shopify_app:add_webhook -t product/create -a https://example.com/webhooks/product/create')
             .returns(mock(success?: true))
-          run_cmd('generate webhook')
+          Rails::Commands::Generate::Webhook.new(@context).call([], '')
         end
       end
     end

--- a/test/project_types/rails/commands/generate_test.rb
+++ b/test/project_types/rails/commands/generate_test.rb
@@ -6,12 +6,7 @@ module Rails
     class GenerateTest < MiniTest::Test
       def test_without_arguments_calls_help
         @context.expects(:puts).with(Rails::Commands::Generate.help)
-        run_cmd('generate')
-      end
-
-      def test_help_argument_calls_extended_help
-        @context.expects(:puts).with(Rails::Commands::Generate.help + "\n" + Rails::Commands::Generate.extended_help)
-        run_cmd('help generate')
+        Rails::Commands::Generate.new(@context).call
       end
 
       def test_run_generate_raises_abort_when_not_successful

--- a/test/project_types/rails/commands/generate_test.rb
+++ b/test/project_types/rails/commands/generate_test.rb
@@ -1,13 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
     class GenerateTest < MiniTest::Test
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:rails)
-      end
-
       def test_without_arguments_calls_help
         @context.expects(:puts).with(Rails::Commands::Generate.help)
         run_cmd('generate')

--- a/test/project_types/rails/commands/open_test.rb
+++ b/test/project_types/rails/commands/open_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands

--- a/test/project_types/rails/commands/open_test.rb
+++ b/test/project_types/rails/commands/open_test.rb
@@ -7,13 +7,12 @@ module Rails
       def setup
         super
         project_context('app_types', 'rails')
-        ShopifyCli::ProjectType.load_type(:rails)
         @context.stubs(:system)
       end
 
       def test_run
         @context.expects(:open_url!).with('https://example.com/login?shop=my-test-shop.myshopify.com')
-        run_cmd('open')
+        Rails::Commands::Open.new(@context).call
       end
     end
   end

--- a/test/project_types/rails/commands/populate/customer_test.rb
+++ b/test/project_types/rails/commands/populate/customer_test.rb
@@ -1,15 +1,11 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
     module PopulateTests
       class CustomerTest < MiniTest::Test
         include TestHelpers::Schema
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:rails)
-        end
 
         def test_populate_calls_api_with_mutation
           ShopifyCli::Helpers::Haikunator.stubs(:name).returns(['first', 'last'])

--- a/test/project_types/rails/commands/populate/draft_order_test.rb
+++ b/test/project_types/rails/commands/populate/draft_order_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
@@ -6,11 +7,6 @@ module Rails
       class DraftOrderTest < MiniTest::Test
         include TestHelpers::Project
         include TestHelpers::Schema
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:rails)
-        end
 
         def test_populate_calls_api_with_mutation
           ShopifyCli::Helpers::Haikunator.stubs(:title).returns('fake order')

--- a/test/project_types/rails/commands/populate/product_test.rb
+++ b/test/project_types/rails/commands/populate/product_test.rb
@@ -1,15 +1,11 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
     module PopulateTests
       class ProductTest < MiniTest::Test
         include TestHelpers::Schema
-
-        def setup
-          super
-          ShopifyCli::ProjectType.load_type(:rails)
-        end
 
         def test_populate_calls_api_with_mutation
           ShopifyCli::Helpers::Haikunator.expects(:title).returns('fake product')

--- a/test/project_types/rails/commands/populate_test.rb
+++ b/test/project_types/rails/commands/populate_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands

--- a/test/project_types/rails/commands/serve_test.rb
+++ b/test/project_types/rails/commands/serve_test.rb
@@ -10,7 +10,6 @@ module Rails
         super
         project_context('app_types', 'rails')
         ShopifyCli::Tasks::EnsureTestShop.stubs(:call)
-        ShopifyCli::ProjectType.load_type(:rails)
         @context.stubs(:system)
       end
 
@@ -28,7 +27,7 @@ module Rails
             'PORT' => '8081',
           }
         )
-        run_cmd('serve')
+        Rails::Commands::Serve.new(@context).call
       end
 
       def test_server_command_with_invalid_host_url
@@ -47,7 +46,7 @@ module Rails
         ).never
 
         assert_raises ShopifyCli::Abort do
-          run_cmd('serve')
+          Rails::Commands::Serve.new(@context).call
         end
       end
 
@@ -62,7 +61,7 @@ module Rails
         ShopifyCli::Context.any_instance.expects(:open_url!).with(
           'https://example.com/login?shop=my-test-shop.myshopify.com'
         )
-        run_cmd('serve')
+        Rails::Commands::Serve.new(@context).call
       end
 
       def test_update_env_with_host
@@ -71,7 +70,9 @@ module Rails
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
           @context, :host, 'https://example-foo.com'
         )
-        run_cmd('serve --host="https://example-foo.com"')
+        command = Rails::Commands::Serve.new(@context)
+        command.options.flags[:host] = 'https://example-foo.com'
+        command.call
       end
     end
   end

--- a/test/project_types/rails/commands/serve_test.rb
+++ b/test/project_types/rails/commands/serve_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands

--- a/test/project_types/rails/commands/tunnel_test.rb
+++ b/test/project_types/rails/commands/tunnel_test.rb
@@ -1,13 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
     class TunnelTest < MiniTest::Test
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:rails)
-      end
-
       def test_auth
         ShopifyCli::Tunnel.any_instance.expects(:auth)
         run_cmd('tunnel auth adfhauf98q7rtqhfkajf')

--- a/test/project_types/rails/forms/create_test.rb
+++ b/test/project_types/rails/forms/create_test.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'project_types/rails/test_helper'
 
 module Rails
   module Forms
     class CreateTest < MiniTest::Test
       include TestHelpers::Partners
-
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:rails)
-      end
 
       def test_returns_all_defined_attributes_if_valid
         form = ask

--- a/test/project_types/rails/gem_test.rb
+++ b/test/project_types/rails/gem_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require 'project_types/rails/test_helper'
 
 module Rails
   class GemTest < MiniTest::Test
@@ -7,7 +7,6 @@ module Rails
 
     def setup
       super
-      ShopifyCli::ProjectType.load_type(:rails)
       @home = Dir.mktmpdir
       @context.setenv('HOME', @home)
     end

--- a/test/project_types/rails/ruby_test.rb
+++ b/test/project_types/rails/ruby_test.rb
@@ -1,9 +1,9 @@
-require 'test_helper'
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
 
 module Rails
   class RubyTest < MiniTest::Test
     def test_ruby_matches
-      ShopifyCli::ProjectType.load_type(:rails)
       context = ShopifyCli::Context.new(env: {})
       context.expects(:capture2).with('ruby', '-v').returns(
         ['ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin18]', nil]

--- a/test/project_types/rails/test_helper.rb
+++ b/test/project_types/rails/test_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+require "test_helper"
+
+ShopifyCli::ProjectType.load_type(:rails)

--- a/test/shopify-cli/project_type_test.rb
+++ b/test/shopify-cli/project_type_test.rb
@@ -18,11 +18,6 @@ module ShopifyCli
       assert(all_types.include?(Node::Project))
     end
 
-    def test_load_all_loads_shallow
-      assert(Rails::Project.project_load_shallow)
-      assert(Node::Project.project_load_shallow)
-    end
-
     def test_for_app_type_can_find_the_app_by_name
       assert_equal(ProjectType.for_app_type(:rails), Rails::Project)
       assert_equal(ProjectType.for_app_type(:node), Node::Project)
@@ -46,12 +41,8 @@ module ShopifyCli
 
     def test_register_command_does_not_call_if_shallow
       ShopifyCli::Commands.expects(:register).never
+      Rails::Project.project_load_shallow = true
       Rails::Project.register_command('Nonsense::Module::Help', 'help')
-    end
-
-    def test_register_task_does_not_call_if_shallow
-      ShopifyCli::Commands.expects(:register).never
-      Rails::Project.register_task('Nonsense::Task::Foo', 'too')
     end
   end
 end

--- a/test/shopify-cli/project_type_test.rb
+++ b/test/shopify-cli/project_type_test.rb
@@ -18,6 +18,11 @@ module ShopifyCli
       assert(all_types.include?(Node::Project))
     end
 
+    def test_load_all_loads_shallow
+      assert(Rails::Project.project_load_shallow)
+      assert(Node::Project.project_load_shallow)
+    end
+
     def test_for_app_type_can_find_the_app_by_name
       assert_equal(ProjectType.for_app_type(:rails), Rails::Project)
       assert_equal(ProjectType.for_app_type(:node), Node::Project)
@@ -37,6 +42,16 @@ module ShopifyCli
       assert_raises ShopifyCli::Abort, "Can't register duplicate core command" do
         ProjectType.register_command('Nonsense::Module::Help', 'help')
       end
+    end
+
+    def test_register_command_does_not_call_if_shallow
+      ShopifyCli::Commands.expects(:register).never
+      Rails::Project.register_command('Nonsense::Module::Help', 'help')
+    end
+
+    def test_register_task_does_not_call_if_shallow
+      ShopifyCli::Commands.expects(:register).never
+      Rails::Project.register_task('Nonsense::Task::Foo', 'too')
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #610

This fixes help commands outputting in different project types.

### WHAT is this pull request doing?
I have changed ProjectType to only load the creators and messages when loading all of the project types because that is the only information needed during processes that need all of the information.

### DEAR GOD WHAT HAVE YOU DONE
It seems like once I stopped loading all of the commands for all of the projects then the tests got more flakey. I believe that this is because some commands were loading over each other and using `run_cmd` would call the other implemented commands! *oh shit* 
 
So what I have done here is for quite a few tests
- Added a pattern introduced by @jacobsteves where each project type has it's own test helper that it imports, loading their own project type
- Refactored a lot of the calling code to call the commands directly instead of using run_cmd (some progress on making real unit tests)

This has made the tests a lot more stable for me once again!