### PR TITLE
Bump discount EP version

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,8 +1,8 @@
 discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    version: "~0.0.21"
-    sdk-version: "^4.0.0"
+    version: "~0.1.0"
+    sdk-version: "^5.0.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"


### PR DESCRIPTION
### WHY are these changes introduced?

The discount EP version was updated and the CLI needs to reflect that.

Related issue: https://github.com/Shopify/script-service/issues/1232

### WHAT is this pull request doing?

Bumps the discount EP and SDK versions.