### PR TITLE
Creating extension project type

### DIFF
--- a/lib/graphql/extension_create.graphql
+++ b/lib/graphql/extension_create.graphql
@@ -1,0 +1,21 @@
+mutation ExtensionCreate($api_key: String!, $type: ExtensionType!, $title: String!, $config: JSON!, $extension_context: String) {
+  extensionCreate(input: {apiKey: $api_key, type: $type, title: $title, config: $config, context: $extension_context}) {
+    extensionRegistration {
+      id
+      type
+      title
+      draftVersion {
+        registrationId
+        lastUserInteractionAt
+        validationErrors {
+          field
+          message
+        }
+      }
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}

--- a/lib/graphql/extension_update_draft.graphql
+++ b/lib/graphql/extension_update_draft.graphql
@@ -1,0 +1,18 @@
+mutation ExtensionUpdateDraft($api_key: String!, $registration_id: ID!, $config: JSON!, $context: String) {
+  extensionUpdateDraft(input: {apiKey: $api_key, registrationId: $registration_id, config: $config, context: $context}) {
+    extensionVersion {
+      registrationId
+      context
+      lastUserInteractionAt
+      location
+      validationErrors {
+        field
+        message
+      }
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Extension
+  class Project < ShopifyCli::ProjectType
+    hidden_project_type
+    creator 'App Extension', 'Extension::Commands::Create'
+
+    register_command('Extension::Commands::Build', "build")
+    register_command('Extension::Commands::Register', "register")
+    register_command('Extension::Commands::Push', "push")
+    register_command('Extension::Commands::Serve', "serve")
+    register_command('Extension::Commands::Tunnel', "tunnel")
+
+    require Project.project_filepath('messages/messages')
+    require Project.project_filepath('messages/message_loading')
+    require Project.project_filepath('extension_project_keys')
+    register_messages(Extension::Messages::MessageLoading.load)
+  end
+
+  module Commands
+    autoload :ExtensionCommand, Project.project_filepath('commands/extension_command')
+    autoload :Create, Project.project_filepath('commands/create')
+    autoload :Register, Project.project_filepath('commands/register')
+    autoload :Build, Project.project_filepath('commands/build')
+    autoload :Serve, Project.project_filepath('commands/serve')
+    autoload :Push, Project.project_filepath('commands/push')
+    autoload :Tunnel, Project.project_filepath('commands/tunnel')
+  end
+
+  module Tasks
+    autoload :UserErrors, Project.project_filepath('tasks/user_errors')
+    autoload :GetApps, Project.project_filepath('tasks/get_apps')
+    autoload :CreateExtension, Project.project_filepath('tasks/create_extension')
+    autoload :UpdateDraft, Project.project_filepath('tasks/update_draft')
+
+    module Converters
+      autoload :RegistrationConverter, Project.project_filepath('tasks/converters/registration_converter')
+      autoload :VersionConverter, Project.project_filepath('tasks/converters/version_converter')
+      autoload :ValidationErrorConverter, Project.project_filepath('tasks/converters/validation_error_converter')
+    end
+  end
+
+  module Forms
+    autoload :Create, Project.project_filepath('forms/create')
+    autoload :Register, Project.project_filepath('forms/register')
+  end
+
+  module Features
+    autoload :Argo, Project.project_filepath('features/argo')
+    autoload :ArgoSetup, Project.project_filepath('features/argo_setup')
+    autoload :ArgoSetupStep, Project.project_filepath('features/argo_setup_step')
+    autoload :ArgoSetupSteps, Project.project_filepath('features/argo_setup_steps')
+    autoload :ArgoDependencies, Project.project_filepath('features/argo_dependencies')
+    autoload :TunnelUrl, Project.project_filepath('features/tunnel_url')
+  end
+
+  module Models
+    autoload :App, Project.project_filepath('models/app')
+    autoload :Registration, Project.project_filepath('models/registration')
+    autoload :Version, Project.project_filepath('models/version')
+    autoload :Type, Project.project_filepath('models/type')
+    autoload :ValidationError, Project.project_filepath('models/validation_error')
+
+    class << self
+      Models::Type.load_all
+    end
+  end
+
+  autoload :ExtensionProjectKeys, Project.project_filepath('extension_project_keys')
+  autoload :ExtensionProject, Project.project_filepath('extension_project')
+end

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Commands
+    class Build < ExtensionCommand
+      hidden_command
+
+      YARN_BUILD_COMMAND = %w(yarn build)
+      NPM_BUILD_COMMAND = %w(npm run-script build)
+
+      def call(args, command_name)
+        CLI::UI::Frame.open(frame_title) do
+          @ctx.abort(@ctx.message('build.build_failure_message')) unless build.success?
+        end
+      end
+
+      def self.help
+        <<~HELP
+          Build your extension to prepare for deployment.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} build}}
+        HELP
+      end
+
+      private
+
+      def frame_title
+        @ctx.message('build.frame_title', (yarn_available? ? 'yarn' : 'npm'))
+      end
+
+      def yarn_available?
+        @yarn_availability ||= ShopifyCli::JsSystem.yarn?(@ctx)
+      end
+
+      def build
+        build_command = yarn_available? ? YARN_BUILD_COMMAND : NPM_BUILD_COMMAND
+        @ctx.system(*build_command)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -9,7 +9,7 @@ module Extension
       YARN_BUILD_COMMAND = %w(yarn build)
       NPM_BUILD_COMMAND = %w(npm run-script build)
 
-      def call(args, command_name)
+      def call(_args, _command_name)
         CLI::UI::Frame.open(frame_title) do
           @ctx.abort(@ctx.message('build.build_failure_message')) unless build.success?
         end

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -5,7 +5,7 @@ module Extension
     class Create < ShopifyCli::SubCommand
       options do |parser, flags|
         parser.on('--name=NAME') { |name| flags[:name] = name }
-        parser.on('--type=TYPE') { |type| flags[:type] = type.upcase  }
+        parser.on('--type=TYPE') { |type| flags[:type] = type.upcase }
       end
 
       def call(args, _)

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Extension
+  module Commands
+    class Create < ShopifyCli::SubCommand
+      options do |parser, flags|
+        parser.on('--name=NAME') { |name| flags[:name] = name }
+        parser.on('--type=TYPE') { |type| flags[:type] = type.upcase  }
+      end
+
+      def call(args, _)
+        with_create_form(args) do |form|
+          if form.type.create(form.directory_name, @ctx)
+            ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
+            ExtensionProject.write_env_file(context: @ctx, title: form.name)
+
+            @ctx.puts(@ctx.message('create.ready_to_start', form.directory_name, form.name))
+            @ctx.puts(@ctx.message('create.learn_more', form.type.name))
+          else
+            @ctx.puts(@ctx.message('create.try_again'))
+          end
+        end
+      end
+
+      def self.help
+        <<~HELP
+          Create a new app extension.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} create extension <name>}}
+            Options:
+              {{command:--type=TYPE}} The type of extension you would like to create.
+              {{command:--name=NAME}} The name of your extension (50 characters).”
+        HELP
+      end
+
+      private
+
+      def with_create_form(args)
+        form = Forms::Create.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) if form.nil?
+
+        yield form
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/commands/extension_command.rb
+++ b/lib/project_types/extension/commands/extension_command.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Commands
+    class ExtensionCommand < ShopifyCli::Command
+      def project
+        @project ||= ExtensionProject.current
+      end
+
+      def extension_type
+        @extension_type ||= begin
+          unless Models::Type.valid?(project.extension_type_identifier)
+            @ctx.abort(@ctx.message('errors.unknown_type', project.extension_type_identifier))
+          end
+
+          Models::Type.load_type(project.extension_type_identifier)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -38,7 +38,7 @@ module Extension
         @ctx.puts(@ctx.message('push.pushed_with_errors', format_time(draft.last_user_interaction_at)))
 
         draft.validation_errors.each do |error|
-          @ctx.puts('{{x}} %s: %s' % [error.field.last, error.message])
+          @ctx.puts(format('{{x}} %s: %s', error.field.last, error.message))
         end
 
         @ctx.puts(@ctx.message('push.push_with_errors_info'))

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Commands
+    class Push < ExtensionCommand
+      TIME_DISPLAY_FORMAT = "%B %d, %Y %H:%M:%S %Z"
+
+      def call(args, name)
+        Commands::Register.new(@ctx).call(args, name) unless project.registered?
+        Commands::Build.new(@ctx).call(args, name)
+
+        CLI::UI::Frame.open(@ctx.message('push.frame_title')) do
+          updated_draft_version = update_draft
+          show_message(updated_draft_version)
+        end
+      end
+
+      def self.help
+        <<~HELP
+          Push the current extension to Shopify.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} push}}
+        HELP
+      end
+
+      private
+
+      def show_message(draft)
+        draft.validation_errors.empty? ? output_success_messages(draft) : output_validation_errors(draft)
+      end
+
+      def output_success_messages(draft)
+        @ctx.puts(@ctx.message('push.success_confirmation', project.title, format_time(draft.last_user_interaction_at)))
+        @ctx.puts(@ctx.message('push.success_info', draft.location))
+      end
+
+      def output_validation_errors(draft)
+        @ctx.puts(@ctx.message('push.pushed_with_errors', format_time(draft.last_user_interaction_at)))
+
+        draft.validation_errors.each do |error|
+          @ctx.puts('{{x}} %s: %s' % [error.field.last, error.message])
+        end
+
+        @ctx.puts(@ctx.message('push.push_with_errors_info'))
+      end
+
+      def format_time(time)
+        time.utc.strftime(TIME_DISPLAY_FORMAT)
+      end
+
+      def with_waiting_text
+        @ctx.puts(@ctx.message('push.waiting_text'))
+        yield
+      end
+
+      def update_draft
+        with_waiting_text do
+          Tasks::UpdateDraft.call(
+            context: @ctx,
+            api_key: project.app.api_key,
+            registration_id: project.registration_id,
+            config: extension_type.config(@ctx),
+            extension_context: extension_type.extension_context(@ctx)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -7,7 +7,7 @@ module Extension
         parser.on('--api_key=KEY') { |key| flags[:api_key] = key.downcase }
       end
 
-      def call(args, command_name)
+      def call(args, _command_name)
         CLI::UI::Frame.open(@ctx.message('register.frame_title')) do
           @ctx.abort(@ctx.message('register.already_registered')) if project.registered?
 
@@ -25,10 +25,10 @@ module Extension
 
       def self.help
         <<~HELP
-        Register your local extension to a Shopify app
-            Usage: {{command:#{ShopifyCli::TOOL_NAME} register}}
-            Options:
-              {{command:--api_key=API_KEY}} The API key used to register an app with the extension. This can be found on the app page on Partners Dashboard.
+          Register your local extension to a Shopify app
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} register}}
+              Options:
+                {{command:--api_key=API_KEY}} The API key used to register an app with the extension. This can be found on the app page on Partners Dashboard.
         HELP
       end
 

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Extension
+  module Commands
+    class Register < ExtensionCommand
+      options do |parser, flags|
+        parser.on('--api_key=KEY') { |key| flags[:api_key] = key.downcase }
+      end
+
+      def call(args, command_name)
+        CLI::UI::Frame.open(@ctx.message('register.frame_title')) do
+          @ctx.abort(@ctx.message('register.already_registered')) if project.registered?
+
+          with_register_form(args) do |form|
+            should_continue = confirm_registration(form.app)
+            registration = should_continue ? register_extension(form.app) : abort_not_registered
+
+            update_project_files(form.app, registration)
+
+            @ctx.puts(@ctx.message('register.success', project.title, form.app.title))
+            @ctx.puts(@ctx.message('register.success_info'))
+          end
+        end
+      end
+
+      def self.help
+        <<~HELP
+        Register your local extension to a Shopify app
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} register}}
+            Options:
+              {{command:--api_key=API_KEY}} The API key used to register an app with the extension. This can be found on the app page on Partners Dashboard.
+        HELP
+      end
+
+      private
+
+      def with_register_form(args)
+        form = Forms::Register.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) if form.nil?
+
+        yield form
+      end
+
+      def confirm_registration(app)
+        @ctx.puts(@ctx.message('register.confirm_info', extension_type.name))
+        CLI::UI::Prompt.confirm(@ctx.message('register.confirm_question', app.title))
+      end
+
+      def register_extension(app)
+        @ctx.puts(@ctx.message('register.waiting_text'))
+
+        Tasks::CreateExtension.call(
+          context: @ctx,
+          api_key: app.api_key,
+          type: extension_type.identifier,
+          title: project.title,
+          config: {},
+          extension_context: extension_type.extension_context(@ctx)
+        )
+      end
+
+      def update_project_files(app, registration)
+        ExtensionProject.write_env_file(
+          context: @ctx,
+          api_key: app.api_key,
+          api_secret: app.secret,
+          registration_id: registration.id,
+          title: project.title
+        )
+      end
+
+      def abort_not_registered
+        @ctx.puts(@ctx.message('register.confirm_abort'))
+        raise ShopifyCli::AbortSilent
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -3,11 +3,10 @@
 module Extension
   module Commands
     class Serve < ExtensionCommand
-
       YARN_SERVE_COMMAND = %w(yarn server)
       NPM_SERVE_COMMAND = %w(npm run-script server)
 
-      def call(args, command_name)
+      def call(_args, _command_name)
         CLI::UI::Frame.open(@ctx.message('serve.frame_title')) do
           @ctx.abort(@ctx.message('serve.serve_failure_message')) unless serve.success?
         end

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Extension
+  module Commands
+    class Serve < ExtensionCommand
+
+      YARN_SERVE_COMMAND = %w(yarn server)
+      NPM_SERVE_COMMAND = %w(npm run-script server)
+
+      def call(args, command_name)
+        CLI::UI::Frame.open(@ctx.message('serve.frame_title')) do
+          @ctx.abort(@ctx.message('serve.serve_failure_message')) unless serve.success?
+        end
+      end
+
+      def self.help
+        <<~HELP
+          Serve your extension in a local simulator for development.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} serve}}
+        HELP
+      end
+
+      private
+
+      def yarn_available?
+        @yarn_availability ||= ShopifyCli::JsSystem.yarn?(@ctx)
+      end
+
+      def serve
+        serve_command = yarn_available? ? YARN_SERVE_COMMAND : NPM_SERVE_COMMAND
+        @ctx.system(*serve_command)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/commands/tunnel.rb
+++ b/lib/project_types/extension/commands/tunnel.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Commands
+    class Tunnel < ExtensionCommand
+      options do |parser, flags|
+        parser.on('--port=PORT') { |port| flags[:port] = port }
+      end
+
+      AUTH_SUBCOMMAND = 'auth'
+      START_SUBCOMMAND = 'start'
+      STOP_SUBCOMMAND = 'stop'
+      STATUS_SUBCOMMAND = 'status'
+      DEFAULT_PORT = 39351
+
+      def call(args, _name)
+        subcommand = args.shift
+
+        case subcommand
+        when AUTH_SUBCOMMAND then authorize(args)
+        when START_SUBCOMMAND then ShopifyCli::Tunnel.start(@ctx, port: port)
+        when STOP_SUBCOMMAND then ShopifyCli::Tunnel.stop(@ctx)
+        when STATUS_SUBCOMMAND then status
+        else @ctx.puts(self.class.help)
+        end
+      end
+
+      private
+
+      def self.help
+        ShopifyCli::Context.message('tunnel.help', ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message('tunnel.extended_help', ShopifyCli::TOOL_NAME, DEFAULT_PORT)
+      end
+
+      def status
+        tunnel_url = Features::TunnelUrl.fetch
+
+        if tunnel_url.nil?
+          @ctx.puts(@ctx.message('tunnel.no_tunnel_running'))
+        else
+          @ctx.puts(@ctx.message('tunnel.tunnel_running_at', tunnel_url))
+        end
+      end
+
+      def port
+        return DEFAULT_PORT unless options.flags.key?(:port)
+
+        port = options.flags[:port].to_i
+        @ctx.abort(@ctx.message('tunnel.invalid_port', options.flags[:port])) unless port > 0
+        port
+      end
+
+      def authorize(args)
+        token = args.shift
+
+        if token.nil?
+          @ctx.puts(@ctx.message('tunnel.missing_token'))
+          @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
+        else
+          ShopifyCli::Tunnel.auth(@ctx, token)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/commands/tunnel.rb
+++ b/lib/project_types/extension/commands/tunnel.rb
@@ -26,8 +26,6 @@ module Extension
         end
       end
 
-      private
-
       def self.help
         ShopifyCli::Context.message('tunnel.help', ShopifyCli::TOOL_NAME)
       end
@@ -35,6 +33,8 @@ module Extension
       def self.extended_help
         ShopifyCli::Context.message('tunnel.extended_help', ShopifyCli::TOOL_NAME, DEFAULT_PORT)
       end
+
+      private
 
       def status
         tunnel_url = Features::TunnelUrl.fetch

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  class ExtensionProject < ShopifyCli::Project
+    class << self
+      def write_cli_file(context:, type:)
+        ShopifyCli::Project.write(
+          context,
+          project_type: :extension,
+          organization_id: nil,
+          "#{ExtensionProjectKeys::EXTENSION_TYPE_KEY}": type
+        )
+      end
+
+      def write_env_file(context:, title:, api_key: '', api_secret: '', registration_id: nil)
+        ShopifyCli::Resources::EnvFile.new(
+          api_key: api_key,
+          secret: api_secret,
+          extra: {
+            ExtensionProjectKeys::TITLE_KEY => title,
+            ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id,
+          }.compact
+        ).write(context)
+
+        self.current.reload unless project_empty?
+      end
+
+      private
+
+      def project_empty?
+        directory(Dir.pwd).nil?
+      end
+    end
+
+    def app
+      Models::App.new(api_key: env['api_key'], secret: env['secret'])
+    end
+
+    def registered?
+      property_present?('api_key') && property_present?('secret') && registration_id?
+    end
+
+    def title
+      get_extra_field(ExtensionProjectKeys::TITLE_KEY)
+    end
+
+    def extension_type_identifier
+      config[ExtensionProjectKeys::EXTENSION_TYPE_KEY]
+    end
+
+    def registration_id?
+      extra_property_present?(ExtensionProjectKeys::REGISTRATION_ID_KEY) &&
+        is_integer?(get_extra_field(ExtensionProjectKeys::REGISTRATION_ID_KEY)) &&
+        registration_id > 0
+    end
+
+    def registration_id
+      get_extra_field(ExtensionProjectKeys::REGISTRATION_ID_KEY).to_i
+    end
+
+    def reload
+      @env = nil
+    end
+
+    private
+
+    def get_extra_field(key)
+      extra = env[:extra] || {}
+      extra[key]
+    end
+
+    def extra_property_present?(key)
+      env[:extra].key?(key) && !get_extra_field(key).nil?
+    end
+
+    def property_present?(key)
+      !env[key].nil? && !env[key].strip.empty?
+    end
+
+    def is_integer?(value)
+      value.to_i.to_s == value.to_s
+    end
+  end
+end

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -23,7 +23,7 @@ module Extension
           }.compact
         ).write(context)
 
-        self.current.reload unless project_empty?
+        current.reload unless project_empty?
       end
 
       private
@@ -51,7 +51,7 @@ module Extension
 
     def registration_id?
       extra_property_present?(ExtensionProjectKeys::REGISTRATION_ID_KEY) &&
-        is_integer?(get_extra_field(ExtensionProjectKeys::REGISTRATION_ID_KEY)) &&
+        integer?(get_extra_field(ExtensionProjectKeys::REGISTRATION_ID_KEY)) &&
         registration_id > 0
     end
 
@@ -78,7 +78,7 @@ module Extension
       !env[key].nil? && !env[key].strip.empty?
     end
 
-    def is_integer?(value)
+    def integer?(value)
       value.to_i.to_s == value.to_s
     end
   end

--- a/lib/project_types/extension/extension_project_keys.rb
+++ b/lib/project_types/extension/extension_project_keys.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module ExtensionProjectKeys
+    REGISTRATION_ID_KEY = 'EXTENSION_ID'
+    EXTENSION_TYPE_KEY = 'EXTENSION_TYPE'
+    TITLE_KEY = 'EXTENSION_TITLE'
+  end
+end

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -6,8 +6,8 @@ module Extension
     class Argo
       include SmartProperties
 
-      GIT_ADMIN_TEMPLATE = 'https://github.com/Shopify/argo-admin-template.git'.freeze
-      GIT_CHECKOUT_TEMPLATE = 'https://github.com/Shopify/argo-checkout-template.git'.freeze
+      GIT_ADMIN_TEMPLATE = 'https://github.com/Shopify/argo-admin-template.git'
+      GIT_CHECKOUT_TEMPLATE = 'https://github.com/Shopify/argo-checkout-template.git'
       SCRIPT_PATH = %w(build main.js).freeze
 
       class << self
@@ -33,13 +33,13 @@ module Extension
 
       def config(context)
         filepath = File.join(context.root, SCRIPT_PATH)
-        context.abort(context.message('features.argo.missing_file_error')) unless File.exists?(filepath)
+        context.abort(context.message('features.argo.missing_file_error')) unless File.exist?(filepath)
 
         begin
           {
-            serialized_script: Base64.strict_encode64(File.open(filepath).read.chomp)
+            serialized_script: Base64.strict_encode64(File.open(filepath).read.chomp),
           }
-        rescue Exception
+        rescue StandardError
           context.abort(context.message('features.argo.script_prepare_error'))
         end
       end

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Features
+    class Argo
+      include SmartProperties
+
+      GIT_ADMIN_TEMPLATE = 'https://github.com/Shopify/argo-admin-template.git'.freeze
+      GIT_CHECKOUT_TEMPLATE = 'https://github.com/Shopify/argo-checkout-template.git'.freeze
+      SCRIPT_PATH = %w(build main.js).freeze
+
+      class << self
+        def admin
+          @admin ||= Argo.new(setup: ArgoSetup.new(git_template: GIT_ADMIN_TEMPLATE))
+        end
+
+        def checkout
+          @checkout ||= Argo.new(
+            setup: ArgoSetup.new(
+              git_template: GIT_CHECKOUT_TEMPLATE,
+              dependency_checks: [ArgoDependencies.node_installed(min_major: 10, min_minor: 16)]
+            )
+          )
+        end
+      end
+
+      property! :setup, accepts: Features::ArgoSetup
+
+      def create(directory_name, identifier, context)
+        setup.call(directory_name, identifier, context)
+      end
+
+      def config(context)
+        filepath = File.join(context.root, SCRIPT_PATH)
+        context.abort(context.message('features.argo.missing_file_error')) unless File.exists?(filepath)
+
+        begin
+          {
+            serialized_script: Base64.strict_encode64(File.open(filepath).read.chomp)
+          }
+        rescue Exception
+          context.abort(context.message('features.argo.script_prepare_error'))
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/argo_dependencies.rb
+++ b/lib/project_types/extension/features/argo_dependencies.rb
@@ -5,10 +5,10 @@ module Extension
     class ArgoDependencies
       def self.node_installed(min_major:, min_minor: nil)
         -> (context) do
-          out, status = CLI::Kit::System.capture2(*%w(node -v))
+          out, status = CLI::Kit::System.capture2('node', '-v')
           context.abort(context.message('features.argo.dependencies.node.node_not_installed')) unless status.success?
 
-          min_version = 'v' + min_major .to_s+ '.' + (min_minor.nil? ? 'x' : min_minor.to_s) + '.x'
+          min_version = 'v' + min_major .to_s + '.' + (min_minor.nil? ? 'x' : min_minor.to_s) + '.x'
           version = out.strip
           parsed_version = version.match(/v(?<major>\d+).(?<minor>\d+).(?<patch>\d+)/)
 

--- a/lib/project_types/extension/features/argo_dependencies.rb
+++ b/lib/project_types/extension/features/argo_dependencies.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Extension
+  module Features
+    class ArgoDependencies
+      def self.node_installed(min_major:, min_minor: nil)
+        -> (context) do
+          out, status = CLI::Kit::System.capture2(*%w(node -v))
+          context.abort(context.message('features.argo.dependencies.node.node_not_installed')) unless status.success?
+
+          min_version = 'v' + min_major .to_s+ '.' + (min_minor.nil? ? 'x' : min_minor.to_s) + '.x'
+          version = out.strip
+          parsed_version = version.match(/v(?<major>\d+).(?<minor>\d+).(?<patch>\d+)/)
+
+          unless min_major.nil? || parsed_version[:major].to_i >= min_major
+            context.abort(context.message('features.argo.dependencies.node.version_too_low', version, min_version))
+          end
+
+          return if parsed_version[:major].to_i > min_major
+
+          unless min_minor.nil? || parsed_version[:minor].to_i >= min_minor
+            context.abort(context.message('features.argo.dependencies.node.version_too_low', version, min_version))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/argo_setup.rb
+++ b/lib/project_types/extension/features/argo_setup.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Extension
+  module Features
+    class ArgoSetup
+      include SmartProperties
+
+      GIT_DIRECTORY = '.git'.freeze
+      SCRIPTS_DIRECTORY = 'scripts'.freeze
+
+      property! :git_template, accepts: String
+      property! :dependency_checks, default: []
+
+      def call(directory_name, identifier, context)
+        steps = [
+          ArgoSetupSteps.check_dependencies(dependency_checks),
+          ArgoSetupSteps.clone_template(git_template),
+          ArgoSetupSteps.install_dependencies,
+          ArgoSetupSteps.initialize_project
+        ]
+
+        install_result = run_install_steps(context, steps, identifier, directory_name)
+
+        cleanup(context, install_result, directory_name)
+        install_result
+      end
+
+      def run_install_steps(context, steps, identifier, directory_name)
+        system = ShopifyCli::JsSystem.new(ctx: context)
+
+        steps.inject(true) { |success, setup_step|
+          success && setup_step.call(context, identifier, directory_name, system)
+        }
+      end
+
+      def cleanup(context, install_result, directory_name)
+        install_result ? cleanup_template(context) : cleanup_on_failure(context, directory_name)
+      end
+
+      def cleanup_template(context)
+        begin
+          context.rm_r(GIT_DIRECTORY)
+          context.rm_r(SCRIPTS_DIRECTORY)
+        rescue Errno::ENOENT => e
+          context.debug(e)
+        end
+      end
+
+      def cleanup_on_failure(context, directory_name)
+        begin
+          FileUtils.rm_r(directory_name) if Dir.exists?(directory_name)
+        rescue Errno::ENOENT => e
+          context.debug(e)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/argo_setup.rb
+++ b/lib/project_types/extension/features/argo_setup.rb
@@ -5,8 +5,8 @@ module Extension
     class ArgoSetup
       include SmartProperties
 
-      GIT_DIRECTORY = '.git'.freeze
-      SCRIPTS_DIRECTORY = 'scripts'.freeze
+      GIT_DIRECTORY = '.git'
+      SCRIPTS_DIRECTORY = 'scripts'
 
       property! :git_template, accepts: String
       property! :dependency_checks, default: []
@@ -16,7 +16,7 @@ module Extension
           ArgoSetupSteps.check_dependencies(dependency_checks),
           ArgoSetupSteps.clone_template(git_template),
           ArgoSetupSteps.install_dependencies,
-          ArgoSetupSteps.initialize_project
+          ArgoSetupSteps.initialize_project,
         ]
 
         install_result = run_install_steps(context, steps, identifier, directory_name)
@@ -28,9 +28,9 @@ module Extension
       def run_install_steps(context, steps, identifier, directory_name)
         system = ShopifyCli::JsSystem.new(ctx: context)
 
-        steps.inject(true) { |success, setup_step|
+        steps.inject(true) do |success, setup_step|
           success && setup_step.call(context, identifier, directory_name, system)
-        }
+        end
       end
 
       def cleanup(context, install_result, directory_name)
@@ -38,20 +38,16 @@ module Extension
       end
 
       def cleanup_template(context)
-        begin
-          context.rm_r(GIT_DIRECTORY)
-          context.rm_r(SCRIPTS_DIRECTORY)
-        rescue Errno::ENOENT => e
-          context.debug(e)
-        end
+        context.rm_r(GIT_DIRECTORY)
+        context.rm_r(SCRIPTS_DIRECTORY)
+      rescue Errno::ENOENT => e
+        context.debug(e)
       end
 
       def cleanup_on_failure(context, directory_name)
-        begin
-          FileUtils.rm_r(directory_name) if Dir.exists?(directory_name)
-        rescue Errno::ENOENT => e
-          context.debug(e)
-        end
+        FileUtils.rm_r(directory_name) if Dir.exist?(directory_name)
+      rescue Errno::ENOENT => e
+        context.debug(e)
       end
     end
   end

--- a/lib/project_types/extension/features/argo_setup_step.rb
+++ b/lib/project_types/extension/features/argo_setup_step.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Extension
+  module Features
+    class ArgoSetupStep
+      include SmartProperties
+
+      property! :step
+      property! :can_fail, accepts: [true, false], reader: :can_fail?
+
+      def call(context, identifier, directory_name, js_system)
+        step_result = step.call(context, identifier, directory_name, js_system)
+        can_fail? ? step_result : true
+      rescue ShopifyCli::Abort => e
+        context.puts(e.message)
+        false
+      rescue Exception => e
+        context.puts("{{x}} #{e.message}")
+        false
+      end
+
+      def self.default(&block)
+        ArgoSetupStep.new(step: block, can_fail: true)
+      end
+
+      def self.always_successful(&block)
+        ArgoSetupStep.new(step: block, can_fail: false)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/argo_setup_step.rb
+++ b/lib/project_types/extension/features/argo_setup_step.rb
@@ -14,7 +14,7 @@ module Extension
       rescue ShopifyCli::Abort => e
         context.puts(e.message)
         false
-      rescue Exception => e
+      rescue StandardError => e
         context.puts("{{x}} #{e.message}")
         false
       end

--- a/lib/project_types/extension/features/argo_setup_steps.rb
+++ b/lib/project_types/extension/features/argo_setup_steps.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Extension
+  module Features
+    module ArgoSetupSteps
+      YARN_INITIALIZE_COMMAND = %w(generate).freeze
+      NPM_INITIALIZE_COMMAND = %w(run generate --).freeze
+      INITIALIZE_TYPE_PARAMETER = '--type=%s'.freeze
+
+      def self.check_dependencies(dependency_checks)
+        ArgoSetupStep.always_successful do |context, _identifier, _directory_name, _js_system|
+          dependency_checks.each do |dependency_check|
+            dependency_check.call(context)
+          end
+        end
+      end
+
+      def self.clone_template(git_template)
+        ArgoSetupStep.default do |context, _identifier, directory_name, _js_system|
+          begin
+            ShopifyCli::Git.clone(git_template, directory_name, ctx: context)
+            context.root = File.join(context.root, directory_name)
+          rescue Exception
+            context.puts('{{x}} Unable to clone the repository.')
+          end
+        end
+      end
+
+      def self.install_dependencies
+        ArgoSetupStep.default do |context, _identifier, _directory_name, js_system|
+          ShopifyCli::JsDeps.new(ctx: context, system: js_system).install
+        end
+      end
+
+      def self.initialize_project
+        ArgoSetupStep.default do |context, identifier, _directory_name, js_system|
+          frame_title = context.message('create.setup_project_frame_title')
+          failure_message = context.message('features.argo.initialization_error')
+
+          result = true
+          CLI::UI::Frame.open(frame_title, failure_text: failure_message) do
+            result = js_system.call(
+              yarn: YARN_INITIALIZE_COMMAND + [INITIALIZE_TYPE_PARAMETER % identifier],
+              npm: NPM_INITIALIZE_COMMAND + [INITIALIZE_TYPE_PARAMETER % identifier]
+            )
+          end
+
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/argo_setup_steps.rb
+++ b/lib/project_types/extension/features/argo_setup_steps.rb
@@ -5,7 +5,7 @@ module Extension
     module ArgoSetupSteps
       YARN_INITIALIZE_COMMAND = %w(generate).freeze
       NPM_INITIALIZE_COMMAND = %w(run generate --).freeze
-      INITIALIZE_TYPE_PARAMETER = '--type=%s'.freeze
+      INITIALIZE_TYPE_PARAMETER = '--type=%s'
 
       def self.check_dependencies(dependency_checks)
         ArgoSetupStep.always_successful do |context, _identifier, _directory_name, _js_system|
@@ -20,7 +20,7 @@ module Extension
           begin
             ShopifyCli::Git.clone(git_template, directory_name, ctx: context)
             context.root = File.join(context.root, directory_name)
-          rescue Exception
+          rescue StandardError
             context.puts('{{x}} Unable to clone the repository.')
           end
         end

--- a/lib/project_types/extension/features/tunnel_url.rb
+++ b/lib/project_types/extension/features/tunnel_url.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Features
+    module TunnelUrl
+      NGROK_TUNNELS_URI = URI.parse('http://localhost:4040/api/tunnels')
+      TUNNELS_FIELD = 'tunnels'
+      PUBLIC_URL_FIELD = 'public_url'
+
+      def self.fetch
+        begin
+          response = Net::HTTP.get_response(NGROK_TUNNELS_URI)
+          json = JSON.parse(response.body)
+          return json.dig(TUNNELS_FIELD, 0, PUBLIC_URL_FIELD)
+        rescue
+          return nil
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/tunnel_url.rb
+++ b/lib/project_types/extension/features/tunnel_url.rb
@@ -9,13 +9,11 @@ module Extension
       PUBLIC_URL_FIELD = 'public_url'
 
       def self.fetch
-        begin
-          response = Net::HTTP.get_response(NGROK_TUNNELS_URI)
-          json = JSON.parse(response.body)
-          return json.dig(TUNNELS_FIELD, 0, PUBLIC_URL_FIELD)
-        rescue
-          return nil
-        end
+        response = Net::HTTP.get_response(NGROK_TUNNELS_URI)
+        json = JSON.parse(response.body)
+        json.dig(TUNNELS_FIELD, 0, PUBLIC_URL_FIELD)
+      rescue
+        nil
       end
     end
   end

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -11,14 +11,14 @@ module Extension
       end
 
       def directory_name
-        @directory_name ||= self.name.strip.gsub(/( )/, '_').downcase
+        @directory_name ||= name.strip.gsub(/( )/, '_').downcase
       end
 
       private
 
       def ask_name
         ask_with_reprompt(
-          initial_value: self.name,
+          initial_value: name,
           break_condition: -> (current_name) { Models::Registration.valid_title?(current_name) },
           prompt_message: ctx.message('create.ask_name'),
           reprompt_message: ctx.message('create.invalid_name', Models::Registration::MAX_TITLE_LENGTH)
@@ -40,7 +40,7 @@ module Extension
         value = initial_value
         reprompt = false
 
-        while !break_condition.call(value) do
+        until break_condition.call(value)
           ctx.puts(reprompt_message) if reprompt
           value = CLI::UI::Prompt.ask(prompt_message)&.strip
           reprompt = true

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Extension
+  module Forms
+    class Create < ShopifyCli::Form
+      flag_arguments :name, :type
+
+      def ask
+        self.type = ask_type
+        self.name = ask_name
+      end
+
+      def directory_name
+        @directory_name ||= self.name.strip.gsub(/( )/, '_').downcase
+      end
+
+      private
+
+      def ask_name
+        ask_with_reprompt(
+          initial_value: self.name,
+          break_condition: -> (current_name) { Models::Registration.valid_title?(current_name) },
+          prompt_message: ctx.message('create.ask_name'),
+          reprompt_message: ctx.message('create.invalid_name', Models::Registration::MAX_TITLE_LENGTH)
+        )
+      end
+
+      def ask_type
+        return Models::Type.load_type(type) if Models::Type.valid?(type)
+        ctx.puts(ctx.message('create.invalid_type')) unless type.nil?
+
+        CLI::UI::Prompt.ask(ctx.message('create.ask_type')) do |handler|
+          Models::Type.repository.values.each do |type|
+            handler.option("#{type.name} #{type.tagline}") { type }
+          end
+        end
+      end
+
+      def ask_with_reprompt(initial_value:, break_condition:, prompt_message:, reprompt_message:)
+        value = initial_value
+        reprompt = false
+
+        while !break_condition.call(value) do
+          ctx.puts(reprompt_message) if reprompt
+          value = CLI::UI::Prompt.ask(prompt_message)&.strip
+          reprompt = true
+        end
+        value
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/forms/register.rb
+++ b/lib/project_types/extension/forms/register.rb
@@ -20,7 +20,7 @@ module Extension
 
         if !api_key.nil?
           found_app = apps.find { |app| app.api_key == api_key }
-          ctx.abort(ctx.message('register.invalid_api_key',api_key)) if found_app.nil?
+          ctx.abort(ctx.message('register.invalid_api_key', api_key)) if found_app.nil?
           found_app
         else
           CLI::UI::Prompt.ask(ctx.message('register.ask_app')) do |handler|

--- a/lib/project_types/extension/forms/register.rb
+++ b/lib/project_types/extension/forms/register.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Extension
+  module Forms
+    class Register < ShopifyCli::Form
+      flag_arguments :api_key
+
+      attr_reader :app
+
+      def ask
+        self.app = ask_app
+      end
+
+      private
+
+      attr_writer :app
+
+      def ask_app
+        apps = load_apps
+
+        if !api_key.nil?
+          found_app = apps.find { |app| app.api_key == api_key }
+          ctx.abort(ctx.message('register.invalid_api_key',api_key)) if found_app.nil?
+          found_app
+        else
+          CLI::UI::Prompt.ask(ctx.message('register.ask_app')) do |handler|
+            apps.each do |app|
+              handler.option("#{app.title} by #{app.business_name}") { app }
+            end
+          end
+        end
+      end
+
+      def load_apps
+        ctx.puts(@ctx.message('register.loading_apps'))
+        apps = Tasks::GetApps.call(context: ctx)
+
+        apps.empty? ? abort_no_apps : apps
+      end
+
+      def abort_no_apps
+        ctx.puts(@ctx.message('register.no_apps'))
+        ctx.puts(@ctx.message('register.learn_about_apps'))
+        raise ShopifyCli::AbortSilent
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/messages/message_loading.rb
+++ b/lib/project_types/extension/messages/message_loading.rb
@@ -23,15 +23,13 @@ module Extension
         return if type_identifier.nil?
 
         type_identifier_symbol = type_identifier.downcase.to_sym
-        return unless Messages::TYPES.has_key?(type_identifier_symbol)
+        return unless Messages::TYPES.key?(type_identifier_symbol)
 
         TYPES[type_identifier_symbol]
       end
 
-      private
-
       def self.deep_merge(first, second)
-        merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+        merger = proc { |_key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
         first.merge(second, &merger)
       end
     end

--- a/lib/project_types/extension/messages/message_loading.rb
+++ b/lib/project_types/extension/messages/message_loading.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Extension
+  module Messages
+    module MessageLoading
+      def self.load
+        type_specific_messages = load_current_type_messages
+        return Messages::MESSAGES if type_specific_messages.nil?
+
+        if type_specific_messages.key?(:overrides)
+          deep_merge(Messages::MESSAGES, type_specific_messages[:overrides])
+        else
+          Messages::MESSAGES
+        end
+      end
+
+      def self.load_current_type_messages
+        return unless ShopifyCli::Project.has_current?
+        messages_for_type(ShopifyCli::Project.current.config[Extension::ExtensionProjectKeys::EXTENSION_TYPE_KEY])
+      end
+
+      def self.messages_for_type(type_identifier)
+        return if type_identifier.nil?
+
+        type_identifier_symbol = type_identifier.downcase.to_sym
+        return unless Messages::TYPES.has_key?(type_identifier_symbol)
+
+        TYPES[type_identifier_symbol]
+      end
+
+      private
+
+      def self.deep_merge(first, second)
+        merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+        first.merge(second, &merger)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Messages
+    MESSAGES = {
+      create: {
+        ask_name: 'Extension name',
+        invalid_name: 'Extension name must be under %s characters',
+        ask_type: 'What type of extension are you creating?',
+        invalid_type: 'Extension type is invalid.',
+        setup_project_frame_title: 'Initializing project',
+        ready_to_start: <<~MESSAGE,
+        {{v}} A new folder was generated at {{green:./%s}}.
+        {{*}} You’re ready to start building {{green:%s}}!
+        Navigate to the new folder, then run {{command:shopify serve}} to start a local server.
+        MESSAGE
+        learn_more: <<~MESSAGE,
+        {{*}} Once you're ready to version and publish your extension,
+        run {{command:shopify register}} to register this extension with one of your apps.
+        MESSAGE
+        try_again: '{{*}} Fix the errors and run {{command:shopify create extension}} again.',
+      },
+      build: {
+        frame_title: 'Building extension with: %s...',
+        build_failure_message: 'Failed to build extension code.',
+      },
+      register: {
+        frame_title: 'Registering Extension',
+        waiting_text: 'Registering with Shopify...',
+        already_registered: 'Extension is already registered.',
+        loading_apps: 'Loading your apps...',
+        ask_app: 'Which app would you like to register this extension with?',
+        no_apps: '{{x}} You don’t have any apps.',
+        learn_about_apps: '{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, or try creating a new app using {{command:shopify create}}.',
+        invalid_api_key: 'The API key %s does not match any of your apps.',
+        confirm_info: 'This will create a new extension registration for %s, which can’t be undone.',
+        confirm_question: 'Would you like to register this extension with {{green:%s}}? (y/n)',
+        confirm_abort: 'Extension was not registered.',
+        success: '{{v}} Registered {{green:%s}} with {{green:%s}}.',
+        success_info: '{{*}} Run {{command:shopify push}} to push your extension to Shopify.',
+      },
+      push: {
+        frame_title: 'Pushing your extension to Shopify',
+        waiting_text: 'Pushing code to Shopify...',
+        pushed_with_errors: '{{x}} Code pushed to Shopify with errors on %s.',
+        push_with_errors_info: '{{*}} Fix these errors and run {{command:shopify push}} to revalidate your extension.',
+        success_confirmation: '{{v}} Pushed {{green:%s}} to a draft on %s.',
+        success_info: '{{*}} Visit %s to version and publish your extension.',
+      },
+      serve: {
+        frame_title: 'Serving extension...',
+        serve_failure_message: 'Failed to run extension code.',
+      },
+      tunnel: {
+        missing_token: '{{x}} {{red:auth requires a token argument}}. Find it on your ngrok dashboard: {{underline:https://dashboard.ngrok.com/auth/your-authtoken}}.',
+        invalid_port: '%s is not a valid port.',
+        no_tunnel_running: 'No tunnel running.',
+        tunnel_running_at: 'Tunnel running at: {{underline:%s}}',
+        help: <<~HELP,
+          Start or stop an http tunnel to your local development extension using ngrok.
+            Usage: {{command:%s tunnel [ auth | start | stop | status ]}}
+        HELP
+        extended_help: <<~HELP,
+          {{bold:Subcommands:}}
+
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
+              Usage: {{command:%1$s tunnel auth <token>}}
+
+            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
+              Usage: {{command:%1$s tunnel start}}
+              Options:
+              {{command:--port=PORT}} Forward the ngrok subdomain to local port PORT. Defaults to %2$s.
+
+            {{cyan:stop}}: Stops the ngrok tunnel.
+              Usage: {{command:%1$s tunnel stop}}
+
+            {{cyan:status}}: Output the current status of the ngrok tunnel.
+              Usage: {{command:%1$s tunnel status}}
+        HELP
+      },
+      features: {
+        argo: {
+          missing_file_error: 'Could not find built extension file.',
+          script_prepare_error: 'An error occurred while attempting to prepare your script.',
+          initialization_error: '{{x}} There was an error while initializing the project.',
+          dependencies: {
+            node: {
+              node_not_installed: 'Node must be installed to create this extension.',
+              version_too_low: 'Your node version %s does not meet the minimum required version %s',
+            }
+          }
+        },
+      },
+      tasks: {
+        errors: {
+          parse_error: 'Unable to parse response from Partners Dashboard.'
+        }
+      },
+      errors: {
+        unknown_type: 'Unknown extension type %s'
+      }
+    }
+
+    TYPES = {
+      subscription_management: {
+        name: 'Subscription Management',
+        tagline: '(limit 1 per app)',
+        overrides: {
+          register: {
+            confirm_info: 'You can only create one %s extension per app, which can’t be undone.',
+          }
+        }
+      },
+      checkout_post_purchase: {
+        name: 'Checkout Post Purchase',
+      }
+    }
+  end
+end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -11,13 +11,13 @@ module Extension
         invalid_type: 'Extension type is invalid.',
         setup_project_frame_title: 'Initializing project',
         ready_to_start: <<~MESSAGE,
-        {{v}} A new folder was generated at {{green:./%s}}.
-        {{*}} You’re ready to start building {{green:%s}}!
-        Navigate to the new folder, then run {{command:shopify serve}} to start a local server.
+          {{v}} A new folder was generated at {{green:./%s}}.
+          {{*}} You’re ready to start building {{green:%s}}!
+          Navigate to the new folder, then run {{command:shopify serve}} to start a local server.
         MESSAGE
         learn_more: <<~MESSAGE,
-        {{*}} Once you're ready to version and publish your extension,
-        run {{command:shopify register}} to register this extension with one of your apps.
+          {{*}} Once you're ready to version and publish your extension,
+          run {{command:shopify register}} to register this extension with one of your apps.
         MESSAGE
         try_again: '{{*}} Fix the errors and run {{command:shopify create extension}} again.',
       },
@@ -32,7 +32,8 @@ module Extension
         loading_apps: 'Loading your apps...',
         ask_app: 'Which app would you like to register this extension with?',
         no_apps: '{{x}} You don’t have any apps.',
-        learn_about_apps: '{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, or try creating a new app using {{command:shopify create}}.',
+        learn_about_apps: '{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, ' \
+          'or try creating a new app using {{command:shopify create}}.',
         invalid_api_key: 'The API key %s does not match any of your apps.',
         confirm_info: 'This will create a new extension registration for %s, which can’t be undone.',
         confirm_question: 'Would you like to register this extension with {{green:%s}}? (y/n)',
@@ -53,7 +54,8 @@ module Extension
         serve_failure_message: 'Failed to run extension code.',
       },
       tunnel: {
-        missing_token: '{{x}} {{red:auth requires a token argument}}. Find it on your ngrok dashboard: {{underline:https://dashboard.ngrok.com/auth/your-authtoken}}.',
+        missing_token: '{{x}} {{red:auth requires a token argument}}. '\
+          'Find it on your ngrok dashboard: {{underline:https://dashboard.ngrok.com/auth/your-authtoken}}.',
         invalid_port: '%s is not a valid port.',
         no_tunnel_running: 'No tunnel running.',
         tunnel_running_at: 'Tunnel running at: {{underline:%s}}',
@@ -64,7 +66,8 @@ module Extension
         extended_help: <<~HELP,
           {{bold:Subcommands:}}
 
-            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. 
+            Visit https://dashboard.ngrok.com/signup to sign up.
               Usage: {{command:%1$s tunnel auth <token>}}
 
             {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
@@ -88,18 +91,18 @@ module Extension
             node: {
               node_not_installed: 'Node must be installed to create this extension.',
               version_too_low: 'Your node version %s does not meet the minimum required version %s',
-            }
-          }
+            },
+          },
         },
       },
       tasks: {
         errors: {
-          parse_error: 'Unable to parse response from Partners Dashboard.'
-        }
+          parse_error: 'Unable to parse response from Partners Dashboard.',
+        },
       },
       errors: {
-        unknown_type: 'Unknown extension type %s'
-      }
+        unknown_type: 'Unknown extension type %s',
+      },
     }
 
     TYPES = {
@@ -109,12 +112,12 @@ module Extension
         overrides: {
           register: {
             confirm_info: 'You can only create one %s extension per app, which can’t be undone.',
-          }
-        }
+          },
+        },
       },
       checkout_post_purchase: {
         name: 'Checkout Post Purchase',
-      }
+      },
     }
   end
 end

--- a/lib/project_types/extension/models/app.rb
+++ b/lib/project_types/extension/models/app.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class App
+      include SmartProperties
+
+      property! :api_key, accepts: String
+      property! :secret, accepts: String
+      property :title, accepts: String
+      property :business_name, accepts: String
+    end
+  end
+end

--- a/lib/project_types/extension/models/registration.rb
+++ b/lib/project_types/extension/models/registration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class Registration
+      MAX_TITLE_LENGTH = 50
+      include SmartProperties
+
+      property! :id, accepts: Integer
+      property! :type, accepts: String
+      property! :title, accepts: String
+      property! :draft_version, accepts: Extension::Models::Version
+
+      def self.valid_title?(title)
+        !title.nil? && !title.strip.empty? && title.length <= MAX_TITLE_LENGTH
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/type.rb
+++ b/lib/project_types/extension/models/type.rb
@@ -64,7 +64,7 @@ module Extension
       private
 
       def message(key, *params)
-        return unless messages.has_key?(key.to_sym)
+        return unless messages.key?(key.to_sym)
         messages[key.to_sym] % params
       end
 

--- a/lib/project_types/extension/models/type.rb
+++ b/lib/project_types/extension/models/type.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class Type
+      TYPES_PATH = %w(lib project_types extension models types *.rb)
+
+      class << self
+        def load_all
+          return unless @all_extension_types.nil? || @all_extension_types.empty?
+          Dir.glob(File.join(ShopifyCli::ROOT, TYPES_PATH)).map { |file_path| load(file_path) }
+        end
+
+        def inherited(klass)
+          @all_extension_types ||= []
+          @all_extension_types << klass
+        end
+
+        def valid?(identifier)
+          repository.key?(identifier)
+        end
+
+        def repository
+          load_all if @all_extension_types.empty?
+
+          @repository ||= @all_extension_types.map(&:new).each_with_object({}) do |type, hash|
+            hash[type.identifier] = type
+          end
+        end
+
+        def load_type(identifier)
+          repository[identifier]
+        end
+      end
+
+      def identifier
+        self.class::IDENTIFIER
+      end
+
+      def name
+        message('name')
+      end
+
+      def tagline
+        message('tagline') || ""
+      end
+
+      def config(_context)
+        raise NotImplementedError, "'#{__method__}' must be implemented for #{self.class}"
+      end
+
+      def create(_directory_name, _context)
+        raise NotImplementedError, "'#{__method__}' must be implemented for #{self.class}"
+      end
+
+      def extension_context(_context)
+        nil
+      end
+
+      def valid_extension_contexts
+        []
+      end
+
+      private
+
+      def message(key, *params)
+        return unless messages.has_key?(key.to_sym)
+        messages[key.to_sym] % params
+      end
+
+      def messages
+        @messages ||= Messages::TYPES[identifier.downcase.to_sym] || {}
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/types/checkout_post_purchase.rb
+++ b/lib/project_types/extension/models/types/checkout_post_purchase.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Models
+    module Types
+      class CheckoutPostPurchase < Models::Type
+        IDENTIFIER = 'CHECKOUT_POST_PURCHASE'
+
+        def create(directory_name, context)
+          Features::Argo.checkout.create(directory_name, IDENTIFIER, context)
+        end
+
+        def config(context)
+          Features::Argo.checkout.config(context)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/types/subscription_management.rb
+++ b/lib/project_types/extension/models/types/subscription_management.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Models
+    module Types
+      class SubscriptionManagement < Models::Type
+        IDENTIFIER = 'SUBSCRIPTION_MANAGEMENT'
+
+        def create(directory_name, context)
+          Features::Argo.admin.create(directory_name, IDENTIFIER, context)
+        end
+
+        def config(context)
+          Features::Argo.admin.config(context)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/validation_error.rb
+++ b/lib/project_types/extension/models/validation_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class ValidationError
+      include SmartProperties
+
+      IS_VALIDATION_ERROR_LIST = -> (errors) { errors.is_a?(Array) && errors.all?(IS_VALIDATION_ERROR) }
+      IS_VALIDATION_ERROR = -> (error) { error.is_a?(ValidationError) }
+
+      property! :field, accepts: -> (fields) { fields.all? { |field| field.is_a?(String) } }
+      property! :message, accepts: String
+    end
+  end
+end

--- a/lib/project_types/extension/models/validation_error.rb
+++ b/lib/project_types/extension/models/validation_error.rb
@@ -5,7 +5,9 @@ module Extension
     class ValidationError
       include SmartProperties
 
-      IS_VALIDATION_ERROR_LIST = -> (errors) { errors.is_a?(Array) && errors.all?(IS_VALIDATION_ERROR) }
+      IS_VALIDATION_ERROR_LIST = -> (errors) do
+        errors.is_a?(Array) && errors.all? { |error| IS_VALIDATION_ERROR.call(error) }
+      end
       IS_VALIDATION_ERROR = -> (error) { error.is_a?(ValidationError) }
 
       property! :field, accepts: -> (fields) { fields.all? { |field| field.is_a?(String) } }

--- a/lib/project_types/extension/models/version.rb
+++ b/lib/project_types/extension/models/version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class Version
+      include SmartProperties
+
+      property! :registration_id, accepts: Integer
+      property! :last_user_interaction_at, accepts: Time
+      property  :context, accepts: String
+      property  :location, accepts: String
+      property :validation_errors, accepts: Models::ValidationError::IS_VALIDATION_ERROR_LIST, default: []
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/converters/registration_converter.rb
+++ b/lib/project_types/extension/tasks/converters/registration_converter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module Converters
+      module RegistrationConverter
+        ID_FIELD = 'id'
+        TYPE_FIELD = 'type'
+        TITLE_FIELD = 'title'
+        DRAFT_VERSION_FIELD = 'draftVersion'
+
+        def self.from_hash(context, hash)
+          context.abort(context.message('tasks.errors.parse_error')) if hash.nil?
+
+          Models::Registration.new(
+            id: hash[ID_FIELD].to_i,
+            type: hash[TYPE_FIELD],
+            title: hash[TITLE_FIELD],
+            draft_version: VersionConverter.from_hash(context, hash[DRAFT_VERSION_FIELD])
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/converters/validation_error_converter.rb
+++ b/lib/project_types/extension/tasks/converters/validation_error_converter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module Converters
+      module ValidationErrorConverter
+        FIELD_FIELD = 'field'
+        MESSAGE_FIELD = 'message'
+
+        def self.from_array(context, errors)
+          return [] if errors.nil?
+          context.abort(context.message('tasks.errors.parse_error')) unless errors.is_a?(Array)
+
+          errors.map do |error|
+            Models::ValidationError.new(
+              field: error[FIELD_FIELD],
+              message: error[MESSAGE_FIELD]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/converters/version_converter.rb
+++ b/lib/project_types/extension/tasks/converters/version_converter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module Converters
+      module VersionConverter
+        REGISTRATION_ID_FIELD = 'registrationId'
+        CONTEXT_FIELD = 'context'
+        LAST_USER_INTERACTION_AT_FIELD = 'lastUserInteractionAt'
+        LOCATION_FIELD = 'location'
+        VALIDATION_ERRORS_FIELD = 'validationErrors'
+
+        def self.from_hash(context, hash)
+          context.abort(context.message('tasks.errors.parse_error')) if hash.nil?
+
+          Models::Version.new(
+            registration_id: hash[REGISTRATION_ID_FIELD].to_i,
+            context: hash[CONTEXT_FIELD],
+            last_user_interaction_at: Time.parse(hash[LAST_USER_INTERACTION_AT_FIELD]),
+            location: hash[LOCATION_FIELD],
+            validation_errors: Converters::ValidationErrorConverter.from_array(context, hash[VALIDATION_ERRORS_FIELD])
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -17,7 +17,7 @@ module Extension
           type: type,
           title: title,
           config: JSON.generate(config),
-          extension_context: extension_context
+          extension_context: extension_context,
         }
 
         response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    class CreateExtension < ShopifyCli::Task
+      include UserErrors
+
+      GRAPHQL_FILE = 'extension_create'
+
+      RESPONSE_FIELD = %w(data extensionCreate)
+      REGISTRATION_FIELD = 'extensionRegistration'
+
+      def call(context:, api_key:, type:, title:, config:, extension_context: nil)
+        input = {
+          api_key: api_key,
+          type: type,
+          title: title,
+          config: JSON.generate(config),
+          extension_context: extension_context
+        }
+
+        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
+        context.abort(context.message('tasks.errors.parse_error')) if response.nil?
+
+        abort_if_user_errors(context, response)
+        Converters::RegistrationConverter.from_hash(context, response.dig(REGISTRATION_FIELD))
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/get_apps.rb
+++ b/lib/project_types/extension/tasks/get_apps.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    class GetApps < ShopifyCli::Task
+      def call(context:)
+        organizations = ShopifyCli::PartnersAPI::Organizations.fetch_with_app(context)
+        apps_from_organizations(organizations)
+      end
+
+      private
+
+      def apps_from_organizations(organizations)
+        organizations.flat_map do |organization|
+          apps_owned_by_organization(organization)
+        end
+      end
+
+      def apps_owned_by_organization(organization)
+        return [] unless organization.key?('apps') && organization['apps'].any?
+
+        organization['apps'].map do |app|
+          Models::App.new(
+            api_key: app['apiKey'],
+            secret: app["apiSecretKeys"].first["secret"],
+            title: app['title'],
+            business_name: organization['businessName']
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/update_draft.rb
+++ b/lib/project_types/extension/tasks/update_draft.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    class UpdateDraft < ShopifyCli::Task
+      include UserErrors
+
+      GRAPHQL_FILE = 'extension_update_draft'
+
+      RESPONSE_FIELD = %w(data extensionUpdateDraft)
+      VERSION_FIELD = 'extensionVersion'
+
+      def call(context:, api_key:, registration_id:, config:, extension_context:)
+        input = {
+          api_key: api_key,
+          registration_id: registration_id,
+          config: JSON.generate(config),
+          extension_context: extension_context,
+        }
+        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
+        context.abort(context.message('tasks.errors.parse_error')) if response.nil?
+
+        abort_if_user_errors(context, response)
+        Converters::VersionConverter.from_hash(context, response.dig(VERSION_FIELD))
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/user_errors.rb
+++ b/lib/project_types/extension/tasks/user_errors.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module UserErrors
+      USER_ERRORS_FIELD = 'userErrors'
+      MESSAGE_FIELD = 'message'
+      USER_ERRORS_PARSE_ERROR = 'Unable to parse errors from server.'
+
+      def abort_if_user_errors(context, response)
+        return if response.nil?
+
+        user_errors = response.dig(USER_ERRORS_FIELD)
+        output_all_user_errors(context, user_errors)
+      end
+
+      private
+
+      def output_all_user_errors(context, user_errors)
+        return if user_errors.nil? || user_errors.empty?
+        last_user_error = user_errors.pop
+
+        user_errors.each { |user_error| puts_user_error(context, user_error) }
+        abort_user_error(context, last_user_error)
+      end
+
+      def puts_user_error(context, user_error)
+        output_user_error(context, user_error) { |message| context.puts("{{x}} #{message}") }
+      end
+
+      def abort_user_error(context, user_error)
+        output_user_error(context, user_error) { |message| context.abort(message) }
+      end
+
+      def output_user_error(context, user_error)
+        if user_error.key?(MESSAGE_FIELD)
+          yield(user_error[MESSAGE_FIELD])
+        else
+          context.abort(USER_ERRORS_PARSE_ERROR)
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -28,7 +28,7 @@ module Extension
 
       def test_prints_help
         @context.expects(:puts).with(Extension::Commands::Build.help)
-        run_cmd('help build')
+        run_cmd('build --help')
       end
 
       def test_uses_yarn_when_yarn_is_available

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -35,14 +35,14 @@ module Extension
         Build.any_instance.stubs(:yarn_available?).returns(true)
         @context.expects(:system).with(*Build::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(true))
 
-        run_cmd('build')
+        run_build
       end
 
       def test_uses_npm_when_yarn_is_unavailable
         Build.any_instance.stubs(:yarn_available?).returns(false)
         @context.expects(:system).with(*Build::NPM_BUILD_COMMAND).returns(FakeProcessStatus.new(true))
 
-        run_cmd('build')
+        run_build
       end
 
       def test_aborts_and_informs_the_user_when_build_fails
@@ -50,7 +50,14 @@ module Extension
         @context.expects(:system).with(*Build::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(false))
         @context.expects(:abort).with(@context.message('build.build_failure_message'))
 
-        run_cmd('build')
+        run_build
+      end
+
+      private
+
+      def run_build(*args)
+        Build.ctx = @context
+        Build.call(args, 'tunnel')
       end
     end
   end

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Commands
+    class BuildTest < MiniTest::Test
+      include TestHelpers::Partners
+      include TestHelpers::FakeUI
+
+      class FakeProcessStatus
+        def initialize(success)
+          @success = success
+        end
+
+        def success?
+          @success
+        end
+      end
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_is_a_hidden_command
+        assert Commands::Build.hidden
+      end
+
+      def test_prints_help
+        @context.expects(:puts).with(Extension::Commands::Build.help)
+        run_cmd('help build')
+      end
+
+      def test_uses_yarn_when_yarn_is_available
+        Build.any_instance.stubs(:yarn_available?).returns(true)
+        @context.expects(:system).with(*Build::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(true))
+
+        run_cmd('build')
+      end
+
+      def test_uses_npm_when_yarn_is_unavailable
+        Build.any_instance.stubs(:yarn_available?).returns(false)
+        @context.expects(:system).with(*Build::NPM_BUILD_COMMAND).returns(FakeProcessStatus.new(true))
+
+        run_cmd('build')
+      end
+
+      def test_aborts_and_informs_the_user_when_build_fails
+        Build.any_instance.stubs(:yarn_available?).returns(true)
+        @context.expects(:system).with(*Build::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(false))
+        @context.expects(:abort).with(@context.message('build.build_failure_message'))
+
+        run_cmd('build')
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -26,9 +26,8 @@ module Extension
         assert Commands::Build.hidden
       end
 
-      def test_prints_help
-        @context.expects(:puts).with(Extension::Commands::Build.help)
-        run_cmd('build --help')
+      def test_implements_help
+        refute_empty(Build.help)
       end
 
       def test_uses_yarn_when_yarn_is_available
@@ -57,7 +56,7 @@ module Extension
 
       def run_build(*args)
         Build.ctx = @context
-        Build.call(args, 'tunnel')
+        Build.call(args, 'build')
       end
     end
   end

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -32,7 +32,7 @@ module Extension
 
         assert_message_output(io: io, expected_content: [
           @context.message('create.ready_to_start', @directory_name, @name),
-          @context.message('create.learn_more', @test_extension_type.name)
+          @context.message('create.learn_more', @test_extension_type.name),
         ])
       end
 

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Commands
+    class CreateTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TestExtensionSetup
+      include ExtensionTestHelpers::Messages
+      include ExtensionTestHelpers::Stubs::GetOrganizations
+
+      def setup
+        super
+        @name = "My Ext"
+        @directory_name = 'my_ext'
+      end
+
+      def test_prints_help
+        io = capture_io { run_cmd('create extension --help') }
+        assert_message_output(io: io, expected_content: [Extension::Commands::Create.help])
+      end
+
+      def test_runs_type_create_and_writes_project_files
+        @test_extension_type.expects(:create).with(@directory_name, @context).returns(true).once
+        ExtensionProject.expects(:write_cli_file).with(context: @context, type: @test_extension_type.identifier).once
+        ExtensionProject.expects(:write_env_file).with(context: @context, title: @name).once
+
+        io = capture_io do
+          run_create(%W(extension --name=#{@name} --type=#{@test_extension_type.identifier}))
+        end
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('create.ready_to_start', @directory_name, @name),
+          @context.message('create.learn_more', @test_extension_type.name)
+        ])
+      end
+
+      def test_does_not_create_project_files_and_outputs_try_again_message_if_type_create_failed
+        @test_extension_type.expects(:create).with(@directory_name, @context).returns(false).once
+        ExtensionProject.expects(:write_cli_file).never
+        ExtensionProject.expects(:write_env_file).never
+
+        io = capture_io do
+          run_create(%W(extension --name=#{@name} --type=#{@test_extension_type.identifier}))
+        end
+
+        assert_message_output(io: io, expected_content: @context.message('create.try_again'))
+      end
+
+      def test_help_does_not_load_extension_project_type
+        io = capture_io do
+          run_create(%w(create --help))
+        end
+
+        output = io.join
+        refute_match('extension', output)
+      end
+
+      private
+
+      def run_create(arguments)
+        Commands::Create.ctx = @context
+        Commands::Create.call(arguments, 'create', 'create')
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/extension_command_test.rb
+++ b/test/project_types/extension/commands/extension_command_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Commands
+    class ExtensionCommandTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::Messages
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+        @command = ExtensionCommand.new
+      end
+
+      def test_project_returns_the_current_extension_project
+        setup_temp_project
+
+        assert_equal @project, @command.project
+      end
+
+      def test_project_memoizes_the_current_extension_project
+        setup_temp_project
+        ExtensionProject.expects(:current).returns(@project).once
+
+        @command.project
+        @command.project
+      end
+
+      def test_extension_type_aborts_if_the_type_is_unknown
+        unknown_type = 'unknown_type'
+        setup_temp_project(type_identifier: unknown_type)
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) { @command.extension_type }
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('errors.unknown_type', unknown_type)
+        ])
+      end
+
+      def test_extension_type_returns_the_extension_type_instance_if_it_exists
+        setup_temp_project
+
+        assert_equal @test_extension_type, @command.extension_type
+      end
+
+      def test_extension_type_memoizes_the_extension_type
+        setup_temp_project
+        Models::Type.expects(:load_type).returns(@test_extension_type).once
+
+        @command.extension_type
+        @command.extension_type
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/extension_command_test.rb
+++ b/test/project_types/extension/commands/extension_command_test.rb
@@ -36,7 +36,7 @@ module Extension
         io = capture_io_and_assert_raises(ShopifyCli::Abort) { @command.extension_type }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('errors.unknown_type', unknown_type)
+          @context.message('errors.unknown_type', unknown_type),
         ])
       end
 

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Commands
+    class PushTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TempProjectSetup
+      include ExtensionTestHelpers::Messages
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+        setup_temp_project
+
+        @version = Models::Version.new(
+          registration_id: 42,
+          last_user_interaction_at: Time.now.utc
+        )
+      end
+
+      def test_help_implemented
+        assert_nothing_raised do
+          refute_nil Commands::Push.help
+        end
+      end
+
+      def test_runs_register_command_if_extension_not_yet_registered
+        @project.expects(:registered?).returns(false).once
+
+        Commands::Register.any_instance.expects(:call).once
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
+
+        run_push
+      end
+
+      def test_does_not_run_register_command_if_extension_already_registered
+        assert @project.registered?
+
+        Commands::Register.any_instance.expects(:call).never
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
+
+        run_push
+      end
+
+      def test_runs_build_command
+        Commands::Build.any_instance.expects(:call).once
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
+
+        run_push
+      end
+
+      def test_updates_the_extensions_draft_version
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.expects(:call)
+          .with(
+            context: @context,
+            api_key: @api_key,
+            registration_id: @registration_id,
+            config: @test_extension_type.config(@context),
+            extension_context: @test_extension_type.extension_context(@context)
+          )
+          .returns(@version)
+          .once
+
+        run_push
+      end
+
+      def test_shows_confirmation_message_with_time_updated_on_successful_update
+        @version.last_user_interaction_at = Time.parse("2020-05-07 19:01:56 UTC")
+        @version.location = "https://www.fakeurl.com"
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
+
+        io = capture_io { run_push }
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('push.waiting_text'),
+          @context.message('push.success_confirmation', @title, 'May 07, 2020 19:01:56 UTC'),
+          @context.message('push.success_info', 'https://www.fakeurl.com')
+        ])
+      end
+
+      def test_displays_time_the_draft_was_updated_at_in_utc
+        response_time = '2020-05-07T19:01:56-04:00'
+        expected_formatted_time_in_utc = 'May 07, 2020 23:01:56 UTC'
+
+        @version.last_user_interaction_at = Time.parse(response_time)
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
+
+        io = capture_io { run_push }
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('push.success_confirmation', @title, expected_formatted_time_in_utc)
+        ])
+      end
+
+      def test_shows_error_messages_and_validation_errors_if_any_occurred_on_push
+        @version.last_user_interaction_at = Time.parse("2020-05-07 19:01:56 UTC")
+        @version.validation_errors = [
+          Models::ValidationError.new(field: %w(test_field), message: 'Error message'),
+          Models::ValidationError.new(field: %w(test_field1 test_field2), message: 'Error message2')
+        ]
+
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
+
+        io = capture_io { run_push }
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('push.pushed_with_errors', 'May 07, 2020 19:01:56 UTC'),
+          '{{x}} test_field: Error message',
+          '{{x}} test_field2: Error message2',
+          @context.message('push.push_with_errors_info')
+        ])
+      end
+
+      private
+
+      def run_push
+        push_command = Commands::Push.new
+        push_command.ctx = @context
+        push_command.call({}, :push)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -80,7 +80,7 @@ module Extension
         assert_message_output(io: io, expected_content: [
           @context.message('push.waiting_text'),
           @context.message('push.success_confirmation', @title, 'May 07, 2020 19:01:56 UTC'),
-          @context.message('push.success_info', 'https://www.fakeurl.com')
+          @context.message('push.success_info', 'https://www.fakeurl.com'),
         ])
       end
 
@@ -95,7 +95,7 @@ module Extension
         io = capture_io { run_push }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('push.success_confirmation', @title, expected_formatted_time_in_utc)
+          @context.message('push.success_confirmation', @title, expected_formatted_time_in_utc),
         ])
       end
 
@@ -103,7 +103,7 @@ module Extension
         @version.last_user_interaction_at = Time.parse("2020-05-07 19:01:56 UTC")
         @version.validation_errors = [
           Models::ValidationError.new(field: %w(test_field), message: 'Error message'),
-          Models::ValidationError.new(field: %w(test_field1 test_field2), message: 'Error message2')
+          Models::ValidationError.new(field: %w(test_field1 test_field2), message: 'Error message2'),
         ]
 
         Commands::Build.any_instance.stubs(:call)
@@ -115,7 +115,7 @@ module Extension
           @context.message('push.pushed_with_errors', 'May 07, 2020 19:01:56 UTC'),
           '{{x}} test_field: Error message',
           '{{x}} test_field2: Error message2',
-          @context.message('push.push_with_errors_info')
+          @context.message('push.push_with_errors_info'),
         ])
       end
 

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -48,7 +48,7 @@ module Extension
 
         assert_message_output(io: io, expected_content: [
           @context.message('register.confirm_abort'),
-          @context.message('register.confirm_info', @test_extension_type.name)
+          @context.message('register.confirm_info', @test_extension_type.name),
         ])
       end
 

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Commands
+    class RegisterTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TempProjectSetup
+      include ExtensionTestHelpers::Messages
+      include ExtensionTestHelpers::Stubs::GetOrganizations
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+        setup_temp_project(api_key: '', api_secret: '', registration_id: nil)
+
+        @app = Models::App.new(api_key: @api_key, secret: @api_secret)
+        stub_get_organizations([organization(name: "Organization One", apps: [@app])])
+      end
+
+      def test_help_implemented
+        assert_nothing_raised { refute_nil Commands::Register.help }
+      end
+
+      def test_if_extension_is_already_registered_the_register_command_aborts
+        @project.expects(:registered?).returns(true).once
+        Tasks::CreateExtension.any_instance.expects(:call).never
+        ExtensionProject.expects(:write_env_file).never
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) { run_register_command }
+
+        assert_message_output(io: io, expected_content: @context.message('register.already_registered'))
+      end
+
+      def test_does_not_run_create_if_user_does_not_confirm
+        refute @project.registered?
+        Tasks::CreateExtension.any_instance.expects(:call).never
+        ExtensionProject.expects(:write_env_file).never
+
+        CLI::UI::Prompt
+          .expects(:confirm)
+          .with(@context.message('register.confirm_question', @app.title))
+          .returns(false)
+          .once
+
+        io = capture_io_and_assert_raises(ShopifyCli::AbortSilent) { run_register_command }
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('register.confirm_abort'),
+          @context.message('register.confirm_info', @test_extension_type.name)
+        ])
+      end
+
+      def test_creates_the_extension_if_user_confirms
+        registration = Models::Registration.new(
+          id: 55,
+          type: @test_extension_type.identifier,
+          title: @project.title,
+          draft_version: Models::Version.new(
+            registration_id: 55,
+            last_user_interaction_at: Time.now.utc,
+          )
+
+        )
+        refute @project.registered?
+
+        CLI::UI::Prompt
+          .expects(:confirm)
+          .with(@context.message('register.confirm_question', @app.title))
+          .returns(true)
+          .once
+
+        Tasks::CreateExtension.any_instance.expects(:call).with(
+          context: @context,
+          api_key: @app.api_key,
+          type: @test_extension_type.identifier,
+          title: @project.title,
+          config: {},
+          extension_context: @test_extension_type.extension_context(@context)
+        ).returns(registration).once
+
+        ExtensionProject.expects(:write_env_file).with(
+          context: @context,
+          api_key: @app.api_key,
+          api_secret: @app.secret,
+          registration_id: registration.id,
+          title: @project.title
+        ).once
+
+        io = capture_io { run_register_command }
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('register.confirm_info', @test_extension_type.name),
+          @context.message('register.waiting_text'),
+          @context.message('register.success', @project.title, @app.title),
+          @context.message('register.success_info'),
+        ])
+      end
+
+      def run_register_command(api_key: @api_key)
+        Commands::Register.ctx = @context
+        Commands::Register.call(
+          %W(--api_key=#{api_key}),
+          :register
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -22,16 +22,8 @@ module Extension
         ShopifyCli::ProjectType.load_type(:extension)
       end
 
-      def test_prints_help
-        @context.expects(:puts).with(Extension::Commands::Serve.help)
-        run_cmd('serve --help')
-      end
-
-      def test_uses_yarn_when_yarn_is_available
-        Serve.any_instance.stubs(:yarn_available?).returns(true)
-        @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(true))
-
-        run_serve
+      def test_implements_help
+        refute_empty(Serve.help)
       end
 
       def test_uses_npm_when_yarn_is_unavailable
@@ -53,7 +45,7 @@ module Extension
 
       def run_serve(*args)
         Serve.ctx = @context
-        Serve.call(args, 'tunnel')
+        Serve.call(args, 'serve')
       end
     end
   end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -24,7 +24,7 @@ module Extension
 
       def test_prints_help
         @context.expects(:puts).with(Extension::Commands::Serve.help)
-        run_cmd('help serve')
+        run_cmd('serve --help')
       end
 
       def test_uses_yarn_when_yarn_is_available

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -31,14 +31,14 @@ module Extension
         Serve.any_instance.stubs(:yarn_available?).returns(true)
         @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(true))
 
-        run_cmd('serve')
+        run_serve
       end
 
       def test_uses_npm_when_yarn_is_unavailable
         Serve.any_instance.stubs(:yarn_available?).returns(false)
         @context.expects(:system).with(*Serve::NPM_SERVE_COMMAND).returns(FakeProcessStatus.new(true))
 
-        run_cmd('serve')
+        run_serve
       end
 
       def test_aborts_and_informs_the_user_when_serve_fails
@@ -46,7 +46,14 @@ module Extension
         @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(false))
         @context.expects(:abort).with(@context.message('serve.serve_failure_message'))
 
-        run_cmd('serve')
+        run_serve
+      end
+
+      private
+
+      def run_serve(*args)
+        Serve.ctx = @context
+        Serve.call(args, 'tunnel')
       end
     end
   end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Commands
+    class ServeTest < MiniTest::Test
+      include TestHelpers::Partners
+      include TestHelpers::FakeUI
+
+      class FakeProcessStatus
+        def initialize(success)
+          @success = success
+        end
+
+        def success?
+          @success
+        end
+      end
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_prints_help
+        @context.expects(:puts).with(Extension::Commands::Serve.help)
+        run_cmd('help serve')
+      end
+
+      def test_uses_yarn_when_yarn_is_available
+        Serve.any_instance.stubs(:yarn_available?).returns(true)
+        @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(true))
+
+        run_cmd('serve')
+      end
+
+      def test_uses_npm_when_yarn_is_unavailable
+        Serve.any_instance.stubs(:yarn_available?).returns(false)
+        @context.expects(:system).with(*Serve::NPM_SERVE_COMMAND).returns(FakeProcessStatus.new(true))
+
+        run_cmd('serve')
+      end
+
+      def test_aborts_and_informs_the_user_when_serve_fails
+        Serve.any_instance.stubs(:yarn_available?).returns(true)
+        @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(false))
+        @context.expects(:abort).with(@context.message('serve.serve_failure_message'))
+
+        run_cmd('serve')
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/tunnel_test.rb
+++ b/test/project_types/extension/commands/tunnel_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Commands
+    class TunnelTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::Messages
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_prints_help
+        @context.expects(:puts).with(Tunnel.help)
+        run_tunnel('help')
+      end
+
+      def test_auth_errors_if_no_token_is_provided
+        io = capture_io { run_tunnel(Tunnel::AUTH_SUBCOMMAND) }
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('tunnel.missing_token'),
+          Tunnel::help,
+          Tunnel::extended_help
+        ])
+      end
+
+      def test_auth_runs_the_core_cli_tunnel_auth_if_token_is_present
+        fake_token = 'FAKE_TOKEN'
+        ShopifyCli::Tunnel.expects(:auth).with(@context, fake_token).once
+
+        capture_io { run_tunnel(Tunnel::AUTH_SUBCOMMAND, fake_token) }
+      end
+
+      def test_start_runs_with_the_default_port_if_no_port_provided
+        ShopifyCli::Tunnel.expects(:start).with(@context, port: Tunnel::DEFAULT_PORT).once
+
+        capture_io { run_tunnel(Tunnel::START_SUBCOMMAND) }
+      end
+
+      def test_start_runs_with_the_requested_port_if_provided
+        ShopifyCli::Tunnel.expects(:start).with(@context, port: Tunnel::DEFAULT_PORT).once
+
+        capture_io { run_tunnel(Tunnel::START_SUBCOMMAND) }
+      end
+
+      def test_start_aborts_if_an_invalid_port_is_provided
+        invalid_port = 'NOT_PORT'
+
+        ShopifyCli::Tunnel.expects(:start).never
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          run_tunnel(Tunnel::START_SUBCOMMAND, "--port=#{invalid_port}")
+        end
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('tunnel.invalid_port', invalid_port)
+        ])
+      end
+
+      def test_stop_runs_the_core_cli_tunnel_stop
+        ShopifyCli::Tunnel.expects(:stop).with(@context).once
+
+        capture_io { run_tunnel(Tunnel::STOP_SUBCOMMAND) }
+      end
+
+      def test_status_outputs_no_tunnel_running_if_tunnel_url_returns_nil
+        Features::TunnelUrl.expects(:fetch).returns(nil).once
+
+        io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
+
+        assert_message_output(io: io, expected_content: @context.message('tunnel.no_tunnel_running'))
+      end
+
+      def test_status_outputs_the_running_tunnel_url_if_returned_by_tunnel_url
+        fake_url = 'http://12345.ngrok.io'
+        Features::TunnelUrl.expects(:fetch).returns(fake_url).once
+
+        io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
+
+        assert_message_output(io: io, expected_content: @context.message('tunnel.tunnel_running_at', fake_url))
+      end
+
+      private
+
+      def run_tunnel(*args)
+        Tunnel.ctx = @context
+        Tunnel.call(args, 'tunnel')
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/tunnel_test.rb
+++ b/test/project_types/extension/commands/tunnel_test.rb
@@ -23,8 +23,8 @@ module Extension
 
         assert_message_output(io: io, expected_content: [
           @context.message('tunnel.missing_token'),
-          Tunnel::help,
-          Tunnel::extended_help
+          Tunnel.help,
+          Tunnel.extended_help,
         ])
       end
 
@@ -57,7 +57,7 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('tunnel.invalid_port', invalid_port)
+          @context.message('tunnel.invalid_port', invalid_port),
         ])
       end
 

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  class ExtensionProjectTest < MiniTest::Test
+    include TestHelpers::FakeUI
+    include ExtensionTestHelpers::TempProjectSetup
+
+    def test_write_cli_file_create_shopify_cli_yml_file
+      new_context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
+      FileUtils.cd(new_context.root)
+
+      ExtensionProject.write_cli_file(context: new_context, type: @test_extension_type.identifier)
+
+      assert File.exists?('.shopify-cli.yml')
+      assert_equal :extension, ShopifyCli::Project.current_project_type
+      assert_equal @test_extension_type.identifier, ExtensionProject.current.extension_type_identifier
+    end
+
+    def test_write_env_file_creates_env_file
+      api_key = '1234'
+      api_secret = '5678'
+      title = 'Test Title'
+      registration_id = 55
+
+      new_context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
+      FileUtils.cd(new_context.root)
+
+      ExtensionProject.write_cli_file(context: new_context, type: @test_extension_type.identifier)
+      ExtensionProject.write_env_file(
+        context: new_context,
+        api_key: api_key,
+        api_secret: api_secret,
+        title: title,
+        registration_id: registration_id
+      )
+
+      assert File.exists?('.env')
+      project = ExtensionProject.current
+      assert_equal api_key, project.app.api_key
+      assert_equal api_secret, project.app.secret
+      assert_equal title, project.title
+      assert_equal registration_id, project.registration_id
+    end
+
+    def test_ensures_registered_is_true_only_if_api_key_api_secret_and_registration_id_are_present
+      setup_temp_project(api_key: '', api_secret: '', title: 'title', registration_id: nil)
+      refute @project.registered?
+
+      setup_temp_project(api_key: '1234', api_secret: '', title: 'title', registration_id: nil)
+      refute @project.registered?
+
+      setup_temp_project(api_key: '1234', api_secret: '456', title: 'title', registration_id: nil)
+      refute @project.registered?
+
+      setup_temp_project(api_key: '', api_secret: '', title: 'title', registration_id: 5)
+      refute @project.registered?
+
+      setup_temp_project(api_key: '1234', api_secret: '456', title: 'title', registration_id: 55)
+      assert @project.registered?
+    end
+
+    def test_can_access_app_specific_values_as_an_app
+      setup_temp_project
+
+      assert_kind_of Models::App, @project.app
+      assert_equal @api_key, @project.app.api_key
+      assert_equal @api_secret, @project.app.secret
+    end
+
+    def test_title_returns_the_title
+      setup_temp_project
+
+      assert_equal @title, @project.title
+    end
+
+    def test_title_returns_nil_if_title_is_missing
+      setup_temp_project(title: nil)
+      assert_nil ExtensionProject.current.title
+    end
+
+    def test_extension_type_returns_the_set_type_identifier
+      setup_temp_project
+
+      assert_equal @type, @project.extension_type_identifier
+    end
+
+    def test_detects_if_registration_id_is_missing_or_invalid
+      setup_temp_project(registration_id: nil)
+      refute @project.registration_id?
+
+      setup_temp_project(registration_id: 0)
+      refute @project.registration_id?
+
+      setup_temp_project(registration_id: 'wrong')
+      refute @project.registration_id?
+    end
+  end
+end

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -13,7 +13,7 @@ module Extension
 
       ExtensionProject.write_cli_file(context: new_context, type: @test_extension_type.identifier)
 
-      assert File.exists?('.shopify-cli.yml')
+      assert File.exist?('.shopify-cli.yml')
       assert_equal :extension, ShopifyCli::Project.current_project_type
       assert_equal @test_extension_type.identifier, ExtensionProject.current.extension_type_identifier
     end
@@ -36,7 +36,7 @@ module Extension
         registration_id: registration_id
       )
 
-      assert File.exists?('.env')
+      assert File.exist?('.env')
       project = ExtensionProject.current
       assert_equal api_key, project.app.api_key
       assert_equal api_secret, project.app.secret
@@ -64,7 +64,7 @@ module Extension
     def test_can_access_app_specific_values_as_an_app
       setup_temp_project
 
-      assert_kind_of Models::App, @project.app
+      assert_kind_of(Models::App, @project.app)
       assert_equal @api_key, @project.app.api_key
       assert_equal @api_secret, @project.app.secret
     end
@@ -77,7 +77,7 @@ module Extension
 
     def test_title_returns_nil_if_title_is_missing
       setup_temp_project(title: nil)
-      assert_nil ExtensionProject.current.title
+      assert_nil(ExtensionProject.current.title)
     end
 
     def test_extension_type_returns_the_set_type_identifier

--- a/test/project_types/extension/extension_test_helpers.rb
+++ b/test/project_types/extension/extension_test_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    autoload :FakeExtensionProject, 'project_types/extension/extension_test_helpers/fake_extension_project'
+    autoload :TestExtension, 'project_types/extension/extension_test_helpers/test_extension'
+    autoload :TestExtensionSetup, 'project_types/extension/extension_test_helpers/test_extension_setup'
+    autoload :TempProjectSetup, 'project_types/extension/extension_test_helpers/temp_project_setup'
+    autoload :Messages, 'project_types/extension/extension_test_helpers/messages'
+
+    module Stubs
+      autoload :GetOrganizations, 'project_types/extension/extension_test_helpers/stubs/get_organizations'
+      autoload :CreateExtension, 'project_types/extension/extension_test_helpers/stubs/create_extension'
+      autoload :UpdateDraft, 'project_types/extension/extension_test_helpers/stubs/update_draft'
+      autoload :ArgoScript, 'project_types/extension/extension_test_helpers/stubs/argo_script'
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -14,7 +14,7 @@ module Extension
 
       def config
         {
-          ExtensionProjectKeys::EXTENSION_TYPE_KEY => type
+          ExtensionProjectKeys::EXTENSION_TYPE_KEY => type,
         }
       end
 
@@ -24,7 +24,7 @@ module Extension
           secret: api_secret,
           extra: {
             ExtensionProjectKeys::TITLE_KEY => title,
-            ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id
+            ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id,
           }
         )
       end

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    class FakeExtensionProject < Extension::ExtensionProject
+      include SmartProperties
+
+      property :directory
+      property :title
+      property :type
+      property :registration_id
+      property :api_key
+      property :api_secret
+
+      def config
+        {
+          ExtensionProjectKeys::EXTENSION_TYPE_KEY => type
+        }
+      end
+
+      def env
+        @env ||= ShopifyCli::Resources::EnvFile.new(
+          api_key: api_key,
+          secret: api_secret,
+          extra: {
+            ExtensionProjectKeys::TITLE_KEY => title,
+            ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id
+          }
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/messages.rb
+++ b/test/project_types/extension/extension_test_helpers/messages.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module Messages
+      def assert_message_output(io:, expected_content:)
+        all_output = io.join
+
+        Array(expected_content).each do |expected|
+          assert_includes all_output, CLI::UI.fmt(expected)
+        end
+      end
+
+      def capture_io_and_assert_raises(exception_class)
+        io = []
+        io << capture_io do
+          exception = assert_raises(exception_class) { yield }
+          io << CLI::UI.fmt(exception.message.gsub("{{x}} ", ""))
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/stubs/argo_script.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/argo_script.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module Stubs
+      module ArgoScript
+        TEMPLATE_SCRIPT = <<~SCRIPT
+            import React from 'react';
+            import {render, ExtensionPoint} from '@shopify/app-extensions-renderer';
+            import {Card} from '@shopify/app-extensions-polaris-components/dist/client';
+            
+            render(ExtensionPoint.AppLink, () => <App />);
+            
+            function App() {
+              return (
+                <Card title="Hello world" sectioned>From my app.</Card>
+              );
+            }
+        SCRIPT
+
+        def with_stubbed_script(context, path, script = TEMPLATE_SCRIPT)
+          filepath = File.join(context.root, path)
+          directory = File.dirname(filepath)
+
+          FileUtils.mkdir_p(directory)
+          File.open(filepath, 'w+') { |file| file.puts(script) }
+          yield
+        ensure
+          FileUtils.rm_r(directory)
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/stubs/argo_script.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/argo_script.rb
@@ -5,17 +5,17 @@ module Extension
     module Stubs
       module ArgoScript
         TEMPLATE_SCRIPT = <<~SCRIPT
-            import React from 'react';
-            import {render, ExtensionPoint} from '@shopify/app-extensions-renderer';
-            import {Card} from '@shopify/app-extensions-polaris-components/dist/client';
-            
-            render(ExtensionPoint.AppLink, () => <App />);
-            
-            function App() {
-              return (
-                <Card title="Hello world" sectioned>From my app.</Card>
-              );
-            }
+          import React from 'react';
+          import {render, ExtensionPoint} from '@shopify/app-extensions-renderer';
+          import {Card} from '@shopify/app-extensions-polaris-components/dist/client';
+          
+          render(ExtensionPoint.AppLink, () => <App />);
+          
+          function App() {
+            return (
+              <Card title="Hello world" sectioned>From my app.</Card>
+            );
+          }
         SCRIPT
 
         def with_stubbed_script(context, path, script = TEMPLATE_SCRIPT)

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -14,10 +14,10 @@ module Extension
               type: type,
               title: title,
               config: JSON.generate(config),
-              extension_context: extension_context
+              extension_context: extension_context,
             },
             resp: {
-              data: yield(title, type, config, extension_context)
+              data: yield(title, type, config, extension_context),
             }
           )
         end
@@ -33,20 +33,20 @@ module Extension
                   title: title,
                   draftVersion: {
                     registrationId: registration_id,
-                    lastUserInteractionAt: Time.now.utc.to_s
-                  }
+                    lastUserInteractionAt: Time.now.utc.to_s,
+                  },
                 },
-                userErrors: []
+                userErrors: [],
               },
             }
           end
         end
 
-        def stub_create_extension_failure(userErrors:, **args)
+        def stub_create_extension_failure(userErrors:, **args) # rubocop:disable Naming/VariableName
           stub_create_extension(args) do
             {
               extensionCreate: {
-                userErrors: userErrors
+                userErrors: userErrors, # rubocop:disable Naming/VariableName
               },
             }
           end

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module Stubs
+      module CreateExtension
+        include TestHelpers::Partners
+
+        def stub_create_extension(api_key:, type:, title:, config:, extension_context: nil)
+          stub_partner_req(
+            'extension_create',
+            variables: {
+              api_key: api_key,
+              type: type,
+              title: title,
+              config: JSON.generate(config),
+              extension_context: extension_context
+            },
+            resp: {
+              data: yield(title, type, config, extension_context)
+            }
+          )
+        end
+
+        def stub_create_extension_success(**args)
+          registration_id = rand(9999)
+          stub_create_extension(args) do |title, type|
+            {
+              extensionCreate: {
+                extensionRegistration: {
+                  id: registration_id,
+                  type: type,
+                  title: title,
+                  draftVersion: {
+                    registrationId: registration_id,
+                    lastUserInteractionAt: Time.now.utc.to_s
+                  }
+                },
+                userErrors: []
+              },
+            }
+          end
+        end
+
+        def stub_create_extension_failure(userErrors:, **args)
+          stub_create_extension(args) do
+            {
+              extensionCreate: {
+                userErrors: userErrors
+              },
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
@@ -9,7 +9,7 @@ module Extension
         def organization(name:, apps:)
           {
             name: name,
-            apps: apps
+            apps: apps,
           }
         end
 
@@ -19,11 +19,11 @@ module Extension
             resp: {
               data: {
                 organizations: {
-                  nodes: create_organizations_json(organizations)
+                  nodes: create_organizations_json(organizations),
                 },
               },
             },
-            )
+          )
         end
 
         def create_organizations_json(organizations)
@@ -43,7 +43,7 @@ module Extension
             },
             'apps': {
               nodes: create_apps_json(apps),
-            }
+            },
           }
         end
 
@@ -53,7 +53,7 @@ module Extension
               id: rand(9999),
               title: app.title,
               'apiKey': app.api_key,
-              'apiSecretKeys': [{'secret': app.secret, }],
+              'apiSecretKeys': [{ 'secret': app.secret }],
             }
           end
         end

--- a/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module Stubs
+      module GetOrganizations
+        include TestHelpers::Partners
+
+        def organization(name:, apps:)
+          {
+            name: name,
+            apps: apps
+          }
+        end
+
+        def stub_get_organizations(organizations)
+          stub_partner_req(
+            'all_orgs_with_apps',
+            resp: {
+              data: {
+                organizations: {
+                  nodes: create_organizations_json(organizations)
+                },
+              },
+            },
+            )
+        end
+
+        def create_organizations_json(organizations)
+          organizations.map do |organization|
+            create_organization_json(name: organization[:name], apps: organization[:apps])
+          end
+        end
+
+        def create_organization_json(name:, apps:)
+          {
+            'id': rand(9999),
+            'businessName': name,
+            'stores': {
+              'nodes': [
+                { 'shopDomain': 'store.myshopify.com' },
+              ],
+            },
+            'apps': {
+              nodes: create_apps_json(apps),
+            }
+          }
+        end
+
+        def create_apps_json(apps)
+          apps.map do |app|
+            {
+              id: rand(9999),
+              title: app.title,
+              'apiKey': app.api_key,
+              'apiSecretKeys': [{'secret': app.secret, }],
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
@@ -15,23 +15,22 @@ module Extension
               extension_context: extension_context,
             },
             resp: {
-              data: yield(registration_id, config, extension_context)
-            }
-          )
+              data: yield(registration_id, config, extension_context),
+            })
         end
 
         def stub_update_draft_success(**args)
-          stub_update_draft(args) do |registration_id, config, extension_context|
+          stub_update_draft(args) do |registration_id, _config, extension_context|
             {
               extensionUpdateDraft: {
                 extensionVersion: {
                   registrationId: registration_id,
                   context: extension_context,
                   lastUserInteractionAt: Time.now.utc.to_s,
-                  location: 'https://www.fakeurl.com'
+                  location: 'https://www.fakeurl.com',
                 },
-                Tasks::UserErrors::USER_ERRORS_FIELD => []
-              }
+                Tasks::UserErrors::USER_ERRORS_FIELD => [],
+              },
             }
           end
         end
@@ -40,8 +39,8 @@ module Extension
           stub_update_draft(args) do
             {
               extensionUpdateDraft: {
-                Tasks::UserErrors::USER_ERRORS_FIELD => errors
-              }
+                Tasks::UserErrors::USER_ERRORS_FIELD => errors,
+              },
             }
           end
         end

--- a/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module Stubs
+      module UpdateDraft
+        include TestHelpers::Partners
+
+        def stub_update_draft(registration_id:, config:, extension_context: nil, api_key: 'FAKE_API_KEY')
+          stub_partner_req(Tasks::UpdateDraft::GRAPHQL_FILE,
+            variables: {
+              api_key: api_key,
+              registration_id: registration_id,
+              config: JSON.generate(config),
+              extension_context: extension_context,
+            },
+            resp: {
+              data: yield(registration_id, config, extension_context)
+            }
+          )
+        end
+
+        def stub_update_draft_success(**args)
+          stub_update_draft(args) do |registration_id, config, extension_context|
+            {
+              extensionUpdateDraft: {
+                extensionVersion: {
+                  registrationId: registration_id,
+                  context: extension_context,
+                  lastUserInteractionAt: Time.now.utc.to_s,
+                  location: 'https://www.fakeurl.com'
+                },
+                Tasks::UserErrors::USER_ERRORS_FIELD => []
+              }
+            }
+          end
+        end
+
+        def stub_update_draft_failure(errors:, **args)
+          stub_update_draft(args) do
+            {
+              extensionUpdateDraft: {
+                Tasks::UserErrors::USER_ERRORS_FIELD => errors
+              }
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module TempProjectSetup
+      include TestHelpers::Partners
+      include ExtensionTestHelpers::TestExtensionSetup
+
+      def setup_temp_project(
+        api_key: 'TEST_KEY',
+        api_secret: 'TEST_SECRET',
+        title: 'Test',
+        type_identifier: @test_extension_type.identifier,
+        registration_id: 55)
+
+        @context = TestHelpers::FakeContext.new(root: '/fake/root')
+        @api_key = api_key
+        @api_secret = api_secret
+        @title = title
+        @type = type_identifier
+        @registration_id = registration_id
+
+        @project = FakeExtensionProject.new(
+          api_key: @api_key,
+          api_secret: @api_secret,
+          title: @title,
+          type: @type,
+          registration_id: @registration_id
+        )
+
+        ExtensionProject.stubs(:current).returns(@project)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -11,7 +11,8 @@ module Extension
         api_secret: 'TEST_SECRET',
         title: 'Test',
         type_identifier: @test_extension_type.identifier,
-        registration_id: 55)
+        registration_id: 55
+      )
 
         @context = TestHelpers::FakeContext.new(root: '/fake/root')
         @api_key = api_key

--- a/test/project_types/extension/extension_test_helpers/test_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    class TestExtension < Models::Type
+      IDENTIFIER = 'TEST_EXTENSION'
+
+      def name
+        'Test Extension'
+      end
+
+      def tagline
+        'An extension for testing'
+      end
+
+      def config(_context)
+        {
+          title: 'A Test Extension Title',
+          field: 'field_for_test_extension'
+        }
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/test_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension.rb
@@ -16,7 +16,7 @@ module Extension
       def config(_context)
         {
           title: 'A Test Extension Title',
-          field: 'field_for_test_extension'
+          field: 'field_for_test_extension',
         }
       end
     end

--- a/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module TestExtensionSetup
+      def setup
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @test_extension_type = ExtensionTestHelpers::TestExtension.new
+        Models::Type.repository[@test_extension_type.identifier] = @test_extension_type
+        super
+      end
+
+      def teardown
+        super
+        Models::Type.repository.delete(ExtensionTestHelpers::TestExtension::IDENTIFIER)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_dependencies_test.rb
+++ b/test/project_types/extension/features/argo_dependencies_test.rb
@@ -38,7 +38,7 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('features.argo.dependencies.node.node_not_installed')
+          @context.message('features.argo.dependencies.node.node_not_installed'),
         ])
       end
 
@@ -50,7 +50,7 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v11.x.x')
+          @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v11.x.x'),
         ])
       end
 
@@ -62,7 +62,7 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v10.12.x')
+          @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v10.12.x'),
         ])
       end
 

--- a/test/project_types/extension/features/argo_dependencies_test.rb
+++ b/test/project_types/extension/features/argo_dependencies_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Features
+    class ArgoTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::Messages
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_nothing_is_raised_if_node_version_meets_minimum_major_and_minor_versions
+        mock_node_version('v10.11.12')
+        assert_nothing_raised(ShopifyCli::Abort) do
+          ArgoDependencies.node_installed(min_major: 10, min_minor: 11).call(@context)
+        end
+
+        mock_node_version('v10.11.12')
+        assert_nothing_raised(ShopifyCli::Abort) do
+          ArgoDependencies.node_installed(min_major: 9, min_minor: 11).call(@context)
+        end
+
+        mock_node_version('v10.11.12')
+        assert_nothing_raised(ShopifyCli::Abort) do
+          ArgoDependencies.node_installed(min_major: 10, min_minor: 10).call(@context)
+        end
+      end
+
+      def test_if_node_version_command_fails_abort_with_missing_node_message
+        mock_node_version('', success: false)
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          ArgoDependencies.node_installed(min_major: 11).call(@context)
+        end
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('features.argo.dependencies.node.node_not_installed')
+        ])
+      end
+
+      def test_if_node_exists_but_major_version_is_under_the_minimum_abort_with_message
+        mock_node_version('v10.11.12')
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          ArgoDependencies.node_installed(min_major: 11).call(@context)
+        end
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v11.x.x')
+        ])
+      end
+
+      def test_if_major_version_is_the_minimum_version_abort_with_message_if_minor_version_is_under_the_minimum_version
+        mock_node_version('v10.11.12')
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          ArgoDependencies.node_installed(min_major: 10, min_minor: 12).call(@context)
+        end
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v10.12.x')
+        ])
+      end
+
+      def test_if_major_version_is_the_above_the_minimum_version_do_not_check_minor_version
+        mock_node_version('v13.7.0')
+
+        assert_nothing_raised do
+          ArgoDependencies.node_installed(min_major: 10, min_minor: 13).call(@context)
+        end
+      end
+
+      private
+
+      def mock_node_version(version, success: true)
+        CLI::Kit::System
+          .expects(:capture2)
+          .returns([version, mock(success?: success)])
+          .once
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_setup_step_test.rb
+++ b/test/project_types/extension/features/argo_setup_step_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Features
+    class ArgoSetupStepsTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::Messages
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @identifier = 'FAKE_ARGO_TYPE'
+        @directory = 'fake_directory'
+        @system = ShopifyCli::JsSystem.new(ctx: @context)
+      end
+
+      def test_always_successful_steps_return_true_no_matter_what_the_step_block_returns
+        assert call_step(ArgoSetupStep.always_successful { false })
+        assert call_step(ArgoSetupStep.always_successful { true })
+      end
+
+      def test_default_steps_return_what_the_step_block_returns
+        refute call_step(ArgoSetupStep.default { false })
+        assert call_step(ArgoSetupStep.default { true })
+      end
+
+      def test_all_step_types_catch_shopify_cli_abort_exceptions_and_output_their_message_and_return_false
+        always_successful_io = capture_io do
+          refute call_step(ArgoSetupStep.always_successful { raise ShopifyCli::Abort, 'always_successful error' })
+        end
+
+        default_io = capture_io do
+          refute call_step(ArgoSetupStep.default { raise ShopifyCli::Abort, 'default_io error' })
+        end
+
+        assert_message_output(io: always_successful_io, expected_content: 'always_successful error')
+        assert_message_output(io: default_io, expected_content: 'default_io error')
+      end
+
+      def test_all_step_types_catch_any_exceptions_and_output_their_message_and_return_false
+        always_successful_io = capture_io do
+          refute call_step(ArgoSetupStep.always_successful { raise 'always_successful error' })
+        end
+
+        default_io = capture_io do
+          refute call_step(ArgoSetupStep.default { raise 'default_io error' })
+        end
+
+        assert_message_output(io: always_successful_io, expected_content: '{{x}} always_successful error')
+        assert_message_output(io: default_io, expected_content: '{{x}} default_io error')
+      end
+
+      private
+
+      def call_step(step, context: @context, identifier: @identifier, directory_name: @directory, system: @system)
+        step.call(context, identifier, directory_name, system)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_setup_steps_test.rb
+++ b/test/project_types/extension/features/argo_setup_steps_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Features
+    class ArgoSetupStepsTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @git_template = 'https://www.github.com/fake_template.git'
+        @identifier = 'FAKE_ARGO_TYPE'
+        @directory = 'fake_directory'
+        @system = ShopifyCli::JsSystem.new(ctx: @context)
+      end
+
+
+      def test_check_dependencies_loops_through_the_provided_dependencies
+        execution_mock = Minitest::Mock.new
+        execution_mock.expect(:executed, nil)
+
+        test_proc = Proc.new do |context|
+          execution_mock.executed
+          assert_equal @context, context
+        end
+
+        call_step(ArgoSetupSteps.check_dependencies([test_proc]))
+        execution_mock.verify
+      end
+
+      def test_clone_template_clones_argo_template_git_repo_into_directory_and_updates_context_root
+        ShopifyCli::Git.expects(:clone).with(@git_template, @directory, ctx: @context).once
+
+        call_step(ArgoSetupSteps.clone_template(@git_template))
+
+        assert_equal @directory, Pathname(@context.root).each_filename.to_a.last
+      end
+
+      def test_install_dependencies_calls_js_deps_to_install_dependencies_and_returns_the_install_result
+        ShopifyCli::JsDeps.any_instance.expects(:install).returns(true).once
+        assert call_step(ArgoSetupSteps.install_dependencies)
+
+        ShopifyCli::JsDeps.any_instance.expects(:install).returns(false).once
+        refute call_step(ArgoSetupSteps.install_dependencies)
+      end
+
+      def test_initialize_project_runs_the_initialize_command_with_js_system_and_returns_true_if_successful
+        type_parameter = [ArgoSetupSteps::INITIALIZE_TYPE_PARAMETER % @identifier]
+        expected_npm_command = ArgoSetupSteps::NPM_INITIALIZE_COMMAND + type_parameter
+        expected_yarn_command = ArgoSetupSteps::YARN_INITIALIZE_COMMAND + type_parameter
+
+        @system
+          .expects(:call)
+          .with(yarn: expected_yarn_command, npm: expected_npm_command)
+          .returns(true)
+          .once
+
+        assert call_step(ArgoSetupSteps.initialize_project)
+      end
+
+      def test_initialize_project_runs_the_initialize_command_with_js_system_and_returns_false_when_fails
+        type_parameter = [ArgoSetupSteps::INITIALIZE_TYPE_PARAMETER % @identifier]
+        expected_npm_command = ArgoSetupSteps::NPM_INITIALIZE_COMMAND + type_parameter
+        expected_yarn_command = ArgoSetupSteps::YARN_INITIALIZE_COMMAND + type_parameter
+
+        @system
+          .expects(:call)
+          .with(yarn: expected_yarn_command, npm: expected_npm_command)
+          .returns(false)
+          .once
+
+        refute call_step(ArgoSetupSteps.initialize_project)
+      end
+
+      private
+
+      def call_step(step, context: @context, identifier: @identifier, directory_name: @directory, system: @system)
+        step.call(context, identifier, directory_name, system)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_setup_steps_test.rb
+++ b/test/project_types/extension/features/argo_setup_steps_test.rb
@@ -17,12 +17,11 @@ module Extension
         @system = ShopifyCli::JsSystem.new(ctx: @context)
       end
 
-
       def test_check_dependencies_loops_through_the_provided_dependencies
         execution_mock = Minitest::Mock.new
         execution_mock.expect(:executed, nil)
 
-        test_proc = Proc.new do |context|
+        test_proc = proc do |context|
           execution_mock.executed
           assert_equal @context, context
         end

--- a/test/project_types/extension/features/argo_setup_test.rb
+++ b/test/project_types/extension/features/argo_setup_test.rb
@@ -64,14 +64,14 @@ module Extension
       end
 
       def test_cleanup_on_failure_removes_extension_directory_if_it_has_been_created
-        Dir.expects(:exists?).with(@directory).returns(true).once
+        Dir.expects(:exist?).with(@directory).returns(true).once
         FileUtils.expects(:rm_r).with(@directory).once
 
         @initializer.cleanup_on_failure(@context, @directory)
       end
 
       def test_cleanup_on_failure_does_nothing_if_failure_occurred_before_extension_directory_was_created
-        Dir.expects(:exists?).with(@directory).returns(false).once
+        Dir.expects(:exist?).with(@directory).returns(false).once
         FileUtils.expects(:rm_r).with(@directory).never
 
         @initializer.cleanup_on_failure(@context, @directory)

--- a/test/project_types/extension/features/argo_setup_test.rb
+++ b/test/project_types/extension/features/argo_setup_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+require 'pathname'
+
+module Extension
+  module Features
+    class ArgoSetupTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @git_template = 'https://www.github.com/fake_template.git'
+        @initializer = ArgoSetup.new(git_template: @git_template)
+        @identifier = 'FAKE_ARGO_TYPE'
+        @directory = 'fake_directory'
+
+        @passing_step = ArgoSetupStep.default { true }
+        @failing_step = ArgoSetupStep.default { false }
+        @never_run_step = mock.expects(:call).never
+      end
+
+      def test_call_sets_up_the_default_setup_steps_runs_them_and_cleans_up
+        ArgoSetupSteps.expects(:check_dependencies).with([]).returns(@passing_step).once
+        ArgoSetupSteps.expects(:clone_template).with(@git_template).returns(@passing_step).once
+        ArgoSetupSteps.expects(:install_dependencies).returns(@passing_step).once
+        ArgoSetupSteps.expects(:initialize_project).returns(@passing_step).once
+
+        @initializer.expects(:cleanup).with(@context, true, @directory).once
+        @initializer.call(@directory, @identifier, @context)
+      end
+
+      def test_if_any_step_fails_subsequent_steps_are_not_run_and_cleanup_is_called
+        ArgoSetupSteps.expects(:check_dependencies).with([]).returns(@passing_step).once
+        ArgoSetupSteps.expects(:clone_template).with(@git_template).returns(@passing_step).once
+        ArgoSetupSteps.expects(:install_dependencies).returns(@failing_step).once
+        ArgoSetupSteps.expects(:initialize_project).returns(@never_run_step).once
+
+        @initializer.expects(:cleanup).with(@context, false, @directory).once
+        @initializer.call(@directory, @identifier, @context)
+      end
+
+      def test_cleanup_runs_cleanup_template_if_success_is_true
+        @initializer.expects(:cleanup_template).with(@context).once
+        @initializer.expects(:cleanup_on_failure).never
+
+        @initializer.cleanup(@context, true, @directory)
+      end
+
+      def test_cleanup_runs_cleanup_on_failure_if_success_is_false
+        @initializer.expects(:cleanup_template).never
+        @initializer.expects(:cleanup_on_failure).with(@context, @directory).once
+
+        @initializer.cleanup(@context, false, @directory)
+      end
+
+      def test_cleanup_template_removes_git_and_script_directories
+        @context.expects(:rm_r).with(ArgoSetup::GIT_DIRECTORY).once
+        @context.expects(:rm_r).with(ArgoSetup::SCRIPTS_DIRECTORY).once
+
+        @initializer.cleanup_template(@context)
+      end
+
+      def test_cleanup_on_failure_removes_extension_directory_if_it_has_been_created
+        Dir.expects(:exists?).with(@directory).returns(true).once
+        FileUtils.expects(:rm_r).with(@directory).once
+
+        @initializer.cleanup_on_failure(@context, @directory)
+      end
+
+      def test_cleanup_on_failure_does_nothing_if_failure_occurred_before_extension_directory_was_created
+        Dir.expects(:exists?).with(@directory).returns(false).once
+        FileUtils.expects(:rm_r).with(@directory).never
+
+        @initializer.cleanup_on_failure(@context, @directory)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+require 'base64'
+require 'pathname'
+
+module Extension
+  module Features
+    class ArgoTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::Stubs::ArgoScript
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @git_template = 'https://www.github.com/fake_template.git'
+        @argo = Argo.new(setup: Features::ArgoSetup.new(git_template: @git_template))
+        @identifier = 'FAKE_ARGO_TYPE'
+        @directory = 'fake_directory'
+      end
+
+      def test_config_aborts_with_error_if_script_file_doesnt_exist
+        error = assert_raises ShopifyCli::Abort do
+          @argo.config(@context)
+        end
+
+        assert error.message.include?(@context.message('features.argo.missing_file_error'))
+      end
+
+      def test_config_aborts_with_error_if_script_serialization_fails
+        File.stubs(:exists?).returns(true)
+        Base64.stubs(:strict_encode64).raises(IOError)
+
+        error = assert_raises(ShopifyCli::Abort) { @argo.config(@context) }
+        assert error.message.include?(@context.message('features.argo.script_prepare_error'))
+      end
+
+      def test_config_aborts_with_error_if_file_read_fails
+        File.stubs(:exists?).returns(true)
+        File.any_instance.stubs(:read).raises(IOError)
+
+        error = assert_raises(ShopifyCli::Abort) { @argo.config(@context) }
+        assert error.message.include?(@context.message('features.argo.script_prepare_error'))
+      end
+
+      def test_config_encodes_script_into_context_if_it_exists
+        with_stubbed_script(@context, Argo::SCRIPT_PATH) do
+          config = @argo.config(@context)
+
+          assert_equal [:serialized_script], config.keys
+          assert_equal Base64.strict_encode64(TEMPLATE_SCRIPT.chomp), config[:serialized_script]
+        end
+      end
+
+      def test_admin_method_returns_an_argo_extension_with_the_subscription_management_template
+        git_admin_template = 'https://github.com/Shopify/argo-admin-template.git'.freeze
+        argo = Argo.admin
+        assert_equal(argo.setup.git_template, git_admin_template)
+      end
+
+      def test_checkout_method_returns_an_argo_extension_with_the_checkout_post_purchase_template
+        git_checkout_template = 'https://github.com/Shopify/argo-checkout-template.git'.freeze
+        argo = Argo.checkout
+        assert_equal(argo.setup.git_template, git_checkout_template)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -29,7 +29,7 @@ module Extension
       end
 
       def test_config_aborts_with_error_if_script_serialization_fails
-        File.stubs(:exists?).returns(true)
+        File.stubs(:exist?).returns(true)
         Base64.stubs(:strict_encode64).raises(IOError)
 
         error = assert_raises(ShopifyCli::Abort) { @argo.config(@context) }
@@ -37,7 +37,7 @@ module Extension
       end
 
       def test_config_aborts_with_error_if_file_read_fails
-        File.stubs(:exists?).returns(true)
+        File.stubs(:exist?).returns(true)
         File.any_instance.stubs(:read).raises(IOError)
 
         error = assert_raises(ShopifyCli::Abort) { @argo.config(@context) }
@@ -54,13 +54,13 @@ module Extension
       end
 
       def test_admin_method_returns_an_argo_extension_with_the_subscription_management_template
-        git_admin_template = 'https://github.com/Shopify/argo-admin-template.git'.freeze
+        git_admin_template = 'https://github.com/Shopify/argo-admin-template.git'
         argo = Argo.admin
         assert_equal(argo.setup.git_template, git_admin_template)
       end
 
       def test_checkout_method_returns_an_argo_extension_with_the_checkout_post_purchase_template
-        git_checkout_template = 'https://github.com/Shopify/argo-checkout-template.git'.freeze
+        git_checkout_template = 'https://github.com/Shopify/argo-checkout-template.git'
         argo = Argo.checkout
         assert_equal(argo.setup.git_template, git_checkout_template)
       end

--- a/test/project_types/extension/features/tunnel_url_test.rb
+++ b/test/project_types/extension/features/tunnel_url_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Features
+    class TunnelUrlTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_fetch_returns_the_first_ngrok_url_if_it_exists
+        fake_tunnel_uri = 'http://7b121913fab9.ngrok.io'
+        fake_tunnel_response = {
+          "tunnels": [
+            {
+              "name": "command_line (http)",
+              "uri": "/api/tunnels/command_line%20%28http%29",
+              "public_url": fake_tunnel_uri,
+              "proto": "http",
+              "config": {"addr": "http://localhost:39351", "inspect": true},
+              "metrics": {
+                "conns": {"count": 0, "gauge": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0},
+                "http": {"count": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0}
+              }
+            },
+            {
+              "name": "command_line",
+              "uri": "/api/tunnels/command_line",
+              "public_url": fake_tunnel_uri,
+              "proto": "https",
+              "config": {"addr": "http://localhost:39351", "inspect": true},
+              "metrics": {
+                "conns": {"count": 0, "gauge": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0},
+                "http": {"count": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0}
+              }
+            }
+          ],
+          "uri": "/api/tunnels"
+        }
+
+        mock_ngrok_tunnels_http_call(response_body: JSON.dump(fake_tunnel_response))
+
+        fetched_tunnel_uri = TunnelUrl.fetch
+        assert_equal fake_tunnel_uri, fetched_tunnel_uri
+      end
+
+      def test_fetch_returns_nil_and_does_not_raise_if_the_response_cannot_be_parsed_as_json
+        invalid_json_response = '<html><head></head><body><p>Error</p></html>'
+
+        mock_ngrok_tunnels_http_call(response_body: invalid_json_response)
+
+        assert_nothing_raised do
+          assert_nil TunnelUrl.fetch
+        end
+      end
+
+      def test_fetch_returns_nil_and_does_not_raise_if_the_response_has_no_tunnels
+        fake_tunnel_response = {
+          "tunnels": [ ],
+          "uri": "/api/tunnels"
+        }
+
+        mock_ngrok_tunnels_http_call(response_body: JSON.dump(fake_tunnel_response))
+
+        assert_nothing_raised do
+          assert_nil TunnelUrl.fetch
+        end
+      end
+
+      private
+
+      def mock_ngrok_tunnels_http_call(response_body:)
+        Net::HTTP
+          .expects(:get_response)
+          .with(TunnelUrl::NGROK_TUNNELS_URI)
+          .returns(mock(body: response_body))
+          .once
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/tunnel_url_test.rb
+++ b/test/project_types/extension/features/tunnel_url_test.rb
@@ -21,25 +21,33 @@ module Extension
               "uri": "/api/tunnels/command_line%20%28http%29",
               "public_url": fake_tunnel_uri,
               "proto": "http",
-              "config": {"addr": "http://localhost:39351", "inspect": true},
+              "config": { "addr": "http://localhost:39351", "inspect": true },
               "metrics": {
-                "conns": {"count": 0, "gauge": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0},
-                "http": {"count": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0}
-              }
+                "conns": {
+                  "count": 0, "gauge": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0
+                },
+                "http": {
+                  "count": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0
+                },
+              },
             },
             {
               "name": "command_line",
               "uri": "/api/tunnels/command_line",
               "public_url": fake_tunnel_uri,
               "proto": "https",
-              "config": {"addr": "http://localhost:39351", "inspect": true},
+              "config": { "addr": "http://localhost:39351", "inspect": true },
               "metrics": {
-                "conns": {"count": 0, "gauge": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0},
-                "http": {"count": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0}
-              }
-            }
+                "conns": {
+                  "count": 0, "gauge": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0
+                },
+                "http": {
+                  "count": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0
+                },
+              },
+            },
           ],
-          "uri": "/api/tunnels"
+          "uri": "/api/tunnels",
         }
 
         mock_ngrok_tunnels_http_call(response_body: JSON.dump(fake_tunnel_response))
@@ -60,8 +68,8 @@ module Extension
 
       def test_fetch_returns_nil_and_does_not_raise_if_the_response_has_no_tunnels
         fake_tunnel_response = {
-          "tunnels": [ ],
-          "uri": "/api/tunnels"
+          "tunnels": [],
+          "uri": "/api/tunnels",
         }
 
         mock_ngrok_tunnels_http_call(response_body: JSON.dump(fake_tunnel_response))

--- a/test/project_types/extension/forms/create_test.rb
+++ b/test/project_types/extension/forms/create_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Forms
+    class CreateTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TestExtensionSetup
+
+      def setup
+        super
+        @app = Models::App.new(title: 'Fake', api_key: '1234', secret: '4567', business_name: 'Fake Business')
+      end
+
+      def test_returns_defined_attributes_if_valid
+        form = ask
+        assert_equal form.name, 'test-extension'
+        assert_equal form.type, @test_extension_type
+      end
+
+      def test_prompts_the_user_to_choose_a_name_if_no_name_was_provided
+        CLI::UI::Prompt.expects(:ask).with(@context.message('create.ask_name')).times(3).returns('A name')
+        capture_io { ask(name: nil) }
+        capture_io { ask(name: "") }
+        capture_io { ask(name: " ") }
+      end
+
+      def test_reprompts_the_user_to_choose_a_name_until_valid_response_is_given
+        CLI::UI::Prompt.stubs(:ask).with(@context.message('create.ask_name'))
+          .returns(nil, nil)
+          .then.returns('A name')
+        ShopifyCli::Context.any_instance.expects(:puts).with(
+          @context.message('create.invalid_name', Models::Registration::MAX_TITLE_LENGTH)
+        ).times(2)
+
+        capture_io do
+          form = ask(name: nil)
+          assert_equal form.name, 'A name'
+        end
+      end
+
+      def test_strips_whitespace_from_beginning_and_end_of_name
+        CLI::UI::Prompt.expects(:ask).with(@context.message('create.ask_name')).returns('  A name  ')
+        capture_io do
+          form = ask(name: nil)
+          assert_equal form.name, 'A name'
+        end
+      end
+
+      def test_directory_name_is_a_lowercase_underscored_version_of_name
+        assert_equal 'demo', ask(name: 'Demo').directory_name
+        assert_equal 'spaces', ask(name: ' Spaces ').directory_name
+        assert_equal 'demo_extension', ask(name: 'Demo Extension').directory_name
+        assert_equal 'testlongstring', ask(name: 'TestLongString').directory_name
+        assert_equal 'double__spaces', ask(name: 'double  spaces').directory_name
+      end
+
+      def test_accepts_any_valid_extension_type
+        form = ask(type: @test_extension_type.identifier)
+        assert_equal form.type, @test_extension_type
+      end
+
+      def test_outputs_an_error_and_prompts_the_user_to_choose_a_type_if_an_unknown_type_was_provided_as_flag
+        CLI::UI::Prompt
+          .expects(:interactive_prompt)
+          .returns("#{@test_extension_type.name} #{@test_extension_type.tagline}")
+          .once
+
+        io = capture_io { ask(type: 'unknown-type') }
+
+        assert_match(@context.message('create.invalid_type'), io.join)
+        assert_match(@context.message('create.ask_type'), io.join)
+      end
+
+      def test_prompts_the_user_to_choose_a_type_if_no_type_was_provided
+        CLI::UI::Prompt.expects(:ask).with(@context.message('create.ask_type'))
+
+        capture_io do
+          ask(type: nil)
+        end
+      end
+
+      private
+
+      def ask(name: 'test-extension', type: @test_extension_type.identifier)
+        Create.ask(
+          @context,
+          [],
+          name: name,
+          type: type,
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/extension/forms/register_test.rb
+++ b/test/project_types/extension/forms/register_test.rb
@@ -25,7 +25,7 @@ module Extension
 
         assert_message_output(io: io, expected_content: [
           @context.message('register.no_apps'),
-          @context.message('register.learn_about_apps')
+          @context.message('register.learn_about_apps'),
         ])
       end
 

--- a/test/project_types/extension/forms/register_test.rb
+++ b/test/project_types/extension/forms/register_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Forms
+    class RegisterTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TestExtensionSetup
+      include ExtensionTestHelpers::Messages
+
+      def setup
+        super
+        @app = Models::App.new(title: 'Fake', api_key: '1234', secret: '4567', business_name: 'Fake Business')
+        Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([@app]).at_least_once
+      end
+
+      def test_aborts_and_informs_user_if_there_are_no_apps
+        Tasks::GetApps.any_instance.unstub(:call)
+        Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([]).once
+
+        io = capture_io do
+          assert_raises(ShopifyCli::AbortSilent) { ask }
+        end
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('register.no_apps'),
+          @context.message('register.learn_about_apps')
+        ])
+      end
+
+      def test_accepts_the_api_key_to_associate_with_extension
+        form = ask(api_key: '1234')
+        assert_equal form.app, @app
+      end
+
+      def test_prompts_the_user_to_choose_an_app_to_associate_with_extension_if_no_app_is_provided
+        CLI::UI::Prompt.expects(:ask).with(@context.message('register.ask_app'))
+
+        capture_io do
+          ask(api_key: nil)
+        end
+      end
+
+      def test_fails_with_invalid_api_key_to_associate_with_extension
+        api_key = '00001'
+
+        io = capture_io { ask(api_key: api_key) }
+
+        assert_match(@context.message('register.invalid_api_key', api_key), io.join)
+      end
+
+      private
+
+      def ask(api_key: @app.api_key)
+        Register.ask(@context, [], api_key: api_key)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/messages/message_loading_test.rb
+++ b/test/project_types/extension/messages/message_loading_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Messages
+    class MessageLoadingTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @fake_messages = {
+          name: 'Fake Type',
+          tagline: 'Fake tagline'
+        }
+
+        @fake_overrides = {
+          build: {
+            frame_title: 'Overridden Title'
+          }
+        }
+
+        @fake_override_messages = @fake_messages.merge(overrides: @fake_overrides)
+      end
+
+      def test_load_returns_default_messages_if_no_type_messages_exist
+        Messages::MessageLoading.expects(:load_current_type_messages).returns(nil).once
+        Messages::MESSAGES.expects(:merge).never
+
+        assert_equal Messages::MESSAGES, Messages::MessageLoading.load
+      end
+
+      def test_load_returns_default_messages_if_type_messages_exist_with_no_overrides
+        Messages::MessageLoading.expects(:load_current_type_messages).returns(@fake_messages).once
+        Messages::MESSAGES.expects(:merge).never
+
+        assert_equal Messages::MESSAGES, Messages::MessageLoading.load
+      end
+
+      def test_load_returns_default_messages_merged_with_overrides_if_types_messages_exist_and_have_overrides
+        Messages::MessageLoading.expects(:load_current_type_messages).returns(@fake_override_messages).once
+
+        loaded_messages = Messages::MessageLoading.load
+        assert_equal @fake_overrides[:build][:frame_title], loaded_messages[:build][:frame_title]
+      end
+
+      def test_load_does_a_deep_merge_and_retains_nested_non_overridden_messages
+        Messages::MessageLoading.expects(:load_current_type_messages).returns(@fake_override_messages).once
+
+        loaded_messages = Messages::MessageLoading.load
+        assert_equal Messages::MESSAGES[:build][:build_failure_message], loaded_messages[:build][:build_failure_message]
+      end
+
+      def test_load_current_type_messages_returns_nil_if_there_is_no_current_project
+        ShopifyCli::Project.expects(:has_current?).returns(false).once
+
+        assert_nil Messages::MessageLoading.load_current_type_messages
+      end
+
+      def test_load_current_type_messages_calls_messages_for_type_with_type_if_there_is_a_current_project
+        setup_temp_project
+        ShopifyCli::Project.expects(:has_current?).returns(true).once
+        ShopifyCli::Project.stubs(:current).returns(@project).once
+        Messages::MessageLoading.expects(:messages_for_type).with(@type).once
+
+        Messages::MessageLoading.load_current_type_messages
+      end
+
+      def test_messages_for_type_returns_nil_if_the_type_identifier_is_nil
+        assert_nil Messages::MessageLoading.messages_for_type(nil)
+      end
+
+      def test_messages_for_type_returns_nil_if_the_type_key_does_not_exist
+        setup_temp_project
+        Messages::TYPES.expects(:has_key?).with(@type.downcase.to_sym).returns(false).once
+
+        assert_nil Messages::MessageLoading.messages_for_type(@type)
+      end
+
+      def test_messages_for_type_returns_type_messages_if_they_exist
+        setup_temp_project
+        Messages::TYPES.expects(:has_key?).with(@type.downcase.to_sym).returns(true).once
+        Messages::TYPES.expects(:[]).with(@type.downcase.to_sym).returns(@fake_overrides).once
+
+        assert_equal @fake_overrides, Messages::MessageLoading.messages_for_type(@type)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/messages/message_loading_test.rb
+++ b/test/project_types/extension/messages/message_loading_test.rb
@@ -14,13 +14,13 @@ module Extension
 
         @fake_messages = {
           name: 'Fake Type',
-          tagline: 'Fake tagline'
+          tagline: 'Fake tagline',
         }
 
         @fake_overrides = {
           build: {
-            frame_title: 'Overridden Title'
-          }
+            frame_title: 'Overridden Title',
+          },
         }
 
         @fake_override_messages = @fake_messages.merge(overrides: @fake_overrides)
@@ -57,7 +57,7 @@ module Extension
       def test_load_current_type_messages_returns_nil_if_there_is_no_current_project
         ShopifyCli::Project.expects(:has_current?).returns(false).once
 
-        assert_nil Messages::MessageLoading.load_current_type_messages
+        assert_nil(Messages::MessageLoading.load_current_type_messages)
       end
 
       def test_load_current_type_messages_calls_messages_for_type_with_type_if_there_is_a_current_project
@@ -70,19 +70,19 @@ module Extension
       end
 
       def test_messages_for_type_returns_nil_if_the_type_identifier_is_nil
-        assert_nil Messages::MessageLoading.messages_for_type(nil)
+        assert_nil(Messages::MessageLoading.messages_for_type(nil))
       end
 
       def test_messages_for_type_returns_nil_if_the_type_key_does_not_exist
         setup_temp_project
-        Messages::TYPES.expects(:has_key?).with(@type.downcase.to_sym).returns(false).once
+        Messages::TYPES.expects(:key?).with(@type.downcase.to_sym).returns(false).once
 
-        assert_nil Messages::MessageLoading.messages_for_type(@type)
+        assert_nil(Messages::MessageLoading.messages_for_type(@type))
       end
 
       def test_messages_for_type_returns_type_messages_if_they_exist
         setup_temp_project
-        Messages::TYPES.expects(:has_key?).with(@type.downcase.to_sym).returns(true).once
+        Messages::TYPES.expects(:key?).with(@type.downcase.to_sym).returns(true).once
         Messages::TYPES.expects(:[]).with(@type.downcase.to_sym).returns(@fake_overrides).once
 
         assert_equal @fake_overrides, Messages::MessageLoading.messages_for_type(@type)

--- a/test/project_types/extension/models/registration_test.rb
+++ b/test/project_types/extension/models/registration_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Models
+    class RegistrationTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_valid_title_returns_true_for_valid_title
+        assert Models::Registration.valid_title?('A title')
+      end
+
+      def test_valid_title_returns_false_for_missing_title
+        refute Models::Registration.valid_title?(nil)
+        refute Models::Registration.valid_title?('')
+        refute Models::Registration.valid_title?('  ')
+      end
+
+      def test_valid_title_returns_false_when_title_too_long
+        refute Models::Registration.valid_title?(
+          Array.new(Registration::MAX_TITLE_LENGTH + 1, 'a').join
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/type_test.rb
+++ b/test/project_types/extension/models/type_test.rb
@@ -29,11 +29,11 @@ module Extension
       end
 
       def test_valid_extension_contexts_returns_empty_array
-        assert_empty Models::Type.new.valid_extension_contexts
+        assert_empty(Models::Type.new.valid_extension_contexts)
       end
 
       def test_extension_context_returns_nil
-        assert_nil Models::Type.new.extension_context(@context)
+        assert_nil(Models::Type.new.extension_context(@context))
       end
     end
   end

--- a/test/project_types/extension/models/type_test.rb
+++ b/test/project_types/extension/models/type_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Models
+    class TypeTest < MiniTest::Test
+      include ExtensionTestHelpers::TestExtensionSetup
+
+      def test_can_load_type_by_identifier
+        assert_equal @test_extension_type.identifier, Models::Type.load_type(@test_extension_type.identifier).identifier
+      end
+
+      def test_valid_determines_if_a_type_is_valid
+        assert Models::Type.valid?(ExtensionTestHelpers::TestExtension::IDENTIFIER)
+        refute Models::Type.valid?('INVALID')
+      end
+
+      def test_tagline_returns_empty_string_if_not_defined_in_content
+        base_type = Models::Type.new
+        base_type.stubs(:identifier).returns('INVALID')
+
+        assert_equal '', base_type.tagline
+      end
+
+      def test_raises_not_implemented_error_for_required_methods
+        assert_raises(NotImplementedError) { Models::Type.new.config(@context) }
+        assert_raises(NotImplementedError) { Models::Type.new.create('name', @context) }
+      end
+
+      def test_valid_extension_contexts_returns_empty_array
+        assert_empty Models::Type.new.valid_extension_contexts
+      end
+
+      def test_extension_context_returns_nil
+        assert_nil Models::Type.new.extension_context(@context)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/types/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/models/types/checkout_post_purchase_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Models
+    module Types
+      class CheckoutPostPurchaseTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+          @checkout_post_purchase = Models::Type.load_type(CheckoutPostPurchase::IDENTIFIER)
+        end
+
+        def test_create_uses_standard_argo_create_implementation
+          directory_name = 'checkout_post_purchase'
+
+          Features::Argo.checkout
+            .expects(:create)
+            .with(directory_name, CheckoutPostPurchase::IDENTIFIER, @context)
+            .once
+
+          @checkout_post_purchase.create(directory_name, @context)
+        end
+
+        def test_config_uses_standard_argo_config_implementation
+          Features::Argo.checkout.expects(:config).with(@context).once
+
+          @checkout_post_purchase.config(@context)
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/types/subscription_management_test.rb
+++ b/test/project_types/extension/models/types/subscription_management_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Models
+    module Types
+      class SubscriptionManagementTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+          @subscription_management = Models::Type.load_type(SubscriptionManagement::IDENTIFIER)
+        end
+
+        def test_create_uses_standard_argo_create_implementation
+          directory_name = 'subscription_management'
+
+          Features::Argo.admin
+            .expects(:create)
+            .with(directory_name, SubscriptionManagement::IDENTIFIER, @context)
+            .once
+
+          @subscription_management.create(directory_name, @context)
+        end
+
+        def test_config_uses_standard_argo_config_implementation
+          Features::Argo.admin.expects(:config).with(@context).once
+
+          @subscription_management.config(@context)
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/types_test.rb
+++ b/test/project_types/extension/models/types_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Models
+    class TypesTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_loads_all_extension_types_within_types_folder
+        extension_type_count = 2
+        assert_equal extension_type_count, Models::Type.repository.size
+      end
+
+      def test_all_type_identifiers_are_defined_and_uppercase
+        Models::Type.repository.values.each do |type|
+          refute_nil type.identifier
+          assert_equal type.identifier.upcase, type.identifier
+          refute_empty type.identifier.strip
+        end
+      end
+
+      def test_all_type_identifiers_are_accessible_as_class_or_instance_methods
+        Models::Type.repository.values.each do |type|
+          assert_equal type.class::IDENTIFIER, type.identifier
+        end
+      end
+
+      def test_all_type_names_are_defined
+        Models::Type.repository.values.each do |type|
+          refute_empty type.name.strip
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/validation_error_test.rb
+++ b/test/project_types/extension/models/validation_error_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Models
+    class ValidationErrorTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @error = ValidationError.new(field: ['Hi'], message: 'message')
+      end
+
+      def test_field_only_accepts_an_array_of_strings
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: [1], message: '') }
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: [Object], message: '') }
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: ['field', 1], message: '') }
+
+        assert_nothing_raised { ValidationError.new(field: [], message: '') }
+        assert_nothing_raised { ValidationError.new(field: ['field'], message: '') }
+        assert_nothing_raised { ValidationError.new(field: %w(field1 field2), message: '') }
+      end
+
+      def test_is_validation_error_returns_true_if_an_object_is_a_validation_error
+        refute Models::ValidationError::IS_VALIDATION_ERROR.call(Object)
+        refute Models::ValidationError::IS_VALIDATION_ERROR.call(nil)
+        refute Models::ValidationError::IS_VALIDATION_ERROR.call([])
+
+        assert Models::ValidationError::IS_VALIDATION_ERROR.call(@error)
+      end
+
+      def test_is_validation_error_list_returns_true_if_an_object_is_a_list_of_validation_errors
+        refute Models::ValidationError::IS_VALIDATION_ERROR_LIST.call(nil)
+        refute Models::ValidationError::IS_VALIDATION_ERROR_LIST.call(Object)
+        refute Models::ValidationError::IS_VALIDATION_ERROR_LIST.call([Object])
+        refute Models::ValidationError::IS_VALIDATION_ERROR_LIST.call([@error, 1])
+
+        assert Models::ValidationError::IS_VALIDATION_ERROR_LIST.call([])
+        assert Models::ValidationError::IS_VALIDATION_ERROR_LIST.call([@error])
+        assert Models::ValidationError::IS_VALIDATION_ERROR_LIST.call(Array.new(2) { @error })
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/registration_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/registration_converter_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    module Converters
+      class RegistrationConverterTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::Messages
+
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+
+          @registration_id = 42
+          @fake_type = 'TEST_EXTENSION'
+          @fake_title = 'Fake Title'
+          @fake_extension_context = 'fake_context'
+          @last_user_interaction_at = Time.now.to_s
+        end
+
+        def test_from_hash_aborts_with_a_parse_error_if_the_hash_is_nil
+          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+            Converters::RegistrationConverter.from_hash(@context, nil)
+          end
+
+          assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+        end
+
+        def test_from_hash_parses_registration_from_a_hash
+          hash = {
+            Converters::RegistrationConverter::ID_FIELD => @registration_id,
+            Converters::RegistrationConverter::TYPE_FIELD => @fake_type,
+            Converters::RegistrationConverter::TITLE_FIELD => @fake_title,
+            Converters::RegistrationConverter::DRAFT_VERSION_FIELD => {
+              Converters::VersionConverter::REGISTRATION_ID_FIELD => @registration_id,
+              Converters::VersionConverter::LAST_USER_INTERACTION_AT_FIELD => @last_user_interaction_at
+            }
+          }
+
+          parsed_registration = Converters::RegistrationConverter.from_hash(@context, hash)
+
+          assert_kind_of Models::Registration, parsed_registration
+          assert_equal @registration_id, parsed_registration.id
+          assert_equal @fake_type, parsed_registration.type
+          assert_equal @fake_title, parsed_registration.title
+          assert_equal @registration_id, parsed_registration.draft_version.registration_id
+          assert_kind_of Time, parsed_registration.draft_version.last_user_interaction_at
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/registration_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/registration_converter_test.rb
@@ -35,18 +35,18 @@ module Extension
             Converters::RegistrationConverter::TITLE_FIELD => @fake_title,
             Converters::RegistrationConverter::DRAFT_VERSION_FIELD => {
               Converters::VersionConverter::REGISTRATION_ID_FIELD => @registration_id,
-              Converters::VersionConverter::LAST_USER_INTERACTION_AT_FIELD => @last_user_interaction_at
-            }
+              Converters::VersionConverter::LAST_USER_INTERACTION_AT_FIELD => @last_user_interaction_at,
+            },
           }
 
           parsed_registration = Converters::RegistrationConverter.from_hash(@context, hash)
 
-          assert_kind_of Models::Registration, parsed_registration
+          assert_kind_of(Models::Registration, parsed_registration)
           assert_equal @registration_id, parsed_registration.id
           assert_equal @fake_type, parsed_registration.type
           assert_equal @fake_title, parsed_registration.title
           assert_equal @registration_id, parsed_registration.draft_version.registration_id
-          assert_kind_of Time, parsed_registration.draft_version.last_user_interaction_at
+          assert_kind_of(Time, parsed_registration.draft_version.last_user_interaction_at)
         end
       end
     end

--- a/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    module Converters
+      class ValidationErrorConverterTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::Messages
+
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+        end
+
+        def test_from_hash_returns_empty_array_if_errors_are_nil
+          assert_equal [], ValidationErrorConverter.from_array(@context, nil)
+        end
+
+        def test_from_hash_aborts_with_parse_error_if_errors_are_not_an_array_and_not_nil
+          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+            ValidationErrorConverter.from_array(@context, Object)
+          end
+
+          assert_message_output(io: io, expected_content: [
+            @context.message('tasks.errors.parse_error')
+          ])
+        end
+
+        def test_from_hash_returns_parsed_validation_errors_if_valid
+          fields = %w(config name)
+          message = 'error message'
+
+          errors = [{ 'field' => fields, 'message' => message }]
+          parsed_validation_errors = ValidationErrorConverter.from_array(@context, errors)
+
+          assert_equal 1, parsed_validation_errors.count
+          assert_equal fields, parsed_validation_errors.first.field
+          assert_equal message, parsed_validation_errors.first.message
+        end
+
+        def test_from_hash_returns_all_parsed_validation_errors_if_valid
+          message = 'error message'
+          message2 = 'error message 2'
+
+          errors = [
+            { 'field' => %w(field1), 'message' => message },
+            { 'field' => %w(config name), 'message' => message2 }
+          ]
+          parsed_validation_messages = ValidationErrorConverter.from_array(@context, errors).map(&:message)
+
+          assert_equal [message, message2], parsed_validation_messages
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
@@ -24,7 +24,7 @@ module Extension
           end
 
           assert_message_output(io: io, expected_content: [
-            @context.message('tasks.errors.parse_error')
+            @context.message('tasks.errors.parse_error'),
           ])
         end
 
@@ -46,7 +46,7 @@ module Extension
 
           errors = [
             { 'field' => %w(field1), 'message' => message },
-            { 'field' => %w(config name), 'message' => message2 }
+            { 'field' => %w(config name), 'message' => message2 },
           ]
           parsed_validation_messages = ValidationErrorConverter.from_array(@context, errors).map(&:message)
 

--- a/test/project_types/extension/tasks/converters/version_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/version_converter_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    module Converters
+      class VersionConverterTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::Messages
+
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+
+          @api_key = 'FAKE_API_KEY'
+          @registration_id = 42
+          @config = { }
+          @extension_context = 'fake#context'
+          @location = 'https://www.fakeurl.com'
+          @last_user_interaction_at = Time.now.to_s
+        end
+
+        def test_from_hash_aborts_with_a_parse_error_if_the_hash_is_nil
+          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+            Converters::VersionConverter.from_hash(@context, nil)
+          end
+
+          assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+        end
+
+        def test_from_hash_parses_a_version_from_a_hash
+          hash = {
+            Converters::VersionConverter::REGISTRATION_ID_FIELD => @registration_id,
+            Converters::VersionConverter::LAST_USER_INTERACTION_AT_FIELD => @last_user_interaction_at,
+            Converters::VersionConverter::CONTEXT_FIELD => @extension_context,
+            Converters::VersionConverter::LOCATION_FIELD => @location,
+            Converters::VersionConverter::VALIDATION_ERRORS_FIELD => []
+          }
+
+          parsed_version = Tasks::Converters::VersionConverter.from_hash(@context, hash)
+
+          assert_kind_of Models::Version, parsed_version
+          assert_equal @registration_id, parsed_version.registration_id
+          assert_kind_of Time, parsed_version.last_user_interaction_at
+          assert_equal @extension_context, parsed_version.context
+          assert_equal @location, parsed_version.location
+          assert_equal [], parsed_version.validation_errors
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/version_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/version_converter_test.rb
@@ -15,7 +15,7 @@ module Extension
 
           @api_key = 'FAKE_API_KEY'
           @registration_id = 42
-          @config = { }
+          @config = {}
           @extension_context = 'fake#context'
           @location = 'https://www.fakeurl.com'
           @last_user_interaction_at = Time.now.to_s
@@ -35,14 +35,14 @@ module Extension
             Converters::VersionConverter::LAST_USER_INTERACTION_AT_FIELD => @last_user_interaction_at,
             Converters::VersionConverter::CONTEXT_FIELD => @extension_context,
             Converters::VersionConverter::LOCATION_FIELD => @location,
-            Converters::VersionConverter::VALIDATION_ERRORS_FIELD => []
+            Converters::VersionConverter::VALIDATION_ERRORS_FIELD => [],
           }
 
           parsed_version = Tasks::Converters::VersionConverter.from_hash(@context, hash)
 
-          assert_kind_of Models::Version, parsed_version
+          assert_kind_of(Models::Version, parsed_version)
           assert_equal @registration_id, parsed_version.registration_id
-          assert_kind_of Time, parsed_version.last_user_interaction_at
+          assert_kind_of(Time, parsed_version.last_user_interaction_at)
           assert_equal @extension_context, parsed_version.context
           assert_equal @location, parsed_version.location
           assert_equal [], parsed_version.validation_errors

--- a/test/project_types/extension/tasks/create_extension_test.rb
+++ b/test/project_types/extension/tasks/create_extension_test.rb
@@ -18,7 +18,7 @@ module Extension
         @fake_type = 'TEST_EXTENSION'
         @fake_title = 'Fake Title'
         @fake_config = {
-          field: 'with stuff'
+          field: 'with stuff',
         }
         @fake_extension_context = 'fake_context'
 
@@ -27,7 +27,7 @@ module Extension
           type: @fake_type,
           title: @fake_title,
           config: @fake_config,
-          extension_context: @fake_extension_context
+          extension_context: @fake_extension_context,
         }
       end
 
@@ -43,7 +43,7 @@ module Extension
           extension_context: @fake_extension_context
         )
 
-        assert_kind_of Models::Registration, created_registration
+        assert_kind_of(Models::Registration, created_registration)
       end
 
       def test_aborts_with_parse_error_if_no_created_registration_or_errors_are_returned
@@ -64,7 +64,7 @@ module Extension
       end
 
       def test_aborts_with_errors_if_user_errors_are_returned
-        user_errors = [ {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error occurred on field'} ]
+        user_errors = [{ field: ['field'], UserErrors::MESSAGE_FIELD => 'An error occurred on field' }]
         stub_create_extension_failure(userErrors: user_errors, **@input)
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) do

--- a/test/project_types/extension/tasks/create_extension_test.rb
+++ b/test/project_types/extension/tasks/create_extension_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    class CreateExtensionTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include TestHelpers::Partners
+      include ExtensionTestHelpers::Messages
+      include ExtensionTestHelpers::Stubs::CreateExtension
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @api_key = 'FAKE_API_KEY'
+        @fake_type = 'TEST_EXTENSION'
+        @fake_title = 'Fake Title'
+        @fake_config = {
+          field: 'with stuff'
+        }
+        @fake_extension_context = 'fake_context'
+
+        @input = {
+          api_key: @api_key,
+          type: @fake_type,
+          title: @fake_title,
+          config: @fake_config,
+          extension_context: @fake_extension_context
+        }
+      end
+
+      def test_parses_registration_from_the_graphql_response
+        stub_create_extension_success(**@input)
+
+        created_registration = Tasks::CreateExtension.call(
+          context: @context,
+          api_key: @api_key,
+          type: @fake_type,
+          title: @fake_title,
+          config: @fake_config,
+          extension_context: @fake_extension_context
+        )
+
+        assert_kind_of Models::Registration, created_registration
+      end
+
+      def test_aborts_with_parse_error_if_no_created_registration_or_errors_are_returned
+        stub_create_extension_failure(userErrors: [], **@input)
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          Tasks::CreateExtension.call(
+            context: @context,
+            api_key: @api_key,
+            type: @fake_type,
+            title: @fake_title,
+            config: @fake_config,
+            extension_context: @fake_extension_context
+          )
+        end
+
+        assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+      end
+
+      def test_aborts_with_errors_if_user_errors_are_returned
+        user_errors = [ {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error occurred on field'} ]
+        stub_create_extension_failure(userErrors: user_errors, **@input)
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          Tasks::CreateExtension.call(
+            context: @context,
+            api_key: @api_key,
+            type: @fake_type,
+            title: @fake_title,
+            config: @fake_config,
+            extension_context: @fake_extension_context
+          )
+        end
+
+        assert_message_output(io: io, expected_content: 'An error occurred on field')
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/get_apps_test.rb
+++ b/test/project_types/extension/tasks/get_apps_test.rb
@@ -16,7 +16,7 @@ module Extension
 
       def test_loads_all_apps_into_a_list_from_organizations
         stub_get_organizations([
-          organization(name: 'Organization One', apps: [@app])
+          organization(name: 'Organization One', apps: [@app]),
         ])
 
         app_list = Tasks::GetApps.call(context: @context)
@@ -32,15 +32,15 @@ module Extension
       def test_returns_empty_array_if_there_are_no_organizations
         stub_get_organizations([])
 
-        assert_empty Tasks::GetApps.call(context: @context)
+        assert_empty(Tasks::GetApps.call(context: @context))
       end
 
       def test_returns_empty_array_if_there_are_no_apps
         stub_get_organizations([
-          organization(name: 'Organization One', apps: [])
+          organization(name: 'Organization One', apps: []),
         ])
 
-        assert_empty Tasks::GetApps.call(context: @context)
+        assert_empty(Tasks::GetApps.call(context: @context))
       end
 
       def test_can_handle_multiple_organizations_where_one_has_no_apps

--- a/test/project_types/extension/tasks/get_apps_test.rb
+++ b/test/project_types/extension/tasks/get_apps_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    class GetAppsTest < MiniTest::Test
+      include TestHelpers::Partners
+      include ExtensionTestHelpers::Stubs::GetOrganizations
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+        @app = Models::App.new(title: 'App One', api_key: '1234', secret: '5678')
+      end
+
+      def test_loads_all_apps_into_a_list_from_organizations
+        stub_get_organizations([
+          organization(name: 'Organization One', apps: [@app])
+        ])
+
+        app_list = Tasks::GetApps.call(context: @context)
+        app = app_list.first
+
+        assert_equal 1, app_list.size
+        assert_equal 'Organization One', app.business_name
+        assert_equal 'App One', app.title
+        assert_equal '1234', app.api_key
+        assert_equal '5678', app.secret
+      end
+
+      def test_returns_empty_array_if_there_are_no_organizations
+        stub_get_organizations([])
+
+        assert_empty Tasks::GetApps.call(context: @context)
+      end
+
+      def test_returns_empty_array_if_there_are_no_apps
+        stub_get_organizations([
+          organization(name: 'Organization One', apps: [])
+        ])
+
+        assert_empty Tasks::GetApps.call(context: @context)
+      end
+
+      def test_can_handle_multiple_organizations_where_one_has_no_apps
+        stub_get_organizations([
+          organization(name: 'Organization One', apps: [@app]),
+          organization(name: 'Organization Two', apps: []),
+        ])
+
+        assert_equal 1, Tasks::GetApps.call(context: @context).size
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/update_draft_test.rb
+++ b/test/project_types/extension/tasks/update_draft_test.rb
@@ -16,7 +16,7 @@ module Extension
 
         @api_key = 'FAKE_API_KEY'
         @registration_id = 42
-        @config = { }
+        @config = {}
         @extension_context = 'fake#context'
         @location = 'https://www.fakeurl.com'
 
@@ -39,7 +39,7 @@ module Extension
           extension_context: @extension_context,
         )
 
-        assert_kind_of Models::Version, updated_draft
+        assert_kind_of(Models::Version, updated_draft)
         assert_equal @registration_id, updated_draft.registration_id
       end
 
@@ -60,7 +60,7 @@ module Extension
       end
 
       def test_aborts_with_errors_if_user_errors_are_returned
-        user_errors = [ {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error occurred on field'} ]
+        user_errors = [{ field: ['field'], UserErrors::MESSAGE_FIELD => 'An error occurred on field' }]
         stub_update_draft_failure(errors: user_errors, **@input)
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) do

--- a/test/project_types/extension/tasks/update_draft_test.rb
+++ b/test/project_types/extension/tasks/update_draft_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    class UpdateDraftTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include TestHelpers::Partners
+      include ExtensionTestHelpers::Messages
+      include ExtensionTestHelpers::Stubs::UpdateDraft
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @api_key = 'FAKE_API_KEY'
+        @registration_id = 42
+        @config = { }
+        @extension_context = 'fake#context'
+        @location = 'https://www.fakeurl.com'
+
+        @input = {
+          api_key: @api_key,
+          registration_id: @registration_id,
+          config: @config,
+          extension_context: @extension_context,
+        }
+      end
+
+      def test_returns_the_updated_draft_if_no_errors_occurred
+        stub_update_draft_success(**@input)
+
+        updated_draft = Tasks::UpdateDraft.call(
+          context: @context,
+          api_key: @api_key,
+          registration_id: @registration_id,
+          config: @config,
+          extension_context: @extension_context,
+        )
+
+        assert_kind_of Models::Version, updated_draft
+        assert_equal @registration_id, updated_draft.registration_id
+      end
+
+      def test_aborts_with_parse_error_if_no_updated_version_or_errors_are_returned
+        stub_update_draft_failure(errors: [], **@input)
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          Tasks::UpdateDraft.call(
+            context: @context,
+            api_key: @api_key,
+            registration_id: @registration_id,
+            config: @config,
+            extension_context: @extension_context,
+          )
+        end
+
+        assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+      end
+
+      def test_aborts_with_errors_if_user_errors_are_returned
+        user_errors = [ {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error occurred on field'} ]
+        stub_update_draft_failure(errors: user_errors, **@input)
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          Tasks::UpdateDraft.call(
+            context: @context,
+            api_key: @api_key,
+            registration_id: @registration_id,
+            config: @config,
+            extension_context: @extension_context,
+          )
+        end
+
+        assert_message_output(io: io, expected_content: 'An error occurred on field')
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/user_errors_test.rb
+++ b/test/project_types/extension/tasks/user_errors_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Tasks
+    class UserErrorsTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @test_user_errors = Object.new.extend(Tasks::UserErrors)
+      end
+
+      def test_does_not_output_or_abort_if_no_user_errors_are_present
+        @context.expects(:puts).never
+        @context.expects(:abort).never
+
+        @test_user_errors.abort_if_user_errors(@context, {})
+        @test_user_errors.abort_if_user_errors(@context, {UserErrors::USER_ERRORS_FIELD => []})
+        @test_user_errors.abort_if_user_errors(@context, nil)
+      end
+
+      def test_aborts_with_message_if_only_one_user_error_present
+        fake_response = {
+          UserErrors::USER_ERRORS_FIELD => [
+            {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.'}
+          ]
+        }
+
+        @context.expects(:abort).with('An error has occurred.').once
+        @test_user_errors.abort_if_user_errors(@context, fake_response)
+      end
+
+      def test_no_matter_how_many_errors_only_last_error_calls_abort
+        fake_errors = Array.new(6, {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.'})
+        fake_errors << {field: ['field2'], UserErrors::MESSAGE_FIELD => 'Last error abort.'}
+        fake_response = { UserErrors::USER_ERRORS_FIELD => fake_errors }
+
+        @context.expects(:puts).with('{{x}} An error has occurred.').times(6)
+        @context.expects(:abort).with('Last error abort.').once
+
+        @test_user_errors.abort_if_user_errors(@context, fake_response)
+      end
+
+      def test_aborts_with_parse_error_message_if_user_errors_parsing_fails
+        fake_response = {
+          UserErrors::USER_ERRORS_FIELD => [
+            {field: ['field'], wrong_message_field: 'An error has occurred.'}
+          ]
+        }
+
+        @context.expects(:abort).with(UserErrors::USER_ERRORS_PARSE_ERROR).once
+        @test_user_errors.abort_if_user_errors(@context, fake_response)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/user_errors_test.rb
+++ b/test/project_types/extension/tasks/user_errors_test.rb
@@ -18,15 +18,15 @@ module Extension
         @context.expects(:abort).never
 
         @test_user_errors.abort_if_user_errors(@context, {})
-        @test_user_errors.abort_if_user_errors(@context, {UserErrors::USER_ERRORS_FIELD => []})
+        @test_user_errors.abort_if_user_errors(@context, { UserErrors::USER_ERRORS_FIELD => [] })
         @test_user_errors.abort_if_user_errors(@context, nil)
       end
 
       def test_aborts_with_message_if_only_one_user_error_present
         fake_response = {
           UserErrors::USER_ERRORS_FIELD => [
-            {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.'}
-          ]
+            { field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.' },
+          ],
         }
 
         @context.expects(:abort).with('An error has occurred.').once
@@ -34,8 +34,8 @@ module Extension
       end
 
       def test_no_matter_how_many_errors_only_last_error_calls_abort
-        fake_errors = Array.new(6, {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.'})
-        fake_errors << {field: ['field2'], UserErrors::MESSAGE_FIELD => 'Last error abort.'}
+        fake_errors = Array.new(6, { field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.' })
+        fake_errors << { field: ['field2'], UserErrors::MESSAGE_FIELD => 'Last error abort.' }
         fake_response = { UserErrors::USER_ERRORS_FIELD => fake_errors }
 
         @context.expects(:puts).with('{{x}} An error has occurred.').times(6)
@@ -47,8 +47,8 @@ module Extension
       def test_aborts_with_parse_error_message_if_user_errors_parsing_fails
         fake_response = {
           UserErrors::USER_ERRORS_FIELD => [
-            {field: ['field'], wrong_message_field: 'An error has occurred.'}
-          ]
+            { field: ['field'], wrong_message_field: 'An error has occurred.' },
+          ],
         }
 
         @context.expects(:abort).with(UserErrors::USER_ERRORS_PARSE_ERROR).once


### PR DESCRIPTION
### WHY are these changes introduced?
Co-authored by: @NatMorcos 
Allow Shopify App Extensions to be created through the Shopify App CLI.

### WHAT is this pull request doing?
All changes are isolated to the `project_types/extension` folder with the exception of GraphQL files.
Introduces a new type `extension` to the project types.
The project type is currently hidden until general availability. 

### Demos
Note: From working on the tunnel code the command it got into a weird state which is why there are two GIFs.
![2020-06-18 16 57 04](https://user-images.githubusercontent.com/42751082/85071280-3e2b1900-b185-11ea-9a35-95ebd8903735.gif)

![2020-06-18 16 58 59](https://user-images.githubusercontent.com/42751082/85071307-48e5ae00-b185-11ea-9428-3d3f4a434ea6.gif)
