### PR TITLE
Hide which yarn ouput when checking yarn version

### DIFF
--- a/lib/shopify-cli/js_system.rb
+++ b/lib/shopify-cli/js_system.rb
@@ -63,7 +63,10 @@ module ShopifyCli
     #   ShopifyCli::JsSystem.new(ctx: ctx).yarn?
     #
     def yarn?
-      @has_yarn ||= File.exist?(File.join(ctx.root, 'yarn.lock')) && CLI::Kit::System.system('which', 'yarn').success?
+      @has_yarn ||= begin
+        _, status = CLI::Kit::System.capture2('which', 'yarn')
+        File.exist?(File.join(ctx.root, 'yarn.lock')) && status.success?
+      end
     end
 
     ##

--- a/test/shopify-cli/js_system_test.rb
+++ b/test/shopify-cli/js_system_test.rb
@@ -76,7 +76,44 @@ module ShopifyCli
       JsSystem.yarn?(@context)
     end
 
+    def test_yarn_check_returns_false_if_yarn_lock_missing_and_which_yarn_call_fails
+      mock_yarn_check(lock_exists: false, status: stubs(success?: false))
+
+      refute JsSystem.yarn?(@context)
+    end
+
+    def test_yarn_check_returns_false_if_yarn_lock_not_present
+      mock_yarn_check(lock_exists: false, status: stubs(success?: true))
+
+      refute JsSystem.yarn?(@context)
+    end
+
+    def test_yarn_check_returns_false_if_yarn_lock_present_but_which_yarn_call_fails
+      mock_yarn_check(lock_exists: true, status: mock(success?: false))
+
+      refute JsSystem.yarn?(@context)
+    end
+
+    def test_yarn_check_returns_true_if_yarn_lock_present_and_which_yarn_call_succeeds
+      mock_yarn_check(lock_exists: true, status: mock(success?: true))
+
+      assert JsSystem.yarn?(@context)
+    end
+
     private
+
+    def mock_yarn_check(status:, lock_exists:)
+      CLI::Kit::System
+        .expects(:capture2)
+        .with('which', 'yarn')
+        .returns(['v1.0.0', status])
+        .once
+      File
+        .expects(:exist?)
+        .with(File.join(@context.root, 'yarn.lock'))
+        .returns(lock_exists)
+        .once
+    end
 
     def mock_kit_system(*input)
       CLI::Kit::System


### PR DESCRIPTION
### WHY are these changes introduced?
Currently when running `which yarn` to determine if `yarn` is available the output is being presented to the user. I don't believe this is the expected result of this check.

### WHAT is this pull request doing?
- Updated the `which yarn` call to use `capture2` instead of `system`
- Added some tests around `yarn?` since it had been untested previously

### Example
For some testing, I commented out all of the `node` create command so it just outputs `yarn` status.

#### Previous Output
![before_change](https://user-images.githubusercontent.com/42751082/84679713-a4066f00-aeff-11ea-95c6-94b3427e96e2.png)

#### After change
![after_change](https://user-images.githubusercontent.com/42751082/84679730-a9fc5000-aeff-11ea-87ab-a6214ded7df0.png)

#### After change without `yarn.lock`
![remove_yarn_lock](https://user-images.githubusercontent.com/42751082/84679756-b2ed2180-aeff-11ea-836a-f2c9e326506d.png)


