### PR TITLE
Connect command update

### DIFF
--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -6,13 +6,16 @@ module ShopifyCli
       core: {
         connect: {
           help: <<~HELP,
-          Connect a Shopify App CLI project. Restores the ENV file.
+          Connect (or re-connect) an existing project to a Shopify partner organization and/or a store. Creates or updates the {{green:.env}} file, and creates the {{green:.shopify-cli.yml}} file.
             Usage: {{command:%s connect}}
           HELP
 
-          production_warning: "{{yellow:! Don't use}} {{cyan:connect}} {{yellow:for production apps}}",
+          production_warning: <<~MESSAGE,
+          {{yellow:! Warning: if you have connected to an {{bold:app in production}}, running {{command:serve}} may update the app URL and cause an outage.
+          MESSAGE
+          already_connected_warning: "{{yellow:! This app appears to be already connected}}",
           connected: "{{v}} Project now connected to {{green:%s}}",
-          serve: "{{*}} Run {{command:%s serve}} to start a local development server",
+          project_type_select: "What type of project would you like to connect?",
           organization_select: "To which organization does this project belong?",
           app_select: "To which app does this project belong?",
           no_development_stores: <<~MESSAGE,
@@ -20,6 +23,7 @@ module ShopifyCli
           Visit {{underline:https://partners.shopify.com/%d/stores}} to create one
           MESSAGE
           development_store_select: "Which development store would you like to use?",
+          cli_yml_saved: ".shopify-cli.yml saved to project root",
         },
 
         context: {

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -38,7 +38,7 @@ module ShopifyCli
       #
       # #### Returns
       #
-      # * `has_project` - boolean, true if there is a current project
+      # * `has_current?` - boolean, true if there is a current project
       #
       def has_current?
         !directory(Dir.pwd).nil?

--- a/lib/shopify-cli/resources/env_file.rb
+++ b/lib/shopify-cli/resources/env_file.rb
@@ -14,17 +14,8 @@ module ShopifyCli
       }
 
       class << self
-        def read(directory = Dir.pwd)
-          input = {}
-          extra = {}
-          parse(directory).each do |key, value|
-            if KEY_MAP[key]
-              input[KEY_MAP[key]] = value
-            else
-              extra[key] = value
-            end
-          end
-          input[:extra] = extra
+        def read(_directory = Dir.pwd)
+          input = parse_external_env
           new(input)
         end
 
@@ -44,6 +35,20 @@ module ShopifyCli
             end
             output
           end
+        end
+
+        def parse_external_env(directory = Dir.pwd)
+          env_details = {}
+          extra = {}
+          parse(directory).each do |key, value|
+            if KEY_MAP[key]
+              env_details[KEY_MAP[key]] = value
+            else
+              extra[key] = value
+            end
+          end
+          env_details[:extra] = extra
+          env_details
         end
       end
 

--- a/test/shopify-cli/commands/connect_test.rb
+++ b/test/shopify-cli/commands/connect_test.rb
@@ -5,41 +5,94 @@ module ShopifyCli
     class ConnectTest < MiniTest::Test
       include TestHelpers::Partners
 
-      def test_run
-        response = [{
-          "id" => 421,
-          "businessName" => "one",
-          "stores" => [{
-            "shopDomain" => "store.myshopify.com",
-          }],
-          "apps" => [{
-            "title" => "app",
-            "apiKey" => 1234,
-            "apiSecretKeys" => [{
-              "secret" => 1233,
-            }],
-          }],
-        }, {
-          "id" => 422,
-          "businessName" => "two",
-          "stores" => [
-            { "shopDomain" => "store2.myshopify.com", "shopName" => "foo" },
-            { "shopDomain" => "store1.myshopify.com", "shopName" => "bar" },
-          ],
-          "apps" => [{
-            "title" => "app",
-            "apiKey" => 1235,
-            "apiSecretKeys" => [{
-              "secret" => 1234,
-            }],
-          }],
-        }]
-        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns(response)
-        CLI::UI::Prompt.expects(:ask).with('To which organization does this project belong?').returns(422)
+      def test_connect_asks_project_type_and_writes_yml_when_no_project_exists
+        ShopifyCli::Project.stubs(:has_current?).returns(false)
+        Resources::EnvFile.expects(:parse_external_env).returns({})
+        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns(partners_api_response)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.organization_select')).returns(101)
         CLI::UI::Prompt.expects(:ask).with(
-          'Which development store would you like to use?'
+          @context.message('core.connect.development_store_select')
         ).returns('store.myshopify.com')
-        Resources::EnvFile.any_instance.stubs(:write)
+
+        Resources::EnvFile.any_instance.expects(:write)
+        ShopifyCli::Project.expects(:write)
+        run_cmd('connect')
+      end
+
+      def test_connect_uses_default_values_for_env_file
+        ShopifyCli::Project.stubs(:has_current?).returns(false)
+        Resources::EnvFile.expects(:parse_external_env).returns({})
+        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns(partners_api_response)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.organization_select')).returns(101)
+        CLI::UI::Prompt.expects(:ask).with(
+          @context.message('core.connect.development_store_select')
+        ).returns('store.myshopify.com')
+
+        Resources::EnvFile.expects(:new).with(
+          api_key: 1235,
+          secret: 1234,
+          shop: "store.myshopify.com",
+          scopes: "write_products,write_customers,write_draft_orders",
+          extra: {}
+        ).returns(stub(:write))
+        ShopifyCli::Project.expects(:write)
+        run_cmd('connect')
+      end
+
+      def test_connect_adds_to_env_file_if_already_exists
+        ShopifyCli::Project.stubs(:has_current?).returns(false)
+        Resources::EnvFile.expects(:parse_external_env).returns({
+          scopes: 'read_products',
+          extra: { "additional" => "things" },
+        })
+        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns(partners_api_response)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.organization_select')).returns(101)
+        CLI::UI::Prompt.expects(:ask).with(
+          @context.message('core.connect.development_store_select')
+        ).returns('store.myshopify.com')
+
+        Resources::EnvFile.expects(:new).with(
+          api_key: 1235,
+          secret: 1234,
+          shop: "store.myshopify.com",
+          scopes: "read_products",
+          extra: { "additional" => "things" }
+        ).returns(stub(:write))
+        ShopifyCli::Project.expects(:write)
+        run_cmd('connect')
+      end
+
+      def test_connect_doesnt_write_yml_when_current_project_exists
+        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns(partners_api_response)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.organization_select')).returns(101)
+        CLI::UI::Prompt.expects(:ask).with(
+          @context.message('core.connect.development_store_select')
+        ).returns('store.myshopify.com')
+
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).never
+        Resources::EnvFile.any_instance.expects(:write)
+        ShopifyCli::Project.expects(:write).never
+        run_cmd('connect')
+      end
+
+      def test_connect_outputs_warnings_if_already_connected
+        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns(partners_api_response)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).never
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.organization_select')).returns(101)
+        CLI::UI::Prompt.expects(:ask).with(
+          @context.message('core.connect.development_store_select')
+        ).returns('store.myshopify.com')
+        Resources::EnvFile.any_instance.expects(:write)
+        ShopifyCli::Project.expects(:write).never
+        ShopifyCli::Project.stubs(:current_project_type).returns(:rails)
+
+        @context.expects(:puts).with(@context.message('core.connect.already_connected_warning'))
+        @context.expects(:puts).with(@context.message('core.connect.production_warning'))
+        @context.expects(:puts).with(@context.message('core.connect.connected', 'app'))
+
         run_cmd('connect')
       end
 
@@ -61,6 +114,39 @@ module ShopifyCli
         ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns(response)
         Resources::EnvFile.any_instance.stubs(:write)
         run_cmd('connect')
+      end
+
+      private
+
+      def partners_api_response
+        [{
+          "id" => 100,
+          "businessName" => "one",
+          "stores" => [{
+            "shopDomain" => "store.myshopify.com",
+          }],
+          "apps" => [{
+            "title" => "app",
+            "apiKey" => 1234,
+            "apiSecretKeys" => [{
+              "secret" => 1233,
+            }],
+          }],
+        }, {
+          "id" => 101,
+          "businessName" => "two",
+          "stores" => [
+            { "shopDomain" => "store2.myshopify.com", "shopName" => "foo" },
+            { "shopDomain" => "store1.myshopify.com", "shopName" => "bar" },
+          ],
+          "apps" => [{
+            "title" => "app",
+            "apiKey" => 1235,
+            "apiSecretKeys" => [{
+              "secret" => 1234,
+            }],
+          }],
+        }]
       end
     end
   end

--- a/test/shopify-cli/resources/env_file_test.rb
+++ b/test/shopify-cli/resources/env_file_test.rb
@@ -15,6 +15,15 @@ module ShopifyCli
         assert_equal(env_file.extra['AWSKEY'], 'awskey')
       end
 
+      def test_parse_external_env
+        env_file = EnvFile.parse_external_env
+        assert_equal(env_file[:api_key], 'apikey')
+        assert_equal(env_file[:secret], 'secret')
+        assert_equal(env_file[:host], 'https://example.com')
+        assert_equal(env_file[:shop], 'my-test-shop.myshopify.com')
+        assert_equal(env_file[:extra], { 'AWSKEY' => 'awskey' })
+      end
+
       def test_write_writes_env_content_to_file
         env_file = EnvFile.new(
           api_key: 'foo',


### PR DESCRIPTION
### WHY are these changes introduced?

The `shopify connect` command isn't doing as much as it could. It should allow you to take a project that wasn't created by the CLI and 'hook it up' so that you can perform CLI commands on it. Right now it only creates a `.env` file, and if there's no `.shopify-cli.yml` file the whole command blows up.

### WHAT is this pull request doing?

I have updated the `connect` command to do the following:

- the help text is now more explicit
![image](https://user-images.githubusercontent.com/30087610/84935565-def6d700-b0a6-11ea-915b-fe81a4694552.png)

- it will prompt you to select the type of project (currently node/rails)
- it will still give you a warning if you run this command on a project that already has a `.shopify-cli.yml`, but it will still run through the flow (as it did before). An optional Production warning will show if the app is a node/rails app.
<img width="600" src="https://user-images.githubusercontent.com/30087610/84945195-f6d55780-b0b4-11ea-87b2-d43dea0aab82.png">

- it only writes the `.shopify-cli.yml` if one doesn't already exist
- the flow output now includes writing the yml if it did write it, and 'start a server' has been removed as that is not applicable for all project types
<img width="400" src="https://user-images.githubusercontent.com/30087610/84166007-593db080-aa42-11ea-8706-deb037d78550.png">

- it will check if you've already got an `.env` file and add to it, it will override some keys (SHOPIFY_API_KEY, SHOPIFY_API_SECRET, SHOP), but SCOPES will only be added if it hasn't already been declared (added with our 3 default scopes), and any existing fields will be kept
<img width="400" alt="portfolio_view" src="https://user-images.githubusercontent.com/30087610/84059963-706c9780-a989-11ea-91a7-a47342757181.png">

- I needed to add a new method to `lib/shopify-cli/resources/env_file.rb` to parse an existing `.env` file because we didn't have a way to read one without blowing up if it didn't contain our Shopify-specific keys.

### To Dos
This update does not add any 'missing' node/rails files that might be added by our `create` command, as such, more work will be needed to make this command run even more smoothly. This is just the first step.