### PR TITLE
Adds a new help page for helping you start your app server

### DIFF
--- a/docs/help/start-app/index.md
+++ b/docs/help/start-app/index.md
@@ -1,0 +1,6 @@
+---
+title: Start your app
+toc: false
+---
+
+Your app is not running, and no app URL has been set. Try running `shopify serve` in your project to get started.


### PR DESCRIPTION
This PR introduces a new "start app" help page, intended to replace the existing getting-started page. This complements and precedes #636, where I will update the code that directs people to this page, but the tests in that PR won't pass until this page is live. 🙂