### PR TITLE
Update Auth page copy and typos

### DIFF
--- a/lib/project_types/rails/cli.rb
+++ b/lib/project_types/rails/cli.rb
@@ -16,7 +16,7 @@ module Rails
     register_messages(Rails::Messages::MESSAGES)
   end
 
-  # define/autoload project specific Commads
+  # define/autoload project specific Commands
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -14,7 +14,7 @@ module Script
     register_messages(Script::Messages::MESSAGES)
   end
 
-  # define/autoload project specific Commads
+  # define/autoload project specific Commands
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -148,7 +148,7 @@ module ShopifyCli
             "{{i}} Authentication required. Login to the URL below with your %s credentials to continue.",
 
           servlet: {
-            success_response: "Authenticated Successfully, this page will close shortly.",
+            success_response: "Authenticated Successfully, you may now close this page.",
             invalid_request_response: "Invalid Request: %s",
             invalid_state_response: "Anti-forgery state token does not match the initial request.",
             authenticated: "Authenticate Successfully",


### PR DESCRIPTION
### WHY are these changes introduced?

There were some typos. Also, the 'Authenticated Successfully' page claims the page will auto-close but that will never happen, so I updated the copy to let the user know they could close the page themselves. I didn't want to just say 'Authenticated Successfully' in case they thought they had to leave the page open for whatever reason. 

![image](https://user-images.githubusercontent.com/30087610/84040208-583c4e80-a970-11ea-9c3b-e53af258c3aa.png)
