### PR TITLE
Remove autoload reference to extinct update command

### DIFF
--- a/lib/shopify-cli/core.rb
+++ b/lib/shopify-cli/core.rb
@@ -4,6 +4,5 @@ module ShopifyCli
     autoload :Executor, 'shopify-cli/core/executor'
     autoload :HelpResolver, 'shopify-cli/core/help_resolver'
     autoload :Monorail, 'shopify-cli/core/monorail'
-    autoload :Update, 'shopify-cli/core/update'
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

During the process of migrating the CLI to be installer-based, we dropped the `update` command since it no longer made sense. @carmelal then noticed that we failed to remove the autoload reference to the command, even though the file doesn't exist any more.

### WHAT is this pull request doing?

Removing the autoload reference.