### PR TITLE
Add missing brackets to message

### DIFF
--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -101,7 +101,7 @@ module Node
             HELP
             type_select: "How would you like to charge for your app?",
             generating: "Generating %s code ...",
-            generated: "{{green:%s generated in server/server.js",
+            generated: "{{green:%s}} generated in server/server.js",
           },
 
           page: {


### PR DESCRIPTION
### WHY are these changes introduced?

- Terminal text remained green after running `shopify generate billing`.

### WHAT is this pull request doing?

- Add missing `}}` to appropriate message in `lib/project_types/node/messages/message.rb`
