### PR TITLE
Allow creating an API Client while connecting

### DIFF
--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -24,6 +24,15 @@ module ShopifyCli
           MESSAGE
           development_store_select: "Which development store would you like to use?",
           cli_yml_saved: ".shopify-cli.yml saved to project root",
+
+          no_apps: 'You have no apps to connect to, creating a new app.',
+          app_name: "App name",
+          app_type: {
+            select: "What type of app are you building?",
+            select_public: "Public: An app built for a wide merchant audience.",
+            select_custom: "Custom: An app custom built for a single client.",
+            selected: "App type {{green:%s}}",
+          },
         },
 
         context: {

--- a/test/shopify-cli/commands/connect_test.rb
+++ b/test/shopify-cli/commands/connect_test.rb
@@ -116,6 +116,31 @@ module ShopifyCli
         run_cmd('connect')
       end
 
+      def test_create_new_app_if_none_available
+        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_with_app).returns([{
+          "id" => 421,
+          "businessName" => "one",
+          "stores" => [{
+            "shopDomain" => "store.myshopify.com",
+          }],
+          "apps" => [],
+        }])
+        CLI::UI::Prompt.expects(:ask).with(@context.message('rails.forms.create.app_name')).returns('new app')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('rails.forms.create.app_type.select')).returns('public')
+        ShopifyCli::Tasks::CreateApiClient.expects(:call).with(
+          @context,
+          org_id: 421,
+          title: 'new app',
+          type: 'public',
+        ).returns({
+          "apiKey" => "ljdlkajfaljf",
+          "apiSecretKeys" => [{ "secret" => "kldjakljjkj" }],
+          "id" => "12345678",
+        })
+        Resources::EnvFile.any_instance.stubs(:write)
+        run_cmd('connect')
+      end
+
       private
 
       def partners_api_response


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #751

We actually didn't handle the case where a developer may want to connect an app but not have any existing API clients in the dashboard.

### WHAT is this pull request doing?
I have actually added the creation of an ApiClient within the create action. 

