### PR TITLE
A Temporary fix for monorail

### DIFF
--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -99,7 +99,7 @@ module ShopifyCli
 
               if Project.has_current?
                 project = Project.current
-                payload[:api_client_id] = project.env.api_key
+                # payload[:api_client_id] = project.env.api_key
                 payload[:partner_id] = project.config['organization_id']
               end
             end,

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -67,7 +67,7 @@ module ShopifyCli
                   cli_sha: "bb6f42193239a248f054e5019e469bc75f3adf1b",
                   ruby_version: RUBY_VERSION,
                   metadata: "{\"foo\":\"identifier\"}",
-                  api_client_id: "apikey",
+                  #api_client_id: "apikey",
                   partner_id: 42,
                 },
               })

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -67,7 +67,7 @@ module ShopifyCli
                   cli_sha: "bb6f42193239a248f054e5019e469bc75f3adf1b",
                   ruby_version: RUBY_VERSION,
                   metadata: "{\"foo\":\"identifier\"}",
-                  #api_client_id: "apikey",
+                  # api_client_id: "apikey",
                   partner_id: 42,
                 },
               })

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -105,7 +105,7 @@ module ShopifyCli
                   uname: RbConfig::CONFIG["host"],
                   cli_sha: "bb6f42193239a248f054e5019e469bc75f3adf1b",
                   ruby_version: RUBY_VERSION,
-                  api_client_id: "apikey",
+                  # api_client_id: "apikey",
                   partner_id: 42,
                 },
               })


### PR DESCRIPTION
Related to #627

currently the schema was expecting the api_client_id which is internal to the partners dashboard and we were expecting to pass along the ApiKey so the was a bit of a communication break down.

Todd is currently putting in a fix for this but while he is doing that I am putting this temporary fix in place so that we can get our data. When the schema is updated I will remove this "fix" and update the schema.



