### PR TITLE
Add development env message on every command

### DIFF
--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -5,6 +5,8 @@ module ShopifyCli
     module EntryPoint
       class << self
         def call(args, ctx = Context.new)
+          ctx.puts(ctx.message('core.development_version_warning')) if ctx.development?
+
           ProjectType.load_type(Project.current_project_type)
 
           task_registry = ShopifyCli::Tasks::Registry

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -42,6 +42,8 @@ module ShopifyCli
           project_type_select: "What type of project would you like to create?",
         },
 
+        development_version_warning: "{{yellow:You are running the development version of the CLI}}",
+
         env_file: {
           saving_header: "writing %s file...",
           saving: "writing %s file",


### PR DESCRIPTION
### WHY are these changes introduced?

With the changes being made to not have to explicitly switch between production and development instances of the CLI (by switching the shell shims), it may not be immediately clear to developers which one is running a certain command.

This change addresses that by adding a message to every command run in a development instance to make sure developers can easily see where they are.

### WHAT is this pull request doing?

This simply adds a message to the entry point, before any commands are dispatched.

The end result is this:

<img width="553" alt="Screen Shot 2020-06-09 at 2 55 23 PM" src="https://user-images.githubusercontent.com/64600052/84188221-4090c300-aa61-11ea-97e5-6128b9dcfeef.png">

It's worth pointing out that the executable is currently called `shopify-cli` until we remove the deprecated `shopify` executable.