### PR TITLE
Add gem_tasks to the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require_relative 'bin/load_shopify'
 require 'rake/testtask'
 require 'rubocop/rake_task'
+require "bundler/gem_tasks"
 
 Rake::TestTask.new do |t|
   t.libs += %w(test)

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require_relative 'bin/load_shopify'
 require 'rake/testtask'
 require 'rubocop/rake_task'
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 
 Rake::TestTask.new do |t|
   t.libs += %w(test)


### PR DESCRIPTION
### WHAT is this pull request doing?

It adds `gem_tasks` to Rakefile so we can release the CLI gem to rubygems.org.