### PR TITLE
Remove configuration field from shop_script_delete query

### DIFF
--- a/lib/project_types/script/graphql/shop_script_delete.graphql
+++ b/lib/project_types/script/graphql/shop_script_delete.graphql
@@ -9,7 +9,6 @@ mutation ShopScriptDelete($extensionPointName: ExtensionPointName!) {
       extensionPointName
       shopId
       title
-      configuration
     }
   }
 }

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -348,7 +348,6 @@ describe Script::Layers::Infrastructure::ScriptService do
               extensionPointName
               shopId
               title
-              configuration
             }
           }
         }
@@ -395,7 +394,6 @@ describe Script::Layers::Infrastructure::ScriptService do
             "shopScriptDelete" => {
               "shopScript" => {
                 "shopId" => "1",
-                "configuration" => nil,
                 "extensionPointName" => extension_point_type,
                 "title" => "foo2",
               },


### PR DESCRIPTION
### WHY are these changes introduced?

We don't use configuration after disabling a script right now, so we don't need it. There was a change to the server that makes configuration a ConfigurationInput rather than a string, so this is broken right now anyway.

### WHAT is this pull request doing?

Removes `configuration` field from our queries.