### PR TITLE
Terminology change: test shop > development store

### DIFF
--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -16,7 +16,7 @@ module Node
               {{command:--name=NAME}} App name. Any string.
               {{command:--app_url=APPURL}} App URL. Must be valid URL.
               {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
-              {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
+              {{command:--shop_domain=MYSHOPIFYDOMAIN }} Development store URL. Must be an existing development store.
           HELP
           error: {
             node_required: "node is required to create an app project. Download at https://nodejs.org/en/download.",

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -22,7 +22,7 @@ module Rails
               {{command:--name=NAME}} App name. Any string.
               {{command:--app_url=APPURL}} App URL. Must be valid URL.
               {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
-              {{command:--shop_domain=MYSHOPIFYDOMAIN }} Test store URL. Must be existing test store.
+              {{command:--shop_domain=MYSHOPIFYDOMAIN }} Development store URL. Must be an existing development store.
               {{command:--db=DB}} Database type. Must be one of: mysql, postgresql, sqlite3, oracle, frontbase, ibm_db, sqlserver, jdbcmysql, jdbcsqlite3, jdbcpostgresql, jdbc.
               {{command:--rails_opts=RAILSOPTS}} Additional options. Must be string containing one or more valid Rails options, separated by spaces.
           HELP

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -120,11 +120,11 @@ module ShopifyCli
 
         logout: {
           help: <<~HELP,
-          Log out of a currently authenticated Organization and Shop, or clear invalid credentials
+          Log out of a currently authenticated Organization and Store, or clear invalid credentials
             Usage: {{command:%s logout}}
           HELP
 
-          success: "Logged out of Organization and Shop",
+          success: "Logged out of Organization and Store",
         },
 
         monorail: {
@@ -243,10 +243,10 @@ module ShopifyCli
           ensure_env: {
             api_key_question: "What is your Shopify API key?",
             api_secret_key_question: "What is your Shopify API secret key?",
-            development_store_question: "What is your development store URL? (e.g. my-test-shop.myshopify.com)",
+            development_store_question: "What is your development store URL? (Example: my-dev-store.myshopify.com)",
           },
           ensure_test_shop: {
-            could_not_verify_shop: "Couldn't verify your shop %s",
+            could_not_verify_shop: "Couldn't verify your store %s",
             convert_dev_to_test_store:
               "Do you want to convert %s to a development store? This will enable you to install your app on this store.",
             transfer_disabled: "{{v}} Transfer has been disabled on %s.",

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -248,7 +248,7 @@ module ShopifyCli
           ensure_test_shop: {
             could_not_verify_shop: "Couldn't verify your shop %s",
             convert_dev_to_test_store:
-              "Do you want to convert %s to a test shop? This will enable you to install your app on this store.",
+              "Do you want to convert %s to a development store? This will enable you to install your app on this store.",
             transfer_disabled: "{{v}} Transfer has been disabled on %s.",
           },
           update_dashboard_urls: {

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -247,8 +247,11 @@ module ShopifyCli
           },
           ensure_test_shop: {
             could_not_verify_shop: "Couldn't verify your store %s",
-            convert_dev_to_test_store:
-              "Do you want to convert %s to a development store? This will enable you to install your app on this store.",
+            convert_dev_to_test_store: <<~MESSAGE,
+              Do you want to convert %s to a development store?
+              Doing this will allow you to install your app, but the store will become {{bold:transfer-disabled}}.
+              Learn more: https://shopify.dev/tutorials/transfer-a-development-store-to-a-merchant#transfer-disabled-stores
+              MESSAGE
             transfer_disabled: "{{v}} Transfer has been disabled on %s.",
           },
           update_dashboard_urls: {

--- a/test/fixtures/shopify_schema.json
+++ b/test/fixtures/shopify_schema.json
@@ -38946,7 +38946,7 @@
             },
             {
               "name": "partnerDevelopment",
-              "description": "Whether the shop is a partner development shop for testing purposes.",
+              "description": "Whether the store is a partner development store for testing purposes.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",

--- a/test/task/ensure_test_shop_test.rb
+++ b/test/task/ensure_test_shop_test.rb
@@ -13,7 +13,7 @@ module ShopifyCli
       def test_outputs_if_shop_cant_be_queried
         stub_org_request
         stub_env(domain: 'notther.myshopify.com')
-        @context.expects(:puts).with("Couldn't verify your shop notther.myshopify.com")
+        @context.expects(:puts).with("Couldn't verify your store notther.myshopify.com")
         EnsureTestShop.call(@context)
       end
 


### PR DESCRIPTION
This PR updates several messages that refer to "test shops" or "development shops", which doesn't comply with our standard terminology. This updates these instances to "development stores".

(Originally reported by @jenstanicak 🙏)