### PR TITLE
Fix delete of symlink

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -3,7 +3,15 @@ Gem.post_uninstall do |uninstaller|
     require 'fileutils'
 
     symlink = '/usr/local/bin/shopify-cli'
-    system("sudo rm -f #{symlink}") if File.symlink?(symlink)
+
+    # delete the symbolic link IFF it exists AND it does not point to a file
+    # (i.e., it's been left hanging as a result of the uninstall, as expected)
+    #
+    # if the file still exists, either the uninstall failed (possible but
+    # unlikely) OR
+    # there's another installation of the gem in another ruby folder that has
+    # overwritten it, so leave the symbolic link alone
+    system("sudo rm -f #{symlink}") if File.symlink?(symlink) && !File.exist?(symlink)
   end
 
   true


### PR DESCRIPTION
### WHY are these changes introduced?

If the end user has installed another instance of the CLI gem using another ruby version, then deleting the older one will inadvertently delete the symlink (which is now pointing to the 2nd installation).

### WHAT is this pull request doing?

Deletes the symbolic link if and only if
- the symlink exists, AND
- it does not point to a file (i.e., it's been left hanging as a result of the uninstall, as expected)