### PR TITLE
Fix red frame on successful npm check

### DIFF
--- a/lib/project_types/script/layers/application/project_dependencies.rb
+++ b/lib/project_types/script/layers/application/project_dependencies.rb
@@ -9,23 +9,23 @@ module Script
 
         def self.install(ctx:, language:, extension_point:, script_name:)
           dep_manager = Infrastructure::DependencyManager.for(ctx, language, extension_point, script_name)
-
-          unless CLI::UI::Frame.open(ctx.message('script.project_deps.checking_with_npm')) do
-            return ctx.puts(ctx.message('script.project_deps.none_required')) if dep_manager.installed?
+          CLI::UI::Frame.open(ctx.message('script.project_deps.checking_with_npm')) do
             begin
-              UI::StrictSpinner.spin(ctx.message('script.project_deps.installing')) do |spinner|
-                dep_manager.install
-                spinner.update_title(ctx.message('script.project_deps.installed'))
+              if dep_manager.installed?
+                ctx.puts(ctx.message('script.project_deps.none_required'))
+              else
+                UI::StrictSpinner.spin(ctx.message('script.project_deps.installing')) do |spinner|
+                  dep_manager.install
+                  spinner.update_title(ctx.message('script.project_deps.installed'))
+                end
               end
               true
             rescue Infrastructure::Errors::DependencyInstallError => e
               CLI::UI::Frame.with_frame_color_override(:red) do
                 ctx.puts("\n#{e.message}")
               end
-              false
+              raise e
             end
-          end
-            raise Infrastructure::Errors::DependencyInstallError
           end
         end
       end

--- a/test/project_types/script/layers/application/project_dependencies_test.rb
+++ b/test/project_types/script/layers/application/project_dependencies_test.rb
@@ -72,6 +72,7 @@ describe Script::Layers::Application::ProjectDependencies do
           @context.expects(:puts).with("\n#{error_message}")
           assert_raises(Script::Layers::Infrastructure::Errors::DependencyInstallError) do
             subject
+            assert_raises(Script::Layers::Infrastructure::Errors::DependencyInstallError)
           end
         end
       end


### PR DESCRIPTION
### WHAT is this pull request doing?

If a script is pushed successfully, the frame that checks if dependencies need to be installed has a red bottom when none are required. It should use the default frame colour (cyan) when successful.

**Before:**
<img width="579" alt="Screen Shot 2020-06-15 at 9 39 36 AM" src="https://user-images.githubusercontent.com/64974039/84683524-2e44d800-aeec-11ea-81e8-2aa3df3ef231.png">

**After:**
<img width="618" alt="Screen Shot 2020-06-15 at 9 33 29 AM" src="https://user-images.githubusercontent.com/64974039/84683263-cee6c800-aeeb-11ea-97e7-13661fe65db5.png">

