### PR TITLE
[WIP] Use .env file for script commands

### DIFF
--- a/lib/project_types/script/forms/push.rb
+++ b/lib/project_types/script/forms/push.rb
@@ -6,13 +6,24 @@ module Script
       flag_arguments :api_key, :force
 
       def ask
-        self.api_key ||= ask_api_key
+        if ScriptProject.current.env.nil?
+          org = ask_org
+          app = ask_app(org)
+          self.api_key = app['apiKey']
+          write_env(JSON.generate(org), api_key, app['apiSecretKeys'].first['secret'], nil)
+        else
+          self.api_key ||= ScriptProject.current.env[:api_key]
+        end
       end
 
       private
 
-      def ask_api_key
-        ask_app_api_key(organization['apps'])
+      def ask_app(org)
+        super(org['apps'], api_key)
+      end
+
+      def ask_org
+        organization(api_key)
       end
     end
   end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -176,7 +176,7 @@ module Script
             },
           },
           script_form: {
-            ask_app_api_key_default: "Which app do you want this script to belong to?",
+            ask_app_default: "Which app do you want this script to belong to?",
             ask_shop_domain_default: "Select a development store",
             fetching_organizations: "{{i}} Fetching partner organizations",
             select_organization: "Select partner organization.",
@@ -185,7 +185,7 @@ module Script
             using_organization: "Partner organization {{green:%s}}.",
           },
           enable: {
-            ask_app_api_key: "Which app is the script pushed to?",
+            ask_app: "Which app is the script pushed to?",
             ask_shop_domain: "Which development store is the app installed on?",
           },
         },

--- a/lib/shopify-cli/resources/env_file.rb
+++ b/lib/shopify-cli/resources/env_file.rb
@@ -11,6 +11,7 @@ module ShopifyCli
         'SHOP' => :shop,
         'SCOPES' => :scopes,
         'HOST' => :host,
+        'ORG' => :org,
       }
 
       class << self
@@ -56,6 +57,7 @@ module ShopifyCli
       property :secret, required: true
       property :shop
       property :scopes
+      property :org
       property :host
       property :extra, default: {}
 

--- a/test/project_types/script/forms/enable_test.rb
+++ b/test/project_types/script/forms/enable_test.rb
@@ -16,7 +16,7 @@ module Script
 
       def test_calls_superclass_methods_when_no_flags
         ScriptForm.any_instance.stubs(:organization).returns({})
-        ScriptForm.any_instance.expects(:ask_app_api_key).once
+        ScriptForm.any_instance.expects(:ask_app).once
         ScriptForm.any_instance.expects(:ask_shop_domain).once
         ask(api_key: nil, shop_domain: nil)
       end

--- a/test/project_types/script/forms/push_test.rb
+++ b/test/project_types/script/forms/push_test.rb
@@ -13,16 +13,16 @@ module Script
         assert_equal(form.api_key, 'fakekey')
       end
 
-      def test_ask_calls_form_ask_app_api_key_when_no_flag
+      def test_ask_calls_form_ask_app_when_no_flag
         apps = [{ "apiKey" => 1234 }]
-        Push.any_instance.expects(:ask_app_api_key).with(apps)
+        Push.any_instance.expects(:ask_app).with(apps)
         ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns([{ "apps" => apps }])
         ask
       end
 
       def test_calls_superclass_methods_when_no_flags
         ScriptForm.any_instance.stubs(:organization).returns({})
-        ScriptForm.any_instance.expects(:ask_app_api_key).once
+        ScriptForm.any_instance.expects(:ask_app).once
         ask(api_key: nil)
       end
 

--- a/test/project_types/script/forms/script_form_test.rb
+++ b/test/project_types/script/forms/script_form_test.rb
@@ -37,7 +37,7 @@ module Script
       end
 
       def test_no_apps_raises_error
-        assert_raises(Errors::NoExistingAppsError) { form.send(:ask_app_api_key, []) }
+        assert_raises(Errors::NoExistingAppsError) { form.send(:ask_app, []) }
       end
 
       def test_one_app_auto_selects
@@ -47,14 +47,14 @@ module Script
           title: 'title',
           api_key: 'key'
         ))
-        assert_equal 'key', form.send(:ask_app_api_key, [app])
+        assert_equal 'key', form.send(:ask_app, [app])['apiKey']
       end
 
       def test_multiple_apps_invoke_prompt
         app1 = { 'apiKey' => 'key1', 'title' => 'title1' }
         app2 = { 'apiKey' => 'key2', 'title' => 'title2' }
         CLI::UI::Prompt.expects(:ask).returns(app1['apiKey'])
-        assert_equal 'key1', form.send(:ask_app_api_key, [app1, app2])
+        assert_equal 'key1', form.send(:ask_app, [app1, app2])
       end
 
       def test_no_shops_raises_error


### PR DESCRIPTION
### WHAT is this pull request doing?

If org/app/dev store information are not in the .env file, the next push, enable, or disable command should prompt and store the org/app/dev store information in the .env file, such that subsequent commands do not prompt for app information if this information exists in .env.

This PR is still in progress, but I'm looking for some feedback on how I've implemented this ticket so far.

It would be helpful to me if in a review you could focus on where the logic is located (I struggled to find the right place for it, but settled on where it is because I felt I was duplicating code otherwise and it required not much modification), and whether there is an obvious issue in the logic that I've missed.

**Parts that are still in progress:**
- I know many tests are still failing - hanging tight on fixing them because I think it would be best to check the logic first right now.
- I'm working on retrieving the org information from the .env file, but it's coming out as a string and not parsing nicely into JSON, but otherwise I believe the logic works.