### PR TITLE
Fix semantic versionning not being loaded

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb
@@ -34,9 +34,10 @@ module Script
           output, status = @ctx.capture2e("node", "--version")
           raise Errors::DependencyInstallError, output unless status.success?
 
-          version = Semantic::Version.new(output[1..-1])
-          unless version >= Semantic::Version.new("12.16.0")
-            raise Errors::DependencyInstallError, "Node version must be >= v12.16.0 Current version: #{output}."
+          require 'semantic/semantic'
+          version = ::Semantic::Version.new(output[1..-1])
+          unless version >= ::Semantic::Version.new("12.16.0")
+            raise Errors::DependencyInstallError, "Node version must be >= v12.16.0. Current version: #{output.strip}."
           end
         end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Not sure why this was working previously, since it was working perfectly fine on my machine last week. But today this was no longer working. Instead of assuming that the semantic versionning module is loaded properly, I'm lazy loading it only when I actually need it.

### WHAT is this pull request doing?

Fixes the following error:

```
This command ran with ID: 98181
Please include this information in any issues/report along with relevant logs
Traceback (most recent call last):
	7: from /Users/maximebedard/Github/shopify-app-cli/vendor/deps/cli-ui/lib/cli/ui/spinner/spin_group.rb:46:in `block in initialize'
	6: from /Users/maximebedard/Github/shopify-app-cli/vendor/deps/cli-ui/lib/cli/ui/stdout_router.rb:120:in `run'
	5: from /Users/maximebedard/Github/shopify-app-cli/vendor/deps/cli-ui/lib/cli/ui/stdout_router.rb:91:in `with_stdin_masked'
	4: from /Users/maximebedard/Github/shopify-app-cli/vendor/deps/cli-ui/lib/cli/ui/stdout_router.rb:132:in `block in run'
	3: from /Users/maximebedard/Github/shopify-app-cli/lib/project_types/script/ui/strict_spinner.rb:12:in `block in spin'
	2: from /Users/maximebedard/Github/shopify-app-cli/lib/project_types/script/layers/application/project_dependencies.rb:18:in `block (2 levels) in install'
	1: from /Users/maximebedard/Github/shopify-app-cli/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb:25:in `install'
/Users/maximebedard/Github/shopify-app-cli/lib/project_types/script/layers/infrastructure/assemblyscript_dependency_manager.rb:37:in `check_node_version!': uninitialized constant Semantic (NameError)
```
