### PR TITLE
Updating clone output

### DIFF
--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -60,8 +60,8 @@ module ShopifyCli
             no_commits_made: "No git commits have been made. Please make at least one commit.",
           },
 
-          cloning: "Cloning into %s...",
-          cloned: "Cloned into %s",
+          cloning: "Cloning %s into %s...",
+          cloned: "{{v}} Cloned into %s",
         },
 
         help: {

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'open3'
 
 module ShopifyCli
   class GitTest < MiniTest::Test
@@ -75,7 +76,7 @@ module ShopifyCli
     end
 
     def test_clones_git_repo
-      @context.expects(:system).with(
+      Open3.expects(:popen3).with(
         'git',
         'clone',
         '--single-branch',
@@ -90,7 +91,7 @@ module ShopifyCli
 
     def test_clone_failure
       assert_raises(ShopifyCli::Abort) do
-        @context.expects(:system).with(
+        Open3.expects(:popen3).with(
           'git',
           'clone',
           '--single-branch',


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed in the `Git`.`clone` command that the entire git output was being presented to the console. I do not believe this was the original intention so this is just trying to bring it back in line with what I felt was the original goal.

### WHAT is this pull request doing?
- Output git clone status as a progress bar
- No longer output full git output on success
- No longer output success if clone failed

### Demo
#### Old UX
![old](https://user-images.githubusercontent.com/42751082/85170709-c9ff7c80-b23b-11ea-8bd8-a59dfd8c5c83.gif)

#### New UX
![new](https://user-images.githubusercontent.com/42751082/85170724-cf5cc700-b23b-11ea-9568-a077ad01f0ee.gif)

