### PR TITLE
Lock CLI to ruby instance during installation

### DIFF
--- a/ext/shopify-cli/extconf.rb
+++ b/ext/shopify-cli/extconf.rb
@@ -1,0 +1,27 @@
+require 'rbconfig'
+require 'fileutils'
+
+gem = File.expand_path('../../../', __FILE__)
+exe = File.join(gem, 'bin', 'shopify-cli')
+script = exe + '.sh'
+symlink = '/usr/local/bin/shopify-cli'
+
+script_content = <<~SCRIPT
+  #!/usr/bin/env bash
+  #{RbConfig.ruby} --disable=gems -I #{gem} #{exe} $@
+SCRIPT
+
+File.write(script, script_content)
+FileUtils.chmod("+x", script)
+
+makefile_content = <<~MAKEFILE
+  .PHONY: clean install
+  
+  clean:
+  \t@sudo rm -f #{symlink}
+  
+  install: clean
+  \t@sudo ln -s #{script} #{symlink}
+MAKEFILE
+
+File.write('Makefile', makefile_content)

--- a/lib/graphql/api_versions.graphql
+++ b/lib/graphql/api_versions.graphql
@@ -1,5 +1,5 @@
 query {
-  publicApiVersions() {
+  publicApiVersions {
     handle
     displayName
   }

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,0 +1,10 @@
+Gem.post_uninstall do |uninstaller|
+  if uninstaller.spec.name == 'shopify-cli'
+    require 'fileutils'
+
+    symlink = '/usr/local/bin/shopify-cli'
+    system("sudo rm -f #{symlink}") if File.symlink?(symlink)
+  end
+
+  true
+end

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |spec|
     %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir = "bin"
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| f.sub('bin/', '') }
+  # spec.executables = spec.files.grep(%r{^bin/}) { |f| f.sub('bin/', '') }
   spec.require_paths = ["lib", "vendor"]
+  spec.extensions = ["ext/shopify-cli/extconf.rb"]
 
   spec.add_development_dependency('bundler', '~> 1.17')
   spec.add_development_dependency('rake', '~> 12.3', '>= 12.3.3')


### PR DESCRIPTION
### WHY are these changes introduced?

Locking the CLI to the version/instance of `ruby` that is used to install it, which will help reduce the variability of behaviour and bug reports due to a multi-ruby-installation development environment.

### WHAT is this pull request doing?

Adding `ext/shopify-cli/extconf.rb` to:
- dynamically create a script file that calls the CLI ruby script with a the ruby version used during CLI installation
- dynamically create a `Makefile` (expected by RubyGems extensions) that will create a symbolic link to the location of the dynamically created script file (above) from `/usr/local/bin/shopify-cli`

Adding `lib/rubygems_plugin.rb` to:
- add a post-uninstall hook that will:
  - check if the gem being uninstalled is named `shopify-cli`
  - if so, delete the symbolic link `/usr/local/bin/shopify-cli` (the target of the symbolic link will already have been deleted during the `gem uninstall` process.

Note: this post-uninstall hook is run for EVERY `gem uninstall` that the user will run after installing the CLI gem, hence the need to check the name of the gem being uninstalled.

### TO-DO
- [ ] Testing across multiple Linux versions, macOS and multiple multi-ruby installation managers (`dev`, `chruby`, `rvm`, `rbenv`)