### PR TITLE
Add script validation on enable/disable

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -5,6 +5,7 @@ module Script
     module Infrastructure
       module Errors
         class AppNotInstalledError < ScriptProjectError; end
+        class AppScriptNotPushedError < ScriptProjectError; end
         class AppScriptUndefinedError < ScriptProjectError; end
         class BuildError < ScriptProjectError; end
         class DependencyInstallError < ScriptProjectError; end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -60,6 +60,8 @@ module Script
             raise Errors::AppScriptUndefinedError, api_key
           elsif user_errors.any? { |e| e['tag'] == 'shop_script_conflict' }
             raise Errors::ShopScriptConflictError
+          elsif user_errors.any? { |e| e['tag'] == 'app_script_not_pushed' }
+            raise Errors::AppScriptNotPushedError
           else
             raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
           end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -42,6 +42,8 @@ module Script
 
           app_not_installed_cause: "App not installed on development store.",
 
+          app_script_not_pushed_help: "Push the script and then try this command again.",
+
           app_script_undefined_help: "Push script to app.",
 
           build_error_cause: "Something went wrong while building the script.",
@@ -120,6 +122,7 @@ module Script
 
           error: {
             operation_failed: "Can't disable script.",
+            not_pushed_to_app: "Can't disable the script because it hasn't been pushed to the app.",
           },
 
           script_disabled: "{{v}} Script disabled. Script is turned off in development store.",
@@ -142,6 +145,7 @@ module Script
 
           error: {
             operation_failed: "Can't enable script.",
+            not_pushed_to_app: "Can't enable the script because it hasn't been pushed to the app.",
           },
 
           script_enabled: "{{v}} Script enabled. %{type} script %{title} in app (API key: %{api_key}) "\

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -92,6 +92,10 @@ module Script
           {
             cause_of_error: ShopifyCli::Context.message('script.error.app_not_installed_cause'),
           }
+        when Layers::Infrastructure::Errors::AppScriptNotPushedError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.app_script_not_pushed_help'),
+          }
         when Layers::Infrastructure::Errors::AppScriptUndefinedError
           {
             help_suggestion: ShopifyCli::Context.message('script.error.app_script_undefined_help'),

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -298,6 +298,14 @@ describe Script::Layers::Infrastructure::ScriptService do
         end
       end
 
+      describe 'when app script not pushed' do
+        let(:tag) { "app_script_not_pushed" }
+
+        it 'should raise AppScriptNotPushedError' do
+          assert_raises(Script::Layers::Infrastructure::Errors::AppScriptNotPushedError) { subject }
+        end
+      end
+
       describe 'when shop script conflict' do
         let(:tag) { "shop_script_conflict" }
 

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -216,6 +216,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when AppScriptNotPushedError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::AppScriptNotPushedError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when ShopScriptUndefinedError" do
         let(:err) { Script::Layers::Infrastructure::Errors::ShopScriptUndefinedError.new }
         it "should call display_and_raise" do


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR adds the appropriate error message for when enable/disable are called acting on another script project. We need to ensure that we are only acting upon the script project we are in.

For example, Script A is deployed on App and we are in the Script B context. `shopify enable` should fail for Script B if it contains `api_key=<API key for APP>` in its `.env` file, saying that Script B is not enabled on the App. Right now, whatever script is deployed to App would be enabled.

<img width="848" alt="good one" src="https://user-images.githubusercontent.com/64974039/88197005-ba86a100-cbf6-11ea-985e-1b0304d26ad6.png">
