### PR TITLE
Scripts: remove schema generation

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -3,16 +3,16 @@ discount:
     package: "@shopify/extension-point-as-discount"
     version: "^0.2.2"
     sdk-version: "^6.0.0"
-    toolchain-version: "^1.0.1"
+    toolchain-version: "^1.1.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
     version: "^0.1.2"
     sdk-version: "^6.0.0"
-    toolchain-version: "^1.0.1"
+    toolchain-version: "^1.1.0"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
     version: "^0.1.2"
     sdk-version: "^6.0.0"
-    toolchain-version: "^1.0.1"
+    toolchain-version: "^1.1.0"

--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -3,7 +3,6 @@ mutation AppScriptUpdateOrCreate(
   $title: String,
   $sourceCode: String,
   $language: String,
-  $schema: String,
   $force: Boolean
 ) {
   appScriptUpdateOrCreate(
@@ -11,7 +10,6 @@ mutation AppScriptUpdateOrCreate(
     title: $title
     sourceCode: $sourceCode
     language: $language
-    schema: $schema,
     force: $force
 ) {
     userErrors {

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -29,12 +29,12 @@ module Script
             script_repo = Infrastructure::ScriptRepository.new
             script_builder = Infrastructure::ScriptBuilder.for(script)
             compiled_type = script_builder.compiled_type
-            script_content, schema = script_repo.with_temp_build_context do
+            script_content = script_repo.with_temp_build_context do
               script_builder.build
             end
 
             Infrastructure::PushPackageRepository.new
-              .create_push_package(script, script_content, schema, compiled_type)
+              .create_push_package(script, script_content, compiled_type)
           end
         end
       end

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -4,14 +4,13 @@ module Script
   module Layers
     module Domain
       class PushPackage
-        attr_reader :id, :script, :script_content, :compiled_type, :schema
+        attr_reader :id, :script, :script_content, :compiled_type
 
-        def initialize(id, script, script_content, compiled_type, schema)
+        def initialize(id, script, script_content, compiled_type)
           @id = id
           @script = script
           @script_content = script_content
           @compiled_type = compiled_type
-          @schema = schema
         end
 
         def push(script_service, api_key, force)
@@ -20,7 +19,6 @@ module Script
             script_name: @script.name,
             script_content: @script_content,
             compiled_type: @compiled_type,
-            schema: schema,
             api_key: api_key,
             force: force
           )

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_wasm_builder.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_wasm_builder.rb
@@ -5,9 +5,8 @@ module Script
     module Infrastructure
       class AssemblyScriptWasmBuilder
         BYTECODE_FILE = "%{name}.wasm"
-        SCHEMA_FILE = "schema"
         SCRIPT_SDK_BUILD = "npx --no-install shopify-scripts-build --src=../%{source} --binary=#{BYTECODE_FILE} "\
-                           "--schema=#{SCHEMA_FILE} -- --lib=../node_modules --validate --optimize"
+                           "-- --lib=../node_modules --validate --optimize"
 
         attr_reader :script
 
@@ -17,7 +16,7 @@ module Script
 
         def build
           compile
-          [bytecode, schema]
+          bytecode
         end
 
         def compiled_type
@@ -33,10 +32,6 @@ module Script
 
         def bytecode
           File.read(format(BYTECODE_FILE, name: script.name))
-        end
-
-        def schema
-          File.read(SCHEMA_FILE)
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -4,17 +4,15 @@ module Script
   module Layers
     module Infrastructure
       class PushPackageRepository
-        def create_push_package(script, script_content, schema, compiled_type)
+        def create_push_package(script, script_content, compiled_type)
           build_file_path = file_path(script.name, compiled_type)
           write_to_path(build_file_path, script_content)
-          write_to_path(schema_path, schema)
 
           Domain::PushPackage.new(
             build_file_path,
             script,
             script_content,
             compiled_type,
-            schema
           )
         end
 
@@ -24,14 +22,12 @@ module Script
           raise Domain::PushPackageNotFoundError unless File.exist?(build_file_path)
 
           script_content = File.read(build_file_path)
-          schema = File.exist?(schema_path) ? File.read(schema_path) : ''
 
           Domain::PushPackage.new(
             build_file_path,
             script,
             script_content,
             compiled_type,
-            schema
           )
         end
 
@@ -44,10 +40,6 @@ module Script
 
         def file_path(script_name, compiled_type)
           "#{ScriptProject.current.directory}/build/#{script_name}.#{compiled_type}"
-        end
-
-        def schema_path
-          "#{ScriptProject.current.directory}/build/schema"
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -12,7 +12,6 @@ module Script
 
         def push(
           extension_point_type:,
-          schema:,
           script_name:,
           script_content:,
           compiled_type:,
@@ -25,7 +24,6 @@ module Script
             title: script_name,
             sourceCode: Base64.encode64(script_content),
             language: compiled_type,
-            schema: schema,
             force: force,
           }
           resp_hash = script_service_request(query_name: query_name, api_key: api_key, variables: variables)

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -12,7 +12,6 @@ describe Script::Layers::Application::BuildScript do
     let(:script_name) { 'name' }
     let(:op_failed_msg) { 'msg' }
     let(:content) { 'content' }
-    let(:schema) { 'schema' }
     let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
     let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
     let(:script_repository) { Script::Layers::Infrastructure::FakeScriptRepository.new }
@@ -34,11 +33,11 @@ describe Script::Layers::Application::BuildScript do
         Script::Layers::Infrastructure::AssemblyScriptWasmBuilder
           .any_instance
           .expects(:build)
-          .returns([content, schema])
+          .returns(content)
         Script::Layers::Infrastructure::PushPackageRepository
           .any_instance
           .expects(:create_push_package)
-          .with(script, content, schema, 'wasm')
+          .with(script, content, 'wasm')
         capture_io { subject }
       end
     end
@@ -50,7 +49,7 @@ describe Script::Layers::Application::BuildScript do
         Script::Layers::Infrastructure::AssemblyScriptWasmBuilder
           .any_instance
           .expects(:build)
-          .returns([content, schema])
+          .returns(content)
         Script::Layers::Infrastructure::PushPackageRepository
           .any_instance
           .expects(:create_push_package)

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -30,7 +30,7 @@ describe Script::Layers::Application::PushScript do
     Script::Layers::Infrastructure::ExtensionPointRepository.stubs(:new).returns(extension_point_repository)
     Script::ScriptProject.stubs(:current).returns(project)
     extension_point_repository.create_extension_point(extension_point_type)
-    push_package_repository.create_push_package(script, 'content', 'schema', compiled_type)
+    push_package_repository.create_push_package(script, 'content', compiled_type)
   end
 
   describe '.call' do

--- a/test/project_types/script/layers/domain/domain_package_test.rb
+++ b/test/project_types/script/layers/domain/domain_package_test.rb
@@ -4,7 +4,6 @@ require "project_types/script/test_helper"
 
 describe Script::Layers::Domain::PushPackage do
   let(:extension_point_type) { "discount" }
-  let(:extension_point_schema) { "discount" }
   let(:script_id) { 'id' }
   let(:script_name) { "foo_script" }
   let(:script) do
@@ -16,7 +15,7 @@ describe Script::Layers::Domain::PushPackage do
   let(:script_content) { "(module)" }
   let(:compiled_type) { "wasm" }
   let(:push_package) do
-    Script::Layers::Domain::PushPackage.new(id, script, script_content, compiled_type, extension_point_schema)
+    Script::Layers::Domain::PushPackage.new(id, script, script_content, compiled_type)
   end
   let(:script_service) { Minitest::Mock.new }
   let(:id) { "push_package_id" }
@@ -39,7 +38,6 @@ describe Script::Layers::Domain::PushPackage do
           kwargs[:script_name] == script_name &&
           kwargs[:script_content] == script_content &&
           kwargs[:compiled_type] == compiled_type &&
-          kwargs[:schema] == extension_point_schema &&
           kwargs[:api_key] == api_key
       end
       subject

--- a/test/project_types/script/layers/infrastructure/assemblyscript_wasm_builder_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_wasm_builder_test.rb
@@ -5,7 +5,6 @@ require 'project_types/script/test_helper'
 describe Script::Layers::Infrastructure::AssemblyScriptWasmBuilder do
   let(:script_id) { 'id' }
   let(:script_name) { "foo" }
-  let(:schema) { "schema" }
   let(:extension_point_config) do
     {
       "assemblyscript" => {
@@ -23,7 +22,6 @@ describe Script::Layers::Infrastructure::AssemblyScriptWasmBuilder do
 
   describe ".build" do
     it "should trigger the compilation process" do
-      File.expects(:read).with("schema")
       File.expects(:read).with("#{script_name}.wasm")
 
       CLI::Kit::System

--- a/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
@@ -8,9 +8,9 @@ module Script
           @cache = {}
         end
 
-        def create_push_package(script, script_content, schema, compiled_type)
+        def create_push_package(script, script_content, compiled_type)
           id = id(script.name, compiled_type)
-          @cache[id] = Domain::PushPackage.new(script.id, script, script_content, compiled_type, schema)
+          @cache[id] = Domain::PushPackage.new(script.id, script, script_content, compiled_type)
         end
 
         def get_push_package(script, compiled_type)

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -23,12 +23,10 @@ describe Script::Layers::Infrastructure::ScriptService do
   end
 
   describe ".push" do
-    let(:extension_point_schema) { "schema" }
     let(:script_name) { "foo_bar" }
     let(:script_content) { "(module)" }
     let(:content_type) { "ts" }
     let(:api_key) { "fake_key" }
-    let(:schema) { "schema" }
     let(:app_script_update_or_create) do
       <<~HERE
         mutation AppScriptUpdateOrCreate(
@@ -36,14 +34,12 @@ describe Script::Layers::Infrastructure::ScriptService do
           $title: String,
           $sourceCode: String,
           $language: String,
-          $schema: String
         ) {
           appScriptUpdateOrCreate(
             extensionPointName: $extensionPointName
             title: $title
             sourceCode: $sourceCode
             language: $language
-            schema: $schema
         ) {
             userErrors {
               field
@@ -72,7 +68,6 @@ describe Script::Layers::Infrastructure::ScriptService do
             title: script_name,
             sourceCode: Base64.encode64(script_content),
             language: "ts",
-            schema: extension_point_schema,
             force: false,
           }.to_json,
           query: app_script_update_or_create,
@@ -84,7 +79,6 @@ describe Script::Layers::Infrastructure::ScriptService do
     subject do
       script_service.push(
         extension_point_type: extension_point_type,
-        schema: extension_point_schema,
         script_name: script_name,
         script_content: script_content,
         compiled_type: "ts",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/1236.

This PR removes the schema generation from the CLI. It was already made optional yesterday, so sending it was no longer necessary. It was also made optional from the toolchain too [here](https://github.com/Shopify/scripts-toolchain-as/pull/2).

### WHAT is this pull request doing?

:burn: schema everywhere