### PR TITLE
Adapt the vendored CLI UI / Kit code to Windows

### DIFF
--- a/vendor/deps/cli-kit/lib/cli/kit/system.rb
+++ b/vendor/deps/cli-kit/lib/cli/kit/system.rb
@@ -169,7 +169,9 @@ module CLI
           host = RbConfig::CONFIG["host"]
           return :mac if /darwin/.match(host)
           return :linux if /linux/.match(host)
-          :windows if /mingw32/.match(host)
+          return :windows if /mingw32/.match(host)
+
+          raise "Could not determine OS from host #{host}"
         end
 
         private
@@ -198,10 +200,12 @@ module CLI
         # See https://github.com/Shopify/dev/pull/625 for more details.
         def resolve_path(a, env)
           # If only one argument was provided, make sure it's interpreted by a shell.
-          if os == :windows
-            return ["break && " + a[0]] if a.size == 1
-          else
-            return ["true ; " + a[0]] if a.size == 1
+          if a.size == 1
+            if os == :windows
+              return ["break && " + a[0]]
+            else
+              return ["true ; " + a[0]]
+            end
           end
           return a if a.first.include?('/')
 

--- a/vendor/deps/cli-kit/lib/cli/kit/system.rb
+++ b/vendor/deps/cli-kit/lib/cli/kit/system.rb
@@ -163,6 +163,15 @@ module CLI
           [data.byteslice(0...partial_character_index), data.byteslice(partial_character_index..-1)]
         end
 
+        def os
+          require 'rbconfig'
+
+          host = RbConfig::CONFIG["host"]
+          return :mac if /darwin/.match(host)
+          return :linux if /linux/.match(host)
+          :windows if /mingw32/.match(host)
+        end
+
         private
 
         def apply_sudo(*a, sudo)
@@ -189,7 +198,11 @@ module CLI
         # See https://github.com/Shopify/dev/pull/625 for more details.
         def resolve_path(a, env)
           # If only one argument was provided, make sure it's interpreted by a shell.
-          return ["true ; " + a[0]] if a.size == 1
+          if os == :windows
+            return ["break && " + a[0]] if a.size == 1
+          else
+            return ["true ; " + a[0]] if a.size == 1
+          end
           return a if a.first.include?('/')
 
           paths = env.fetch('PATH', '').split(':')

--- a/vendor/deps/cli-ui/lib/cli/ui.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui.rb
@@ -13,9 +13,6 @@ module CLI
     autoload :Spinner,            'cli/ui/spinner'
     autoload :Widgets,            'cli/ui/widgets'
 
-    # Convenience accessor to +CLI::UI::Spinner::SpinGroup+
-    SpinGroup = Spinner::SpinGroup
-
     # Glyph resolution using +CLI::UI::Glyph.lookup+
     # Look at the method signature for +Glyph.lookup+ for more details
     #
@@ -210,6 +207,29 @@ module CLI
 
     self.enable_color = $stdout.tty?
 
+    # Check whether emojis are enabled in Formatter output. This depends on
+    # the OS running the CLI UI, since Windows does not fully support them yet
+    # See https://github.com/microsoft/terminal/issues/190 for more info.
+    #
+    def self.enable_emoji?
+      @enable_emoji
+    end
+
+    # Determine which OS is running [:mac, :linux, :windows]
+    #
+    # ==== Returns
+    # A symbol indicating the current OS
+    def self.os
+      require 'rbconfig'
+
+      host = RbConfig::CONFIG["host"]
+      return :mac if /darwin/.match(host)
+      return :linux if /linux/.match(host)
+      :windows if /mingw32/.match(host)
+    end
+
+    @enable_emoji = (self.os != :windows)
+
     # Set the default frame style.
     # Convenience method for setting the default frame style with +CLI::UI::Frame.frame_style=+
     #
@@ -222,6 +242,10 @@ module CLI
     def self.frame_style=(frame_style)
       Frame.frame_style = frame_style.to_sym
     end
+
+    # Convenience accessor to +CLI::UI::Spinner::SpinGroup+
+    # This needs to be defined after @enable_emoji, otherwise we will try to load the class before we're ready for it
+    SpinGroup = Spinner::SpinGroup
   end
 end
 

--- a/vendor/deps/cli-ui/lib/cli/ui.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui.rb
@@ -4,6 +4,7 @@ module CLI
     autoload :Glyph,              'cli/ui/glyph'
     autoload :Color,              'cli/ui/color'
     autoload :Frame,              'cli/ui/frame'
+    autoload :OS,                 'cli/ui/os'
     autoload :Printer,            'cli/ui/printer'
     autoload :Progress,           'cli/ui/progress'
     autoload :Prompt,             'cli/ui/prompt'
@@ -12,6 +13,9 @@ module CLI
     autoload :Formatter,          'cli/ui/formatter'
     autoload :Spinner,            'cli/ui/spinner'
     autoload :Widgets,            'cli/ui/widgets'
+
+    # Convenience accessor to +CLI::UI::Spinner::SpinGroup+
+    SpinGroup = Spinner::SpinGroup
 
     # Glyph resolution using +CLI::UI::Glyph.lookup+
     # Look at the method signature for +Glyph.lookup+ for more details
@@ -207,29 +211,6 @@ module CLI
 
     self.enable_color = $stdout.tty?
 
-    # Check whether emojis are enabled in Formatter output. This depends on
-    # the OS running the CLI UI, since Windows does not fully support them yet
-    # See https://github.com/microsoft/terminal/issues/190 for more info.
-    #
-    def self.enable_emoji?
-      @enable_emoji
-    end
-
-    # Determine which OS is running [:mac, :linux, :windows]
-    #
-    # ==== Returns
-    # A symbol indicating the current OS
-    def self.os
-      require 'rbconfig'
-
-      host = RbConfig::CONFIG["host"]
-      return :mac if /darwin/.match(host)
-      return :linux if /linux/.match(host)
-      :windows if /mingw32/.match(host)
-    end
-
-    @enable_emoji = (self.os != :windows)
-
     # Set the default frame style.
     # Convenience method for setting the default frame style with +CLI::UI::Frame.frame_style=+
     #
@@ -242,10 +223,6 @@ module CLI
     def self.frame_style=(frame_style)
       Frame.frame_style = frame_style.to_sym
     end
-
-    # Convenience accessor to +CLI::UI::Spinner::SpinGroup+
-    # This needs to be defined after @enable_emoji, otherwise we will try to load the class before we're ready for it
-    SpinGroup = Spinner::SpinGroup
   end
 end
 

--- a/vendor/deps/cli-ui/lib/cli/ui/ansi.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/ansi.rb
@@ -137,7 +137,7 @@ module CLI
       #
       def self.next_line
         cmd = cursor_down + control('1', 'G')
-        cmd += control('1', 'D') if CLI::UI.os == :windows
+        cmd += control('1', 'D') if CLI::UI::OS.current.shift_cursor_on_line_reset?
         cmd
       end
 
@@ -145,7 +145,7 @@ module CLI
       #
       def self.previous_line
         cmd = cursor_up + control('1', 'G')
-        cmd += control('1', 'D') if CLI::UI.os == :windows
+        cmd += control('1', 'D') if CLI::UI::OS.current.shift_cursor_on_line_reset?
         cmd
       end
 

--- a/vendor/deps/cli-ui/lib/cli/ui/ansi.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/ansi.rb
@@ -136,13 +136,17 @@ module CLI
       # Move to the next line
       #
       def self.next_line
-        cursor_down + control('1', 'G')
+        cmd = cursor_down + control('1', 'G')
+        cmd += control('1', 'D') if CLI::UI.os == :windows
+        cmd
       end
 
       # Move to the previous line
       #
       def self.previous_line
-        cursor_up + control('1', 'G')
+        cmd = cursor_up + control('1', 'G')
+        cmd += control('1', 'D') if CLI::UI.os == :windows
+        cmd
       end
 
       def self.clear_to_end_of_line

--- a/vendor/deps/cli-ui/lib/cli/ui/frame/frame_style/box.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/frame/frame_style/box.rb
@@ -140,10 +140,12 @@ module CLI
               o << "\r"
 
               o << color.code
-              o << print_at_x(preamble_start, HORIZONTAL * (termwidth - preamble_start)) # draw a full line
-              o << print_at_x(preamble_start, preamble)
+              o << preamble
               o << color.code
-              o << print_at_x(suffix_start, suffix)
+              o << HORIZONTAL * (suffix_start - preamble_end) # draw a full line
+              o << suffix
+              o << HORIZONTAL * (termwidth - suffix_end)
+              o << color.code
               o << CLI::UI::Color::RESET.code
               o << CLI::UI::ANSI.show_cursor
               o << "\n"

--- a/vendor/deps/cli-ui/lib/cli/ui/glyph.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/glyph.rb
@@ -43,7 +43,7 @@ module CLI
       # ==== Returns
       # Returns the glyph string
       def char
-        CLI::UI.enable_emoji? ? @char : @plain
+        CLI::UI::OS.current.supports_emoji? ? @char : @plain
       end
 
       # Mapping of glyphs to terminal output

--- a/vendor/deps/cli-ui/lib/cli/ui/glyph.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/glyph.rb
@@ -15,7 +15,7 @@ module CLI
         end
       end
 
-      attr_reader :handle, :codepoint, :color, :char, :to_s, :fmt
+      attr_reader :handle, :codepoint, :color, :to_s, :fmt
 
       # Creates a new glyph
       #
@@ -24,11 +24,13 @@ module CLI
       # * +handle+ - The handle in the +MAP+ constant
       # * +codepoint+ - The codepoint used to create the glyph (e.g. +0x2717+ for a ballot X)
       # * +color+ - What color to output the glyph. Check +CLI::UI::Color+ for options.
+      # * +plain+ - A fallback plain string to be used in case glyphs are disabled
       #
-      def initialize(handle, codepoint, color)
+      def initialize(handle, codepoint, color, plain)
         @handle    = handle
         @codepoint = codepoint
         @color     = color
+        @plain     = plain
         @char      = Array(codepoint).pack('U*')
         @to_s      = color.code + char + Color::RESET.code
         @fmt       = "{{#{color.name}:#{char}}}"
@@ -36,16 +38,24 @@ module CLI
         MAP[handle] = self
       end
 
+      # Fetches the actual character(s) to be displayed for a glyph
+      #
+      # ==== Returns
+      # Returns the glyph string
+      def char
+        CLI::UI.enable_emoji? ? @char : @plain
+      end
+
       # Mapping of glyphs to terminal output
       MAP = {}
-      STAR      = new('*', 0x2b51,           Color::YELLOW) # YELLOW SMALL STAR (⭑)
-      INFO      = new('i', 0x1d4be,          Color::BLUE)   # BLUE MATHEMATICAL SCRIPT SMALL i (𝒾)
-      QUESTION  = new('?', 0x003f,           Color::BLUE)   # BLUE QUESTION MARK (?)
-      CHECK     = new('v', 0x2713,           Color::GREEN)  # GREEN CHECK MARK (✓)
-      X         = new('x', 0x2717,           Color::RED)    # RED BALLOT X (✗)
-      BUG       = new('b', 0x1f41b,          Color::WHITE)  # Bug emoji (🐛)
-      CHEVRON   = new('>', 0xbb,             Color::YELLOW) # RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK (»)
-      HOURGLASS = new('H', [0x231b, 0xfe0e], Color::BLUE)   # HOURGLASS + VARIATION SELECTOR 15 (⌛︎)
+      STAR      = new('*', 0x2b51,           Color::YELLOW, '*')   # YELLOW SMALL STAR (⭑)
+      INFO      = new('i', 0x1d4be,          Color::BLUE,   'i')   # BLUE MATHEMATICAL SCRIPT SMALL i (𝒾)
+      QUESTION  = new('?', 0x003f,           Color::BLUE,   '?')   # BLUE QUESTION MARK (?)
+      CHECK     = new('v', 0x2713,           Color::GREEN,  '√')   # GREEN CHECK MARK (✓)
+      X         = new('x', 0x2717,           Color::RED,    'X')   # RED BALLOT X (✗)
+      BUG       = new('b', 0x1f41b,          Color::WHITE,  'bug') # Bug emoji (🐛)
+      CHEVRON   = new('>', 0xbb,             Color::YELLOW, '>')   # RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK (»)
+      HOURGLASS = new('H', [0x231b, 0xfe0e], Color::BLUE,   'H')   # HOURGLASS + VARIATION SELECTOR 15 (⌛︎)
 
       # Looks up a glyph by name
       #

--- a/vendor/deps/cli-ui/lib/cli/ui/os.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/os.rb
@@ -1,0 +1,64 @@
+module CLI
+  module UI
+    module OS
+      # Determines which OS is currently running the UI, to make it easier to
+      # adapt its behaviour to the features of the OS.
+      def self.current
+        return @current_os unless @current_os.nil?
+
+        require 'rbconfig'
+
+        host = RbConfig::CONFIG["host"]
+        @current_os = Mac if /darwin/.match(host)
+        @current_os = Linux if /linux/.match(host)
+        @current_os = Windows if /mingw32/.match(host)
+
+        raise "Could not determine OS from host #{host}" if @current_os.nil?
+        @current_os
+      end
+
+      class Mac
+        class << self
+          def supports_emoji?
+            true
+          end
+
+          def supports_color_prompt?
+            true
+          end
+
+          def supports_arrow_keys?
+            true
+          end
+
+          def shift_cursor_on_line_reset?
+            false
+          end
+        end
+      end
+
+      class Linux < Mac
+      end
+
+      class Windows
+        class << self
+          def supports_emoji?
+            false
+          end
+
+          def supports_color_prompt?
+            false
+          end
+
+          def supports_arrow_keys?
+            false
+          end
+
+          def shift_cursor_on_line_reset?
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/vendor/deps/cli-ui/lib/cli/ui/prompt.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/prompt.rb
@@ -192,7 +192,8 @@ module CLI
           raise(ArgumentError, 'insufficient options') if options.nil? || options.empty?
           # Windows doesn't capture the up/down arrow keys with getc, so we simply don't mention that possibility
           instructions = []
-          instructions << (multiple ? "Toggle options. " : "") + "Choose with ↑ ↓ ⏎" unless CLI::UI.os == :windows
+          instructions << (multiple ? "Toggle options. " : "") + "Choose with ↑ ↓ ⏎" if
+            CLI::UI::OS.current.supports_arrow_keys?
           instructions << "filter with 'f'" if filter_ui
           instructions << "enter option with 'e'" if select_ui && (options.size > 9)
 
@@ -271,7 +272,7 @@ module CLI
           # If a prompt is interrupted on Windows it locks the colour of the terminal from that point on, so we should
           # not change the colour here.
           prompt = prefix + CLI::UI.fmt('{{blue:> }}')
-          prompt += CLI::UI::Color::YELLOW.code unless CLI::UI.os == :windows
+          prompt += CLI::UI::Color::YELLOW.code if CLI::UI::OS.current.supports_color_prompt?
 
           begin
             line = Readline.readline(prompt, true)

--- a/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb
@@ -273,6 +273,7 @@ module CLI
             case char
             when ESC        ; @state = :esc
             when "\r", "\n" ; select_current
+            when "\b"       ; update_search(BACKSPACE) # Happens on Windows
             else            ; update_search(char)
             end
           when :line_select

--- a/vendor/deps/cli-ui/lib/cli/ui/spinner.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/spinner.rb
@@ -10,11 +10,11 @@ module CLI
       PERIOD = 0.1 # seconds
       TASK_FAILED = :task_failed
 
-      RUNES = %w(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏).freeze
+      RUNES = CLI::UI.enable_emoji? ? %w(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏).freeze : %w(\\ | / _ \\ | / _).freeze
 
       begin
-        colors = [CLI::UI::Color::CYAN.code] * 5 + [CLI::UI::Color::MAGENTA.code] * 5
-        raise unless RUNES.size == colors.size
+        colors = [CLI::UI::Color::CYAN.code] * (RUNES.size / 2).ceil +
+          [CLI::UI::Color::MAGENTA.code] * (RUNES.size / 2).to_i
         GLYPHS = colors.zip(RUNES).map(&:join)
       end
 

--- a/vendor/deps/cli-ui/lib/cli/ui/spinner.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/spinner.rb
@@ -10,7 +10,7 @@ module CLI
       PERIOD = 0.1 # seconds
       TASK_FAILED = :task_failed
 
-      RUNES = CLI::UI.enable_emoji? ? %w(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏).freeze : %w(\\ | / _ \\ | / _).freeze
+      RUNES = CLI::UI::OS.current.supports_emoji? ? %w(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏).freeze : %w(\\ | / - \\ | / -).freeze
 
       begin
         colors = [CLI::UI::Color::CYAN.code] * (RUNES.size / 2).ceil +


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

In order to run the CLI natively on Windows, there are a few changes that need to happen in the vendor code from Shopify/cli-ui and Shopify/cli-kit. This PR introduces these changes locally to this repo, but the intention is that they will be ported to the original repos once we're confident they work.

If these changes are approved in the upstream repos, we can then pull them back in over the vendor code with these changes in them.

### WHAT is this pull request doing?

These changes fix a few issues found with the CLI on Windows:

* The UI Prompt can't handle the up / down arrow keys because Windows doesn't capture those keystrokes natively. According to the internet, it may be possible to make that work by using external gems, which are not an option here.
  * The proposed fix is to simply not indicate that as an option as pressing those keys does nothing.
* Windows terminals don't seem to deal properly with emojis just yet (see Microsoft/Terminal/issues/190), so this PR changes the UI so that glyphs can fall back to plain text options, like so:
![Screen Shot 2020-07-22 at 4 31 05 PM](https://user-images.githubusercontent.com/64600052/88227539-c21c6900-cc3b-11ea-9aac-78bd1ce74a77.png)
* Fixing the way we spawn child processes on CLI-Kit so that it works on Windows as well.
* Fixing UI frames, which were not aligning properly (see above screenshot for **after** example):
![Screen Shot 2020-07-16 at 2 34 03 PM](https://user-images.githubusercontent.com/64600052/88225868-3c97b980-cc39-11ea-9105-9a4049f5756d.png)
* Fixing an issue where interrupting a script during a prompt that colors the input text made the terminal continue to have that color:
before:
![Screen Shot 2020-07-16 at 2 42 27 PM](https://user-images.githubusercontent.com/64600052/88226025-78328380-cc39-11ea-82b8-38ad039085ff.png)
after:
![Screen Shot 2020-07-22 at 4 22 41 PM](https://user-images.githubusercontent.com/64600052/88226007-6f41b200-cc39-11ea-9ac1-c01b0d33d451.png)
* Fixing the spinner icon with a non-emoji based alternative:
![Plain Spinner 2](https://user-images.githubusercontent.com/64600052/88307258-b8494300-ccd9-11ea-86dc-78ae63641bb6.gif)

