### PR TITLE
[Feature] Add --config_file and --config_props flags for scripts enable

### DIFF
--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -123,6 +123,11 @@ module Script
           Turn on script in development store.
             Usage: {{command:%s enable}}
           HELP
+          extended_help: <<~HELP,
+            \s\sOptions:
+              \s\s{{command:--config_props='name1:value1, name2:value2'}} Optional. Define the configuration of your script by passing individual name and value pairs. If used with --config_file, then matching values in --config_props will override those set in the file.
+              \s\s{{command:--config_file=<path/to/YAMLFilename>}} Optional. Define the configuration of your script using a YAML formatted file. --config_props values override properties in this file.
+          HELP
 
           info: "{{*}} A script always remains enabled until you disable it - even after pushing "\
                 "script changes with the same extension point to an app. To disable a script, use "\


### PR DESCRIPTION
### WHY are these changes introduced?

Related issue: https://github.com/Shopify/script-service/issues/1427

Right now it's not possible to provide configuration values when enabling scripts through the CLI, so this PR aims to add that functionality.

### WHAT is this pull request doing?

Adds two new options to the enable command: `--config_file` and `--config_props`. Follows the precedence order set out in this doc that requires `--config_props` to override `config_file` when both are present. The format for the configuration file is JSON:
```JSON
{
  "key1": "value1",
  "key2": "value2"
}
```

**EDIT 2020/07/14:** 
Using YAML instead:
```YAML
key1: "value1"
key2: "value2"
```