### PR TITLE
Update Ruby dependency on packages to 2.5

### DIFF
--- a/packaging/debian/control.base
+++ b/packaging/debian/control.base
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: all
 Essential: no
 Maintainer: github.com/Shopify/shopify-app-cli
-Depends: ruby (>= 2.3), git (>= 2.13), sudo, make
+Depends: ruby (>= 2.5), git (>= 2.13), sudo, make
 Description:
   Shopify CLI helps you build Shopify apps faster. It quickly scaffolds Node.js
   and Ruby on Rails embedded apps. It also automates many common tasks in the

--- a/packaging/rpm/shopify-cli.spec.base
+++ b/packaging/rpm/shopify-cli.spec.base
@@ -15,8 +15,8 @@ License: Distributable
 URL: https://shopify.github.io/shopify-app-cli
 # Make sure the spec template is included in the SRPM
 Source0: %{rbname}.spec.in
-# Requires: ruby [">= 2.3.0"]
-Requires: ruby >= 2.3.0, git >= 2.13, make
+# Requires: ruby [">= 2.5.0"]
+Requires: ruby >= 2.5.0, git >= 2.13, make
 BuildArch: noarch
 Provides: ruby(Shopify-cli) = %{version}
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

So that the packages match the gem requirement for Ruby 2.5.

### WHAT is this pull request doing?

Simply updating the required version number.