### PR TITLE
Add basic structure for .rpm package generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ markdown_intermediate
 .idea
 *.gem
 packaging/debian/shopify-cli.deb
+packaging/rpm/build/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'docs/**/*'
+    - 'packaging/**/*'
   TargetRubyVersion: 2.4
 
 Layout/EmptyLines:

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,0 +1,40 @@
+# Building a .rpm package of the CLI
+
+The RPM package of the CLI is simply a metapackage that installs the CLI gem directly through Ruby. Therefore, 
+the package itself only serves to facilitate the installation and inclusion of non-ruby dependencies.
+
+## Requirements
+
+The `gem2rpm` gem can be used to manage the package templates, even though it's not necessarily used to build the 
+package itself. To install it, simply run:
+
+```
+gem install gem2rpm 
+```
+
+To build the actual packages, you'll also need the `rpm` package from brew:
+
+```
+brew install rpm
+```
+
+## Package creation
+
+If there is a need to bump the version of the metapackage, one needs to re-generate the RPM spec file based on the 
+template. This can be done automatically by `gem2rpm`, by running:
+
+```
+gem2rpm -t rubygem-shopify.spec.template <path>/shopify-X.Y.Z.gem > rubygem-shopify.spec
+```
+
+Then, build the RPM package itself based on the spec:
+
+```
+cd packaging/rpm
+rpmbuild -bb rubygem-shopify.spec
+```
+
+## Version changes
+
+If the required Ruby version changes, make sure to update the `.spec.template` file to reflect that. There seems to be a
+bug in `gem2rpm` that causes the ruby version from the gemspec to be placed inside `[]`, which fails the build.

--- a/packaging/rpm/rubygem-shopify.spec
+++ b/packaging/rpm/rubygem-shopify.spec
@@ -1,0 +1,45 @@
+# Generated from shopify-cli-1.0.1.gem by gem2rpm -*- rpm-spec -*-
+%define rbname shopify-cli
+%define version 1.0.1
+%define release 1
+%define _rpmdir ./build
+%define _target_os linux
+
+Summary: Shopify CLI helps you build Shopify apps faster.
+Name: ruby-gems-%{rbname}
+
+Version: %{version}
+Release: %{release}
+Group: Development/Ruby
+License: Distributable
+URL: https://shopify.github.io/shopify-app-cli/
+# Make sure the spec template is included in the SRPM
+Source0: ruby-gems-%{rbname}.spec.in
+# Requires: ruby [">= 2.3.0"]
+Requires: ruby >= 2.3.0
+BuildArch: noarch
+Provides: ruby(Shopify-cli) = %{version}
+
+%description
+Shopify CLI helps you build Shopify apps faster. It quickly scaffolds Node.js
+and Ruby-on-Rails embedded apps. It also automates many common tasks in the
+development process and lets you quickly add popular features, such as billing
+and webhooks.
+
+
+%prep
+%setup -T -c
+
+%build
+
+%post
+gem install shopify-cli
+
+%preun
+gem uninstall shopify-cli
+
+%clean
+
+%files
+
+%changelog

--- a/packaging/rpm/rubygem-shopify.spec.template
+++ b/packaging/rpm/rubygem-shopify.spec.template
@@ -1,0 +1,41 @@
+# Generated from <%= package.spec.file_name %> by gem2rpm -*- rpm-spec -*-
+%define rbname <%= spec.name %>
+%define version <%= spec.version %>
+%define release 1
+%define _rpmdir ./build
+%define _target_os linux
+
+Summary: <%= spec.summary %>
+Name: ruby-gems-%{rbname}
+
+Version: %{version}
+Release: %{release}
+Group: Development/Ruby
+License: Distributable
+URL: <%= spec.homepage %>
+# Make sure the spec template is included in the SRPM
+Source0: ruby-gems-%{rbname}.spec.in
+# Requires: ruby <%= spec.required_ruby_version %>
+Requires: ruby >= 2.3.0
+BuildArch: noarch
+Provides: ruby(<%= spec.name.capitalize %>) = %{version}
+
+%description
+<%= spec.description %>
+
+%prep
+%setup -T -c
+
+%build
+
+%post
+gem install shopify-cli
+
+%preun
+gem uninstall shopify-cli
+
+%clean
+
+%files
+
+%changelog


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This applies the same logic as PR #646 to create an empty .rpm metapackage that installs the CLI gem, so that it can be installed in the same way for RPM-using Linux distros.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This creates a .rpm package spec that doesn't contain any code itself except for the gem install / uninstall commands, and adds some documentation on how to go about generating it.

What this does **NOT** do yet is consider the actual distribution of the packages we generate.