### PR TITLE
Add messaging about tunnel timeouts, add restarts for expired tunnels (Fix issue 767)

### DIFF
--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -295,10 +295,17 @@ module ShopifyCli
             url_fetch_failure: "Unable to fetch external url",
           },
 
-          stopped: "{{green:x}} ngrok tunnel stopped",
           not_running: "{{green:x}} ngrok tunnel not running",
-          start_with_account: "{{v}} ngrok tunnel running at {{underline:%s}}, with account %s",
+          signup_suggestion: <<~MESSAGE,
+          {{*}} To avoid tunnels that timeout, it is recommended to signup for a free ngrok
+          account at {{underline:https://ngrok.com/signup}}. After you signup, install your
+          personalized authorization token using {{command:%s tunnel auth <token>}}.
+          MESSAGE
           start: "{{v}} ngrok tunnel running at {{underline:%s}}",
+          start_with_account: "{{v}} ngrok tunnel running at {{underline:%s}}, with account %s",
+          stopped: "{{green:x}} ngrok tunnel stopped",
+          timed_out: "{{x}} ngrok tunnel has timed out, restarting ...",
+          will_timeout: "{{*}} This tunnel will timeout in {{red:%s}}",
         },
 
         version: {

--- a/lib/shopify-cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify-cli/tasks/update_dashboard_urls.rb
@@ -28,16 +28,17 @@ module ShopifyCli
       end
 
       def construct_redirect_urls(urls, new_url, callback_url)
-        urls.map do |url|
+        new_urls = urls.map do |url|
           if (match = url.match(NGROK_REGEX))
             "#{new_url}#{match[2]}"
           else
             url
           end
         end
-        if urls.grep(/#{new_url}#{callback_url}/).empty?
-          urls.push("#{new_url}#{callback_url}")
+        if new_urls.grep(/#{new_url}#{callback_url}/).empty?
+          new_urls.push("#{new_url}#{callback_url}")
         end
+        new_urls.uniq
       end
     end
   end

--- a/test/fixtures/ngrok.log
+++ b/test/fixtures/ngrok.log
@@ -1,3 +1,4 @@
+t=2019-03-26T14:45:57-0400 lvl=dbug msg="decoded response" obj=csess id=63b552dbb648 sid=3 resp="&{Version:2 ClientID:640713d23ff34283f8d9c211fb8f2839 Error: Extra:{Version:prod Cookie:redacted AccountName: SessionDuration:28799 PlanName:Free}}" err=nil
 t=2019-03-26T14:45:57-0400 lvl=dbug msg="start tunnel listen" obj=tunnels.session name="command_line (http)" proto=http opts="&{Hostname:example.ngrok.io Auth: Subdomain: HostHeaderRewrite:false LocalURLScheme:http}" err=nil
 t=2019-03-26T14:45:57-0400 lvl=info msg="started tunnel" obj=tunnels name="command_line (http)" addr=http://localhost:8081 url=http://example.ngrok.io
 t=2019-03-26T14:45:57-0400 lvl=info msg="started tunnel" obj=tunnels name=command_line addr=http://localhost:8081 url=https://example.ngrok.io

--- a/test/shopify-cli/task/update_dashboard_urls_test.rb
+++ b/test/shopify-cli/task/update_dashboard_urls_test.rb
@@ -142,7 +142,7 @@ module ShopifyCli
             input: {
               applicationUrl: 'https://newone123.ngrok.io',
               redirectUrlWhitelist: [
-                "https://123abc.ngrok.io",
+                "https://myowndomain.io",
                 "https://fake.fakeurl.com",
                 "https://fake.fakeurl.com/callback/fake",
                 "https://myowndomain.io/callback/fake",
@@ -158,117 +158,131 @@ module ShopifyCli
           callback_url: '/callback/fake',
         )
       end
-    end
 
-    def test_application_url_is_updated_if_user_says_yes
-      Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '1234', secret: 'foo'))
-      api_key = '1234'
-      stub_partner_req(
-        'get_app_urls',
-        variables: {
-          apiKey: api_key,
-        },
-        resp: {
-          data: {
-            app: {
-              applicationUrl: 'https://newone123.ngrok.io',
-              redirectUrlWhitelist: [
-                'https://123abc.ngrok.io',
-                'https://fake.fakeurl.com',
-                'https://fake.fakeurl.com/callback/fake',
-              ],
-            },
-          },
-        }
-      )
-
-      stub_partner_req(
-        'update_dashboard_urls',
-        variables: {
-          input: {
-            applicationUrl: 'https://myowndomain.io',
-            redirectUrlWhitelist: [
-              "https://myowndomain.io",
-              "https://fake.fakeurl.com",
-              "https://fake.fakeurl.com/callback/fake",
-              "https://myowndomain.io/callback/fake",
-            ],
+      def test_application_url_is_updated_if_user_says_yes
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '1234', secret: 'foo'))
+        api_key = '1234'
+        stub_partner_req(
+          'get_app_urls',
+          variables: {
             apiKey: api_key,
           },
-        }
-      )
-      CLI::UI::Prompt.expects(:confirm).returns(true)
-      ShopifyCli::Tasks::UpdateDashboardURLS.call(
-        @context,
-        url: 'https://myowndomain.io',
-        callback_url: '/callback/fake',
-      )
-    end
-
-    def test_whitelist_urls_are_updated_even_if_app_url_is_set
-      Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
-      api_key = '123'
-      stub_partner_req(
-        'get_app_urls',
-        variables: {
-          apiKey: api_key,
-        },
-        resp: {
-          data: {
-            app: {
-              applicationUrl: 'https://newone123.ngrok.io',
-              redirectUrlWhitelist: [],
+          resp: {
+            data: {
+              app: {
+                applicationUrl: 'https://newone123.ngrok.io',
+                redirectUrlWhitelist: [
+                  'https://123abc.ngrok.io',
+                  'https://fake.fakeurl.com',
+                  'https://fake.fakeurl.com/callback/fake',
+                ],
+              },
             },
-          },
-        }
-      )
+          }
+        )
 
-      stub_partner_req(
-        'update_dashboard_urls',
-        variables: {
-          input: {
-            applicationUrl: 'https://newone123.ngrok.io',
-            redirectUrlWhitelist: [
-              'https://newone123.ngrok.io',
-              'https://newone123.ngrok.io/callback/fake',
-            ],
+        stub_partner_req(
+          'update_dashboard_urls',
+          variables: {
+            input: {
+              applicationUrl: 'https://myowndomain.io',
+              redirectUrlWhitelist: [
+                "https://myowndomain.io",
+                "https://fake.fakeurl.com",
+                "https://fake.fakeurl.com/callback/fake",
+                "https://myowndomain.io/callback/fake",
+              ],
+              apiKey: api_key,
+            },
+          }
+        )
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+          @context,
+          url: 'https://myowndomain.io',
+          callback_url: '/callback/fake',
+        )
+      end
+
+      def test_whitelist_urls_are_updated_even_if_app_url_is_set
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
+        api_key = '123'
+        stub_partner_req(
+          'get_app_urls',
+          variables: {
             apiKey: api_key,
           },
-        }
-      )
-      ShopifyCli::Tasks::UpdateDashboardURLS.call(
-        @context,
-        url: 'https://newone123.ngrok.io',
-        callback_url: '/callback/fake',
-      )
-    end
+          resp: {
+            data: {
+              app: {
+                applicationUrl: 'https://newone123.ngrok.io',
+                redirectUrlWhitelist: [],
+              },
+            },
+          }
+        )
 
-    def test_user_is_prompted_to_update_application_url
-      Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
-      api_key = '123'
-      stub_partner_req(
-        'get_app_urls',
-        variables: {
-          apiKey: api_key,
-        },
-        resp: {
-          data: {
-            app: {
-              applicationUrl: 'https://123abc.ngrok.io',
+        stub_partner_req(
+          'update_dashboard_urls',
+          variables: {
+            input: {
+              applicationUrl: 'https://newone123.ngrok.io',
               redirectUrlWhitelist: [
-                'https://123abc.ngrok.io',
-                'https://123abc.ngrok.io/callback/fake',
+                'https://newone123.ngrok.io',
+                'https://newone123.ngrok.io/callback/fake',
               ],
+              apiKey: api_key,
+            },
+          }
+        )
+        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+          @context,
+          url: 'https://newone123.ngrok.io',
+          callback_url: '/callback/fake',
+        )
+      end
+
+      def test_user_is_prompted_to_update_application_url
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
+        api_key = '123'
+        stub_partner_req(
+          'get_app_urls',
+          variables: {
+            apiKey: api_key,
+          },
+          resp: {
+            data: {
+              app: {
+                applicationUrl: 'https://123abc.ngrok.io',
+                redirectUrlWhitelist: [
+                  'https://123abc.ngrok.io',
+                  'https://123abc.ngrok.io/callback/fake',
+                ],
+              },
             },
           },
-        },
-      )
-      CLI::UI::Prompt.expects(:confirm).returns(true)
-      ShopifyCli::Tasks::UpdateDashboardURLS.call(
-        @context,
-        url: 'https://123adifferenturl.ngrok.io',
-        callback_url: '/callback/fake',
-      )
+        )
+
+        stub_partner_req(
+          'update_dashboard_urls',
+          variables: {
+            input: {
+              applicationUrl: 'https://123adifferenturl.ngrok.io',
+              redirectUrlWhitelist: [
+                'https://123adifferenturl.ngrok.io',
+                'https://123adifferenturl.ngrok.io/callback/fake',
+              ],
+              apiKey: api_key,
+            },
+          }
+        )
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+          @context,
+          url: 'https://123adifferenturl.ngrok.io',
+          callback_url: '/callback/fake',
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #767 

### WHAT is this pull request doing?

- `Tunnel.start` displays when the tunnel will timeout if there's no account associated with `ngrok`
- `Tunnel.start` prints a message suggesting to sign up if there's no account associated with `ngrok`

```
% shopify tunnel start
✓ ngrok tunnel running at https://bc662f568adc.ngrok.io
⭑ This tunnel will timeout in 7 hours 8 minutes
⭑ To avoid tunnels that timeout, it is recommended to signup for a free ngrok
account at https://ngrok.com/signup. After you signup, install your
personalized authorization token using shopify tunnel auth <token>.
%
```

- `Tunnel.start` determines if a currently running tunnel has timed out, and restarts it automatically
```
% shopify tunnel start        
✗ ngrok tunnel has timed out, restarting ...
✓ ngrok tunnel running at https://247cffa54d35.ngrok.io
⭑ This tunnel will timeout in 7 hours 59 minutes
⭑ To avoid tunnels that timeout, it is recommended to signup for a free ngrok
account at https://ngrok.com/signup. After you signup, install your
personalized authorization token using shopify tunnel auth <token>.
%
```
NB: all of the above will apply to `shopify serve` also.

- Add `-inspect=false` to `ngrok` command to disable storage of packets for inspection (should aid performance)
- Updated `UpdateDashboardURLS` to actually update the redirection URLs array, instead of repeatedly adding to it for each new tunnel.
- Updated tests for the above.

