### PR TITLE
Add make as a dependency for installing the CLI on debian

### DIFF
--- a/packaging/debian/control.base
+++ b/packaging/debian/control.base
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: all
 Essential: no
 Maintainer: github.com/Shopify/shopify-app-cli
-Depends: ruby (>= 2.3), git (>= 2.13), sudo
+Depends: ruby (>= 2.3), git (>= 2.13), sudo, make
 Description:
   Shopify CLI helps you build Shopify apps faster. It quickly scaffolds Node.js
   and Ruby on Rails embedded apps. It also automates many common tasks in the


### PR DESCRIPTION
### WHY are these changes introduced?

Make is a dependency for installing the gem, and it was not being added for Debian packages, so that may have blocked installing it in some instances.

### WHAT is this pull request doing?

Simply adding `make` to the dependency list for debian.