### PR TITLE
Adding JsSystem for making npm and yarn calls

### DIFF
--- a/lib/shopify-cli/js_system.rb
+++ b/lib/shopify-cli/js_system.rb
@@ -1,0 +1,95 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  ##
+  # ShopifyCli::JsSystem allows conditional system calls of npm or yarn commands.
+  #
+  class JsSystem
+    include SmartProperties
+
+    YARN_CORE_COMMAND = 'yarn'
+    NPM_CORE_COMMAND = 'npm'
+
+    class << self
+      ##
+      # Proxy to instance method `ShopifyCli::JsSystem.new.yarn?`
+      #
+      # #### Parameters
+      # - `ctx`: running context from your command
+      #
+      # #### Example
+      #
+      #   ShopifyCli::JsSystem.yarn?(ctx)
+      #
+      def yarn?(ctx)
+        JsSystem.new(ctx: ctx).yarn?
+      end
+
+      ##
+      # Proxy to instance method `ShopifyCli::JsSystem.new.call`
+      #
+      # #### Parameters
+      # - `ctx`: running context from your command
+      # - `yarn`: The proc, array, or string command to run if yarn is available
+      # - `npm`: The proc, array, or string command to run if npm is available
+      #
+      # #### Example
+      #
+      #   ShopifyCli::JsSystem.call(ctx, yarn: ['install', '--silent'], npm: ['install', '--no-audit'])
+      #
+      def call(ctx, yarn:, npm:)
+        JsSystem.new(ctx: ctx).call(yarn: yarn, npm: npm)
+      end
+    end
+
+    property :ctx, accepts: ShopifyCli::Context
+
+    ##
+    # Returns the name of the JS package manager being used
+    #
+    # #### Example
+    #
+    #   ShopifyCli::JsSystem.new(ctx: ctx).package_manager
+    #
+    def package_manager
+      yarn? ? YARN_CORE_COMMAND : NPM_CORE_COMMAND
+    end
+
+    ##
+    # Returns true if yarn is available and false otherwise
+    #
+    # #### Example
+    #
+    #   ShopifyCli::JsSystem.new(ctx: ctx).yarn?
+    #
+    def yarn?
+      @has_yarn ||= File.exist?(File.join(ctx.root, 'yarn.lock')) && CLI::Kit::System.system('which', 'yarn').success?
+    end
+
+    ##
+    # Runs a command with the proper JS package manager depending on the result of `yarn?`
+    #
+    # #### Parameters
+    # - `ctx`: running context from your command
+    # - `yarn`: The proc, array, or string command to run if yarn is available
+    # - `npm`: The proc, array, or string command to run if npm is available
+    #
+    # #### Example
+    #
+    #   ShopifyCli::JsSystem.new(ctx: ctx).call(yarn: ['install', '--silent'], npm: ['install', '--no-audit'])
+    #
+    def call(yarn:, npm:)
+      yarn? ? call_command(yarn, YARN_CORE_COMMAND) : call_command(npm, NPM_CORE_COMMAND)
+    end
+
+    private
+
+    def call_command(command, core_command)
+      if command.is_a?(String) || command.is_a?(Array)
+        CLI::Kit::System.system(core_command, *command, chdir: ctx.root).success?
+      else
+        command.call
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -110,6 +110,7 @@ module ShopifyCli
   autoload :Helpers, 'shopify-cli/helpers'
   autoload :Heroku, 'shopify-cli/heroku'
   autoload :JsDeps, 'shopify-cli/js_deps'
+  autoload :JsSystem, 'shopify-cli/js_system'
   autoload :Log, 'shopify-cli/log'
   autoload :OAuth, 'shopify-cli/oauth'
   autoload :Options, 'shopify-cli/options'

--- a/test/shopify-cli/js_deps_test.rb
+++ b/test/shopify-cli/js_deps_test.rb
@@ -8,7 +8,7 @@ module ShopifyCli
     end
 
     def test_installs_with_npm
-      JsDeps.any_instance.stubs(:yarn?).returns(false)
+      JsSystem.any_instance.stubs(:yarn?).returns(false)
       CLI::Kit::System.expects(:system).with(
         'npm', 'install', '--no-audit', '--no-optional', '--silent',
         env: @context.env,
@@ -22,7 +22,7 @@ module ShopifyCli
     end
 
     def test_installs_with_yarn
-      JsDeps.any_instance.stubs(:yarn?).returns(true)
+      JsSystem.any_instance.stubs(:yarn?).returns(true)
       CLI::Kit::System.expects(:system).with(
         'yarn', 'install', '--silent',
         chdir: @context.root

--- a/test/shopify-cli/js_system_test.rb
+++ b/test/shopify-cli/js_system_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
+
+module ShopifyCli
+  class JsSystemTest < MiniTest::Test
+    def setup
+      project_context('app_types', 'node')
+      @system = JsSystem.new(ctx: @context)
+
+      @execution_mock = Minitest::Mock.new
+      @execution_mock.expect(:executed, nil)
+    end
+
+    def test_call_executes_yarn_lambda_if_yarn_is_available
+      @system.stubs(:yarn?).returns(true)
+
+      @system.call(yarn: -> { @execution_mock.executed }, npm: -> { raise Exception })
+
+      @execution_mock.verify
+    end
+
+    def test_call_executes_npm_lambda_if_yarn_is_unavailable
+      @system.stubs(:yarn?).returns(false)
+
+      @system.call(yarn: -> { raise Exception }, npm: -> { @execution_mock.executed })
+
+      @execution_mock.verify
+    end
+
+    def test_call_executes_yarn_command_array_if_yarn_is_available
+      yarn_command = %w(install --silent)
+
+      @system.stubs(:yarn?).returns(true)
+      mock_kit_system(JsSystem::YARN_CORE_COMMAND, *yarn_command)
+
+      @system.call(yarn: yarn_command, npm: ['npm'])
+    end
+
+    def test_call_executes_npm_command_array_if_yarn_is_unavailable
+      npm_command = %w(install --other)
+
+      @system.stubs(:yarn?).returns(false)
+      mock_kit_system(JsSystem::NPM_CORE_COMMAND, *npm_command)
+
+      @system.call(yarn: ['yarn'], npm: npm_command)
+    end
+
+    def test_call_executes_yarn_command_string_if_yarn_is_available
+      yarn_command = 'install'
+
+      @system.stubs(:yarn?).returns(true)
+      mock_kit_system(JsSystem::YARN_CORE_COMMAND, yarn_command)
+
+      @system.call(yarn: yarn_command, npm: 'npm')
+    end
+
+    def test_call_executes_npm_command_string_if_yarn_is_unavailable
+      npm_command = 'install'
+
+      @system.stubs(:yarn?).returns(false)
+      mock_kit_system(JsSystem::NPM_CORE_COMMAND, npm_command)
+
+      @system.call(yarn: 'yarn', npm: npm_command)
+    end
+
+    def test_call_on_class_proxies_to_the_instance_version_of_call
+      yarn_command = 'yarn'
+      npm_command = 'npm'
+      JsSystem.any_instance.expects(:call).with(yarn: yarn_command, npm: npm_command).once
+
+      JsSystem.call(@context, yarn: yarn_command, npm: npm_command)
+    end
+
+    def test_yarn_on_class_proxies_to_the_instance_version_of_call
+      JsSystem.any_instance.expects(:yarn?).once
+      JsSystem.yarn?(@context)
+    end
+
+    private
+
+    def mock_kit_system(*input)
+      CLI::Kit::System
+        .expects(:system)
+        .with(*input, chdir: @context.root)
+        .returns(mock(success?: true))
+        .once
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Currently, the `yarn?` command is hidden as private inside the `JsDeps` class. It felt that we could use two reusable concepts when dealing with `project_types` that are JavaScript based.

1. Use `yarn` or `npm`?
2. Conditional calls to `npm` or `yarn` dependant on what is available.

### WHAT is this pull request doing?
Creates the `JsSystem` class which handles the two above cases. `JsDeps` now reuses the `JsSystem` to handle it's conditional logic of `yarn` or `npm`

### Usages
```ruby
# Static yarn? call
JsSystem.yarn?(context)

# Instance-based yarn? call:
@system = JsSystem.new(ctx: context)
@system.yarn?
```

```ruby
# Simple command calls
JsSystem.call(context,
  yarn: 'install',
  npm: 'install'
)

# Array command calls
JsSystem.call(context,
  yarn: ['install', '--silent'],
  npm: ['install', '--no-audit', '--no-optional', '--silent']
)

# Proc/lambda Conditional calls
yarn_lambda = -> { CLI::Kit::System.system('yarn', 'install') }
npm_lambda = -> { CLI::Kit::System.system('npm', 'install') }

JsSystem.call(context,
  yarn: yarn_lambda,
  npm: npm_lambda
)
```
