### PR TITLE
Update required ruby to 2.5

### DIFF
--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     and webhooks.
   HERE
   spec.homepage = "https://shopify.github.io/shopify-app-cli/"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
### WHY are these changes introduced?

Current CLI uses functionality that requires 2.4.0 at minimum (`report_on_exception=`); `shopify create rails` requires 2.5 minimum.

### WHAT is this pull request doing?

Updating the `required_ruby_version` to `>= 2.5`