### PR TITLE
Task to download Themekit if not installed

### DIFF
--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Theme
+  class Project < ShopifyCli::ProjectType
+    hidden_project_type
+    creator 'Theme App', 'Theme::Commands::Create'
+  end
+
+  module Commands
+  end
+
+  module Tasks
+    autoload :EnsureThemekitInstalled, Project.project_filepath('tasks/ensure_themekit_installed')
+  end
+
+  module Forms
+  end
+end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Theme
+  module Messages
+    MESSAGES = {
+      ensure_themekit_installed: {
+        downloading: "Downloading Themekit %s",
+        failed: "Download failed",
+        successful: "Themekit installed successfully",
+        unsuccessful: "Unable to verify download digest",
+        verifying: "Verifying download...",
+      },
+    }.freeze
+  end
+end

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -1,0 +1,40 @@
+module Theme
+  module Tasks
+    class EnsureThemekitInstalled < ShopifyCli::Task
+      def call(ctx)
+        @ctx = ctx
+        unless system(File.join(ShopifyCli::CACHE_DIR, "theme"), [:out, :err] => File::NULL)
+          require 'json'
+          require 'net/http'
+          require 'fileutils'
+          require 'digest'
+
+          url = 'https://shopify-themekit.s3.amazonaws.com/releases/latest.json'
+          osmap = {
+            mac: 'darwin-amd64',
+            linux: 'linux-amd64',
+          }
+
+          releases = JSON.parse(Net::HTTP.get(URI(url)))
+          release = releases["platforms"].find { |r| r["name"] == osmap[@ctx.os] }
+          puts "Downloading Themekit #{releases['version']}"
+          File.write(filename, Net::HTTP.get(URI.parse(release["url"])))
+          puts "Verifying Download"
+          if Digest::MD5.file(filename) == release["digest"]
+            FileUtils.chmod("+x", filename)
+            puts "Themekit installed successfully"
+          else
+            puts "Unable to verify download digest"
+            FileUtils.rm(filename)
+          end
+        end
+      end
+
+      private
+
+      def filename
+        File.join(ShopifyCli::CACHE_DIR, "themekit")
+      end
+    end
+  end
+end

--- a/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
+++ b/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Tasks
+    class EnsureThemekitInstalledTest < MiniTest::Test
+      def setup
+        super
+        @context = TestHelpers::FakeContext.new
+      end
+
+      def test_does_nothing_if_themekit_installed
+        File.expects(:exist?).with(EnsureThemekitInstalled::FILENAME).returns(true)
+        assert_nothing_raised do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      def test_installs_and_makes_executable_if_not_installed
+        File.expects(:exist?).with(EnsureThemekitInstalled::FILENAME).returns(false)
+        stub_releases
+        stub_themekit_file_write
+        Digest::MD5.expects(:file).with(EnsureThemekitInstalled::FILENAME).returns('boop')
+        FileUtils.expects(:chmod).with('+x', EnsureThemekitInstalled::FILENAME)
+
+        EnsureThemekitInstalled.call(@context)
+      end
+
+      def test_deletes_if_bad_digest
+        File.expects(:exist?).with(EnsureThemekitInstalled::FILENAME).returns(false)
+        stub_releases
+        stub_themekit_file_write
+        Digest::MD5.expects(:file).with(EnsureThemekitInstalled::FILENAME).returns('mlem')
+        FileUtils.expects(:chmod).with('+x', EnsureThemekitInstalled::FILENAME).never
+        FileUtils.expects(:rm).with(EnsureThemekitInstalled::FILENAME)
+
+        EnsureThemekitInstalled.call(@context)
+      end
+
+      def test_fails_gracefully_if_errors
+        File.expects(:exist?).with(EnsureThemekitInstalled::FILENAME).returns(false)
+        stub_request(:get, EnsureThemekitInstalled::URL).to_return(status: 504)
+        File.expects(:write)
+          .with(EnsureThemekitInstalled::FILENAME, 'this is data').never
+        Digest::MD5.expects(:file).with(EnsureThemekitInstalled::FILENAME).never
+        FileUtils.expects(:chmod).with('+x', EnsureThemekitInstalled::FILENAME).never
+        FileUtils.expects(:rm).with(EnsureThemekitInstalled::FILENAME).never
+
+        assert_nothing_raised do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      private
+
+      def stub_releases
+        stub_request(:get, EnsureThemekitInstalled::URL)
+          .to_return(body: { "platforms": [
+            {
+              "name": 'darwin-amd64',
+              "version": '123',
+              "url": 'http://www.website.ca',
+              "digest": 'boop',
+            },
+            {
+              "name": 'linux-amd64',
+              "version": '123',
+              "url": 'http://www.website.ca',
+              "digest": 'boop',
+            },
+            {
+              "name": 'windows-amd64',
+              "version": '123',
+              "url": 'http://www.website.ca',
+              "digest": 'boop',
+            },
+          ] }.to_json)
+      end
+
+      def stub_themekit_file_write
+        stub_request(:get, 'http://www.website.ca')
+          .to_return(body: 'this is data')
+
+        File.expects(:write)
+          .with(EnsureThemekitInstalled::FILENAME, 'this is data')
+      end
+    end
+  end
+end

--- a/test/project_types/theme/test_helper.rb
+++ b/test/project_types/theme/test_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+require "test_helper"
+
+ShopifyCli::ProjectType.load_type(:theme)


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
- Themekit commands can't be used in CLI commands without Themekit downloaded
- Is better to check and download as part of CLI processes rather than have users do so separately themselves

### What is this pull request doing? 📋 
- Checks if Themekit is installed
  - If not, installs to cache and makes executable
- Adds task to `cli.rb` for Theme project type
- Tests for task