### PR TITLE
Add dummy Finalize class to avoid warnings

### DIFF
--- a/lib/shopify-cli/core/finalize.rb
+++ b/lib/shopify-cli/core/finalize.rb
@@ -1,0 +1,13 @@
+module ShopifyCli
+  module Core
+    # This class is just a dummy to make sure that we don't trigger warnings on the first time the updated code runs.
+    # The old code would try to call the Finalizer after it is done updating, which would then trigger an autoload of
+    # this class and fail.
+    module Finalize
+      class << self
+        def deliver!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

After the initial release of the installer-based version, we ran into an issue where the very first manual update command (though not auto-updates) would trigger a warning because after pulling the new code it tried to autoload the finalizer, which was gone by that point. This PR introduces a dummy version of that class back to prevent such errors.

### WHAT is this pull request doing?

Adding an empty Finalize class that implements an empty `deliver!` method to prevent warnings.