### PR TITLE
Fetch a single app if api_key parameter is provided

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -30,6 +30,7 @@ module Extension
   module Tasks
     autoload :UserErrors, Project.project_filepath('tasks/user_errors')
     autoload :GetApps, Project.project_filepath('tasks/get_apps')
+    autoload :GetApp, Project.project_filepath('tasks/get_app')
     autoload :CreateExtension, Project.project_filepath('tasks/create_extension')
     autoload :UpdateDraft, Project.project_filepath('tasks/update_draft')
 
@@ -37,6 +38,7 @@ module Extension
       autoload :RegistrationConverter, Project.project_filepath('tasks/converters/registration_converter')
       autoload :VersionConverter, Project.project_filepath('tasks/converters/version_converter')
       autoload :ValidationErrorConverter, Project.project_filepath('tasks/converters/validation_error_converter')
+      autoload :AppConverter, Project.project_filepath('tasks/converters/app_converter')
     end
   end
 

--- a/lib/project_types/extension/forms/register.rb
+++ b/lib/project_types/extension/forms/register.rb
@@ -16,13 +16,12 @@ module Extension
       attr_writer :app
 
       def ask_app
-        apps = load_apps
-
         if !api_key.nil?
-          found_app = apps.find { |app| app.api_key == api_key }
+          found_app = Tasks::GetApp.call(context: ctx, api_key: api_key)
           ctx.abort(ctx.message('register.invalid_api_key', api_key)) if found_app.nil?
           found_app
         else
+          apps = load_apps
           CLI::UI::Prompt.ask(ctx.message('register.ask_app')) do |handler|
             apps.each do |app|
               handler.option("#{app.title} by #{app.business_name}") { app }

--- a/lib/project_types/extension/graphql/get_app_by_api_key.graphql
+++ b/lib/project_types/extension/graphql/get_app_by_api_key.graphql
@@ -1,0 +1,9 @@
+query getApp($api_key: String!) {
+  app(apiKey: $api_key) {
+    title
+    apiKey
+    apiSecretKeys{
+      secret
+    }
+  }
+}

--- a/lib/project_types/extension/tasks/converters/app_converter.rb
+++ b/lib/project_types/extension/tasks/converters/app_converter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module Converters
+      module AppConverter
+        API_KEY_FIELD = 'apiKey'
+        API_SECRET_KEYS_FIELD = 'apiSecretKeys'
+        API_SECRET_FIELD = 'secret'
+        TITLE_FIELD = 'title'
+        ORGANIZATION_NAME_FIELD = 'businessName'
+
+        def self.from_hash(hash, organization = {})
+          return nil if hash.nil?
+
+          Models::App.new(
+            api_key: hash[API_KEY_FIELD],
+            secret: hash[API_SECRET_KEYS_FIELD].first[API_SECRET_FIELD],
+            title: hash[TITLE_FIELD],
+            business_name: organization[ORGANIZATION_NAME_FIELD]
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/get_app.rb
+++ b/lib/project_types/extension/tasks/get_app.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    class GetApp < ShopifyCli::Task
+      GRAPHQL_FILE = 'get_app_by_api_key'
+
+      RESPONSE_FIELD = %w(data)
+      APP_FIELD = 'app'
+
+      def call(context:, api_key:)
+        input = { api_key: api_key }
+
+        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
+        context.abort(context.message('tasks.errors.parse_error')) if response.nil?
+
+        Converters::AppConverter.from_hash(response.dig(APP_FIELD))
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/get_apps.rb
+++ b/lib/project_types/extension/tasks/get_apps.rb
@@ -21,12 +21,7 @@ module Extension
         return [] unless organization.key?('apps') && organization['apps'].any?
 
         organization['apps'].map do |app|
-          Models::App.new(
-            api_key: app['apiKey'],
-            secret: app["apiSecretKeys"].first["secret"],
-            title: app['title'],
-            business_name: organization['businessName']
-          )
+          Converters::AppConverter.from_hash(app, organization)
         end
       end
     end

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -8,7 +8,7 @@ module Extension
       include TestHelpers::FakeUI
       include ExtensionTestHelpers::TempProjectSetup
       include ExtensionTestHelpers::Messages
-      include ExtensionTestHelpers::Stubs::GetOrganizations
+      include ExtensionTestHelpers::Stubs::GetApp
 
       def setup
         super
@@ -16,7 +16,7 @@ module Extension
         setup_temp_project(api_key: '', api_secret: '', registration_id: nil)
 
         @app = Models::App.new(api_key: @api_key, secret: @api_secret)
-        stub_get_organizations([organization(name: "Organization One", apps: [@app])])
+        stub_get_app(app: @app, api_key: @app.api_key)
       end
 
       def test_help_implemented

--- a/test/project_types/extension/extension_test_helpers.rb
+++ b/test/project_types/extension/extension_test_helpers.rb
@@ -10,6 +10,7 @@ module Extension
 
     module Stubs
       autoload :GetOrganizations, 'project_types/extension/extension_test_helpers/stubs/get_organizations'
+      autoload :GetApp, 'project_types/extension/extension_test_helpers/stubs/get_app'
       autoload :CreateExtension, 'project_types/extension/extension_test_helpers/stubs/create_extension'
       autoload :UpdateDraft, 'project_types/extension/extension_test_helpers/stubs/update_draft'
       autoload :ArgoScript, 'project_types/extension/extension_test_helpers/stubs/argo_script'

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -14,6 +14,7 @@ module Extension
 
       def config
         {
+          'project_type' => 'extension',
           ExtensionProjectKeys::EXTENSION_TYPE_KEY => type,
         }
       end

--- a/test/project_types/extension/extension_test_helpers/stubs/get_app.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/get_app.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module Stubs
+      module GetApp
+        include TestHelpers::Partners
+
+        def stub_get_app(api_key:, app:)
+          stub_partner_req(
+            'get_app_by_api_key',
+            variables: {
+              api_key: api_key,
+            },
+            resp: {
+              data: {
+                app: create_app_json(app: app),
+              },
+            },
+          )
+        end
+
+        def create_app_json(app:)
+          return nil if app.nil?
+
+          {
+            id: rand(9999),
+            title: app.title,
+            'apiKey': app.api_key,
+            'apiSecretKeys': [{ 'secret': app.secret }],
+          }
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -29,6 +29,8 @@ module Extension
           registration_id: @registration_id
         )
 
+        ShopifyCli::Project.stubs(:current).returns(@project)
+        ShopifyCli::Project.stubs(:has_current?).returns(true)
         ExtensionProject.stubs(:current).returns(@project)
       end
     end

--- a/test/project_types/extension/tasks/converters/app_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/app_converter_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    module Converters
+      class AppConverterTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::Messages
+
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+
+          @api_key = 'fake_key'
+          @secret = 'fake_secret'
+          @title = 'Fake Title'
+          @organization_name = 'Organization One'
+        end
+
+        def test_from_hash_returns_nil_if_the_hash_is_nil
+          assert_nil(Converters::AppConverter.from_hash(nil))
+        end
+
+        def test_from_hash_parses_app_from_a_hash
+          hash = {
+            Converters::AppConverter::API_KEY_FIELD => @api_key,
+            Converters::AppConverter::TITLE_FIELD => @title,
+            Converters::AppConverter::API_SECRET_KEYS_FIELD => [
+              { Converters::AppConverter::API_SECRET_FIELD => @secret },
+            ],
+          }
+
+          parsed_app = Converters::AppConverter.from_hash(hash)
+
+          assert_kind_of(Models::App, parsed_app)
+          assert_equal @api_key, parsed_app.api_key
+          assert_equal @secret, parsed_app.secret
+          assert_equal @title, parsed_app.title
+          assert_nil(parsed_app.business_name)
+        end
+
+        def test_from_hash_parses_organization_name_if_organization_is_provided
+          app_hash = {
+            Converters::AppConverter::API_KEY_FIELD => @api_key,
+            Converters::AppConverter::TITLE_FIELD => @title,
+            Converters::AppConverter::API_SECRET_KEYS_FIELD => [
+              { Converters::AppConverter::API_SECRET_FIELD => @secret },
+            ],
+          }
+
+          organization_hash = {
+            Converters::AppConverter::ORGANIZATION_NAME_FIELD => @organization_name,
+          }
+
+          parsed_app = Converters::AppConverter.from_hash(app_hash, organization_hash)
+
+          assert_kind_of(Models::App, parsed_app)
+          assert_equal @api_key, parsed_app.api_key
+          assert_equal @secret, parsed_app.secret
+          assert_equal @title, parsed_app.title
+          assert_equal @organization_name, parsed_app.business_name
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/get_app_test.rb
+++ b/test/project_types/extension/tasks/get_app_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    class GetAppTest < MiniTest::Test
+      include TestHelpers::Partners
+      include ExtensionTestHelpers::Stubs::GetApp
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+        setup_temp_project
+        @app = Models::App.new(title: 'App One', api_key: '1234', secret: '5678')
+      end
+
+      def test_loads_app_into_a_single_app_model
+        stub_get_app(api_key: @app.api_key, app: @app)
+
+        app = Tasks::GetApp.call(context: @context, api_key: @app.api_key)
+
+        assert_equal 'App One', app.title
+        assert_equal '1234', app.api_key
+        assert_equal '5678', app.secret
+      end
+
+      def test_returns_nil_if_the_app_was_not_found
+        stub_get_app(api_key: @app.api_key, app: nil)
+
+        assert_nil(Tasks::GetApp.call(context: @context, api_key: @app.api_key))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Currently, the CLI will fetch a Partner's entire list of apps even if a specific API Key is provided. This PR updates the `register` call of extensions to only fetch a single app if an `api_key` flag is provided.

### WHAT is this pull request doing?
- Add `get_app_by_api_key` GraphQL call
- Add a task `GetApp` for fetching single apps
- Update `register` to not fetch all app is an `api_key` is provided
- Create an `AppConverter` that is used by both `GetApps` and `GetApp` tasks

### Demo
![2020-07-13 10 10 12](https://user-images.githubusercontent.com/42751082/87315936-14021800-c4f3-11ea-9e5d-6a948c206b1d.gif)
