### PR TITLE
Refactoring Tunnel to allow configurable port

### DIFF
--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -50,14 +50,15 @@ module ShopifyCli
     # #### Paramters
     #
     # * `ctx` - running context from your command
+    # * `port` - port to use to open the ngrok tunnel
     #
     # #### Returns
     #
     # * `url` - the url that the tunnel is now bound to and available to the public
     #
-    def start(ctx)
+    def start(ctx, port: PORT)
       install(ctx)
-      process = ShopifyCli::ProcessSupervision.start(:ngrok, ngrok_command)
+      process = ShopifyCli::ProcessSupervision.start(:ngrok, ngrok_command(port))
       log = fetch_url(ctx, process.log_path)
       if log.account
         ctx.puts(ctx.message('core.tunnel.start_with_account', log.url, log.account))
@@ -104,8 +105,8 @@ module ShopifyCli
       raise e.class, e.message
     end
 
-    def ngrok_command
-      "exec #{File.join(ShopifyCli::ROOT, 'ngrok')} http -log=stdout -log-level=debug #{PORT}"
+    def ngrok_command(port)
+      "exec #{File.join(ShopifyCli::ROOT, 'ngrok')} http -log=stdout -log-level=debug #{port}"
     end
 
     class LogParser # :nodoc:

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -35,6 +35,21 @@ module ShopifyCli
       end
     end
 
+    def test_start_accepts_configurable_port
+      configured_port = 3000
+      with_log do
+        ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
+        ShopifyCli::ProcessSupervision.expects(:start).with(
+          :ngrok,
+          "exec #{File.join(ShopifyCli::ROOT, 'ngrok')} http -log=stdout -log-level=debug #{configured_port}"
+        ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
+        @context.expects(:puts).with(
+          "{{v}} ngrok tunnel running at {{underline:https://example.ngrok.io}}"
+        )
+        assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context, port: configured_port)
+      end
+    end
+
     def test_start_displays_url_with_account
       with_log('ngrok_account') do
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)


### PR DESCRIPTION
### WHY are these changes introduced?
Some future app types or some developer configurations may require a different port to work with the `ngrok` tunnel.

### WHAT is this pull request doing?
Introduces an optional `port` parameter to the `start` command of `Tunnel`. If no `port` is provided it functions exactly as before and opens the tunnel on port `8081`. If a different `port` is provided that `port` will be used instead.