### PR TITLE
Updating extension build command to use JsSystem

### DIFF
--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -6,12 +6,15 @@ module Extension
     class Build < ExtensionCommand
       hidden_command
 
-      YARN_BUILD_COMMAND = %w(yarn build)
-      NPM_BUILD_COMMAND = %w(npm run-script build)
+      YARN_BUILD_COMMAND = %w(build)
+      NPM_BUILD_COMMAND = %w(run-script build)
 
       def call(_args, _command_name)
-        CLI::UI::Frame.open(frame_title) do
-          @ctx.abort(@ctx.message('build.build_failure_message')) unless build.success?
+        system = ShopifyCli::JsSystem.new(ctx: @ctx)
+
+        CLI::UI::Frame.open(@ctx.message('build.frame_title', system.package_manager)) do
+          success = system.call(yarn: YARN_BUILD_COMMAND, npm: NPM_BUILD_COMMAND)
+          @ctx.abort(@ctx.message('build.build_failure_message')) unless success
         end
       end
 
@@ -20,21 +23,6 @@ module Extension
           Build your extension to prepare for deployment.
             Usage: {{command:#{ShopifyCli::TOOL_NAME} build}}
         HELP
-      end
-
-      private
-
-      def frame_title
-        @ctx.message('build.frame_title', (yarn_available? ? 'yarn' : 'npm'))
-      end
-
-      def yarn_available?
-        @yarn_availability ||= ShopifyCli::JsSystem.yarn?(@ctx)
-      end
-
-      def build
-        build_command = yarn_available? ? YARN_BUILD_COMMAND : NPM_BUILD_COMMAND
-        @ctx.system(*build_command)
       end
     end
   end

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -30,23 +30,18 @@ module Extension
         refute_empty(Build.help)
       end
 
-      def test_uses_yarn_when_yarn_is_available
-        Build.any_instance.stubs(:yarn_available?).returns(true)
-        @context.expects(:system).with(*Build::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(true))
-
-        run_build
-      end
-
-      def test_uses_npm_when_yarn_is_unavailable
-        Build.any_instance.stubs(:yarn_available?).returns(false)
-        @context.expects(:system).with(*Build::NPM_BUILD_COMMAND).returns(FakeProcessStatus.new(true))
+      def test_uses_js_system_to_call_yarn_or_npm_commands
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with(yarn: Build::YARN_BUILD_COMMAND, npm: Build::NPM_BUILD_COMMAND)
+          .returns(true)
+          .once
 
         run_build
       end
 
       def test_aborts_and_informs_the_user_when_build_fails
-        Build.any_instance.stubs(:yarn_available?).returns(true)
-        @context.expects(:system).with(*Build::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(false))
+        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(false)
         @context.expects(:abort).with(@context.message('build.build_failure_message'))
 
         run_build


### PR DESCRIPTION
### WHY are these changes introduced?
The `build` command was written before `JsSystem`. This updates it to use `JsSystem` so it no longer needs to determine it's build command type on its own. This logic is encapsulated by the `JsSystem`.

### WHAT is this pull request doing?
- Remove custom yarn vs npm logic from build
- Update build to use JsSystem

### Demo
![2020-06-19 15 01 30](https://user-images.githubusercontent.com/42751082/85171874-db498880-b23d-11ea-9632-30b235e97037.gif)

