### PR TITLE
Updating extension serve command to use JsSystem

### DIFF
--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -3,12 +3,13 @@
 module Extension
   module Commands
     class Serve < ExtensionCommand
-      YARN_SERVE_COMMAND = %w(yarn server)
-      NPM_SERVE_COMMAND = %w(npm run-script server)
+      YARN_SERVE_COMMAND = %w(server)
+      NPM_SERVE_COMMAND = %w(run-script server)
 
       def call(_args, _command_name)
         CLI::UI::Frame.open(@ctx.message('serve.frame_title')) do
-          @ctx.abort(@ctx.message('serve.serve_failure_message')) unless serve.success?
+          success = ShopifyCli::JsSystem.call(@ctx, yarn: YARN_SERVE_COMMAND, npm: NPM_SERVE_COMMAND)
+          @ctx.abort(@ctx.message('serve.serve_failure_message')) unless success
         end
       end
 
@@ -17,17 +18,6 @@ module Extension
           Serve your extension in a local simulator for development.
             Usage: {{command:#{ShopifyCli::TOOL_NAME} serve}}
         HELP
-      end
-
-      private
-
-      def yarn_available?
-        @yarn_availability ||= ShopifyCli::JsSystem.yarn?(@ctx)
-      end
-
-      def serve
-        serve_command = yarn_available? ? YARN_SERVE_COMMAND : NPM_SERVE_COMMAND
-        @ctx.system(*serve_command)
       end
     end
   end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -26,16 +26,22 @@ module Extension
         refute_empty(Serve.help)
       end
 
-      def test_uses_npm_when_yarn_is_unavailable
-        Serve.any_instance.stubs(:yarn_available?).returns(false)
-        @context.expects(:system).with(*Serve::NPM_SERVE_COMMAND).returns(FakeProcessStatus.new(true))
+      def test_uses_js_system_to_run_npm_or_yarn_serve_commands
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with(yarn: Serve::YARN_SERVE_COMMAND, npm: Serve::NPM_SERVE_COMMAND)
+          .returns(true)
+          .once
 
         run_serve
       end
 
       def test_aborts_and_informs_the_user_when_serve_fails
-        Serve.any_instance.stubs(:yarn_available?).returns(true)
-        @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(false))
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with(yarn: Serve::YARN_SERVE_COMMAND, npm: Serve::NPM_SERVE_COMMAND)
+          .returns(false)
+          .once
         @context.expects(:abort).with(@context.message('serve.serve_failure_message'))
 
         run_serve


### PR DESCRIPTION
### WHY are these changes introduced?
The `serve` command was written before `JsSystem`. This updates it to use `JsSystem` so it no longer needs to determine it's build command type on its own. This logic is encapsulated by the `JsSystem`.

### WHAT is this pull request doing?
- Remove custom yarn vs npm logic from serve
- Update build to use JsSystem

### Demo
![2020-06-19 15 24 19](https://user-images.githubusercontent.com/42751082/85173399-2dd87400-b241-11ea-8856-89ccc2497c7a.gif)
