### PR TITLE
Better error message for not supported node version

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
@@ -34,9 +34,9 @@ module Script
           output, status = @ctx.capture2e("node", "--version")
           raise Errors::DependencyInstallError, output unless status.success?
 
-          major, minor, * = output.split(".")
-          unless Integer(major[1..-1]) >= 12 && Integer(minor) >= 16
-            raise Errors::DependencyInstallError, "Node version must be >= v12.16. Current version: #{output}."
+          version = Semantic::Version.new(output[1..-1])
+          unless version >= Semantic::Version.new("12.16.0")
+            raise Errors::DependencyInstallError, "Node version must be >= v12.16.0 Current version: #{output}."
           end
         end
 

--- a/test/project_types/script/layers/infrastructure/assemblyscript_dependency_manager_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_dependency_manager_test.rb
@@ -30,14 +30,11 @@ describe Script::Layers::Infrastructure::AssemblyScriptDependencyManager do
       @context
         .expects(:system)
         .with('npm', '--userconfig', './.npmrc', 'config', 'set', '@shopify:registry', 'https://registry.npmjs.com')
-      @context
-        .expects(:system)
-        .with('npm', '--userconfig', './.npmrc', 'config', 'set', 'engine-strict', 'true')
       subject
     end
 
     it "should write to package.json" do
-      @context.expects(:system).twice
+      @context.expects(:system)
       subject
       assert File.exist?("package.json")
     end
@@ -60,6 +57,9 @@ describe Script::Layers::Infrastructure::AssemblyScriptDependencyManager do
     subject { as_dep_manager.install }
 
     it "should install using npm" do
+      @context.expects(:capture2e)
+        .with("node", "--version")
+        .returns(["v12.16.1", mock(success?: true)])
       @context.expects(:capture2e)
         .with("npm", "install", "--no-audit", "--no-optional", "--loglevel error")
         .returns([nil, mock(success?: true)])


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/1324

The original error message was quite noisy. Instead, we check the node version before running a NPM install. This way, we can display a better error message when needed.

### WHAT is this pull request doing?

Check node version manually, instead of letting NPM do it.
