### PR TITLE
Add enable/disable visibility to Scripts Commands

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -2,7 +2,7 @@
 
 module Script
   class Project < ShopifyCli::ProjectType
-    hidden_feature
+    hidden_feature(feature_set: :script_project)
     creator 'Script', 'Script::Commands::Create'
 
     register_command('Script::Commands::Push', 'push')


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR allows script commands to be set as visible for the preview. It uses the recent [Feature Sets](https://github.com/Shopify/shopify-app-cli/pull/632) PR.

Use `shopify config feature script --enable` to unhide the create command, and `--disable` to hide it again.

**Disabled:**
<img width="1090" alt="Screen Shot 2020-07-21 at 9 38 00 AM" src="https://user-images.githubusercontent.com/64974039/88081968-fefe3800-cb35-11ea-9e6e-e49a1d03a19c.png">


**Enabled:**
<img width="1089" alt="Screen Shot 2020-07-21 at 9 37 54 AM" src="https://user-images.githubusercontent.com/64974039/88081981-0291bf00-cb36-11ea-99e0-22f8b0c4d7bc.png">

