### PR TITLE
Gracefully ignore ArgumentError in the shim check

### DIFF
--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -11,6 +11,8 @@ module ShopifyCli
             IO.open(9) { is_shell_shim = true }
           rescue Errno::EBADF
             # This is expected if the descriptor doesn't exist
+          rescue ArgumentError
+            # This happens on RVM, for some reason
           end
 
           if !ctx.testing? && is_shell_shim

--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -11,8 +11,12 @@ module ShopifyCli
             IO.open(9) { is_shell_shim = true }
           rescue Errno::EBADF
             # This is expected if the descriptor doesn't exist
-          rescue ArgumentError
-            # This happens on RVM, for some reason
+          rescue ArgumentError => e
+            # This can happen on RVM, because it can use fd 9 itself and block access to it. That only happens if the fd
+            # did not exist beforehand, so that means there was no fd 9 before Ruby started.
+            unless e.message == 'The given fd is not accessible because RubyVM reserves it'
+              raise e
+            end
           end
 
           if !ctx.testing? && is_shell_shim


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #740 and #742 <!-- link to issue if one exists -->

After the release of v1.0.0, we received some reports of the CLI failing to run under RVM because it throws an error when trying to load FD 9 (previously used by the shell shim). The RVM raises an ArgumentError in that case which prevents commands from going forward.

### WHAT is this pull request doing?

This PR adds a check for that particular error so that it cleanly skips this error. I've tested (using FD 3 since I couldn't reproduce this issue with 9) that if the FD exists before we go into Ruby we don't get the error - so we can say that if we got ArgumentError the FD did not exist before Ruby ran. See below:

```
$ irb
2.7.0 :001 > File.for_fd(3)
Traceback (most recent call last):
        5: from /usr/share/rvm/rubies/ruby-2.7.0/bin/irb:23:in `<main>'
        4: from /usr/share/rvm/rubies/ruby-2.7.0/bin/irb:23:in `load'
        3: from /usr/share/rvm/rubies/ruby-2.7.0/lib/ruby/gems/2.7.0/gems/irb-1.2.1/exe/irb:11:in `<top (required)>'
        2: from (irb):1
        1: from (irb):1:in `for_fd'
ArgumentError (The given fd is not accessible because RubyVM reserves it)

$ tmpfile="$(\mktemp -u)"
$ exec 3>"${tmpfile}"
$ rm -f "${tmpfile}"
$ irb
2.7.0 :001 > File.for_fd(3)
 => #<File:fd 3>
```