### PR TITLE
Feature sets

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -2,7 +2,7 @@
 
 module Extension
   class Project < ShopifyCli::ProjectType
-    hidden_project_type
+    hidden_feature
     creator 'App Extension', 'Extension::Commands::Create'
 
     register_command('Extension::Commands::Build', "build")

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -4,7 +4,7 @@ require 'shopify_cli'
 module Extension
   module Commands
     class Build < ExtensionCommand
-      hidden_command
+      hidden_feature
 
       YARN_BUILD_COMMAND = %w(build)
       NPM_BUILD_COMMAND = %w(run-script build)

--- a/lib/project_types/rails/cli.rb
+++ b/lib/project_types/rails/cli.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 module Rails
   class Project < ShopifyCli::ProjectType
-    # hidden_project_type
     creator 'Ruby on Rails App', 'Rails::Commands::Create'
 
     register_command('Rails::Commands::Deploy', "deploy")

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -2,7 +2,7 @@
 
 module Script
   class Project < ShopifyCli::ProjectType
-    hidden_project_type
+    hidden_feature
     creator 'Script', 'Script::Commands::Create'
 
     register_command('Script::Commands::Push', 'push')

--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -3,12 +3,13 @@ require 'shopify_cli'
 
 module ShopifyCli
   class Command < CLI::Kit::BaseCommand
+    extend Feature::Set
+
     attr_writer :ctx
     attr_accessor :options
 
     class << self
       attr_writer :ctx
-      attr_reader :hidden
 
       def call(args, command_name)
         subcommand, resolved_name = subcommand_registry.lookup_command(args.first)
@@ -21,10 +22,6 @@ module ShopifyCli
           return call_help(command_name) if cmd.options.help
           cmd.call(args, command_name)
         end
-      end
-
-      def hidden_command
-        @hidden = true
       end
 
       def options(&block)

--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -18,6 +18,7 @@ module ShopifyCli
       @core_commands.include?(cmd)
     end
 
+    register :Config, 'config', 'shopify-cli/commands/config', true
     register :Connect, 'connect', 'shopify-cli/commands/connect', true
     register :Create, 'create', 'shopify-cli/commands/create', true
     register :Help, 'help', 'shopify-cli/commands/help', true

--- a/lib/shopify-cli/commands/config.rb
+++ b/lib/shopify-cli/commands/config.rb
@@ -1,0 +1,44 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class Config < ShopifyCli::Command
+      hidden_feature(feature_set: :debug)
+
+      subcommand :Feature, 'feature'
+
+      def call(*)
+        @ctx.puts(self.class.help)
+      end
+
+      def self.help
+        ShopifyCli::Context.message('core.config.help', ShopifyCli::TOOL_NAME)
+      end
+
+      class Feature < ShopifyCli::SubCommand
+        options do |parser, flags|
+          parser.on('--enable') { flags[:action] = 'enable' }
+          parser.on('--disable') { flags[:action] = 'disable' }
+          parser.on('--status') { flags[:action] = 'status' }
+        end
+
+        def call(args, _name)
+          feature_name = args.shift
+          return @ctx.puts(@ctx.message('core.config.help', ShopifyCli::TOOL_NAME)) if feature_name.nil?
+          is_enabled = ShopifyCli::Feature.enabled?(feature_name)
+          if options.flags[:action] == 'disable' && is_enabled
+            ShopifyCli::Feature.disable(feature_name)
+            @ctx.puts(@ctx.message('core.config.feature.disabled', is_enabled))
+          elsif options.flags[:action] == 'enable' && !is_enabled
+            ShopifyCli::Feature.enable(feature_name)
+            @ctx.puts(@ctx.message('core.config.feature.enabled', feature_name))
+          elsif is_enabled
+            @ctx.puts(@ctx.message('core.config.feature.is_enabled', feature_name))
+          else
+            @ctx.puts(@ctx.message('core.config.feature.is_disabled', feature_name))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -28,7 +28,7 @@ module ShopifyCli
       def self.all_visible_type
         ProjectType
           .load_all
-          .select { |type| !type.hidden }
+          .select { |type| !type.hidden? }
       end
 
       def self.help

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -47,7 +47,7 @@ module ShopifyCli
 
       def core_commands
         resolved_commands
-          .select { |_name, c| !c.hidden }
+          .select { |_name, c| !c.hidden? }
           .select { |name, _c| Commands.core_command?(name) }
       end
 

--- a/lib/shopify-cli/commands/system.rb
+++ b/lib/shopify-cli/commands/system.rb
@@ -4,7 +4,7 @@ require 'rbconfig'
 module ShopifyCli
   module Commands
     class System < ShopifyCli::Command
-      hidden_command
+      hidden_feature(feature_set: :debug)
 
       def call(args, _name)
         show_all_details = false

--- a/lib/shopify-cli/feature.rb
+++ b/lib/shopify-cli/feature.rb
@@ -1,0 +1,97 @@
+module ShopifyCli
+  ##
+  # ShopifyCli::Feature contains the logic to hide and show features across the CLI
+  # These features can be either commands or project types currently.
+  #
+  # Feature flags will persist between runs so if the flag is enabled or disabled,
+  # it will still be in that same state on the next cli invocation.
+  class Feature
+    SECTION = 'features'
+
+    ##
+    # ShopifyCli::Feature::Set is included on commands and projects to allow you to hide
+    # and enable projects and commands based on feature flags.
+    module Set
+      ##
+      # will hide a feature, either a project_type or a command
+      #
+      # #### Parameters
+      #
+      # * `feature_set` - either a single, or array of symbols that represent feature sets
+      #
+      # #### Example
+      #
+      #    module ShopifyCli
+      #      module Commands
+      #        class Config < ShopifyCli::Command
+      #          hidden_feature(feature_set: :basic)
+      #          ....
+      #
+      def hidden_feature(feature_set: [])
+        @feature_hidden = true
+        @hidden_feature_set = Array(feature_set).compact
+      end
+
+      ##
+      # will return if the feature has been hidden or not
+      #
+      # #### Returns
+      #
+      # * `is_hidden` - returns true if the feature has been hidden and false otherwise
+      #
+      # #### Example
+      #
+      #     ShopifyCli::Commands::Config.hidden?
+      #
+      def hidden?
+        enabled = (@hidden_feature_set || []).any? do |feature|
+          Feature.enabled?(feature)
+        end
+        @feature_hidden && !enabled
+      end
+    end
+
+    class << self
+      ##
+      # will enable a feature in the CLI.
+      #
+      # #### Parameters
+      #
+      # * `feature` - a symbol representing the flag to be enabled
+      def enable(feature)
+        set(feature, true)
+      end
+
+      ##
+      # will disable a feature in the CLI.
+      #
+      # #### Parameters
+      #
+      # * `feature` - a symbol representing the flag to be disabled
+      def disable(feature)
+        set(feature, false)
+      end
+
+      ##
+      # will check if the feature has been enabled
+      #
+      # #### Parameters
+      #
+      # * `feature` - a symbol representing a flag that the status should be requested
+      #
+      # #### Returns
+      #
+      # * `is_enabled` - will be true if the feature has been enabled.
+      def enabled?(feature)
+        return false if feature.nil?
+        ShopifyCli::Config.get_bool(SECTION, feature.to_s)
+      end
+
+      private
+
+      def set(feature, value)
+        ShopifyCli::Config.set(SECTION, feature.to_s, value)
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -52,6 +52,19 @@ module ShopifyCli
           saved: "%s saved to project root",
         },
 
+        config: {
+          help: <<~HELP,
+          Change configuration of how the CLI operates
+            Usage: {{command:%s config [ feature ] [ feature_name ] }}
+          HELP
+          feature: {
+            enabled: "{{v}} feature {{green:%s}} was enabled",
+            disabled: "{{v}} feature {{green:%s}} was disabled",
+            is_enabled: "{{v}} feature {{green:%s}} is enabled",
+            is_disabled: "{{v}} feature {{green:%s}} is disabled",
+          },
+        },
+
         git: {
           error: {
             directory_exists: "Project directory already exists. Please create a project with a new name.",

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -1,11 +1,12 @@
 module ShopifyCli
   class ProjectType
+    extend Feature::Set
+
     class << self
       attr_accessor :project_type,
         :project_name,
         :project_creator_command_class,
         :project_load_shallow
-      attr_reader :hidden
 
       def repository
         @repository ||= []
@@ -51,10 +52,6 @@ module ShopifyCli
 
       def create_command
         const_get(@project_creator_command_class)
-      end
-
-      def hidden_project_type
-        @hidden = true
       end
 
       def register_command(const, cmd)

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -105,6 +105,7 @@ module ShopifyCli
   autoload :Context, 'shopify-cli/context'
   autoload :Core, 'shopify-cli/core'
   autoload :DB, 'shopify-cli/db'
+  autoload :Feature, 'shopify-cli/feature'
   autoload :Form, 'shopify-cli/form'
   autoload :Git, 'shopify-cli/git'
   autoload :Helpers, 'shopify-cli/helpers'

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -23,7 +23,7 @@ module Extension
       end
 
       def test_is_a_hidden_command
-        assert Commands::Build.hidden
+        assert Commands::Build.hidden?
       end
 
       def test_implements_help

--- a/test/shopify-cli/commands/config_test.rb
+++ b/test/shopify-cli/commands/config_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Commands
+    class ConfigTest < MiniTest::Test
+      TEST_FEATURE = :feature_flag_test
+
+      def test_help_argument_calls_help
+        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        run_cmd('config help')
+      end
+
+      def test_no_arguments_calls_help
+        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        run_cmd('config')
+      end
+
+      def test_no_feature_calls_help
+        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        run_cmd('config feature')
+      end
+
+      def test_will_disable_a_feature_that_is_enabled
+        ShopifyCli::Feature.disable(TEST_FEATURE)
+        run_cmd("config feature #{TEST_FEATURE} --enable")
+        assert ShopifyCli::Feature.enabled?(TEST_FEATURE)
+      end
+
+      def test_will_enable_a_feature_that_is_disabled
+        ShopifyCli::Feature.enable(TEST_FEATURE)
+        run_cmd("config feature #{TEST_FEATURE} --disable")
+        refute ShopifyCli::Feature.enabled?(TEST_FEATURE)
+      end
+    end
+  end
+end

--- a/test/shopify-cli/feature_test.rb
+++ b/test/shopify-cli/feature_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+module ShopifyCli
+  class FeatureTest < MiniTest::Test
+    TEST_FEATURE = :feature_set_flag_test
+
+    class TestClass
+      extend Feature::Set
+      hidden_feature feature_set: TEST_FEATURE
+    end
+
+    def test_set_controls_hidden
+      Feature.enable(TEST_FEATURE)
+      refute TestClass.hidden?
+      Feature.disable(TEST_FEATURE)
+      assert TestClass.hidden?
+    end
+
+    def test_enable_sets_true_bool
+      Feature.enable(TEST_FEATURE)
+      assert ShopifyCli::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
+    end
+
+    def test_disable_sets_false_bool
+      Feature.disable(TEST_FEATURE)
+      refute ShopifyCli::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
+    end
+
+    def enabled_returns_bool_status
+      Feature.enable(TEST_FEATURE)
+      assert ShopifyCli::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
+      assert Feature.enabled?(TEST_FEATURE)
+      Feature.disable(TEST_FEATURE)
+      refute ShopifyCli::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
+      refute Feature.enabled?(TEST_FEATURE)
+      refute Feature.enabled?(nil)
+    end
+  end
+end


### PR DESCRIPTION
fixes #620

`shopify config feature` is a hidden command that would allow us to disable some features by default, for instance, Shopify plus features that most developers do not have access to. It has the added benefit of allowing teams to enable their hidden projects and have the CLI operate like they are no longer hidden.

This will allow for checking if a feature is enabled `ShopifyCli::Feature.enabled?(:shopify_plus)` in code paths and will also conditionally show hidden project types and hidden commands if the correct features are enabled

**Example: enabling a debug feature set and it shows the load-dev, load-system, and feature commands**
![image](https://user-images.githubusercontent.com/463193/87337721-e4163d00-c511-11ea-86f7-c1a8e76d96da.png)