### PR TITLE
Fixing an issue with extension create cleanup

### DIFF
--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -10,6 +10,10 @@ module Extension
 
       def call(args, _)
         with_create_form(args) do |form|
+          if Dir.exist?(form.directory_name)
+            @ctx.abort(@ctx.message('create.errors.directory_exists', form.directory_name))
+          end
+
           if form.type.create(form.directory_name, @ctx)
             ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
             ExtensionProject.write_env_file(context: @ctx, title: form.name)

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -20,6 +20,9 @@ module Extension
           run {{command:shopify register}} to register this extension with one of your apps.
         MESSAGE
         try_again: '{{*}} Fix the errors and run {{command:shopify create extension}} again.',
+        errors: {
+          directory_exists: 'Directory ‘%s’ already exists. Please remove it or choose a new name for your project.',
+        },
       },
       build: {
         frame_title: 'Building extension with: %s...',


### PR DESCRIPTION
### WHY are these changes introduced?
Currently, our cleanup is a bit aggressive and will try to `cleanup` a directory if it exists prior to running `shopify create extension` as seen in the demo below.

This PR short circuits create immediately if the planned directory already exists.

### WHAT is this pull request doing?
- Add a check right after filling out the form and abort if the directory exists

### Demo
#### Before
![2020-06-19 12 06 12](https://user-images.githubusercontent.com/42751082/85154395-64a09100-b225-11ea-9d8a-4c68efa345b3.gif)

#### After
![2020-06-19 12 06 50](https://user-images.githubusercontent.com/42751082/85154404-68ccae80-b225-11ea-8285-672426e6d494.gif)


