### PR TITLE
Move File.exist? to use context in scripts repos

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -34,7 +34,7 @@ module Script
 
         def dependencies_installed?
           # Assuming if node_modules folder exist at root of script folder, all deps are installed
-          ctx.exist?("node_modules")
+          ctx.dir_exist?("node_modules")
         end
 
         private

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -22,7 +22,7 @@ module Script
         def get_push_package(script, compiled_type)
           build_file_path = file_path(script.name, compiled_type)
 
-          raise Domain::PushPackageNotFoundError unless File.exist?(build_file_path)
+          raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
 
           script_content = File.read(build_file_path)
 

--- a/lib/project_types/script/layers/infrastructure/script_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_repository.rb
@@ -9,7 +9,7 @@ module Script
 
         def get_script(language, extension_point_type, script_name)
           source_file_path = src_code_file(language)
-          unless File.exist?(source_file_path)
+          unless ctx.file_exist?(source_file_path)
             raise Domain::Errors::ScriptNotFoundError.new(extension_point_type, source_file_path)
           end
 

--- a/lib/project_types/script/script_project.rb
+++ b/lib/project_types/script/script_project.rb
@@ -36,14 +36,14 @@ module Script
 
     class << self
       def create(ctx, dir)
-        raise Errors::ScriptProjectAlreadyExistsError, dir if ctx.exist?(dir)
+        raise Errors::ScriptProjectAlreadyExistsError, dir if ctx.dir_exist?(dir)
         ctx.mkdir_p(dir)
         ctx.chdir(dir)
       end
 
       def cleanup(ctx:, script_name:, root_dir:)
         ctx.chdir(root_dir)
-        ctx.rm_r("#{root_dir}/#{script_name}") if ctx.exist?("#{root_dir}/#{script_name}")
+        ctx.rm_r("#{root_dir}/#{script_name}") if ctx.dir_exist?("#{root_dir}/#{script_name}")
       end
     end
   end

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -146,8 +146,17 @@ module ShopifyCli
     # #### Parameters
     # * `path` - the file path to a directory, relative to the context root to remove from the FS
     #
-    def exist?(path)
+    def dir_exist?(path)
       Dir.exist?(ctx_path(path))
+    end
+
+    # checks if a file exists, the filepath is relative to the command root unless absolute
+    #
+    # #### Parameters
+    # * `path` - the file path to a file, relative to the context root to remove from the FS
+    #
+    def file_exist?(path)
+      File.exist?(ctx_path(path))
     end
 
     # will recursively copy a directory from the FS, the filepath is relative to the command

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -78,7 +78,7 @@ module Script
           end
         end
 
-        refute @context.exist?(@script_name)
+        refute @context.dir_exist?(@script_name)
       end
 
       private

--- a/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
@@ -57,7 +57,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
     it "should write to package.json" do
       context.expects(:system).twice
       subject
-      assert File.exist?("package.json")
+      assert context.file_exist?("package.json")
     end
   end
 

--- a/test/project_types/script/layers/infrastructure/script_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_repository_test.rb
@@ -70,8 +70,8 @@ describe Script::Layers::Infrastructure::ScriptRepository do
 
       script_repository.with_temp_build_context do
         refute_equal script_source_base, Dir.pwd
-        assert File.exist?(script_file)
-        assert File.exist?(helper_file)
+        assert context.file_exist?(script_file)
+        assert context.file_exist?(helper_file)
       end
     end
 
@@ -89,9 +89,9 @@ describe Script::Layers::Infrastructure::ScriptRepository do
     it "should delete the script root temp directory afterwards" do
       temp_dir = "#{script_folder_base}/temp"
       script_repository.with_temp_build_context do
-        assert context.exist?(temp_dir)
+        assert context.dir_exist?(temp_dir)
       end
-      refute context.exist?(temp_dir)
+      refute context.dir_exist?(temp_dir)
     end
   end
 end

--- a/test/project_types/script/script_project_test.rb
+++ b/test/project_types/script/script_project_test.rb
@@ -31,7 +31,7 @@ module Script
 
     def test_create_when_directory_does_not_exist
       @context
-        .expects(:exist?)
+        .expects(:dir_exist?)
         .with(@script_name)
         .returns(false)
 
@@ -48,7 +48,7 @@ module Script
 
     def test_create_when_directory_exists
       @context
-        .expects(:exist?)
+        .expects(:dir_exist?)
         .with(@script_name)
         .returns(true)
 
@@ -63,7 +63,7 @@ module Script
         .with(@context.root)
 
       @context
-        .expects(:exist?)
+        .expects(:dir_exist?)
         .with("#{@context.root}/#{@script_name}")
         .returns(true)
 
@@ -84,7 +84,7 @@ module Script
         .with(@context.root)
 
       @context
-        .expects(:exist?)
+        .expects(:dir_exist?)
         .with("#{@context.root}/#{@script_name}")
         .returns(false)
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Use context to access File.exist?() in script files.
I'm looking for some thoughts on the name of the new context method because I could see easy confusion between this and `context.exist?()` which would fail in these situations since `Dir.exist?()` checks for directories.
