### PR TITLE
Fixing prerequisite tasks for subcommands and project types

### DIFF
--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -9,17 +9,19 @@ module ShopifyCli
     attr_accessor :options
 
     class << self
-      attr_writer :ctx
+      attr_writer :ctx, :task_registry
 
       def call(args, command_name)
         subcommand, resolved_name = subcommand_registry.lookup_command(args.first)
         if subcommand
           subcommand.ctx = @ctx
+          subcommand.task_registry = @task_registry
           subcommand.call(args, resolved_name, command_name)
         else
           cmd = new(@ctx)
           cmd.options.parse(@_options, args)
           return call_help(command_name) if cmd.options.help
+          run_prerequisites
           cmd.call(args, command_name)
         end
       end
@@ -41,13 +43,16 @@ module ShopifyCli
       end
 
       def prerequisite_task(*tasks)
-        tasks.each do |task|
-          prerequisite_tasks[task] = ShopifyCli::Tasks::Registry[task]
-        end
+        @prerequisite_tasks ||= []
+        @prerequisite_tasks += tasks
       end
 
-      def prerequisite_tasks
-        @prerequisite_tasks ||= {}
+      def run_prerequisites
+        (@prerequisite_tasks || []).each { |task| task_registry[task]&.call(@ctx) }
+      end
+
+      def task_registry
+        @task_registry || ShopifyCli::Tasks::Registry
       end
 
       def call_help(*cmds)

--- a/lib/shopify-cli/core/executor.rb
+++ b/lib/shopify-cli/core/executor.rb
@@ -10,9 +10,7 @@ module ShopifyCli
       end
 
       def call(command, command_name, args)
-        command.prerequisite_tasks.each do |task, _|
-          @task_registry[task]&.call(@ctx)
-        end
+        command.task_registry = @task_registry
         command.ctx = @ctx
         super
       end

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -64,7 +64,7 @@ module ShopifyCli
 
       def register_task(task, name)
         return if project_load_shallow
-        Task::Registry.add(const_get(task), name)
+        ShopifyCli::Task.register(task, name)
       end
 
       def register_messages(messages)

--- a/lib/shopify-cli/sub_command.rb
+++ b/lib/shopify-cli/sub_command.rb
@@ -8,6 +8,7 @@ module ShopifyCli
         cmd = new(@ctx)
         args = cmd.options.parse(@_options, args[1..-1] || [])
         return call_help(parent_command, command_name) if cmd.options.help
+        run_prerequisites
         cmd.call(args, command_name)
       end
     end

--- a/lib/shopify-cli/tasks.rb
+++ b/lib/shopify-cli/tasks.rb
@@ -12,15 +12,22 @@ module ShopifyCli
       end
 
       def [](name)
-        @tasks[name]
+        class_or_proc = @tasks[name]
+        if class_or_proc.is_a?(Class)
+          class_or_proc
+        elsif class_or_proc.respond_to?(:call)
+          class_or_proc.call
+        else
+          class_or_proc
+        end
       end
     end
 
     Registry = TaskRegistry.new
 
-    def self.register(task, name, path)
-      autoload(task, path)
-      Registry.add(const_get(task), name)
+    def self.register(task, name, path = nil)
+      autoload(task, path) if path
+      Registry.add(-> () { const_get(task) }, name)
     end
 
     register :CreateApiClient, :create_api_client, 'shopify-cli/tasks/create_api_client'

--- a/test/shopify-cli/core/executor_test.rb
+++ b/test/shopify-cli/core/executor_test.rb
@@ -9,6 +9,8 @@ module ShopifyCli
         prerequisite_task :fake
 
         class FakeSubCommand < ShopifyCli::SubCommand
+          prerequisite_task :fake
+
           def call(*)
             @ctx.puts('subcommand!')
           end


### PR DESCRIPTION
### WHY are these changes introduced?
During a pair programming meeting with @carmelal we realized that tasks do not work on sub-commands and project types. It specifically does not work on project types because there is a load order issue of registering the task and declaring the task to be autoloaded in the project type

### WHAT is this pull request doing?
- `Changes ProjectType.register_task` to use `ShopifyCli::Tasks.register` to unify the functionality
- `ShopifyCli::Tasks.register.register` to wrap the const_get in a proc to act as a closure so that the Class will be lazy loaded when the task is needed.
- `ShopifyCli::Tasks::Registry[]` to resolve a class or proc
- call `run_prerequisites` on commands and subcommands *just* before calling `call` so that they are only run when needed and not before help.
- added a `task_registry` to the command class so that it can be passed around.
