### PR TITLE
Add extended help for script commands

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -9,6 +9,8 @@ module Script
       end
 
       def call(args, _name)
+        return @ctx.puts(self.class.help) if args.include?('help')
+
         language = 'ts'
         cur_dir = @ctx.root
 
@@ -33,8 +35,12 @@ module Script
       end
 
       def self.help
+        ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
         allowed_values = Script::Layers::Application::ExtensionPoints.types.map { |type| "{{cyan:#{type}}}" }
-        ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME, allowed_values.join(', '))
+        ShopifyCli::Context.message('script.create.extended_help', ShopifyCli::TOOL_NAME, allowed_values.join(', '))
       end
     end
   end

--- a/lib/project_types/script/commands/deploy.rb
+++ b/lib/project_types/script/commands/deploy.rb
@@ -9,6 +9,8 @@ module Script
       end
 
       def call(args, _name)
+        return @ctx.puts(self.class.help) if args.include?('help')
+
         form = Forms::Deploy.ask(@ctx, args, options.flags)
         project = ScriptProject.current
 
@@ -29,6 +31,10 @@ module Script
 
       def self.help
         ShopifyCli::Context.message('script.deploy.help', ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message('script.deploy.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/commands/disable.rb
+++ b/lib/project_types/script/commands/disable.rb
@@ -9,6 +9,8 @@ module Script
       end
 
       def call(args, _name)
+        return @ctx.puts(self.class.help) if args.include?('help')
+
         form = Forms::Enable.ask(@ctx, args, options.flags)
         return @ctx.puts(self.class.help) unless form
 
@@ -26,6 +28,10 @@ module Script
 
       def self.help
         ShopifyCli::Context.message('script.disable.help', ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message('script.disable.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/commands/enable.rb
+++ b/lib/project_types/script/commands/enable.rb
@@ -9,6 +9,8 @@ module Script
       end
 
       def call(args, _name)
+        return @ctx.puts(self.class.help) if args.include?('help')
+
         form = Forms::Enable.ask(@ctx, args, options.flags)
         return @ctx.puts(self.class.help) unless form
 
@@ -35,6 +37,10 @@ module Script
 
       def self.help
         ShopifyCli::Context.message('script.enable.help', ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message('script.enable.extended_help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/commands/test.rb
+++ b/lib/project_types/script/commands/test.rb
@@ -3,7 +3,8 @@
 module Script
   module Commands
     class Test < ShopifyCli::Command
-      def call(_args, _name)
+      def call(args, _name)
+        return @ctx.puts(self.class.help) if args.include?('help')
         project = Script::ScriptProject.current
         Layers::Application::TestScript.call(
           ctx: @ctx,

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -70,9 +70,11 @@ module Script
           help: <<~HELP,
           {{command:%1$s create script}}: Creates a script project.
             Usage: {{command:%1$s create script}}
-            Options:
-              {{command:--name=NAME}} Script project name. Any string.
-              {{command:--extension_point=TYPE}} Extension point name. Allowed values: %2$s.
+          HELP
+          extended_help: <<~HELP,
+            \s\sOptions:
+              \s\s{{command:--name=NAME}} Script project name. Any string.
+              \s\s{{command:--extension_point=TYPE}} Extension point name. Allowed values: %2$s.
           HELP
 
           error: {
@@ -88,7 +90,12 @@ module Script
         deploy: {
           help: <<~HELP,
           Build the script and deploy it to app.
-            Usage: {{command:%s deploy --API_key=<API_key> [--force]}}
+            Usage: {{command:%s deploy}}
+          HELP
+          extended_help: <<~HELP,
+            \s\sOptions:
+              \s\s{{command:--API_key=<API_key>}} API key. Must be a valid API key, otherwise store access fails.
+              \s\s{{command:--force}} Forces the script to be overwritten if an instance of it already exists.
           HELP
 
           error: {
@@ -101,7 +108,12 @@ module Script
         disable: {
           help: <<~HELP,
           Turn off script in development store.
-            Usage: {{command:%s disable --API_key=<API_key> --shop_domain=<my_store.myshopify.com>}}
+            Usage: {{command:%s disable}}
+          HELP
+          extended_help: <<~HELP,
+            \s\sOptions:
+              \s\s{{command:--API_key=<API_key>}} API key. Must be a valid API key, otherwise store access fails.
+              \s\s{{command:--shop_domain=<my_store.myshopify.com>}} Test store URL. Must be existing test store.
           HELP
 
           error: {
@@ -114,7 +126,12 @@ module Script
         enable: {
           help: <<~HELP,
           Turn on script in development store.
-            Usage: {{command:%s enable --API_key=<API_key> --shop_domain=<my_store.myshopify.com>}}
+            Usage: {{command:%s enable}}
+          HELP
+          extended_help: <<~HELP,
+            \s\sOptions:
+              \s\s{{command:--API_key=<API_key>}} API key. Must be a valid API key, otherwise store access fails.
+              \s\s{{command:--shop_domain=<my_store.myshopify.com>}} Test store URL. Must be existing test store.
           HELP
 
           error: {

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -39,11 +39,18 @@ module Script
       end
 
       def test_help
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.create.help', ShopifyCli::TOOL_NAME)
+        Script::Commands::Create.help
+      end
+
+      def test_extended_help
         Script::Layers::Application::ExtensionPoints.expects(:types).returns(%w(ep1 ep2))
         ShopifyCli::Context
           .expects(:message)
-          .with('script.create.help', ShopifyCli::TOOL_NAME, '{{cyan:ep1}}, {{cyan:ep2}}')
-        Script::Commands::Create.help
+          .with('script.create.extended_help', ShopifyCli::TOOL_NAME, '{{cyan:ep1}}, {{cyan:ep2}}')
+        Script::Commands::Create.extended_help
       end
 
       def test_cleanup_after_error

--- a/test/project_types/script/commands/deploy_test.rb
+++ b/test/project_types/script/commands/deploy_test.rb
@@ -43,6 +43,20 @@ module Script
         perform_command
       end
 
+      def test_help
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.deploy.help', ShopifyCli::TOOL_NAME)
+        Script::Commands::Deploy.help
+      end
+
+      def test_extended_help
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.deploy.extended_help', ShopifyCli::TOOL_NAME)
+        Script::Commands::Deploy.extended_help
+      end
+
       private
 
       def perform_command

--- a/test/project_types/script/commands/disable_test.rb
+++ b/test/project_types/script/commands/disable_test.rb
@@ -33,6 +33,20 @@ module Script
         end
       end
 
+      def test_help
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.disable.help', ShopifyCli::TOOL_NAME)
+        Script::Commands::Disable.help
+      end
+
+      def test_extended_help
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.disable.extended_help', ShopifyCli::TOOL_NAME)
+        Script::Commands::Disable.extended_help
+      end
+
       private
 
       def perform_command

--- a/test/project_types/script/commands/enable_test.rb
+++ b/test/project_types/script/commands/enable_test.rb
@@ -36,6 +36,20 @@ module Script
         end
       end
 
+      def test_help
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.enable.help', ShopifyCli::TOOL_NAME)
+        Script::Commands::Enable.help
+      end
+
+      def test_extended_help
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.enable.extended_help', ShopifyCli::TOOL_NAME)
+        Script::Commands::Enable.extended_help
+      end
+
       private
 
       def perform_command

--- a/test/project_types/script/commands/test_test.rb
+++ b/test/project_types/script/commands/test_test.rb
@@ -29,6 +29,13 @@ module Script
         perform_command
       end
 
+      def test_help
+        ShopifyCli::Context
+          .expects(:message)
+          .with('script.test.help', ShopifyCli::TOOL_NAME)
+        Script::Commands::Test.help
+      end
+
       private
 
       def perform_command


### PR DESCRIPTION
### WHAT is this pull request doing?

This pull request removes all option references in the help of script commands, and adds an extended help that details command line options.

A script command's help (deploy for this example) can be accessed by: ```shopify deploy help```, and extended help can be accessed through ```shopify deploy --help``` or ```shopify help deploy```.

This is the case for all script commands except create where extended help can only be accessed through ```shopify create script --help``` because ```shopify help create ...``` returns results for project types that aren't hidden only. Code could be added now to make it work, but it would need to be removed later when the project is no longer hidden, so it feels reasonable to me for extended help to only be accessible this one way.


**Create:**
<img width="797" alt="Screen Shot 2020-06-08 at 11 27 05 AM" src="https://user-images.githubusercontent.com/64974039/84067476-4e204d00-a97c-11ea-8040-6d80b6fbe147.png">

**Deploy:**
<img width="631" alt="Screen Shot 2020-06-08 at 10 55 33 AM" src="https://user-images.githubusercontent.com/64974039/84067578-6abc8500-a97c-11ea-94dc-ad164be9079b.png">


**Disable:**
<img width="619" alt="Screen Shot 2020-06-08 at 10 56 30 AM" src="https://user-images.githubusercontent.com/64974039/84067560-62fce080-a97c-11ea-8366-4cf12b09884d.png">


**Enable:**
<img width="622" alt="Screen Shot 2020-06-08 at 10 56 03 AM" src="https://user-images.githubusercontent.com/64974039/84067571-685a2b00-a97c-11ea-8505-967a7393e605.png">


**Test:**
<img width="446" alt="Screen Shot 2020-06-08 at 10 56 49 AM" src="https://user-images.githubusercontent.com/64974039/84067507-537d9780-a97c-11ea-9559-5895488ace8e.png">

