### PR TITLE
Validate script name when passed as option

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -29,7 +29,7 @@ module Script
         @ctx.puts(@ctx.message('script.create.changed_dir', folder: project.script_name))
         @ctx.puts(@ctx.message('script.create.script_created', script_id: project.source_file))
       rescue StandardError => e
-        ScriptProject.cleanup(ctx: @ctx, script_name: form.name, root_dir: cur_dir)
+        ScriptProject.cleanup(ctx: @ctx, script_name: form.name, root_dir: cur_dir) if form
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.create.error.operation_failed'))
       end
 

--- a/lib/project_types/script/errors.rb
+++ b/lib/project_types/script/errors.rb
@@ -3,6 +3,7 @@
 module Script
   module Errors
     class InvalidContextError < ScriptProjectError; end
+    class InvalidScriptNameError < ScriptProjectError; end
     class NoExistingAppsError < ScriptProjectError; end
     class NoExistingOrganizationsError < ScriptProjectError; end
     class NoExistingStoresError < ScriptProjectError

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -6,7 +6,7 @@ module Script
       flag_arguments :extension_point, :name
 
       def ask
-        self.name = (name || ask_name).downcase.gsub(' ', '_')
+        self.name = valid_name
         self.extension_point ||= ask_extension_point
       end
 
@@ -20,9 +20,13 @@ module Script
       end
 
       def ask_name
-        name = CLI::UI::Prompt.ask(@ctx.message('script.forms.create.script_name'))
-        return name if name.match?(/^[0-9A-Za-z _-]*$/)
-        @ctx.abort(@ctx.message('script.forms.create.error.invalid_name'))
+        CLI::UI::Prompt.ask(@ctx.message('script.forms.create.script_name'))
+      end
+
+      def valid_name
+        n = (name || ask_name).downcase.gsub(' ', '_')
+        return n if n.match?(/^[0-9A-Za-z_-]*$/)
+        raise Errors::InvalidScriptNameError
       end
     end
   end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -18,8 +18,12 @@ module Script
           invalid_context_cause: "Your .shopify-cli.yml file is not correct.",
           invalid_context_help: "See https://help.shopify.com",
 
+          invalid_script_name_cause: "Invalid script name.",
+          invalid_script_name_help: "Replace or remove unsupported characters. Valid characters "\
+                                    "are numbers, letters, spaces, hyphens, or underscores.",
+
           no_existing_apps_cause: "You don't have any apps.",
-          no_existing_apps_help: "Please create an app with {{command:shopify create}} or"\
+          no_existing_apps_help: "Please create an app with {{command:shopify create}} or "\
                                  "visit https://partners.shopify.com/.",
 
           no_existing_orgs_cause: "You don't have any partner organizations.",
@@ -169,11 +173,6 @@ module Script
           create: {
             select_extension_point: "Which extension point do you want to use?",
             script_name: "Script Name",
-
-            error: {
-              invalid_name: "Invalid script name: replace or remove unsupported characters. Valid "\
-                            "characters are numbers, letters, spaces, hyphens, or underscores.",
-            },
           },
           script_form: {
             ask_app_api_key_default: "Which app do you want this script to belong to?",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -20,7 +20,7 @@ module Script
 
           invalid_script_name_cause: "Invalid script name.",
           invalid_script_name_help: "Replace or remove unsupported characters. Valid characters "\
-                                    "are numbers, letters, spaces, hyphens, or underscores.",
+                                    "are numbers, letters, hyphens, or underscores.",
 
           no_existing_apps_cause: "You don't have any apps.",
           no_existing_apps_help: "Please create an app with {{command:shopify create}} or "\

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -44,6 +44,11 @@ module Script
             cause_of_error: ShopifyCli::Context.message('script.error.invalid_context_cause'),
             help_suggestion: ShopifyCli::Context.message('script.error.invalid_context_help'),
           }
+        when Errors::InvalidScriptNameError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.invalid_script_name_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.invalid_script_name_help'),
+          }
         when Errors::NoExistingAppsError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.no_existing_apps_cause'),

--- a/test/project_types/script/forms/create_test.rb
+++ b/test/project_types/script/forms/create_test.rb
@@ -54,11 +54,13 @@ module Script
         name = 'na/me'
         CLI::UI::Prompt.expects(:ask).returns(name)
 
-        @context
-          .expects(:abort)
-          .with(@context.message('script.forms.create.error.invalid_name'))
+        assert_raises(Script::Errors::InvalidScriptNameError) { ask }
+      end
 
-        Create.new(@context, [], []).send(:ask_name)
+      def test_invalid_name_as_option
+        assert_raises(Script::Errors::InvalidScriptNameError) do
+          ask(name: 'na/me')
+        end
       end
 
       private

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -104,6 +104,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when InvalidScriptNameError" do
+        let(:err) { Script::Errors::InvalidScriptNameError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when NoExistingAppsError" do
         let(:err) { Script::Errors::NoExistingAppsError.new }
         it "should call display_and_raise" do


### PR DESCRIPTION
Closes https://github.com/Shopify/script-service/issues/1435

### WHY are these changes introduced?

We need to validate the script name when passing an invalid name as an cli option. Otherwise, other pieces of code will fail.

### WHAT is this pull request doing?

Runs the same validations on option provided names as prompted names.

### Screenshot
![image](https://user-images.githubusercontent.com/28009669/87055160-fa4e9100-c1d1-11ea-9b45-9d3890848444.png)
