### PR TITLE
Fixing GraphQL syntax of the public API version query

### DIFF
--- a/lib/graphql/api_versions.graphql
+++ b/lib/graphql/api_versions.graphql
@@ -1,5 +1,5 @@
 query {
-  publicApiVersions() {
+  publicApiVersions {
     handle
     displayName
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The GraphQL command for fetching the available Admin API versions started failing with this message:

```
`fetch_api_version': undefined method `[]' for nil:NilClass
```

Upon further investigation, we noticed that the API itself started returning a failure for that query:

```
"{\"errors\":[{\"message\":\"Parse error on \\\")\\\" (RPAREN) at [1, 28]\",\"locations\":[{\"line\":1,\"column\":28}]}]}"
```

### WHAT is this pull request doing?

While I didn't yet figure out why this started failing, the fix is quite clear as the query syntax is apparently wrong - as per the error message and trying it out in the GraphQL website validator.

This fix simply removes the parenthesis from the `publicApiVersions` object to make it syntactically valid again.