### PR TITLE
Bump as-pect version

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
@@ -42,9 +42,7 @@ module Script
               "devDependencies": {
                 "@shopify/scripts-sdk-as": "#{@extension_point.sdks[:ts].sdk_version}",
                 "#{@extension_point.sdks[:ts].package}": "#{@extension_point.sdks[:ts].version}",
-                "@as-pect/assembly": "3.1.2",
                 "@as-pect/cli": "3.1.4",
-                "@as-pect/core": "3.1.4",
                 "yargs": "10.0.0",
                 "as-wasi": "^0.0.1",
                 "assemblyscript": "^0.9.4",

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
@@ -42,9 +42,9 @@ module Script
               "devDependencies": {
                 "@shopify/scripts-sdk-as": "#{@extension_point.sdks[:ts].sdk_version}",
                 "#{@extension_point.sdks[:ts].package}": "#{@extension_point.sdks[:ts].version}",
-                "@as-pect/assembly": "3.1.1",
-                "@as-pect/cli": "3.1.1",
-                "@as-pect/core": "3.1.1",
+                "@as-pect/assembly": "3.1.2",
+                "@as-pect/cli": "3.1.4",
+                "@as-pect/core": "3.1.4",
                 "yargs": "10.0.0",
                 "as-wasi": "^0.0.1",
                 "assemblyscript": "^0.9.4",


### PR DESCRIPTION
### WHY are these changes introduced?

The latest version of the discount EP relies on a newer version of as-pect. 

### WHAT is this pull request doing?

This PR bumps the as-pect version for new script projects. I've tested that the new version doesn't break the other existing EPs.
