### PR TITLE
Updating monorail to log command names separately

### DIFF
--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -131,7 +131,11 @@ module ShopifyCli
     #   ShopifyCli::Project.current.env
     #
     def env
-      @env ||= Resources::EnvFile.read(directory)
+      @env ||= begin
+                 Resources::EnvFile.read(directory)
+               rescue
+                 nil
+               end
     end
 
     ##

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -133,7 +133,7 @@ module ShopifyCli
     def env
       @env ||= begin
                  Resources::EnvFile.read(directory)
-               rescue
+               rescue Errno::ENOENT
                  nil
                end
     end

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -96,7 +96,8 @@ module ShopifyCli
                 schema_id: ShopifyCli::Core::Monorail::INVOCATIONS_SCHEMA,
                 payload: {
                   project_type: 'fake',
-                  args: "testcommand arg argtwo",
+                  command: 'testcommand',
+                  args: "arg argtwo",
                   time_start: this_time,
                   time_end: this_time,
                   total_time: 0,

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -57,7 +57,8 @@ module ShopifyCli
                 schema_id: ShopifyCli::Core::Monorail::INVOCATIONS_SCHEMA,
                 payload: {
                   project_type: 'fake',
-                  args: "testcommand arg argtwo",
+                  command: 'testcommand',
+                  args: "arg argtwo",
                   time_start: this_time,
                   time_end: this_time,
                   total_time: 0,

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -66,5 +66,28 @@ module ShopifyCli
         assert_equal "myapp", project_name
       end
     end
+
+    def test_project_env_returns_nil_if_doesnt_exist
+      Dir.mktmpdir do |dir|
+        Dir.stubs(:pwd).returns(dir)
+        FileUtils.touch("#{dir}/.shopify-cli.yml")
+        assert_nil(Project.current.env)
+      end
+    end
+
+    def test_project_env_returns_env_file_if_it_exists
+      Dir.mktmpdir do |dir|
+        Dir.stubs(:pwd).returns(dir)
+        FileUtils.touch("#{dir}/.shopify-cli.yml")
+        content = <<~CONTENT
+          SHOPIFY_API_KEY=foo
+          SHOPIFY_API_SECRET=bar
+          HOST=baz
+          AWSKEY=awskey
+        CONTENT
+        File.write(File.join(dir, '.env'), content)
+        refute_nil(Project.current.env)
+      end
+    end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?
For better metrics on what commands are run, this PR splits out the command name from the arguments. 

### WHAT is this pull request doing?
Resolves command name and subcommand names then puts them in a separate field from the argument in the payload to monorail.
