### PR TITLE
Finalize the packager to work with remote gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,11 +76,6 @@ namespace :package do
 
   task all: [:debian, :rpm, :homebrew]
 
-  desc("Builds a gem of the CLI")
-  task :gem do
-    ShopifyCli::Packager.new.build_gem
-  end
-
   desc("Builds a Debian package of the CLI")
   task :debian do
     ShopifyCli::Packager.new.build_debian
@@ -92,7 +87,7 @@ namespace :package do
   end
 
   desc("Builds a Homebrew package of the CLI")
-  task :homebrew => :"package:gem" do
+  task :homebrew do
     ShopifyCli::Packager.new.build_homebrew
   end
 end

--- a/packaging/debian/control.base
+++ b/packaging/debian/control.base
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: all
 Essential: no
 Maintainer: github.com/Shopify/shopify-app-cli
-Depends: ruby (>= 2.3), git (>= 2.13)
+Depends: ruby (>= 2.3), git (>= 2.13), sudo
 Description:
   Shopify CLI helps you build Shopify apps faster. It quickly scaffolds Node.js
   and Ruby on Rails embedded apps. It also automates many common tasks in the

--- a/packaging/rpm/shopify-cli.spec.base
+++ b/packaging/rpm/shopify-cli.spec.base
@@ -16,7 +16,7 @@ URL: https://shopify.github.io/shopify-app-cli
 # Make sure the spec template is included in the SRPM
 Source0: %{rbname}.spec.in
 # Requires: ruby [">= 2.3.0"]
-Requires: ruby >= 2.3.0, git >= 2.13
+Requires: ruby >= 2.3.0, git >= 2.13, make
 BuildArch: noarch
 Provides: ruby(Shopify-cli) = %{version}
 


### PR DESCRIPTION
### WHY are these changes introduced?

Now that the gem is properly hosted on Rubygems, our packaging processes can start installing it directly from there. A few missing dependencies arose from that test, and this PR addresses those issues.

### WHAT is this pull request doing?

This fixes the following issues:
- Debian package requires `sudo` for installation
- RPM package requires `make` for installation
  - It also requires sudo, but yum locks the `sudo` package so that it can't be uninstalled later on. That prevents it from deleting our package too. Under the assumption that most installs should have sudo in any case, the `shopify-cli` package was not updated to depend on it.
- Instead of building the gem locally, the Homebrew process now obtains the SHA-256 hash directly from RubyGems - we can't guarantee that the gem we'd create locally would match the one created by shipit, so we should rely on the actual source for the checksum.
  - Since we no longer need to build the gem locally, the rake task for it can be dropped, which removes duplication with shipit 👍 