### PR TITLE
"Organization" -> "Partner organization"

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -62,7 +62,7 @@ $ shopify create node
 
 ## `logout`
 
-Log out of the currently authentiated organization and store. The `logout` command clears any invalid credentials. You’ll need to re-authenticate the next time you connect your project to Shopify.
+Log out of the currently authenticated partner organization and store. The `logout` command clears any invalid credentials. You’ll need to re-authenticate the next time you connect your project to Shopify.
 
 ```console
 $ shopify logout

--- a/lib/project_types/node/forms/create.rb
+++ b/lib/project_types/node/forms/create.rb
@@ -48,11 +48,15 @@ module Node
           ctx.puts(ctx.message('node.forms.create.authentication_issue', ShopifyCli::TOOL_NAME))
           ctx.abort(ctx.message('node.forms.create.error.no_organizations'))
         elsif organizations.count == 1
-          ctx.puts(ctx.message('node.forms.create.organization', organizations.first['businessName']))
-          organizations.first
+          org = organizations.first
+          ctx.puts(ctx.message('node.forms.create.organization',
+            ctx.message('core.partners_api.org_name_and_id', org['businessName'], org['id'])))
+          org
         else
           org_id = CLI::UI::Prompt.ask(ctx.message('node.forms.create.organization_select')) do |handler|
-            organizations.each { |o| handler.option(o['businessName']) { o['id'] } }
+            organizations.each do |o|
+              handler.option(ctx.message('core.partners_api.org_name_and_id', o['businessName'], o['id'])) { o['id'] }
+            end
           end
           organizations.find { |o| o['id'] == org_id }
         end

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -14,8 +14,8 @@ module Node
             Usage: {{command:%s create node}}
             Options:
               {{command:--name=NAME}} App name. Any string.
-              {{command:--app_url=APPURL}} App URL. Must be valid URL.
-              {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
+              {{command:--app_url=APPURL}} App URL. Must be a valid URL.
+              {{command:--organization_id=ID}} Partner organization ID. Must be an existing organization.
               {{command:--shop_domain=MYSHOPIFYDOMAIN }} Development store URL. Must be an existing development store.
           HELP
           error: {
@@ -29,7 +29,7 @@ module Node
           info: {
             created: "{{v}} {{green:%s}} was created in your Partner Dashboard {{underline:%s}}",
             serve: "{{*}} Run {{command:%s serve}} to start a local server",
-            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
+            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your dev store",
           },
           node_version: "node %s",
           npm_version: "npm %s",
@@ -231,9 +231,9 @@ module Node
         forms: {
           create: {
             error: {
-              invalid_app_type: "Invalid App Type %s",
-              organization_not_found: "Cannot find an organization with that ID",
-              no_organizations: "No organizations available.",
+              invalid_app_type: "Invalid app type %s",
+              organization_not_found: "Cannot find a partner organization with that ID",
+              no_organizations: "No partner organizations available.",
             },
 
             authentication_issue: "For authentication issues, run {{command:%s logout}} to clear invalid credentials",
@@ -245,12 +245,12 @@ module Node
               select: "What type of app are you building?",
               select_public: "Public: An app built for a wide merchant audience.",
               select_custom: "Custom: An app custom built for a single client.",
-              selected: "App Type {{green:%s}}",
+              selected: "App type {{green:%s}}",
             },
-            organization_select: "Select organization",
-            organization: "Organization {{green:%s}}",
-            development_store_select: "Select a Development Store",
-            development_store: "Using Development Store {{green:%s}}",
+            organization_select: "Select partner organization",
+            organization: "Partner organization {{green:%s}}",
+            development_store_select: "Select a development store",
+            development_store: "Using development store {{green:%s}}",
           },
         },
       },

--- a/lib/project_types/rails/forms/create.rb
+++ b/lib/project_types/rails/forms/create.rb
@@ -61,8 +61,10 @@ module Rails
           ctx.puts(ctx.message('rails.forms.create.authentication_issue', ShopifyCli::TOOL_NAME))
           ctx.abort(ctx.message('rails.forms.create.error.no_organizations'))
         elsif organizations.count == 1
-          ctx.puts(ctx.message('rails.forms.create.organization', organizations.first['businessName']))
-          organizations.first
+          org = organizations.first
+          ctx.puts(ctx.message('rails.forms.create.organization',
+            ctx.message('core.partners_api.org_name_and_id', org['businessName'], org['id'])))
+          org
         else
           org_id = CLI::UI::Prompt.ask(ctx.message('rails.forms.create.organization_select')) do |handler|
             organizations.each { |o| handler.option(o['businessName']) { o['id'] } }

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -20,8 +20,8 @@ module Rails
             Usage: {{command:%s create rails}}
             Options:
               {{command:--name=NAME}} App name. Any string.
-              {{command:--app_url=APPURL}} App URL. Must be valid URL.
-              {{command:--organization_id=ID}} App Org ID. Must be existing org ID.
+              {{command:--app_url=APPURL}} App URL. Must be a valid URL.
+              {{command:--organization_id=ID}} Partner organization ID. Must be an existing organization.
               {{command:--shop_domain=MYSHOPIFYDOMAIN }} Development store URL. Must be an existing development store.
               {{command:--db=DB}} Database type. Must be one of: mysql, postgresql, sqlite3, oracle, frontbase, ibm_db, sqlserver, jdbcmysql, jdbcsqlite3, jdbcpostgresql, jdbc.
               {{command:--rails_opts=RAILSOPTS}} Additional options. Must be string containing one or more valid Rails options, separated by spaces.
@@ -38,7 +38,7 @@ module Rails
           info: {
             created: "{{v}} {{green:%s}} was created in your Partner Dashboard {{underline:%s}}",
             serve: "{{*}} Run {{command:%s serve}} to start a local server",
-            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
+            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your dev store",
           },
           installing_bundler: "Installing bundler…",
           generating_app: "Generating new rails app project in %s...",
@@ -233,22 +233,22 @@ module Rails
         forms: {
           create: {
             error: {
-              invalid_app_type: "Invalid App Type %s",
-              invalid_db_type: "Invalid Database Type %s",
-              organization_not_found: "Cannot find an organization with that ID",
-              no_organizations: "No organizations available.",
+              invalid_app_type: "Invalid app type %s",
+              invalid_db_type: "Invalid database type %s",
+              organization_not_found: "Cannot find a partner organization with that ID",
+              no_organizations: "No partner organizations available.",
             },
 
             authentication_issue: "For authentication issues, run {{command:%s logout}} to clear invalid credentials",
             partners_notice: "Please visit https://partners.shopify.com/ to create a partners account",
-            no_development_stores: "{{x}} No Development Stores available.",
+            no_development_stores: "{{x}} No development stores available.",
             create_store: "Visit {{underline:https://partners.shopify.com/%s/stores}} to create one",
-            app_name: "App Name",
+            app_name: "App name",
             app_type: {
               select: "What type of app are you building?",
               select_public: "Public: An app built for a wide merchant audience.",
               select_custom: "Custom: An app custom built for a single client.",
-              selected: "App Type {{green:%s}}",
+              selected: "App type {{green:%s}}",
             },
             db: {
               want_select: <<~WANT_SELECT,
@@ -270,10 +270,10 @@ module Rails
               select_jdbc: "JDBC",
               selected: "Database Type {{green:%s}}",
             },
-            organization_select: "Select organization",
-            organization: "Organization {{green:%s}}",
-            development_store_select: "Select a Development Store",
-            development_store: "Using Development Store {{green:%s}}",
+            organization_select: "Select partner organization",
+            organization: "Partner organization {{green:%s}}",
+            development_store_select: "Select a development store",
+            development_store: "Using development store {{green:%s}}",
           },
         },
       },

--- a/lib/project_types/script/forms/script_form.rb
+++ b/lib/project_types/script/forms/script_form.rb
@@ -36,11 +36,15 @@ module Script
         if organizations.count == 0
           raise Errors::NoExistingOrganizationsError
         elsif organizations.count == 1
-          ctx.puts(ctx.message('script.forms.script_form.using_organization', organizations.first['businessName']))
-          organizations.first
+          org = organizations.first
+          ctx.puts(ctx.message('script.forms.script_form.using_organization',
+            ctx.message('core.partners_api.org_name_and_id', org['businessName'], org['id'])))
+          org
         else
           org_id = CLI::UI::Prompt.ask(ctx.message('script.forms.script_form.select_organization')) do |handler|
-            organizations.each { |o| handler.option(o['businessName']) { o['id'] } }
+            organizations.each do |o|
+              handler.option(ctx.message('core.partners_api.org_name_and_id', o['businessName'], o['id'])) { o['id'] }
+            end
           end
           organizations.find { |o| o['id'] == org_id }
         end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -22,7 +22,7 @@ module Script
           no_existing_apps_help: "Please create an app with {{command:shopify create}} or"\
                                  "visit https://partners.shopify.com/.",
 
-          no_existing_orgs_cause: "You don't have any organizations.",
+          no_existing_orgs_cause: "You don't have any partner organizations.",
           no_existing_orgs_help: "Please visit https://partners.shopify.com/ to create a partners account.",
 
           no_existing_stores_cause: "You don't have any development stores.",
@@ -178,11 +178,11 @@ module Script
           script_form: {
             ask_app_api_key_default: "Which app do you want this script to belong to?",
             ask_shop_domain_default: "Select a development store",
-            fetching_organizations: "{{i}} Fetching organizations",
-            select_organization: "Select organization.",
+            fetching_organizations: "{{i}} Fetching partner organizations",
+            select_organization: "Select partner organization.",
             using_app: "Using app {{green:%{title} (%{api_key})}}.",
             using_development_store: "Using development store {{green:%{domain}}}",
-            using_organization: "Organization {{green:%s}}.",
+            using_organization: "Partner organization {{green:%s}}.",
           },
           enable: {
             ask_app_api_key: "Which app is the script pushed to?",

--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -22,7 +22,11 @@ module ShopifyCli
           orgs.first["id"]
         else
           CLI::UI::Prompt.ask(@ctx.message('core.connect.organization_select')) do |handler|
-            orgs.each { |org| handler.option(org["businessName"]) { org["id"] } }
+            orgs.each do |org|
+              handler.option(
+                ctx.message('core.partners_api.org_name_and_id', org['businessName'], org['id'])
+              ) { org["id"] }
+            end
           end
         end
         org = orgs.find { |o| o["id"] == org_id }

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -13,7 +13,7 @@ module ShopifyCli
           production_warning: "{{yellow:! Don't use}} {{cyan:connect}} {{yellow:for production apps}}",
           connected: "{{v}} Project now connected to {{green:%s}}",
           serve: "{{*}} Run {{command:%s serve}} to start a local development server",
-          organization_select: "To which organization does this project belong?",
+          organization_select: "To which partner organization does this project belong?",
           app_select: "To which app does this project belong?",
           no_development_stores: <<~MESSAGE,
           No development stores available.
@@ -121,11 +121,11 @@ module ShopifyCli
 
         logout: {
           help: <<~HELP,
-          Log out of a currently authenticated Organization and Store, or clear invalid credentials
+          Log out of a currently authenticated partner organization and store, or clear invalid credentials
             Usage: {{command:%s logout}}
           HELP
 
-          success: "Logged out of Organization and Store",
+          success: "Logged out of partner organization and store",
         },
 
         monorail: {
@@ -149,11 +149,11 @@ module ShopifyCli
             "{{i}} Authentication required. Login to the URL below with your %s credentials to continue.",
 
           servlet: {
-            success_response: "Authenticated Successfully, you may now close this page.",
-            invalid_request_response: "Invalid Request: %s",
+            success_response: "Authenticated successfully. You may now close this page.",
+            invalid_request_response: "Invalid request: %s",
             invalid_state_response: "Anti-forgery state token does not match the initial request.",
-            authenticated: "Authenticate Successfully",
-            not_authenticated: "Failed to Authenticate",
+            authenticated: "Authenticated successfully",
+            not_authenticated: "Failed to authenticate",
           },
         },
 
@@ -162,6 +162,7 @@ module ShopifyCli
         },
 
         partners_api: {
+          org_name_and_id: "%s (%s)",
           error: {
             account_not_found: <<~MESSAGE,
             {{x}} error: Your account was not found. Please sign up at https://partners.shopify.com/signup

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -71,7 +71,7 @@ module ShopifyCli
       #
       # * `ctx` - the current running context of your command
       # * `project_type` - a string or symbol of your project type name
-      # * `organization_id` - the id of the organization that the app owned by. Used for metrics
+      # * `organization_id` - the id of the partner organization that the app is owned by. Used for metrics
       # * `identifiers` - an optional hash of other app identifiers
       #
       # #### Example

--- a/test/project_types/node/forms/create_test.rb
+++ b/test/project_types/node/forms/create_test.rb
@@ -35,7 +35,7 @@ module Node
           form = ask(type: "not_a_type")
           assert_nil(form)
         end
-        assert_match('Invalid App Type not_a_type', io.join)
+        assert_match(@context.message('node.forms.create.error.invalid_app_type', 'not_a_type'), io.join)
       end
 
       def test_type_is_prompted
@@ -96,7 +96,7 @@ module Node
           assert_equal(form.organization_id, 421)
           assert_equal(form.shop_domain, 'next.myshopify.com')
         end
-        assert_match(CLI::UI.fmt('Organization {{green:hoopy froods}}'), io.join)
+        assert_match(CLI::UI.fmt('Partner organization {{green:hoopy froods (421)}}'), io.join)
       end
 
       def test_organization_will_be_fetched_if_id_is_provided_but_not_shop
@@ -131,8 +131,8 @@ module Node
           form = ask(org_id: nil, shop: nil)
           assert_nil(form)
         end
-        assert_match('Please visit https://partners.shopify.com/ to create a partners account', io.join)
-        assert_match('No organizations available.', io.join)
+        assert_match(@context.message('node.forms.create.partners_notice'), io.join)
+        assert_match(@context.message('node.forms.create.error.no_organizations'), io.join)
       end
 
       def test_returns_no_shop_if_none_are_available
@@ -178,7 +178,7 @@ module Node
           form = ask(org_id: 123, shop: nil)
           assert_equal(form.shop_domain, 'shopdomain.myshopify.com')
         end
-        assert_match(CLI::UI.fmt("Using Development Store {{green:shopdomain.myshopify.com}}"), io.join)
+        assert_match(CLI::UI.fmt("Using development store {{green:shopdomain.myshopify.com}}"), io.join)
       end
 
       def test_prompts_user_to_pick_from_shops
@@ -205,7 +205,7 @@ module Node
 
         CLI::UI::Prompt.expects(:ask)
           .with(
-            'Select a Development Store',
+            @context.message('node.forms.create.development_store_select'),
             options: %w(shopdomain.myshopify.com shop.myshopify.com)
           )
           .returns('selected')

--- a/test/project_types/rails/forms/create_test.rb
+++ b/test/project_types/rails/forms/create_test.rb
@@ -31,7 +31,7 @@ module Rails
           form = ask(type: "not_a_type")
           assert_nil(form)
         end
-        assert_match('Invalid App Type not_a_type', io.join)
+        assert_match(@context.message('rails.forms.create.error.invalid_app_type', 'not_a_type'), io.join)
       end
 
       def test_type_is_prompted
@@ -49,7 +49,7 @@ module Rails
           form = ask(db: "not_a_db")
           assert_nil(form)
         end
-        assert_match('Invalid Database Type not_a_db', io.join)
+        assert_match(@context.message('rails.forms.create.error.invalid_db_type', 'not_a_db'), io.join)
       end
 
       def test_user_can_change_db_in_app
@@ -129,7 +129,7 @@ module Rails
           assert_equal(form.organization_id, 421)
           assert_equal(form.shop_domain, 'next.myshopify.com')
         end
-        assert_match(CLI::UI.fmt('Organization {{green:hoopy froods}}'), io.join)
+        assert_match(CLI::UI.fmt('Partner organization {{green:hoopy froods (421)}}'), io.join)
       end
 
       def test_organization_will_be_fetched_if_id_is_provided_but_not_shop
@@ -164,8 +164,8 @@ module Rails
           form = ask(org_id: nil, shop: nil)
           assert_nil(form)
         end
-        assert_match('Please visit https://partners.shopify.com/ to create a partners account', io.join)
-        assert_match('No organizations available.', io.join)
+        assert_match(@context.message('rails.forms.create.partners_notice'), io.join)
+        assert_match(@context.message('rails.forms.create.error.no_organizations'), io.join)
       end
 
       def test_returns_no_shop_if_none_are_available
@@ -186,7 +186,7 @@ module Rails
           assert_nil form.shop_domain
         end
         log = io.join
-        assert_match('No Development Stores available.', log)
+        assert_match(CLI::UI.fmt(@context.message('rails.forms.create.no_development_stores')), log)
         assert_match(CLI::UI.fmt("Visit {{underline:https://partners.shopify.com/123/stores}} to create one"), log)
       end
 
@@ -211,7 +211,7 @@ module Rails
           form = ask(org_id: 123, shop: nil)
           assert_equal(form.shop_domain, 'shopdomain.myshopify.com')
         end
-        assert_match(CLI::UI.fmt("Using Development Store {{green:shopdomain.myshopify.com}}"), io.join)
+        assert_match(CLI::UI.fmt("Using development store {{green:shopdomain.myshopify.com}}"), io.join)
       end
 
       def test_prompts_user_to_pick_from_shops
@@ -238,7 +238,7 @@ module Rails
 
         CLI::UI::Prompt.expects(:ask)
           .with(
-            'Select a Development Store',
+            @context.message('rails.forms.create.development_store_select'),
             options: %w(shopdomain.myshopify.com shop.myshopify.com)
           )
           .returns('selected')

--- a/test/project_types/script/forms/script_form_test.rb
+++ b/test/project_types/script/forms/script_form_test.rb
@@ -19,10 +19,10 @@ module Script
       end
 
       def test_one_organization_auto_selects
-        org = { 'businessName' => 'test' }
+        org = { 'businessName' => 'test', 'id' => 123 }
         @context.expects(:puts).with(@context.message(
           'script.forms.script_form.using_organization',
-          'test'
+          'test (123)'
         ))
         form.expects(:organizations).returns([org]).at_least_once
         assert_equal org, form.send(:ask_organization)

--- a/test/shopify-cli/commands/connect_test.rb
+++ b/test/shopify-cli/commands/connect_test.rb
@@ -35,9 +35,9 @@ module ShopifyCli
           }],
         }]
         ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns(response)
-        CLI::UI::Prompt.expects(:ask).with('To which organization does this project belong?').returns(422)
+        CLI::UI::Prompt.expects(:ask).with(Context.message('core.connect.organization_select')).returns(422)
         CLI::UI::Prompt.expects(:ask).with(
-          'Which development store would you like to use?'
+          Context.message('core.connect.development_store_select')
         ).returns('store.myshopify.com')
         Resources::EnvFile.any_instance.stubs(:write)
         run_cmd('connect')


### PR DESCRIPTION
Resolves #661 

Updates references to "organization" to say "partner organization" in all the places where we reference that concept. This aligns better with how Shopify talks about this externally, since "organization" is mainly an internal concept.

Also I changed the way we display organizations to include the name _and_ ID to add clarity in case someone has more than one organization with the same name. (This was mentioned in #639, but this PR does not solve the main issue in that ticket).

![image](https://user-images.githubusercontent.com/71433/84950450-ef19b100-b0bc-11ea-9e4b-9ec751df1fea.png)
