### PR TITLE
Minor fix to debian README file

### DIFF
--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -21,7 +21,7 @@ Before a package can be created, a few metadata files need to be put in the righ
 all have `.base` versions for reference. They should be placed in `packaging/debian/shopify-cli/DEBIAN`:
 
 * `control`
-* `postinst` 
+* `preinst` 
 * `prerm`
 
 All of those files reference the current CLI version as `SHOPIFY_CLI_VERSION`. This is filled automatically in the Rake


### PR DESCRIPTION
### WHAT is this pull request doing?

This just fixes a wrong instruction in the Debian packaging README, since we stopped using `postinst` in favour of `preinst` to fail the package installation on `gem install` failures too.