### PR TITLE
Remove mentions of the upgrade time from the warnings

### DIFF
--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -267,10 +267,10 @@ module ShopifyCli
           DEVELOPMENT
 
           shell_shim: <<~MESSAGE,
-          {{x}} This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it.
+          {{x}} This version of Shopify App CLI is no longer supported. You’ll need to migrate to the new CLI version to continue.
 
             Please visit this page for complete instructions:
-            {{underline:https://shopify.github.io/shopify-app-cli/upgrade/}}
+            {{underline:https://shopify.github.io/shopify-app-cli/migrate/}}
 
           MESSAGE
         },

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -267,7 +267,7 @@ module ShopifyCli
           DEVELOPMENT
 
           shell_shim: <<~MESSAGE,
-          {{x}} This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it. This process typically takes a few minutes.
+          {{x}} This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it.
 
             Please visit this page for complete instructions:
             {{underline:https://shopify.github.io/shopify-app-cli/upgrade/}}

--- a/shopify.fish
+++ b/shopify.fish
@@ -4,7 +4,7 @@
 # If we're not already in a shim environment but still tried to set up a shim, print out the re-installation warning
 type -t shopify > /dev/null 2>&1
 if [ $status != "0" ]
-  echo "This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it. This process typically takes a few minutes.
+  echo "This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it.
 Please visit this page for complete instructions:
   https://shopify.github.io/shopify-app-cli/upgrade/
 "

--- a/shopify.fish
+++ b/shopify.fish
@@ -4,8 +4,9 @@
 # If we're not already in a shim environment but still tried to set up a shim, print out the re-installation warning
 type -t shopify > /dev/null 2>&1
 if [ $status != "0" ]
-  echo "This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it.
+  echo "This version of Shopify App CLI is no longer supported. You’ll need to migrate to the new CLI version to continue.
+
 Please visit this page for complete instructions:
-  https://shopify.github.io/shopify-app-cli/upgrade/
+  https://shopify.github.io/shopify-app-cli/migrate/
 "
 end

--- a/shopify.sh
+++ b/shopify.sh
@@ -3,8 +3,9 @@
 # If we're not already in a shim environment but still tried to set up a shim, print out the re-installation warning
 typeset -f shopify > /dev/null 2>&1
 if [ "$?" != "0" ]; then
-  echo "This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it.
+  echo "This version of Shopify App CLI is no longer supported. You’ll need to migrate to the new CLI version to continue.
+
 Please visit this page for complete instructions:
-  https://shopify.github.io/shopify-app-cli/upgrade/
+  https://shopify.github.io/shopify-app-cli/migrate/
 "
 fi

--- a/shopify.sh
+++ b/shopify.sh
@@ -3,7 +3,7 @@
 # If we're not already in a shim environment but still tried to set up a shim, print out the re-installation warning
 typeset -f shopify > /dev/null 2>&1
 if [ "$?" != "0" ]; then
-  echo "This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it. This process typically takes a few minutes.
+  echo "This version of Shopify App CLI is no longer supported. You’ll need to upgrade to continue using it.
 Please visit this page for complete instructions:
   https://shopify.github.io/shopify-app-cli/upgrade/
 "


### PR DESCRIPTION
### WHY are these changes introduced?

Since we can't say for sure how long the update process will actually take for the user, we should make no mention of it in the warning messages.

### WHAT is this pull request doing?

Simply removing the unneeded text from the messages.