### PR TITLE
Rename deploy to push

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -42,7 +42,7 @@ module Script
 
     module Domain
       autoload :Errors, Project.project_filepath('layers/domain/errors')
-      autoload :DeployPackage, Project.project_filepath('layers/domain/deploy_package')
+      autoload :PushPackage, Project.project_filepath('layers/domain/push_package')
       autoload :ExtensionPoint, Project.project_filepath('layers/domain/extension_point')
       autoload :Script, Project.project_filepath('layers/domain/script')
     end
@@ -55,7 +55,7 @@ module Script
       autoload :AssemblyScriptWasmBuilder,
                Project.project_filepath('layers/infrastructure/assemblyscript_wasm_builder')
       autoload :DependencyManager, Project.project_filepath('layers/infrastructure/dependency_manager')
-      autoload :DeployPackageRepository, Project.project_filepath('layers/infrastructure/deploy_package_repository')
+      autoload :PushPackageRepository, Project.project_filepath('layers/infrastructure/push_package_repository')
       autoload :ExtensionPointRepository, Project.project_filepath('layers/infrastructure/extension_point_repository')
       autoload :ScriptBuilder, Project.project_filepath('layers/infrastructure/script_builder')
       autoload :ScriptRepository, Project.project_filepath('layers/infrastructure/script_repository')

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -33,8 +33,8 @@ module Script
               script_builder.build
             end
 
-            Infrastructure::DeployPackageRepository.new
-              .create_deploy_package(script, script_content, schema, compiled_type)
+            Infrastructure::PushPackageRepository.new
+              .create_push_package(script, script_content, schema, compiled_type)
           end
         end
       end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -18,9 +18,9 @@ module Script
 
           def push_script(ctx, script, api_key, force)
             compiled_type = Infrastructure::ScriptBuilder.for(script).compiled_type
-            Infrastructure::DeployPackageRepository.new
-              .get_deploy_package(script, compiled_type)
-              .deploy(Infrastructure::ScriptService.new(ctx: ctx), api_key, force)
+            Infrastructure::PushPackageRepository.new
+              .get_push_package(script, compiled_type)
+              .push(Infrastructure::ScriptService.new(ctx: ctx), api_key, force)
             ctx.puts(ctx.message('script.application.pushed'))
           end
         end

--- a/lib/project_types/script/layers/domain/errors.rb
+++ b/lib/project_types/script/layers/domain/errors.rb
@@ -4,7 +4,7 @@ module Script
   module Layers
     module Domain
       module Errors
-        class DeployPackageNotFoundError < ScriptProjectError; end
+        class PushPackageNotFoundError < ScriptProjectError; end
         class InvalidExtensionPointError < ScriptProjectError
           attr_reader :type
           def initialize(type)

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -3,7 +3,7 @@
 module Script
   module Layers
     module Domain
-      class DeployPackage
+      class PushPackage
         attr_reader :id, :script, :script_content, :compiled_type, :schema
 
         def initialize(id, script, script_content, compiled_type, schema)
@@ -14,8 +14,8 @@ module Script
           @schema = schema
         end
 
-        def deploy(script_service, api_key, force)
-          script_service.deploy(
+        def push(script_service, api_key, force)
+          script_service.push(
             extension_point_type: @script.extension_point_type,
             script_name: @script.name,
             script_content: @script_content,

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -3,13 +3,13 @@
 module Script
   module Layers
     module Infrastructure
-      class DeployPackageRepository
-        def create_deploy_package(script, script_content, schema, compiled_type)
+      class PushPackageRepository
+        def create_push_package(script, script_content, schema, compiled_type)
           build_file_path = file_path(script.name, compiled_type)
           write_to_path(build_file_path, script_content)
           write_to_path(schema_path, schema)
 
-          Domain::DeployPackage.new(
+          Domain::PushPackage.new(
             build_file_path,
             script,
             script_content,
@@ -18,15 +18,15 @@ module Script
           )
         end
 
-        def get_deploy_package(script, compiled_type)
+        def get_push_package(script, compiled_type)
           build_file_path = file_path(script.name, compiled_type)
 
-          raise Domain::DeployPackageNotFoundError unless File.exist?(build_file_path)
+          raise Domain::PushPackageNotFoundError unless File.exist?(build_file_path)
 
           script_content = File.read(build_file_path)
           schema = File.exist?(schema_path) ? File.read(schema_path) : ''
 
-          Domain::DeployPackage.new(
+          Domain::PushPackage.new(
             build_file_path,
             script,
             script_content,

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -10,7 +10,7 @@ module Script
         include SmartProperties
         property! :ctx, accepts: ShopifyCli::Context
 
-        def deploy(
+        def push(
           extension_point_type:,
           schema:,
           script_name:,

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -35,9 +35,9 @@ describe Script::Layers::Application::BuildScript do
           .any_instance
           .expects(:build)
           .returns([content, schema])
-        Script::Layers::Infrastructure::DeployPackageRepository
+        Script::Layers::Infrastructure::PushPackageRepository
           .any_instance
-          .expects(:create_deploy_package)
+          .expects(:create_push_package)
           .with(script, content, schema, 'wasm')
         capture_io { subject }
       end
@@ -51,9 +51,9 @@ describe Script::Layers::Application::BuildScript do
           .any_instance
           .expects(:build)
           .returns([content, schema])
-        Script::Layers::Infrastructure::DeployPackageRepository
+        Script::Layers::Infrastructure::PushPackageRepository
           .any_instance
-          .expects(:create_deploy_package)
+          .expects(:create_push_package)
           .raises(err_msg)
 
         io = capture_io do

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -3,7 +3,7 @@
 require "project_types/script/test_helper"
 require "project_types/script/layers/infrastructure/fake_script_repository"
 require "project_types/script/layers/infrastructure/fake_extension_point_repository"
-require "project_types/script/layers/infrastructure/fake_deploy_package_repository"
+require "project_types/script/layers/infrastructure/fake_push_package_repository"
 
 describe Script::Layers::Application::PushScript do
   include TestHelpers::FakeFS
@@ -18,19 +18,19 @@ describe Script::Layers::Application::PushScript do
     TestHelpers::FakeScriptProject
       .new(language: @language, extension_point_type: @extension_point_type, script_name: @script_name)
   end
-  let(:deploy_package_repository) { Script::Layers::Infrastructure::FakeDeployPackageRepository.new }
+  let(:push_package_repository) { Script::Layers::Infrastructure::FakePushPackageRepository.new }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
   let(:script_repository) { Script::Layers::Infrastructure::FakeScriptRepository.new }
   let(:script) { script_repository.create_script(language, ep, script_name) }
 
   before do
-    Script::Layers::Infrastructure::DeployPackageRepository.stubs(:new).returns(deploy_package_repository)
+    Script::Layers::Infrastructure::PushPackageRepository.stubs(:new).returns(push_package_repository)
     Script::Layers::Infrastructure::ScriptRepository.stubs(:new).returns(script_repository)
     Script::Layers::Infrastructure::ExtensionPointRepository.stubs(:new).returns(extension_point_repository)
     Script::ScriptProject.stubs(:current).returns(project)
     extension_point_repository.create_extension_point(extension_point_type)
-    deploy_package_repository.create_deploy_package(script, 'content', 'schema', compiled_type)
+    push_package_repository.create_push_package(script, 'content', 'schema', compiled_type)
   end
 
   describe '.call' do
@@ -53,8 +53,8 @@ describe Script::Layers::Application::PushScript do
         .expects(:call).with(ctx: @context, script: script)
       Script::Layers::Infrastructure::ScriptService
         .expects(:new).returns(script_service_instance)
-      Script::Layers::Domain::DeployPackage
-        .any_instance.expects(:deploy).with(script_service_instance, api_key, force)
+      Script::Layers::Domain::PushPackage
+        .any_instance.expects(:push).with(script_service_instance, api_key, force)
       capture_io { subject }
     end
   end

--- a/test/project_types/script/layers/domain/domain_package_test.rb
+++ b/test/project_types/script/layers/domain/domain_package_test.rb
@@ -2,7 +2,7 @@
 
 require "project_types/script/test_helper"
 
-describe Script::Layers::Domain::DeployPackage do
+describe Script::Layers::Domain::PushPackage do
   let(:extension_point_type) { "discount" }
   let(:extension_point_schema) { "discount" }
   let(:script_id) { 'id' }
@@ -15,26 +15,26 @@ describe Script::Layers::Domain::DeployPackage do
   let(:force) { false }
   let(:script_content) { "(module)" }
   let(:compiled_type) { "wasm" }
-  let(:deploy_package) do
-    Script::Layers::Domain::DeployPackage.new(id, script, script_content, compiled_type, extension_point_schema)
+  let(:push_package) do
+    Script::Layers::Domain::PushPackage.new(id, script, script_content, compiled_type, extension_point_schema)
   end
   let(:script_service) { Minitest::Mock.new }
-  let(:id) { "deploy_package_id" }
+  let(:id) { "push_package_id" }
 
   describe ".new" do
-    subject { deploy_package }
+    subject { push_package }
 
-    it "should construct new DeployPackage" do
+    it "should construct new PushPackage" do
       assert_equal id, subject.id
       assert_equal script_content, subject.script_content
     end
   end
 
-  describe ".deploy" do
-    subject { deploy_package.deploy(script_service, api_key, force) }
+  describe ".push" do
+    subject { push_package.push(script_service, api_key, force) }
 
-    it "should open write to build file and deploy" do
-      script_service.expect(:deploy, nil) do |**kwargs|
+    it "should open write to build file and push" do
+      script_service.expect(:push, nil) do |**kwargs|
         kwargs[:extension_point_type] == extension_point_type &&
           kwargs[:script_name] == script_name &&
           kwargs[:script_content] == script_content &&

--- a/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
@@ -3,22 +3,22 @@
 module Script
   module Layers
     module Infrastructure
-      class FakeDeployPackageRepository
+      class FakePushPackageRepository
         def initialize
           @cache = {}
         end
 
-        def create_deploy_package(script, script_content, schema, compiled_type)
+        def create_push_package(script, script_content, schema, compiled_type)
           id = id(script.name, compiled_type)
-          @cache[id] = Domain::DeployPackage.new(script.id, script, script_content, compiled_type, schema)
+          @cache[id] = Domain::PushPackage.new(script.id, script, script_content, compiled_type, schema)
         end
 
-        def get_deploy_package(script, compiled_type)
+        def get_push_package(script, compiled_type)
           id = id(script.name, compiled_type)
           if @cache.key?(id)
             @cache[id]
           else
-            raise Domain::Errors::DeployPackageNotFoundError
+            raise Domain::Errors::PushPackageNotFoundError
           end
         end
 

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -22,7 +22,7 @@ describe Script::Layers::Infrastructure::ScriptService do
     HERE
   end
 
-  describe ".deploy" do
+  describe ".push" do
     let(:extension_point_schema) { "schema" }
     let(:script_name) { "foo_bar" }
     let(:script_content) { "(module)" }
@@ -82,7 +82,7 @@ describe Script::Layers::Infrastructure::ScriptService do
     end
 
     subject do
-      script_service.deploy(
+      script_service.push(
         extension_point_type: extension_point_type,
         schema: extension_point_schema,
         script_name: script_name,
@@ -92,7 +92,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       )
     end
 
-    describe "when deploy to script service succeeds" do
+    describe "when push to script service succeeds" do
       let(:script_service_response) do
         {
           "data" => {
@@ -122,7 +122,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       end
     end
 
-    describe "when deploy to script service responds with errors" do
+    describe "when push to script service responds with errors" do
       let(:response) do
         {
           data: {
@@ -148,7 +148,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       end
     end
 
-    describe "when deploy to script service responds with userErrors" do
+    describe "when push to script service responds with userErrors" do
       describe "when invalid app key" do
         let(:response) do
           {
@@ -169,7 +169,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         end
       end
 
-      describe "when redeploy without a force" do
+      describe "when repush without a force" do
         let(:response) do
           {
             data: {


### PR DESCRIPTION
### WHAT is this pull request doing?

Rename `shopify deploy` for scripts to `shopify push`. There was a script-service spot that wasn't changed in the last PR.
