### PR TITLE
Align yarn and npm install UX

### DIFF
--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -88,13 +88,14 @@ module ShopifyCli
           error: {
             missing_package: "expected to have a file at: %s",
             invalid_package: "{{info:%s}} was not valid JSON. Fix this then try again",
+            install_spinner_error: "Unable to install all %d dependencies",
             install_error: 'An error occurred while installing dependencies',
           },
 
           installing: "Installing dependencies with %s...",
           installed: "Dependencies installed",
-          npm_installing_deps: "Installing %d dependencies...",
-          npm_installed_deps: "%d npm dependencies installed",
+          installing_deps: "Installing %d dependencies...",
+          installed_deps: "%d dependencies installed",
         },
 
         load_dev: {

--- a/test/shopify-cli/js_deps_test.rb
+++ b/test/shopify-cli/js_deps_test.rb
@@ -5,68 +5,82 @@ module ShopifyCli
   class JsDepsTest < MiniTest::Test
     def setup
       project_context('app_types', 'node')
+      @node_fixture_dependencies = 37
     end
 
     def test_installs_with_npm_and_returns_true
       JsSystem.any_instance.stubs(:yarn?).returns(false)
-      CLI::Kit::System.expects(:system).with(
-        'npm', 'install', '--no-audit', '--no-optional', '--silent',
-        env: @context.env,
-        chdir: @context.root,
-      ).returns(mock(success?: true))
+      mock_install_call(
+        command: %w(npm install --no-audit --no-optional --quiet),
+        returns: ['', '', mock(success?: true)]
+      )
 
       io = capture_io do
         assert JsDeps.install(@context)
       end
 
       output = io.join
-      assert_match('Installing dependencies with npm...', output)
+      assert_match(@context.message('core.js_deps.installing', 'npm'), output)
+      assert_match(@context.message('core.js_deps.installed'), output)
     end
 
     def test_install_with_npm_outputs_an_error_message_if_install_fails_and_returns_false
       JsSystem.any_instance.stubs(:yarn?).returns(false)
-      CLI::Kit::System.expects(:system).with(
-        'npm', 'install', '--no-audit', '--no-optional', '--silent',
-        env: @context.env,
-        chdir: @context.root,
-      ).returns(mock(success?: false))
+      mock_install_call(
+        command: %w(npm install --no-audit --no-optional --quiet),
+        returns: ['', mock(lines: ['error message']), mock(success?: false)]
+      )
 
       io = capture_io do
         refute JsDeps.install(@context)
       end
 
       output = io.join
+      assert_match(@context.message('core.js_deps.installing', 'npm'), output)
+      assert_match('error message', output)
       assert_match(@context.message('core.js_deps.error.install_error'), output)
     end
 
     def test_installs_with_yarn_and_returns_true
       JsSystem.any_instance.stubs(:yarn?).returns(true)
-      CLI::Kit::System.expects(:system).with(
-        'yarn', 'install', '--silent',
-        chdir: @context.root
-      ).returns(mock(success?: true))
+      mock_install_call(
+        command: %w(yarn install --silent),
+        returns: ['', '', mock(success?: true)]
+      )
 
       io = capture_io do
         assert JsDeps.install(@context)
       end
 
       output = io.join
-      assert_match('Installing dependencies with yarn...', output)
+      assert_match(@context.message('core.js_deps.installing', 'yarn'), output)
+      assert_match(@context.message('core.js_deps.installed'), output)
     end
 
-    def test_install_with_yarn_outputs_an_error_message_if_install_fails_and_returns_false
+    def test_install_with_yarn_outputs_errors_and_an_error_message_if_install_fails_and_returns_false
       JsSystem.any_instance.stubs(:yarn?).returns(true)
-      CLI::Kit::System.expects(:system).with(
-        'yarn', 'install', '--silent',
-        chdir: @context.root
-      ).returns(mock(success?: false))
+      mock_install_call(
+        command: %w(yarn install --silent),
+        returns: ['', mock(lines: ['error message']), mock(success?: false)]
+      )
 
       io = capture_io do
         refute JsDeps.install(@context)
       end
 
       output = io.join
+      assert_match(@context.message('core.js_deps.installing', 'yarn'), output)
+      assert_match('error message', output)
       assert_match(@context.message('core.js_deps.error.install_error'), output)
+    end
+
+    private
+
+    def mock_install_call(command:, returns:)
+      CLI::Kit::System
+        .expects(:capture3)
+        .with(*command, env: @context.env, chdir: @context.root)
+        .returns(returns)
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?
After completing https://github.com/Shopify/shopify-app-cli/pull/677 I noticed the UX flow of installation between `yarn` and `npm` was not aligned. You can go to that issue to see the misalignment.

### WHAT is this pull request doing?
Updates the flow so JS dependency install has an aligned UX no matter which package manager is being used.
- Split out common parts of `install`
- Reuse the install path for both `yarn` and `npm`

### Updated UX
#### Yarn Success
![yarn_success](https://user-images.githubusercontent.com/42751082/84811817-6ecf4f00-afdb-11ea-89d7-194db887f35f.gif)

#### Yarn Failure
![yarn_failure](https://user-images.githubusercontent.com/42751082/84811835-742c9980-afdb-11ea-8d51-776d8535a0ca.gif)

#### NPM Success
![npm_success](https://user-images.githubusercontent.com/42751082/84811868-80185b80-afdb-11ea-9160-581d7f3fb2e8.gif)

#### NPM Failure
![npm_failure](https://user-images.githubusercontent.com/42751082/84811881-84dd0f80-afdb-11ea-9720-4bdda49f3c70.gif)
