### PR TITLE
Update expectation to ruby 2.5 for `create rails`

### DIFF
--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -28,7 +28,7 @@ module Rails
         return @ctx.puts(self.class.help) if form.nil?
 
         @ctx.abort(@ctx.message('rails.create.error.invalid_ruby_version')) unless
-          Ruby.version(@ctx).satisfies?('~>2.4')
+          Ruby.version(@ctx).satisfies?('~>2.5')
 
         build(form.name, form.db)
         set_custom_ua

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -29,7 +29,7 @@ module Rails
 
           error: {
             invalid_ruby_version: <<~MSG,
-            This project requires a ruby version ~> 2.4.
+            This project requires a ruby version ~> 2.5.
             See {{underline:https://github.com/Shopify/shopify-app-cli/blob/master/docs/installing-ruby.md}}
             for our recommended method of installing ruby.
             MSG

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -40,7 +40,7 @@ module Rails
         gem_path = "/gem/path/"
         Gem.stubs(:gem_home).returns(gem_path)
 
-        Ruby.expects(:version).returns(Semantic::Version.new('2.4.0'))
+        Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
         Gem.expects(:install).with(@context, 'rails', nil)
         Gem.expects(:install).with(@context, 'bundler', '~>1.0')
         Gem.expects(:install).with(@context, 'bundler', '~>2.0')
@@ -93,7 +93,7 @@ module Rails
         gem_path = "/gem/path/"
         Gem.stubs(:gem_home).returns(gem_path)
 
-        Ruby.expects(:version).returns(Semantic::Version.new('2.4.0'))
+        Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
         Gem.expects(:install).with(@context, 'rails', nil)
         Gem.expects(:install).with(@context, 'bundler', '~>1.0')
         Gem.expects(:install).with(@context, 'bundler', '~>2.0')
@@ -142,7 +142,7 @@ module Rails
         gem_path = "/gem/path/"
         Gem.stubs(:gem_home).returns(gem_path)
 
-        Ruby.expects(:version).returns(Semantic::Version.new('2.4.0'))
+        Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
         Gem.expects(:install).with(@context, 'rails', nil)
         Gem.expects(:install).with(@context, 'bundler', '~>1.0')
         Gem.expects(:install).with(@context, 'bundler', '~>2.0')


### PR DESCRIPTION
### WHY are these changes introduced?

The latest gem install rails requires a ruby version of at least 2.5.

### WHAT is this pull request doing?

- Updating the expected ruby version from 2.4 to 2.5 in `lib/project_types/rails/commands/create.rb`
- Updating the corresponding output string in `lib/project_types/rails/messages/messages.rb`
- Updating the associated test cases.