### PR TITLE
Updating JsDeps to improve install failure handling

### DIFF
--- a/lib/shopify-cli/js_deps.rb
+++ b/lib/shopify-cli/js_deps.rb
@@ -37,13 +37,16 @@ module ShopifyCli
     #   ShopifyCli::JsDeps.new(context).install(true)
     #
     def install(verbose = false)
-      CLI::UI::Frame.open(ctx.message('core.js_deps.installing', @system.package_manager)) do
+      title = ctx.message('core.js_deps.installing', @system.package_manager)
+      success = ctx.message('core.js_deps.installed')
+      failure = ctx.message('core.js_deps.error.install_error', @system.package_manager)
+
+      CLI::UI::Frame.open(title, success_text: success, failure_text: failure) do
         @system.call(
           yarn: -> { yarn(verbose) },
           npm: -> { npm(verbose) }
         )
       end
-      ctx.done(ctx.message('core.js_deps.installed'))
     end
 
     private
@@ -74,10 +77,21 @@ module ShopifyCli
       deps = %w(dependencies devDependencies).map do |key|
         pkg.fetch(key, []).keys
       end.flatten
-      CLI::UI::Spinner.spin(ctx.message('core.js_deps.npm_installing_deps', deps.size)) do |spinner|
-        ctx.system(*cmd, chdir: ctx.root)
-        spinner.update_title(ctx.message('core.js_deps.npm_installed_deps', deps.size))
+
+      success = true
+      spinner_title = ctx.message('core.js_deps.npm_installing_deps', deps.size)
+      CLI::UI::Spinner.spin(spinner_title, auto_debrief: false) do |spinner|
+        success = ctx.system(*cmd, chdir: ctx.root).success?
+
+        if success
+          spinner.update_title(ctx.message('core.js_deps.npm_installed_deps', deps.size))
+        else
+          spinner.update_title(ctx.message('core.js_deps.error.install_error'))
+          CLI::UI::Spinner::TASK_FAILED
+        end
       end
+
+      success
     rescue JSON::ParserError
       ctx.puts(
         ctx.message('core.js_deps.error.invalid_package', File.read(File.join(path, 'package.json'))),

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -88,6 +88,7 @@ module ShopifyCli
           error: {
             missing_package: "expected to have a file at: %s",
             invalid_package: "{{info:%s}} was not valid JSON. Fix this then try again",
+            install_error: 'An error occurred while installing dependencies',
           },
 
           installing: "Installing dependencies with %s...",

--- a/test/shopify-cli/js_deps_test.rb
+++ b/test/shopify-cli/js_deps_test.rb
@@ -7,31 +7,66 @@ module ShopifyCli
       project_context('app_types', 'node')
     end
 
-    def test_installs_with_npm
+    def test_installs_with_npm_and_returns_true
       JsSystem.any_instance.stubs(:yarn?).returns(false)
       CLI::Kit::System.expects(:system).with(
         'npm', 'install', '--no-audit', '--no-optional', '--silent',
         env: @context.env,
         chdir: @context.root,
-      )
+      ).returns(mock(success?: true))
+
       io = capture_io do
-        JsDeps.install(@context)
+        assert JsDeps.install(@context)
       end
+
       output = io.join
       assert_match('Installing dependencies with npm...', output)
     end
 
-    def test_installs_with_yarn
+    def test_install_with_npm_outputs_an_error_message_if_install_fails_and_returns_false
+      JsSystem.any_instance.stubs(:yarn?).returns(false)
+      CLI::Kit::System.expects(:system).with(
+        'npm', 'install', '--no-audit', '--no-optional', '--silent',
+        env: @context.env,
+        chdir: @context.root,
+      ).returns(mock(success?: false))
+
+      io = capture_io do
+        refute JsDeps.install(@context)
+      end
+
+      output = io.join
+      assert_match(@context.message('core.js_deps.error.install_error'), output)
+    end
+
+    def test_installs_with_yarn_and_returns_true
       JsSystem.any_instance.stubs(:yarn?).returns(true)
       CLI::Kit::System.expects(:system).with(
         'yarn', 'install', '--silent',
         chdir: @context.root
       ).returns(mock(success?: true))
+
       io = capture_io do
-        JsDeps.install(@context)
+        assert JsDeps.install(@context)
       end
+
       output = io.join
       assert_match('Installing dependencies with yarn...', output)
+    end
+
+    def test_install_with_yarn_outputs_an_error_message_if_install_fails_and_returns_false
+      JsSystem.any_instance.stubs(:yarn?).returns(true)
+      CLI::Kit::System.expects(:system).with(
+        'yarn', 'install', '--silent',
+        chdir: @context.root
+      ).returns(mock(success?: false))
+
+      io = capture_io do
+        refute JsDeps.install(@context)
+      end
+
+      output = io.join
+      assert_match(@context.message('core.js_deps.error.install_error'), output)
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?
The current output for `JsDeps.install` does not handle all possible error cases. In some specific cases, it actually appears to be successful when the install actually failed. 

This PR updates the `JsDeps` class to be able to handle error cases and return that result to the caller.

### WHAT is this pull request doing?
- `install` now outputs an error case when install fails
- `install` now returns true/false dependant on if `install` is a success or fail

### Comparison
#### Yarn Success
![previous_yarn_success](https://user-images.githubusercontent.com/42751082/84706161-869aca80-af2a-11ea-852f-0b3cad48c5d1.png)
⬇️ 
![yarn_success](https://user-images.githubusercontent.com/42751082/84706178-8bf81500-af2a-11ea-8b20-c877565a88e0.png)

#### Yarn Failure
![previous_yarn_failure](https://user-images.githubusercontent.com/42751082/84706234-a16d3f00-af2a-11ea-93c6-088ae0e98062.png)
⬇️ 
![yarn_failure](https://user-images.githubusercontent.com/42751082/84706242-a5995c80-af2a-11ea-8e9f-966be5fbd446.png)

#### NPM Success
![previous_npm_success](https://user-images.githubusercontent.com/42751082/84706301-b8139600-af2a-11ea-8a42-9f027b35acde.png)
⬇️ 
![npm_success](https://user-images.githubusercontent.com/42751082/84706315-bf3aa400-af2a-11ea-8b6d-2e8a717f5226.png)

#### NPM Failure
![previous_npm_failure](https://user-images.githubusercontent.com/42751082/84706329-c497ee80-af2a-11ea-9d7e-85b14971a60c.png)
⬇️ 
![Screen Shot 2020-06-16 at 9 13 40 AM](https://user-images.githubusercontent.com/42751082/84779074-eb4d3800-afb1-11ea-8efa-6d00c9d4e02a.png)



