### PR TITLE
Fix HTML output error on cli

### DIFF
--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -32,6 +32,8 @@ module ShopifyCli
       )
       ctx.debug(resp)
       resp
+    rescue API::APIRequestServerError, API::APIRequestUnexpectedError
+      ctx.puts(ctx.message('core.api.error.internal_server_error'))
     end
 
     protected

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -176,6 +176,12 @@ module ShopifyCli
           },
         },
 
+        api: {
+          error: {
+            internal_server_error: '{{red:{{x}} An unexpected error occurred on Shopify.}}',
+          },
+        },
+
         populate: {
           options: {
             header: "{{bold:{{cyan:%s}} options:}}",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-extension-libs/issues/687 
A failed `shopify push` command returns the HTML for the partners error page.
The actual issue was due to GCS work in Shopify Core which has been already fixed but we need to fix the CLI handling of these errors as well.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Handle the HTML output error on CLI and show it with an appropriate error message.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
### 🎩 
![Screen Shot 2020-06-24 at 2 53 06 PM](https://user-images.githubusercontent.com/56688159/85615671-9f8e3480-b62a-11ea-8357-38a6c2c1eaa2.png)

<!-- ![Screen Shot 2020-06-18 at 5 00 27 PM](https://user-images.githubusercontent.com/56688159/85071388-70d51180-b185-11ea-9dd5-74696e0ad09e.png)-->
