### PR TITLE
Fix flaky monorail test

### DIFF
--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -8,6 +8,7 @@ module ShopifyCli
         super
         ShopifyCli::Git.stubs(:sha).returns("bb6f42193239a248f054e5019e469bc75f3adf1b")
         CLI::UI::Prompt.stubs(:confirm).returns(true)
+        ShopifyCli::Core::Monorail.metadata = {}
       end
 
       def teardown


### PR DESCRIPTION
Looks like a flaky test was introduced when adding in scripts metadata for monorail. The monorail tests will fail when a test that alters the metadata runs before the monorail tests. Resetting the metadata in the setup method will fix this.

### The flaky test in question

```
Finished in 5.397916s, 114.6739 runs/s, 301.0421 assertions/s.

  1) Error:
ShopifyCli::Core::MonorailTest#test_log_event_contains_schema_and_payload_values:
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: POST https://monorail-edge.shopifycloud.com/v1/produce with body '{"schema_id":"app_cli_command/4.0","payload":{"project_type":"fake","command":"testcommand","args":"arg argtwo","time_start":1593443442639,"time_end":1593443442639,"total_time":0,"success":true,"error_message":null,"uname":"x86_64-apple-darwin19.0.0","cli_version":"bb6f42193239a248f054e5019e469bc75f3adf1b","ruby_version":"2.5.1","metadata":"{\"script_name\":\"name\",\"extension_point_type\":\"ep_type\",\"language\":\"ts\",\"foo\":\"identifier\"}","api_key":"apikey","partner_id":42}}' with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>'Ruby', 'X-Monorail-Edge-Event-Created-At-Ms'=>'1593443442639', 'X-Monorail-Edge-Event-Sent-At-Ms'=>'1593443442639'}

You can stub this request with the following snippet:

stub_request(:post, "https://monorail-edge.shopifycloud.com/v1/produce").
  with(:body => "{\"schema_id\":\"app_cli_command/4.0\",\"payload\":{\"project_type\":\"fake\",\"command\":\"testcommand\",\"args\":\"arg argtwo\",\"time_start\":1593443442639,\"time_end\":1593443442639,\"total_time\":0,\"success\":true,\"error_message\":null,\"uname\":\"x86_64-apple-darwin19.0.0\",\"cli_version\":\"bb6f42193239a248f054e5019e469bc75f3adf1b\",\"ruby_version\":\"2.5.1\",\"metadata\":\"{\\\"script_name\\\":\\\"name\\\",\\\"extension_point_type\\\":\\\"ep_type\\\",\\\"language\\\":\\\"ts\\\",\\\"foo\\\":\\\"identifier\\\"}\",\"api_key\":\"apikey\",\"partner_id\":42}}",
       :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>'Ruby', 'X-Monorail-Edge-Event-Created-At-Ms'=>'1593443442639', 'X-Monorail-Edge-Event-Sent-At-Ms'=>'1593443442639'}).
  to_return(:status => 200, :body => "", :headers => {})

registered request stubs:

stub_request(:post, "https://monorail-edge.shopifycloud.com/v1/produce").
  with(:body => "{\"schema_id\":\"app_cli_command/4.0\",\"payload\":{\"project_type\":\"fake\",\"command\":\"testcommand\",\"args\":\"arg argtwo\",\"time_start\":1593443442639,\"time_end\":1593443442639,\"total_time\":0,\"success\":true,\"error_message\":null,\"uname\":\"x86_64-apple-darwin19.0.0\",\"cli_version\":\"bb6f42193239a248f054e5019e469bc75f3adf1b\",\"ruby_version\":\"2.5.1\",\"metadata\":\"{\\\"foo\\\":\\\"identifier\\\"}\",\"api_key\":\"apikey\",\"partner_id\":42}}",
       :headers => {'Content-Type'=>'application/json; charset=utf-8', 'X-Monorail-Edge-Event-Created-At-Ms'=>'1593443442639', 'X-Monorail-Edge-Event-Sent-At-Ms'=>'1593443442639'})
```