### PR TITLE
Remove FakeFS from script unit tests

### DIFF
--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -7,7 +7,6 @@ module Script
     class CreateTest < MiniTest::Test
       include TestHelpers::Partners
       include TestHelpers::FakeUI
-      include TestHelpers::FakeFS
 
       def setup
         @context = TestHelpers::FakeContext.new

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -5,7 +5,6 @@ require "project_types/script/layers/infrastructure/fake_script_repository"
 require "project_types/script/layers/infrastructure/fake_extension_point_repository"
 
 describe Script::Layers::Application::BuildScript do
-  include TestHelpers::FakeFS
   describe '.call' do
     let(:language) { 'ts' }
     let(:extension_point_type) { 'discount' }

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -5,8 +5,6 @@ require "project_types/script/layers/infrastructure/fake_script_repository"
 require "project_types/script/layers/infrastructure/fake_extension_point_repository"
 
 describe Script::Layers::Application::CreateScript do
-  include TestHelpers::FakeFS
-
   let(:language) { 'ts' }
   let(:extension_point_type) { 'discount' }
   let(:script_name) { 'name' }

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -4,8 +4,6 @@ require "project_types/script/test_helper"
 require "project_types/script/layers/infrastructure/fake_extension_point_repository"
 
 describe Script::Layers::Application::ExtensionPoints do
-  include TestHelpers::FakeFS
-
   let(:language) { 'ts' }
   let(:script_name) { 'name' }
   let(:extension_point_type) { 'discount' }

--- a/test/project_types/script/layers/application/project_dependencies_test.rb
+++ b/test/project_types/script/layers/application/project_dependencies_test.rb
@@ -4,8 +4,6 @@ require "project_types/script/test_helper"
 require "project_types/script/layers/infrastructure/fake_extension_point_repository"
 
 describe Script::Layers::Application::ProjectDependencies do
-  include TestHelpers::FakeFS
-
   let(:language) { 'ts' }
   let(:script_name) { 'name' }
   let(:extension_point_type) { 'discount' }

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -6,8 +6,6 @@ require "project_types/script/layers/infrastructure/fake_extension_point_reposit
 require "project_types/script/layers/infrastructure/fake_push_package_repository"
 
 describe Script::Layers::Application::PushScript do
-  include TestHelpers::FakeFS
-
   let(:compiled_type) { 'wasm' }
   let(:language) { 'ts' }
   let(:api_key) { 'api_key' }

--- a/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
@@ -3,8 +3,6 @@
 require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
-  include TestHelpers::FakeFS
-
   let(:script_name) { "myscript" }
   let(:language) { "ts" }
   let(:script_id) { 'id' }

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -3,8 +3,6 @@
 require 'project_types/script/test_helper'
 
 describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
-  include TestHelpers::FakeFS
-
   let(:ctx) { TestHelpers::FakeContext.new }
   let(:script_id) { 'id' }
   let(:script_name) { "foo" }

--- a/test/project_types/script/layers/infrastructure/assemblyscript_tsconfig_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_tsconfig_test.rb
@@ -3,8 +3,6 @@
 require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::AssemblyScriptTsConfig do
-  include TestHelpers::FakeFS
-
   let(:dir_to_write_in) { "foo" }
 
   subject { Script::Layers::Infrastructure::AssemblyScriptTsConfig.new(dir_to_write_in: dir_to_write_in) }


### PR DESCRIPTION
### WHAT is this pull request doing?

We recently switched to doing FS operations via context, so we shouldn't need FakeFS anymore.
