### PR TITLE
Add Rails DB Prompting

### DIFF
--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -30,7 +30,7 @@ module Rails
         @ctx.abort(@ctx.message('rails.create.error.invalid_ruby_version')) unless
           Ruby.version(@ctx).satisfies?('~>2.4')
 
-        build(form.name)
+        build(form.name, form.db)
         set_custom_ua
         ShopifyCli::Project.write(
           @ctx,
@@ -68,7 +68,7 @@ module Rails
 
       private
 
-      def build(name)
+      def build(name, db)
         install_gem('rails')
         CLI::UI::Frame.open(@ctx.message('rails.create.installing_bundler')) do
           install_gem('bundler', '~>1.0')
@@ -78,7 +78,7 @@ module Rails
         CLI::UI::Frame.open(@ctx.message('rails.create.generating_app', name)) do
           new_command = %w(rails new)
           new_command += DEFAULT_RAILS_FLAGS
-          new_command << "--database=#{options.flags[:db]}" unless options.flags[:db].nil?
+          new_command << "--database=#{db}"
           new_command += options.flags[:rails_opts].split unless options.flags[:rails_opts].nil?
           new_command << name
 
@@ -106,6 +106,7 @@ module Rails
         end
 
         CLI::UI::Frame.open(@ctx.message('rails.create.running_migrations')) do
+          syscall(%w(rails db:create))
           syscall(%w(rails db:migrate RAILS_ENV=development))
         end
       end

--- a/lib/project_types/rails/commands/deploy/heroku.rb
+++ b/lib/project_types/rails/commands/deploy/heroku.rb
@@ -11,7 +11,7 @@ module Rails
           ShopifyCli::Context.message('rails.deploy.heroku.help', ShopifyCli::TOOL_NAME)
         end
 
-        def call(_args, _name)
+        def call(*)
           CLI::UI::Frame.open(@ctx.message('rails.deploy.heroku.db_check.validating')) do
             CLI::UI::Spinner.spin(@ctx.message('rails.deploy.heroku.db_check.checking')) do |spinner|
               db_type, err = check_db(@ctx)
@@ -100,11 +100,11 @@ module Rails
         def check_db(ctx)
           out, stat = ctx.capture2e(DB_CHECK_CMD)
           if stat.success? && out.strip == 'sqlite'
-            return ['select_sqlite', 'rails.deploy.heroku.db_check.sqlite']
+            ['sqlite', 'rails.deploy.heroku.db_check.sqlite']
           elsif !stat.success?
-            return [nil, 'rails.deploy.heroku.db_check.problem']
+            [nil, 'rails.deploy.heroku.db_check.problem']
           else
-            return ['select_' + out.strip, nil]
+            [out.strip, nil]
           end
         end
       end

--- a/lib/project_types/rails/forms/create.rb
+++ b/lib/project_types/rails/forms/create.rb
@@ -4,7 +4,7 @@ module Rails
   module Forms
     class Create < ShopifyCli::Form
       attr_accessor :name
-      flag_arguments :title, :organization_id, :shop_domain, :type
+      flag_arguments :title, :organization_id, :shop_domain, :type, :db
 
       def ask
         self.title ||= CLI::UI::Prompt.ask(ctx.message('rails.forms.create.app_name'))
@@ -12,6 +12,7 @@ module Rails
         self.name = self.title.downcase.split(" ").join("_")
         self.organization_id ||= organization["id"].to_i
         self.shop_domain ||= ask_shop_domain
+        self.db = ask_db
       end
 
       private
@@ -77,6 +78,39 @@ module Rails
             options: valid_stores.map { |s| s['shopDomain'] }
           )
         end
+      end
+
+      def ask_db
+        if db.nil?
+          want_select = CLI::UI::Prompt.ask(ctx.message('rails.forms.create.db.want_select.select')) do |handler|
+            handler.option(ctx.message('rails.forms.create.db.want_select.select_no')) { false }
+            handler.option(ctx.message('rails.forms.create.db.want_select.select_yes')) { true }
+          end
+
+          if want_select
+            return CLI::UI::Prompt.ask(ctx.message('rails.forms.create.db.type.select')) do |handler|
+              handler.option(ctx.message('rails.forms.create.db.type.select_sqlite')) { 'sqlite' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_mysql')) { 'mysql' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_pg')) { 'postgresql' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_oracle')) { 'oracle' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_fb')) { 'frontbase' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_ibm')) { 'ibm_db' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_sql')) { 'sqlserver' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_jdbc_mysql')) { 'jdbcmysql' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_jdbc_sqlite')) { 'jdbcsqlite3' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_jdbc_pg')) { 'jdbcpostgresql' }
+              handler.option(ctx.message('rails.forms.create.db.type.select_jdbc')) { 'jdbc' }
+            end
+          else
+            return 'sqlite3'
+          end
+        end
+
+        unless ShopifyCli::Tasks::CreateApiClient::VALID_DB_TYPES.include?(db)
+          ctx.abort(ctx.message('rails.forms.create.error.invalid_db_type', db))
+        end
+        ctx.puts(ctx.message('rails.forms.create.db.type.selected', db))
+        db
       end
     end
   end

--- a/lib/project_types/rails/forms/create.rb
+++ b/lib/project_types/rails/forms/create.rb
@@ -5,6 +5,18 @@ module Rails
     class Create < ShopifyCli::Form
       attr_accessor :name
       flag_arguments :title, :organization_id, :shop_domain, :type, :db
+      VALID_DB_TYPES = ['sqlite3',
+                        'mysql',
+                        'postgresql',
+                        'sqlite3',
+                        'oracle',
+                        'frontbase',
+                        'ibm_db',
+                        'sqlserver',
+                        'jdbcmysql',
+                        'jdbcsqlite3',
+                        'jdbcpostgresql',
+                        'jdbc']
 
       def ask
         self.title ||= CLI::UI::Prompt.ask(ctx.message('rails.forms.create.app_name'))
@@ -82,37 +94,21 @@ module Rails
 
       def ask_db
         if db.nil?
-          want_select = CLI::UI::Prompt.ask(ctx.message('rails.forms.create.db.want_select.select')) do |handler|
-            handler.option(ctx.message('rails.forms.create.db.want_select.select_no')) { false }
-            handler.option(ctx.message('rails.forms.create.db.want_select.select_yes')) { true }
-          end
-
-          if want_select
-            return CLI::UI::Prompt.ask(ctx.message('rails.forms.create.db.type.select')) do |handler|
-              handler.option(ctx.message('rails.forms.create.db.type.select_sqlite')) { 'sqlite' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_mysql')) { 'mysql' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_pg')) { 'postgresql' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_oracle')) { 'oracle' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_fb')) { 'frontbase' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_ibm')) { 'ibm_db' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_sql')) { 'sqlserver' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_jdbc_mysql')) { 'jdbcmysql' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_jdbc_sqlite')) { 'jdbcsqlite3' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_jdbc_pg')) { 'jdbcpostgresql' }
-              handler.option(ctx.message('rails.forms.create.db.type.select_jdbc')) { 'jdbc' }
+          return 'sqlite3' unless CLI::UI::Prompt.confirm(ctx.message('rails.forms.create.db.want_select'),
+                                                          default: false)
+          @db = CLI::UI::Prompt.ask(ctx.message('rails.forms.create.db.select')) do |handler|
+            VALID_DB_TYPES.each do |db_type|
+              handler.option(ctx.message("rails.forms.create.db.select_#{db_type}")) { db_type }
             end
-          else
-            return 'sqlite3'
           end
         end
 
-        unless ShopifyCli::Tasks::CreateApiClient::VALID_DB_TYPES.include?(db)
+        unless VALID_DB_TYPES.include?(db)
           ctx.abort(ctx.message('rails.forms.create.error.invalid_db_type', db))
         end
-        ctx.puts(ctx.message('rails.forms.create.db.type.selected', db))
+        ctx.puts(ctx.message('rails.forms.create.db.selected', db))
         db
       end
     end
   end
 end
-

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -44,7 +44,7 @@ module Rails
           generating_app: "Generating new rails app project in %s...",
           adding_shopify_gem: "{{v}} Adding shopify_app gem…",
           running_bundle_install: "Running bundle install...",
-          running_generator: "Running shopfiy_app generator...",
+          running_generator: "Running shopify_app generator...",
           running_migrations: "Running migrations…",
         },
 
@@ -73,6 +73,13 @@ module Rails
             authenticated: "{{v}} Authenticated with Heroku",
             deploying: "Deploying to Heroku…",
             deployed: "{{v}} Deployed to Heroku",
+            db_check: {
+              validating: "Validating application...",
+              checking: "Checking database type...",
+              validated: "Database type \"%s\" validated for platform \"Heroku\"",
+              problem: "A problem was encountered while checking your database type.",
+              sqlite: "Heroku does not support deployment using SQLite database. Please change database using {{command:db:system:change --to=[new_db_type]}} ({{underline:https://gorails.com/episodes/rails-6-db-system-change-command}})",
+            },
             git: {
               checking: "Checking git repo…",
               initialized: "Git repo initialized",
@@ -223,6 +230,7 @@ module Rails
           create: {
             error: {
               invalid_app_type: "Invalid App Type %s",
+              invalid_db_type: "Invalid DB Type %s",
               organization_not_found: "Cannot find an organization with that ID",
               no_organizations: "No organizations available.",
             },
@@ -237,6 +245,28 @@ module Rails
               select_public: "Public: An app built for a wide merchant audience.",
               select_custom: "Custom: An app custom built for a single client.",
               selected: "App Type {{green:%s}}",
+            },
+            db: {
+              want_select: {
+                select: "Would you like to select your database now? If you want to change this in the future, run {{command:db:system:change --to=[new_db_type]}} ({{underline:https://gorails.com/episodes/rails-6-db-system-change-command}})",
+                select_no: "No",
+                select_yes: "Yes",
+              },
+              type: {
+                select: "What database type would you like to use? Please ensure the database is installed.",
+                select_sqlite: "SQLite (default)",
+                select_mysql: "MySQL",
+                select_pg: "PostgreSQL",
+                select_oracle: "Oracle",
+                select_fb: "FrontBase",
+                select_ibm: "IBM_DB",
+                select_sql: "SQL Server",
+                select_jdbc_mysql: "JDBC MySQL",
+                select_jdbc_sqlite: "JDBC SQlite3",
+                select_jdbc_pg: "JDBC PostgreSQL",
+                select_jdbc: "JDBC",
+                selected: "Database Type {{green:%s}}",
+              },
             },
             organization_select: "Select organization",
             organization: "Organization {{green:%s}}",

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -78,7 +78,11 @@ module Rails
               checking: "Checking database type...",
               validated: "Database type \"%s\" validated for platform \"Heroku\"",
               problem: "A problem was encountered while checking your database type.",
-              sqlite: "Heroku does not support deployment using SQLite database. Please change database using {{command:db:system:change --to=[new_db_type]}} ({{underline:https://gorails.com/episodes/rails-6-db-system-change-command}})",
+              sqlite: <<~SQLITE,
+              Heroku does not support deployment using the SQLite database system.
+              Change the database type using {{command:rails db:system:change --to=[new_db_type]}}. For more info:
+              {{underline:https://gorails.com/episodes/rails-6-db-system-change-command}}
+              SQLITE
             },
             git: {
               checking: "Checking git repo…",
@@ -230,7 +234,7 @@ module Rails
           create: {
             error: {
               invalid_app_type: "Invalid App Type %s",
-              invalid_db_type: "Invalid DB Type %s",
+              invalid_db_type: "Invalid Database Type %s",
               organization_not_found: "Cannot find an organization with that ID",
               no_organizations: "No organizations available.",
             },
@@ -247,26 +251,24 @@ module Rails
               selected: "App Type {{green:%s}}",
             },
             db: {
-              want_select: {
-                select: "Would you like to select your database now? If you want to change this in the future, run {{command:db:system:change --to=[new_db_type]}} ({{underline:https://gorails.com/episodes/rails-6-db-system-change-command}})",
-                select_no: "No",
-                select_yes: "Yes",
-              },
-              type: {
-                select: "What database type would you like to use? Please ensure the database is installed.",
-                select_sqlite: "SQLite (default)",
-                select_mysql: "MySQL",
-                select_pg: "PostgreSQL",
-                select_oracle: "Oracle",
-                select_fb: "FrontBase",
-                select_ibm: "IBM_DB",
-                select_sql: "SQL Server",
-                select_jdbc_mysql: "JDBC MySQL",
-                select_jdbc_sqlite: "JDBC SQlite3",
-                select_jdbc_pg: "JDBC PostgreSQL",
-                select_jdbc: "JDBC",
-                selected: "Database Type {{green:%s}}",
-              },
+              want_select: <<~WANT_SELECT,
+              Would you like to select what database type to use now? (SQLite is the default)
+              If you want to change this in the future, run {{command:rails db:system:change --to=[new_db_type]}}. For more info:
+              {{underline:https://gorails.com/episodes/rails-6-db-system-change-command}}
+              WANT_SELECT
+              select: "What database type would you like to use? Please ensure the database is installed.",
+              select_sqlite3: "SQLite (default)",
+              select_mysql: "MySQL",
+              select_postgresql: "PostgreSQL",
+              select_oracle: "Oracle",
+              select_frontbase: "FrontBase",
+              select_ibm_db: "IBM_DB",
+              select_sqlserver: "SQL Server",
+              select_jdbcmysql: "JDBC MySQL",
+              select_jdbcsqlite3: "JDBC SQlite",
+              select_jdbcpostgresql: "JDBC PostgreSQL",
+              select_jdbc: "JDBC",
+              selected: "Database Type {{green:%s}}",
             },
             organization_select: "Select organization",
             organization: "Organization {{green:%s}}",

--- a/lib/shopify-cli/tasks/create_api_client.rb
+++ b/lib/shopify-cli/tasks/create_api_client.rb
@@ -3,18 +3,7 @@ require 'shopify_cli'
 module ShopifyCli
   module Tasks
     class CreateApiClient < ShopifyCli::Task
-      VALID_APP_TYPES = %w(public custom) # style guide?
-      VALID_DB_TYPES = ['mysql',
-                        'postgresql',
-                        'sqlite3',
-                        'oracle',
-                        'frontbase',
-                        'ibm_db',
-                        'sqlserver',
-                        'jdbcmysql',
-                        'jdbcsqlite3',
-                        'jdbcpostgresql',
-                        'jdbc']
+      VALID_APP_TYPES = %w(public custom)
 
       def call(ctx, org_id:, title:, app_url:, type:)
         resp = ShopifyCli::PartnersAPI.query(

--- a/lib/shopify-cli/tasks/create_api_client.rb
+++ b/lib/shopify-cli/tasks/create_api_client.rb
@@ -3,7 +3,18 @@ require 'shopify_cli'
 module ShopifyCli
   module Tasks
     class CreateApiClient < ShopifyCli::Task
-      VALID_APP_TYPES = %w(public custom)
+      VALID_APP_TYPES = %w(public custom) # style guide?
+      VALID_DB_TYPES = ['mysql',
+                        'postgresql',
+                        'sqlite3',
+                        'oracle',
+                        'frontbase',
+                        'ibm_db',
+                        'sqlserver',
+                        'jdbcmysql',
+                        'jdbcsqlite3',
+                        'jdbcpostgresql',
+                        'jdbc']
 
       def call(ctx, org_id:, title:, app_url:, type:)
         resp = ShopifyCli::PartnersAPI.query(

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -2,6 +2,8 @@
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
+Thread.report_on_exception = false
+
 # Contains backports from newer rubies to make our lives easier
 # require_relative 'support/ruby_backports'
 

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -179,10 +179,6 @@ module Rails
       end
 
       private
-
-      def default_new_cmd
-      end
-
       def expect_command(command, chdir: @context.root)
         @context.expects(:system).with(*command, chdir: chdir)
       end

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -44,12 +44,14 @@ module Rails
         Gem.expects(:install).with(@context, 'rails', nil)
         Gem.expects(:install).with(@context, 'bundler', '~>1.0')
         Gem.expects(:install).with(@context, 'bundler', '~>2.0')
-        expect_command(%w(/gem/path/bin/rails new --skip-spring test-app))
+        expect_command(%w(/gem/path/bin/rails new --skip-spring --database=sqlite3 test-app))
         expect_command(%w(/gem/path/bin/bundle install),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/spring stop),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/rails generate shopify_app),
+                       chdir: File.join(@context.root, 'test-app'))
+        expect_command(%w(/gem/path/bin/rails db:create),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/rails db:migrate RAILS_ENV=development),
                        chdir: File.join(@context.root, 'test-app'))
@@ -95,12 +97,14 @@ module Rails
         Gem.expects(:install).with(@context, 'rails', nil)
         Gem.expects(:install).with(@context, 'bundler', '~>1.0')
         Gem.expects(:install).with(@context, 'bundler', '~>2.0')
-        expect_command(%w(/gem/path/bin/rails new --skip-spring --database="postgresql" test-app))
+        expect_command(%w(/gem/path/bin/rails new --skip-spring --database=postgresql test-app))
         expect_command(%w(/gem/path/bin/bundle install),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/spring stop),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/rails generate shopify_app),
+                       chdir: File.join(@context.root, 'test-app'))
+        expect_command(%w(/gem/path/bin/rails db:create),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/rails db:migrate RAILS_ENV=development),
                        chdir: File.join(@context.root, 'test-app'))
@@ -126,7 +130,7 @@ module Rails
           }
         )
 
-        perform_command('--db="postgresql"')
+        perform_command('--db=postgresql')
 
         FileUtils.rm_r('test-app')
       end
@@ -142,12 +146,14 @@ module Rails
         Gem.expects(:install).with(@context, 'rails', nil)
         Gem.expects(:install).with(@context, 'bundler', '~>1.0')
         Gem.expects(:install).with(@context, 'bundler', '~>2.0')
-        expect_command(%w(/gem/path/bin/rails new --skip-spring --edge -J test-app))
+        expect_command(%w(/gem/path/bin/rails new --skip-spring --database=sqlite3 --edge -J test-app))
         expect_command(%w(/gem/path/bin/bundle install),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/spring stop),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/rails generate shopify_app),
+                       chdir: File.join(@context.root, 'test-app'))
+        expect_command(%w(/gem/path/bin/rails db:create),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%w(/gem/path/bin/rails db:migrate RAILS_ENV=development),
                        chdir: File.join(@context.root, 'test-app'))
@@ -179,6 +185,7 @@ module Rails
       end
 
       private
+
       def expect_command(command, chdir: @context.root)
         @context.expects(:system).with(*command, chdir: chdir)
       end
@@ -188,6 +195,7 @@ module Rails
                              --type=public \
                              --name=test-app \
                              --organization_id=42 \
+                             --db=sqlite3 \
                              --shop_domain=testshop.myshopify.com)
         run_cmd(default_new_cmd << add_cmd, false)
       end

--- a/test/project_types/rails/commands/deploy/heroku_test.rb
+++ b/test/project_types/rails/commands/deploy/heroku_test.rb
@@ -16,6 +16,27 @@ module Rails
           stub_successful_heroku_flow
         end
 
+        def test_call_raises_if_using_sqlite
+          expects_heroku_db_validated(status: false, db: 'sqlite')
+
+          assert_raises ShopifyCli::Abort do
+            Rails::Commands::Deploy::Heroku.new(@context).call
+          end
+        end
+
+        def test_call_raises_if_cannot_validate_db
+          expects_heroku_db_validated(status: false, db: nil)
+
+          assert_raises ShopifyCli::Abort do
+            Rails::Commands::Deploy::Heroku.new(@context).call
+          end
+        end
+
+        def test_call_validates_db_if_not_sqlite
+          expects_heroku_db_validated(status: true, db: 'mysql')
+          Rails::Commands::Deploy::Heroku.new(@context).call
+        end
+
         def test_call_doesnt_download_heroku_cli_if_it_is_installed
           expects_heroku_installed(status: true, twice: true)
           expects_heroku_download(status: nil)

--- a/test/test_helpers/heroku.rb
+++ b/test/test_helpers/heroku.rb
@@ -24,6 +24,11 @@ module TestHelpers
         .with('git', 'status')
         .returns([init_output, status_mock[:true]])
 
+      # db validation
+      @context.stubs(:capture2e)
+        .with('bundle exec rails runner "puts ActiveRecord::Base.connection.adapter_name.downcase"')
+        .returns(['mysql', status_mock[:true]])
+
       # whoami
       @context.stubs(:capture2e)
         .with(heroku_command(full_path: full_path), 'whoami')
@@ -135,6 +140,12 @@ module TestHelpers
       @context.expects(:system)
         .with('git', 'push', '-u', 'heroku', "master:master")
         .returns(status_mock[:"#{status}"])
+    end
+
+    def expects_heroku_db_validated(status:, db:)
+      @context.expects(:capture2e)
+        .with('bundle exec rails runner "puts ActiveRecord::Base.connection.adapter_name.downcase"')
+        .returns([db, status_mock[:"#{status}"]])
     end
 
     def expects_heroku_download_exists(status:)


### PR DESCRIPTION
### WHY are these changes introduced? 🤔 
- Fixes #513 
- Rails default is SQLite database; however, Heroku does not support deployment using SQLite
- Stack traces can be removed, as error messages are being displayed to the user already
- Proper initialization of databases is needed to use models, and eventually, to deploy

### WHAT is this pull request doing? 📋
- Adds prompting for user to choose desired database
- Enforces checking for database type prior to deployment
  - Asks user to change database types if SQLite is being used
- Removes stack traces from spinner errors
- Fixes migrations in database types other than SQLite  
- Adds/changes tests for prompting