### PR TITLE
Add reinstallation warning

### DIFF
--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -5,9 +5,15 @@ module ShopifyCli
     module EntryPoint
       class << self
         def call(args, ctx = Context.new)
+          if ctx.capture2e('type __shopify_cli__')
+            # Looks like we are in a shell shim. Do not proceed with the command
+            ctx.puts(ctx.message('core.warning.shell_shim'))
+            exit 1
+          end
+
           if ctx.development?
             ctx.puts(
-              ctx.message('core.development_version_warning', File.join(ShopifyCli::ROOT, 'bin', ShopifyCli::TOOL_NAME))
+              ctx.message('core.warning.development_version', File.join(ShopifyCli::ROOT, 'bin', ShopifyCli::TOOL_NAME))
             )
           end
 

--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -5,8 +5,15 @@ module ShopifyCli
     module EntryPoint
       class << self
         def call(args, ctx = Context.new)
-          if !ctx.testing? && ctx.capture2e('type __shopify_cli__')
-            # Looks like we are in a shell shim. Do not proceed with the command
+          # Check if the shim is set up by checking whether the old Finalizer FD exists
+          begin
+            is_shell_shim = false
+            IO.open(9) { is_shell_shim = true }
+          rescue Errno::EBADF
+            # This is expected if the descriptor doesn't exist
+          end
+
+          if !ctx.testing? && is_shell_shim
             ctx.puts(ctx.message('core.warning.shell_shim'))
             return
           end

--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -5,10 +5,10 @@ module ShopifyCli
     module EntryPoint
       class << self
         def call(args, ctx = Context.new)
-          if ctx.capture2e('type __shopify_cli__')
+          if !ctx.testing? && ctx.capture2e('type __shopify_cli__')
             # Looks like we are in a shell shim. Do not proceed with the command
             ctx.puts(ctx.message('core.warning.shell_shim'))
-            exit 1
+            return
           end
 
           if ctx.development?

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -42,12 +42,6 @@ module ShopifyCli
           project_type_select: "What type of project would you like to create?",
         },
 
-        development_version_warning: <<~DEVELOPMENT,
-        {{*}} {{yellow:You are running a development version of the CLI at:}}
-            {{yellow:%s}}
-
-        DEVELOPMENT
-
         env_file: {
           saving_header: "writing %s file...",
           saving: "writing %s file",
@@ -263,6 +257,19 @@ module ShopifyCli
           Prints version number.
             Usage: {{command:%s version}}
           HELP
+        },
+
+        warning: {
+          development_version: <<~DEVELOPMENT,
+          {{*}} {{yellow:You are running a development version of the CLI at:}}
+              {{yellow:%s}}
+
+          DEVELOPMENT
+
+          shell_shim: <<~MESSAGE,
+          {{x}} {{red:The Shopify CLI is no longer available as a Git repository. It is now delivered as a package.
+            Please visit https://shopify.github.io/shopify-app-cli for installation instructions.}}
+          MESSAGE
         },
       },
     }.freeze

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -267,8 +267,11 @@ module ShopifyCli
           DEVELOPMENT
 
           shell_shim: <<~MESSAGE,
-          {{x}} {{red:This version of Shopify App CLI is no longer supported. You'll need to upgrade to continue using it, this process typically takes a few minutes.
-            Please visit https://shopify.github.io/shopify-app-cli/upgrade/ for complete instructions.}}
+          {{x}} This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it. This process typically takes a few minutes.
+
+            Please visit this page for complete instructions:
+            {{underline:https://shopify.github.io/shopify-app-cli/upgrade/}}
+
           MESSAGE
         },
       },

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -267,8 +267,8 @@ module ShopifyCli
           DEVELOPMENT
 
           shell_shim: <<~MESSAGE,
-          {{x}} {{red:The Shopify CLI is no longer available as a Git repository. It is now delivered as a package.
-            Please visit https://shopify.github.io/shopify-app-cli for installation instructions.}}
+          {{x}} {{red:This version of Shopify App CLI is no longer supported. You'll need to upgrade to continue using it, this process typically takes a few minutes.
+            Please visit https://shopify.github.io/shopify-app-cli/upgrade/ for complete instructions.}}
           MESSAGE
         },
       },

--- a/shopify.fish
+++ b/shopify.fish
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env fish
+# vi: ft=fish
 
 # If we're not already in a shim environment but still tried to set up a shim, print out the re-installation warning
-typeset -f shopify > /dev/null 2>&1
-if [ "$?" != "0" ]; then
+type -t shopify > /dev/null 2>&1
+if [ $status != "0" ]
   echo "This version of Shopify App CLI is no longer supported. You'll need to upgrade to continue using it, this process typically takes a few minutes.
     Please visit https://shopify.github.io/shopify-app-cli/upgrade/ for complete instructions."
-fi
+end

--- a/shopify.fish
+++ b/shopify.fish
@@ -4,6 +4,8 @@
 # If we're not already in a shim environment but still tried to set up a shim, print out the re-installation warning
 type -t shopify > /dev/null 2>&1
 if [ $status != "0" ]
-  echo "This version of Shopify App CLI is no longer supported. You'll need to upgrade to continue using it, this process typically takes a few minutes.
-    Please visit https://shopify.github.io/shopify-app-cli/upgrade/ for complete instructions."
+  echo "This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it. This process typically takes a few minutes.
+Please visit this page for complete instructions:
+  https://shopify.github.io/shopify-app-cli/upgrade/
+"
 end

--- a/shopify.sh
+++ b/shopify.sh
@@ -3,6 +3,8 @@
 # If we're not already in a shim environment but still tried to set up a shim, print out the re-installation warning
 typeset -f shopify > /dev/null 2>&1
 if [ "$?" != "0" ]; then
-  echo "This version of Shopify App CLI is no longer supported. You'll need to upgrade to continue using it, this process typically takes a few minutes.
-    Please visit https://shopify.github.io/shopify-app-cli/upgrade/ for complete instructions."
+  echo "This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it. This process typically takes a few minutes.
+Please visit this page for complete instructions:
+  https://shopify.github.io/shopify-app-cli/upgrade/
+"
 fi

--- a/shopify.sh
+++ b/shopify.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# If we're not already in a shim environment but still tried to set up a shim, print out the re-installation warning
+type __shopify_cli__ > /dev/null 2>&1
+if [ "$?" != "0" ]; then
+  echo "The Shopify CLI is no longer available as a Git repository. It is now delivered as a package.
+    Please visit https://shopify.github.io/shopify-app-cli for installation instructions."
+fi


### PR DESCRIPTION
### WHY are these changes introduced?

Once the CLI is only distributed as a package, we'll no longer want developers to be able to continue using the `master` branch checkout so we put out a unified experience. Therefore, this change intends to make it clear to the user that they should go through the migration process.

It is quite disruptive to simply force them to reinstall via a package / gem, but there are significant changes in how the CLI works without the shell shims and finalizer, so while things are likely to work, we can't guarantee it either.

The idea behind this is that whenever the user goes through the process of running the shell shim, we simply let them know that the CLI is no longer working. If they try and run any commands with a pre-set shim we'll also show a similar message to really drive the point home.

### WHAT is this pull request doing?

The actual shell shim is replaced with a simple message which would cause this to the user's shell:

<img width="672" alt="Screen Shot 2020-06-11 at 1 24 45 PM" src="https://user-images.githubusercontent.com/64600052/84421169-25e95600-abe9-11ea-8929-b9d67fd9258c.png">

Note that in the example above we are still hitting the `shopify` executable from the `shopify_api` gem. It will also be removed as part of the migration process.

And if the partner actually runs a command while a shim is active, we will print this out:

<img width="684" alt="Screen Shot 2020-06-12 at 9 43 24 AM" src="https://user-images.githubusercontent.com/64600052/84509020-2b9a7680-ac91-11ea-93c3-1a81ecc1d2a4.png">