### PR TITLE
Changed default configuration value when enabling script from '{}' to '{ "entries": [] }'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp/
 .git/*
 markdown_intermediate
 .idea
+vendor/bundle

--- a/lib/project_types/script/commands/enable.rb
+++ b/lib/project_types/script/commands/enable.rb
@@ -18,7 +18,7 @@ module Script
           ctx: @ctx,
           api_key: form.api_key,
           shop_domain: form.shop_domain,
-          configuration: '{}',
+          configuration: '{ "entries": [] }',
           extension_point_type: project.extension_point_type,
           title: project.script_name
         )

--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,18 +1,18 @@
 discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    version: "~0.1.0"
+    version: "^0.2.0"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.0.1"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
-    version: "~0.0.21"
+    version: "^0.1.0"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.0.1"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
-    version: "~0.0.5"
+    version: "^0.1.0"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.0.1"

--- a/test/project_types/script/commands/enable_test.rb
+++ b/test/project_types/script/commands/enable_test.rb
@@ -9,7 +9,7 @@ module Script
         super
         @cmd = Enable
         @cmd.ctx = @context
-        @configuration = '{}'
+        @configuration = '{ "entries": [] }'
         @ep_type = 'discount'
         @script_name = 'script'
         @api_key = 'key'


### PR DESCRIPTION
### WHY are these changes introduced?

The script SDK now defines a `Configuration` object rather than a script author defining their own `Configuration` object. Since it has an explicit structure (entries) now, the default can no longer be vague.

Additional context:
- https://github.com/Shopify/script-service/issues/719
- https://github.com/Shopify/script-service/issues/1319

### WHAT is this pull request doing?

- Changes the default configuration value from '{}' to '{ "entries": [] }'
- Updates the EP versions to those that expect `configuration` as a paramerter