### PR TITLE
Update tests to use translations

### DIFF
--- a/test/project_types/node/commands/deploy/heroku_test.rb
+++ b/test/project_types/node/commands/deploy/heroku_test.rb
@@ -92,9 +92,7 @@ module Node
         def test_call_uses_existing_heroku_auth_if_available
           expects_heroku_whoami(status: true)
 
-          @context.expects(:puts).with(
-            '{{v}} Authenticated with Heroku as `username`'
-          )
+          @context.expects(:puts).with(@context.message('node.deploy.heroku.authenticated_with_account', 'username'))
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end
@@ -118,9 +116,7 @@ module Node
         def test_call_uses_existing_heroku_app_if_available
           expects_git_remote_get_url_heroku(status: true, remote: 'heroku')
 
-          @context.expects(:puts).with(
-            '{{v}} Heroku app `app-name` selected'
-          )
+          @context.expects(:puts).with(@context.message('node.deploy.heroku.app.selected', 'app-name'))
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end
@@ -130,11 +126,11 @@ module Node
           expects_heroku_select_app(status: true)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
+            .with(@context.message('node.deploy.heroku.app.no_apps_found'))
             .returns(:existing)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('What is your Heroku app’s name?')
+            .with(@context.message('node.deploy.heroku.app.name'))
             .returns('app-name')
 
           Node::Commands::Deploy::Heroku.new(@context).call
@@ -145,11 +141,11 @@ module Node
           expects_heroku_select_app(status: false)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
+            .with(@context.message('node.deploy.heroku.app.no_apps_found'))
             .returns(:existing)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('What is your Heroku app’s name?')
+            .with(@context.message('node.deploy.heroku.app.name'))
             .returns('app-name')
 
           assert_raises ShopifyCli::Abort do
@@ -162,7 +158,7 @@ module Node
           expects_heroku_create(status: true)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
+            .with(@context.message('node.deploy.heroku.app.no_apps_found'))
             .returns(:new)
 
           Node::Commands::Deploy::Heroku.new(@context).call
@@ -173,7 +169,7 @@ module Node
           expects_heroku_create(status: false)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
+            .with(@context.message('node.deploy.heroku.app.no_apps_found'))
             .returns(:new)
 
           assert_raises ShopifyCli::Abort do
@@ -184,9 +180,7 @@ module Node
         def test_call_doesnt_prompt_if_only_one_branch_exists
           expects_git_branch(status: true, multiple: false)
 
-          @context.expects(:puts).with(
-            '{{v}} Git branch `master` selected for deploy'
-          )
+          @context.expects(:puts).with(@context.message('node.deploy.heroku.git.branch_selected', 'master'))
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end
@@ -196,7 +190,7 @@ module Node
           expects_git_push_heroku(status: true, branch: "other_branch:master")
 
           CLI::UI::Prompt.expects(:ask)
-            .with('What branch would you like to deploy?')
+            .with(@context.message('node.deploy.heroku.git.what_branch'))
             .returns('other_branch')
 
           Node::Commands::Deploy::Heroku.new(@context).call

--- a/test/project_types/node/forms/create_test.rb
+++ b/test/project_types/node/forms/create_test.rb
@@ -35,11 +35,11 @@ module Node
           form = ask(type: "not_a_type")
           assert_nil(form)
         end
-        assert_match('Invalid App Type not_a_type', io.join)
+        assert_match(@context.message('node.forms.create.error.invalid_app_type', 'not_a_type'), io.join)
       end
 
       def test_type_is_prompted
-        CLI::UI::Prompt.expects(:ask).with('What type of app are you building?').returns('public')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('node.forms.create.app_type.select')).returns('public')
         ask(type: nil)
       end
 
@@ -96,7 +96,7 @@ module Node
           assert_equal(form.organization_id, 421)
           assert_equal(form.shop_domain, 'next.myshopify.com')
         end
-        assert_match(CLI::UI.fmt('Organization {{green:hoopy froods}}'), io.join)
+        assert_match(CLI::UI.fmt(@context.message('node.forms.create.organization', 'hoopy froods')), io.join)
       end
 
       def test_organization_will_be_fetched_if_id_is_provided_but_not_shop
@@ -131,8 +131,8 @@ module Node
           form = ask(org_id: nil, shop: nil)
           assert_nil(form)
         end
-        assert_match('Please visit https://partners.shopify.com/ to create a partners account', io.join)
-        assert_match('No organizations available.', io.join)
+        assert_match(@context.message('node.forms.create.partners_notice'), io.join)
+        assert_match(@context.message('node.forms.create.error.no_organizations'), io.join)
       end
 
       def test_returns_no_shop_if_none_are_available
@@ -153,8 +153,8 @@ module Node
           assert_nil form.shop_domain
         end
         log = io.join
-        assert_match('No Development Stores available.', log)
-        assert_match(CLI::UI.fmt("Visit {{underline:https://partners.shopify.com/123/stores}} to create one"), log)
+        assert_match(CLI::UI.fmt(@context.message('node.forms.create.no_development_stores')), log)
+        assert_match(CLI::UI.fmt(@context.message('node.forms.create.create_store', 123)), log)
       end
 
       def test_autopicks_only_shop
@@ -178,7 +178,9 @@ module Node
           form = ask(org_id: 123, shop: nil)
           assert_equal(form.shop_domain, 'shopdomain.myshopify.com')
         end
-        assert_match(CLI::UI.fmt("Using Development Store {{green:shopdomain.myshopify.com}}"), io.join)
+        assert_match(CLI::UI.fmt(
+          @context.message('node.forms.create.development_store', 'shopdomain.myshopify.com')
+        ), io.join)
       end
 
       def test_prompts_user_to_pick_from_shops
@@ -205,7 +207,7 @@ module Node
 
         CLI::UI::Prompt.expects(:ask)
           .with(
-            'Select a Development Store',
+            @context.message('node.forms.create.development_store_select'),
             options: %w(shopdomain.myshopify.com shop.myshopify.com)
           )
           .returns('selected')

--- a/test/project_types/rails/commands/deploy/heroku_test.rb
+++ b/test/project_types/rails/commands/deploy/heroku_test.rb
@@ -116,9 +116,7 @@ module Rails
         def test_call_uses_existing_heroku_auth_if_available
           expects_heroku_whoami(status: true)
 
-          @context.expects(:puts).with(
-            "{{v}} Authenticated with Heroku as `username`"
-          )
+          @context.expects(:puts).with(@context.message('rails.deploy.heroku.authenticated_with_account', 'username'))
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
@@ -142,9 +140,7 @@ module Rails
         def test_call_uses_existing_heroku_app_if_available
           expects_git_remote_get_url_heroku(status: true, remote: 'heroku')
 
-          @context.expects(:puts).with(
-            '{{v}} Heroku app `app-name` selected'
-          )
+          @context.expects(:puts).with(@context.message('rails.deploy.heroku.authenticated_with_account', 'username'))
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
@@ -154,11 +150,11 @@ module Rails
           expects_heroku_select_app(status: true)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
+            .with(@context.message('rails.deploy.heroku.app.no_apps_found'))
             .returns(:existing)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('What is your Heroku app’s name?')
+            .with(@context.message('rails.deploy.heroku.app.name'))
             .returns('app-name')
 
           Rails::Commands::Deploy::Heroku.new(@context).call
@@ -169,11 +165,11 @@ module Rails
           expects_heroku_select_app(status: false)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
+            .with(@context.message('rails.deploy.heroku.app.no_apps_found'))
             .returns(:existing)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('What is your Heroku app’s name?')
+            .with(@context.message('rails.deploy.heroku.app.name'))
             .returns('app-name')
 
           assert_raises ShopifyCli::Abort do
@@ -186,7 +182,7 @@ module Rails
           expects_heroku_create(status: true)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
+            .with(@context.message('rails.deploy.heroku.app.no_apps_found'))
             .returns(:new)
 
           Rails::Commands::Deploy::Heroku.new(@context).call
@@ -197,7 +193,7 @@ module Rails
           expects_heroku_create(status: false)
 
           CLI::UI::Prompt.expects(:ask)
-            .with('No existing Heroku app found. What would you like to do?')
+            .with(@context.message('rails.deploy.heroku.app.no_apps_found'))
             .returns(:new)
 
           assert_raises ShopifyCli::Abort do
@@ -208,9 +204,7 @@ module Rails
         def test_call_doesnt_prompt_if_only_one_branch_exists
           expects_git_branch(status: true, multiple: false)
 
-          @context.expects(:puts).with(
-            '{{v}} Git branch `master` selected for deploy'
-          )
+          @context.expects(:puts).with(@context.message('rails.deploy.heroku.git.branch_selected', 'master'))
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
@@ -220,7 +214,7 @@ module Rails
           expects_git_push_heroku(status: true, branch: "other_branch:master")
 
           CLI::UI::Prompt.expects(:ask)
-            .with('What branch would you like to deploy?')
+            .with(@context.message('rails.deploy.heroku.git.what_branch'))
             .returns('other_branch')
 
           Rails::Commands::Deploy::Heroku.new(@context).call

--- a/test/project_types/rails/forms/create_test.rb
+++ b/test/project_types/rails/forms/create_test.rb
@@ -31,11 +31,11 @@ module Rails
           form = ask(type: "not_a_type")
           assert_nil(form)
         end
-        assert_match('Invalid App Type not_a_type', io.join)
+        assert_match(@context.message('rails.forms.create.error.invalid_app_type', 'not_a_type'), io.join)
       end
 
       def test_type_is_prompted
-        CLI::UI::Prompt.expects(:ask).with('What type of app are you building?').returns('public')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('rails.forms.create.app_type.select')).returns('public')
         ask(type: nil)
       end
 
@@ -49,7 +49,7 @@ module Rails
           form = ask(db: "not_a_db")
           assert_nil(form)
         end
-        assert_match('Invalid Database Type not_a_db', io.join)
+        assert_match(@context.message('rails.forms.create.error.invalid_db_type', 'not_a_db'), io.join)
       end
 
       def test_user_can_change_db_in_app
@@ -164,8 +164,8 @@ module Rails
           form = ask(org_id: nil, shop: nil)
           assert_nil(form)
         end
-        assert_match('Please visit https://partners.shopify.com/ to create a partners account', io.join)
-        assert_match('No organizations available.', io.join)
+        assert_match(@context.message('rails.forms.create.partners_notice'), io.join)
+        assert_match(@context.message('rails.forms.create.error.no_organizations'), io.join)
       end
 
       def test_returns_no_shop_if_none_are_available
@@ -186,8 +186,8 @@ module Rails
           assert_nil form.shop_domain
         end
         log = io.join
-        assert_match('No Development Stores available.', log)
-        assert_match(CLI::UI.fmt("Visit {{underline:https://partners.shopify.com/123/stores}} to create one"), log)
+        assert_match(CLI::UI.fmt(@context.message('rails.forms.create.no_development_stores')), log)
+        assert_match(CLI::UI.fmt(@context.message('rails.forms.create.create_store', 123)), log)
       end
 
       def test_autopicks_only_shop
@@ -211,7 +211,9 @@ module Rails
           form = ask(org_id: 123, shop: nil)
           assert_equal(form.shop_domain, 'shopdomain.myshopify.com')
         end
-        assert_match(CLI::UI.fmt("Using Development Store {{green:shopdomain.myshopify.com}}"), io.join)
+        assert_match(CLI::UI.fmt(
+          @context.message('rails.forms.create.development_store', 'shopdomain.myshopify.com')
+        ), io.join)
       end
 
       def test_prompts_user_to_pick_from_shops
@@ -238,7 +240,7 @@ module Rails
 
         CLI::UI::Prompt.expects(:ask)
           .with(
-            'Select a Development Store',
+            @context.message('rails.forms.create.development_store_select'),
             options: %w(shopdomain.myshopify.com shop.myshopify.com)
           )
           .returns('selected')

--- a/test/project_types/script/forms/create_test.rb
+++ b/test/project_types/script/forms/create_test.rb
@@ -24,20 +24,23 @@ module Script
       def test_asks_extension_point_if_no_flag
         eps = ['discount', 'another']
         Layers::Application::ExtensionPoints.stubs(:types).returns(eps)
-        CLI::UI::Prompt.expects(:ask).with('Which extension point do you want to use?', options: eps)
+        CLI::UI::Prompt.expects(:ask).with(
+          @context.message('script.forms.create.select_extension_point'),
+          options: eps
+        )
         ask(name: 'name')
       end
 
       def test_asks_name_if_no_flag
         name = 'name'
-        CLI::UI::Prompt.expects(:ask).with('Script Name').returns(name)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('script.forms.create.script_name')).returns(name)
         form = ask(extension_point: 'discount')
         assert_equal name, form.name
       end
 
       def test_name_is_cleaned_after_prompt
         name = 'name with space'
-        CLI::UI::Prompt.expects(:ask).with('Script Name').returns(name)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('script.forms.create.script_name')).returns(name)
         form = ask(extension_point: 'discount')
         assert_equal 'name_with_space', form.name
       end

--- a/test/shopify-cli/commands/create_test.rb
+++ b/test/shopify-cli/commands/create_test.rb
@@ -16,14 +16,14 @@ module ShopifyCli
         io = capture_io do
           run_cmd('create nope')
         end
-        assert_match('invalid app type', io.join)
+        assert_match(CLI::UI.fmt(@context.message('core.create.error.invalid_app_type', 'nope')), io.join)
       end
 
       def test_type_will_be_asked_for_if_not_provided
         ProjectType.load_type(:rails)
         Rails::Commands::Create.expects(:call)
         Rails::Commands::Create.expects(:ctx=)
-        CLI::UI::Prompt.expects(:ask).with('What type of project would you like to create?').returns(:rails)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.create.project_type_select')).returns(:rails)
         run_cmd('create')
       end
     end

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -33,7 +33,7 @@ module ShopifyCli
     def test_open_url_outputs_url_to_open
       url = 'http://cutekitties.com'
       @ctx.stubs(:mac?).returns(true)
-      @ctx.expects(:puts).with("Please open this URL in your browser:\n{{green:#{url}}}\n")
+      @ctx.expects(:puts).with(@context.message('core.context.open_url', url))
       @ctx.open_url!(url)
     end
   end

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -28,9 +28,7 @@ module ShopifyCli
           :ngrok,
           "exec #{File.join(ShopifyCli::ROOT, 'ngrok')} http -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
-        @context.expects(:puts).with(
-          "{{v}} ngrok tunnel running at {{underline:https://example.ngrok.io}}"
-        )
+        @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
         assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context)
       end
     end
@@ -43,9 +41,7 @@ module ShopifyCli
           :ngrok,
           "exec #{File.join(ShopifyCli::ROOT, 'ngrok')} http -log=stdout -log-level=debug #{configured_port}"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
-        @context.expects(:puts).with(
-          "{{v}} ngrok tunnel running at {{underline:https://example.ngrok.io}}"
-        )
+        @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
         assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context, port: configured_port)
       end
     end
@@ -58,7 +54,7 @@ module ShopifyCli
           "exec #{File.join(ShopifyCli::ROOT, 'ngrok')} http -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(
-          "{{v}} ngrok tunnel running at {{underline:https://example.ngrok.io}}, with account Tom Cruise"
+          @context.message('core.tunnel.start_with_account', 'https://example.ngrok.io', 'Tom Cruise')
         )
         assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context)
       end
@@ -79,7 +75,7 @@ module ShopifyCli
 
     def test_stop_doesnt_stop_what_isnt_started
       ShopifyCli::ProcessSupervision.expects(:running?).with(:ngrok).returns(false)
-      @context.expects(:puts).with("{{green:x}} ngrok tunnel not running")
+      @context.expects(:puts).with(@context.message('core.tunnel.not_running'))
       ShopifyCli::Tunnel.stop(@context)
     end
 

--- a/test/task/ensure_dev_store_test.rb
+++ b/test/task/ensure_dev_store_test.rb
@@ -13,7 +13,9 @@ module ShopifyCli
       def test_outputs_if_shop_cant_be_queried
         stub_org_request
         stub_env(domain: 'notther.myshopify.com')
-        @context.expects(:puts).with("Couldn't verify your store notther.myshopify.com")
+        @context.expects(:puts).with(
+          @context.message('core.tasks.ensure_dev_store.could_not_verify_store', 'notther.myshopify.com')
+        )
         EnsureDevStore.call(@context)
       end
 
@@ -44,7 +46,9 @@ module ShopifyCli
             },
           }
         )
-        @context.expects(:puts).with("{{v}} Transfer has been disabled on shopdomain.myshopify.com.")
+        @context.expects(:puts).with(
+          @context.message('core.tasks.ensure_dev_store.transfer_disabled', 'shopdomain.myshopify.com')
+        )
         EnsureDevStore.call(@context)
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Inspired by Paulo's [comment](https://github.com/Shopify/shopify-app-cli/pull/656#discussion_r437396773) I went looking to see how many of our tests were using hardcoded strings rather than the `@context.message` translations. Turns out it's a bunch!
I've updated all those tests to now use translations so they are less likely to break with content changes.