### PR TITLE
Command to create Theme

### DIFF
--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 module Theme
   class Project < ShopifyCli::ProjectType
-    hidden_project_type
+    hidden_feature
     creator 'Theme App', 'Theme::Commands::Create'
+
+    require Project.project_filepath('messages/messages')
+    register_messages(Theme::Messages::MESSAGES)
   end
 
   module Commands
+    autoload :Create, Project.project_filepath('commands/create')
   end
 
   module Tasks
@@ -13,5 +17,8 @@ module Theme
   end
 
   module Forms
+    autoload :Create, Project.project_filepath('forms/create')
   end
+
+  autoload :Themekit, Project.project_filepath('themekit')
 end

--- a/lib/project_types/theme/commands/create.rb
+++ b/lib/project_types/theme/commands/create.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+module Theme
+  module Commands
+    class Create < ShopifyCli::SubCommand
+      # prerequisite_task :ensure_themekit_installed # doesn't work
+
+      options do |parser, flags|
+        parser.on('--name=NAME') { |t| flags[:title] = t }
+        parser.on('--password=PASSWORD') { |p| flags[:password] = p }
+        parser.on('--store=STORE') { |url| flags[:store] = url }
+      end
+
+      def call(args, _name)
+        form = Forms::Create.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) if form.nil?
+
+        build(form.name, form.password, form.store)
+        ShopifyCli::Project.write(@ctx,
+                                  project_type: 'theme',
+                                  organization_id: nil) # private apps are different
+      end
+
+      def self.help
+      end
+
+      private
+
+      def build(name, password, store)
+        unless name == "" || password == "" || store == ""
+          Dir.mkdir(name)
+          Dir.chdir(name)
+        end
+
+        CLI::UI::Frame.open(@ctx.message('create.creating_theme', name)) do
+          unless Themekit.create(@ctx, name: name, password: password, store: store) # this one has continuous output
+            @ctx.abort('error')
+          end
+          # out, err, stat = Themekit.create(@ctx, name: name, password: password, store: store)
+          # @ctx.puts out
+          # unless stat
+          #   CLI::UI::Frame.divider("error")
+          #   @ctx.puts(err)
+          # end
+        end
+        @ctx.root = File.join(@ctx.root, name)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/forms/create.rb
+++ b/lib/project_types/theme/forms/create.rb
@@ -1,0 +1,16 @@
+module Theme
+  module Forms
+    class Create < ShopifyCli::Form
+      attr_accessor :name
+      flag_arguments :title, :password, :store
+
+      def ask
+        self.store ||= CLI::UI::Prompt.ask("Store domain: ")
+        ctx.puts("To create a new theme, we need to connect with a private app. Visit {{underline:#{self.store}/admin/apps/private}} to fetch the password. If you create a new private app, ensure that it has Read and Write Theme access.")
+        self.password ||= CLI::UI::Prompt.ask("Password: ")
+        self.title ||= CLI::UI::Prompt.ask("Title: ")
+        self.name = self.title.downcase.split(" ").join("_")
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/forms/create.rb
+++ b/lib/project_types/theme/forms/create.rb
@@ -5,11 +5,17 @@ module Theme
       flag_arguments :title, :password, :store
 
       def ask
-        self.store ||= CLI::UI::Prompt.ask("Store domain: ")
-        ctx.puts("To create a new theme, we need to connect with a private app. Visit {{underline:#{self.store}/admin/apps/private}} to fetch the password. If you create a new private app, ensure that it has Read and Write Theme access.")
-        self.password ||= CLI::UI::Prompt.ask("Password: ")
-        self.title ||= CLI::UI::Prompt.ask("Title: ")
+        self.store ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.create.ask_store'), allow_empty: false)
+        ctx.puts(ctx.message('theme.forms.create.private_app', self.store))
+        self.password ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.create.ask_password'), allow_empty: false)
+        self.title ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.create.ask_title'), allow_empty: false)
         self.name = self.title.downcase.split(" ").join("_")
+
+        errors = []
+        errors << "store" if store.strip.empty?
+        errors << "password" if password.strip.empty?
+        errors << "title" if title.strip.empty?
+        ctx.abort(ctx.message('theme.forms.create.errors', errors.join(", ").capitalize)) unless errors.empty?
       end
     end
   end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -2,6 +2,9 @@
 module Theme
   module Messages
     MESSAGES = {
+      create: {
+        creating_theme: "Creating theme %s",
+      },
       ensure_themekit_installed: {
         downloading: "Downloading Themekit %s",
         failed: "Download failed",

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -2,15 +2,47 @@
 module Theme
   module Messages
     MESSAGES = {
-      create: {
-        creating_theme: "Creating theme %s",
-      },
-      ensure_themekit_installed: {
-        downloading: "Downloading Themekit %s",
-        failed: "Download failed",
-        successful: "Themekit installed successfully",
-        unsuccessful: "Unable to verify download digest",
-        verifying: "Verifying download...",
+      theme: {
+        create: {
+          creating_theme: "Creating theme %s",
+          checking_themekit: "Verifying Theme Kit",
+          failed: "Theme could not be created",
+          help: <<~HELP,
+            {{command:%s create theme}}: Creates a theme.
+              Usage: {{command:%s create theme}}
+              Options:
+                {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store.
+                {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
+                {{command:--name=NAME}} Theme name. Any string.
+          HELP
+          info: {
+            created: "{{green:%s}} was created for {{underline:%s}} in {{green:%s}}",
+          },
+        },
+        forms: {
+          create: {
+            ask_password: "Password:",
+            ask_store: "Store domain:",
+            ask_title: "Title:",
+            errors: "%s cannot be empty",
+            private_app: <<~APP,
+              To create a new theme, we need to connect with a private app. Visit {{underline:%s/admin/apps/private}} to fetch the password.
+              If you create a new private app, ensure that it has Read and Write Theme access.",
+            APP
+          },
+        },
+        tasks: {
+          ensure_themekit_installed: {
+            downloading: "Downloading Theme Kit %s",
+            errors: {
+              digest_fail: "Unable to verify download digest",
+              releases_fail: "Unable to fetch Theme Kit releases",
+              write_fail: "Unable to download Theme Kit",
+            },
+            successful: "Theme Kit installed successfully",
+            verifying: "Verifying download...",
+          },
+        },
       },
     }.freeze
   end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -6,7 +6,7 @@ module Theme
         create: {
           creating_theme: "Creating theme %s",
           checking_themekit: "Verifying Theme Kit",
-          failed: "Theme could not be created",
+          failed: "Couldn't create the theme",
           help: <<~HELP,
             {{command:%s create theme}}: Creates a theme.
               Usage: {{command:%s create theme}}
@@ -24,9 +24,9 @@ module Theme
             ask_password: "Password:",
             ask_store: "Store domain:",
             ask_title: "Title:",
-            errors: "%s cannot be empty",
+            errors: "%s can't be blank",
             private_app: <<~APP,
-              To create a new theme, we need to connect with a private app. Visit {{underline:%s/admin/apps/private}} to fetch the password.
+              To create a new theme, Shopify App CLI needs to connect with a private app installed on your store. Visit {{underline:%s/admin/apps/private}} to create a new API key and password, or retrieve an existing password.
               If you create a new private app, ensure that it has Read and Write Theme access.",
             APP
           },
@@ -35,8 +35,8 @@ module Theme
           ensure_themekit_installed: {
             downloading: "Downloading Theme Kit %s",
             errors: {
-              digest_fail: "Unable to verify download digest",
-              releases_fail: "Unable to fetch Theme Kit releases",
+              digest_fail: "Unable to verify download",
+              releases_fail: "Unable to fetch Theme Kit's list of releases",
               write_fail: "Unable to download Theme Kit",
             },
             successful: "Theme Kit installed successfully",

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -1,7 +1,6 @@
 module Theme
   module Tasks
     class EnsureThemekitInstalled < ShopifyCli::Task
-      FILENAME = File.join(ShopifyCli::CACHE_DIR, "themekit")
       URL = 'https://shopify-themekit.s3.amazonaws.com/releases/latest.json'
       OSMAP = {
         mac: 'darwin-amd64',
@@ -10,7 +9,7 @@ module Theme
       }
 
       def call(ctx)
-        return if File.exist?(FILENAME)
+        return if File.exist?(Themekit::THEMEKIT)
 
         require 'json'
         require 'net/http'
@@ -21,18 +20,19 @@ module Theme
           releases = JSON.parse(Net::HTTP.get(URI(URL)))
           release = releases["platforms"].find { |r| r["name"] == OSMAP[ctx.os] }
           ctx.puts(ctx.message('ensure_themekit_installed.downloading', releases['version']))
-          File.write(FILENAME, Net::HTTP.get(URI.parse(release["url"])))
+          File.write(Themekit::THEMEKIT, Net::HTTP.get(URI.parse(release["url"])).force_encoding("UTF-8"))
           ctx.puts(ctx.message('ensure_themekit_installed.verifying'))
 
-          if Digest::MD5.file(FILENAME) == release["digest"]
-            FileUtils.chmod("+x", FILENAME)
+          if Digest::MD5.file(Themekit::THEMEKIT) == release["digest"]
+            FileUtils.chmod("+x", Themekit::THEMEKIT)
             ctx.puts(ctx.message('ensure_themekit_installed.successful'))
           else
             ctx.puts(ctx.message('ensure_themekit_installed.unsuccessful'))
-            FileUtils.rm(FILENAME)
+            FileUtils.rm(Themekit::THEMEKIT)
           end
         rescue
           ctx.puts(ctx.message('ensure_themekit_installed.failed'))
+          FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)
         end
       end
     end

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -9,31 +9,35 @@ module Theme
       }
 
       def call(ctx)
-        return if File.exist?(Themekit::THEMEKIT)
+        _out, stat = ctx.capture2e(Themekit::THEMEKIT)
+        return if stat.success?
 
         require 'json'
-        require 'net/http'
         require 'fileutils'
         require 'digest'
+        require 'open-uri'
 
         begin
           releases = JSON.parse(Net::HTTP.get(URI(URL)))
           release = releases["platforms"].find { |r| r["name"] == OSMAP[ctx.os] }
-          ctx.puts(ctx.message('ensure_themekit_installed.downloading', releases['version']))
-          File.write(Themekit::THEMEKIT, Net::HTTP.get(URI.parse(release["url"])).force_encoding("UTF-8"))
-          ctx.puts(ctx.message('ensure_themekit_installed.verifying'))
-
-          if Digest::MD5.file(Themekit::THEMEKIT) == release["digest"]
-            FileUtils.chmod("+x", Themekit::THEMEKIT)
-            ctx.puts(ctx.message('ensure_themekit_installed.successful'))
-          else
-            ctx.puts(ctx.message('ensure_themekit_installed.unsuccessful'))
-            FileUtils.rm(Themekit::THEMEKIT)
-          end
         rescue
-          ctx.puts(ctx.message('ensure_themekit_installed.failed'))
-          FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)
+          ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.releases_fail'))
         end
+
+        ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.downloading', releases['version']))
+        _out, stat = ctx.capture2e('curl', '-o', Themekit::THEMEKIT, release["url"])
+        ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) unless stat.success?
+
+        ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.verifying'))
+        if Digest::MD5.file(Themekit::THEMEKIT) == release['digest']
+          FileUtils.chmod("+x", Themekit::THEMEKIT)
+          ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.successful'))
+        else
+          ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.digest_fail'))
+        end
+      rescue StandardError, ShopifyCli::Abort => e
+        FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)
+        raise e
       end
     end
   end

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -1,0 +1,27 @@
+module Theme
+  class Themekit
+    THEMEKIT = File.join(ShopifyCli::CACHE_DIR, "themekit")
+
+    class << self
+      def create(ctx, password:, store:, name:)
+        ensure_themekit_installed(ctx)
+        # out, err, stat = ctx.capture3(THEMEKIT,
+        #                                 "new",
+        #                                 "--password=#{password}",
+        #                                 "--store=#{store}",
+        #                                 "--name=#{name}")
+        # [out, err == "" ? nil : err, stat.success?]
+        stat = ctx.system(THEMEKIT,
+                          "new",
+                          "--password=#{password}",
+                          "--store=#{store}",
+                          "--name=#{name}")
+        stat.success?
+      end
+
+      def ensure_themekit_installed(ctx)
+        Tasks::EnsureThemekitInstalled.call(ctx)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -4,13 +4,6 @@ module Theme
 
     class << self
       def create(ctx, password:, store:, name:)
-        ensure_themekit_installed(ctx)
-        # out, err, stat = ctx.capture3(THEMEKIT,
-        #                                 "new",
-        #                                 "--password=#{password}",
-        #                                 "--store=#{store}",
-        #                                 "--name=#{name}")
-        # [out, err == "" ? nil : err, stat.success?]
         stat = ctx.system(THEMEKIT,
                           "new",
                           "--password=#{password}",

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -1,6 +1,6 @@
 module Theme
   class Themekit
-    THEMEKIT = File.join(ShopifyCli::CACHE_DIR, "themekit")
+    THEMEKIT = File.join(ShopifyCli.cache_dir, "themekit")
 
     class << self
       def create(ctx, password:, store:, name:)

--- a/test/project_types/theme/commands/create_test.rb
+++ b/test/project_types/theme/commands/create_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class CreateTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      SHOPIFYCLI_FILE = <<~CLI
+        ---
+        project_type: theme
+        organization_id: 0
+      CLI
+
+      def test_can_create_new_theme
+        FakeFS do
+          context = ShopifyCli::Context.new
+          Themekit.expects(:ensure_themekit_installed).with(context)
+          Theme::Forms::Create.expects(:ask)
+            .with(context, [], {})
+            .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
+                                                             store: 'shop.myshopify.com',
+                                                             title: 'My Theme',
+                                                             name: 'my_theme' }))
+          Themekit.expects(:create)
+            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme')
+            .returns(true)
+          context.expects(:done).with(context.message('theme.create.info.created',
+                                                      'my_theme',
+                                                      'shop.myshopify.com',
+                                                      File.join('', 'my_theme')))
+
+          Theme::Commands::Create.ctx = context
+          Theme::Commands::Create.call([], 'create', nil)
+
+          assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/forms/create_test.rb
+++ b/test/project_types/theme/forms/create_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Forms
+    class CreateTest < MiniTest::Test
+      def test_returns_all_defined_attributes_if_valid
+        form = ask
+        assert_equal(form.store, 'shop.myshopify.com')
+        assert_equal(form.password, 'boop')
+        assert_equal(form.title, 'My Theme')
+        assert_equal(form.name, 'my_theme')
+      end
+
+      def test_store_can_be_provided_by_flag
+        form = ask(store: 'shop.myshopify.com')
+        assert_equal(form.store, 'shop.myshopify.com')
+      end
+
+      def test_store_is_prompted
+        CLI::UI::Prompt.expects(:ask)
+          .with(@context.message('theme.forms.create.ask_store'), allow_empty: false)
+          .returns('shop.myshopify.com')
+        ask(store: nil)
+      end
+
+      def test_password_can_be_provided_by_flag
+        form = ask(password: 'boop')
+        assert_equal(form.password, 'boop')
+      end
+
+      def test_password_is_prompted
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_password'), allow_empty: false)
+          .returns('boop')
+        ask(password: nil)
+      end
+
+      def test_title_can_be_provided_by_flag
+        form = ask(title: 'My Theme')
+        assert_equal(form.name, 'my_theme')
+        assert_equal(form.title, 'My Theme')
+      end
+
+      def test_title_is_prompted
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_title'), allow_empty: false)
+          .returns('My Theme')
+        assert_equal(ask.name, 'my_theme')
+        ask(title: nil)
+      end
+
+      def test_aborts_if_field_empty
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_store'), allow_empty: false)
+          .returns(' ')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_password'), allow_empty: false)
+          .returns(' ')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_title'), allow_empty: false)
+          .returns(' ')
+        @context.expects(:abort)
+          .with(@context.message('theme.forms.create.errors', 'store, password, title'.capitalize))
+
+        ask(store: nil, password: nil, title: nil)
+      end
+
+      private
+
+      def ask(title: 'My Theme', password: 'boop', store: 'shop.myshopify.com')
+        Create.ask(
+          @context,
+          [],
+          title: title,
+          password: password,
+          store: store
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
+++ b/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
@@ -10,41 +10,40 @@ module Theme
       end
 
       def test_does_nothing_if_themekit_installed
-        File.expects(:exist?).with(EnsureThemekitInstalled::FILENAME).returns(true)
+        File.expects(:exist?).with(Themekit::THEMEKIT).returns(true)
         assert_nothing_raised do
           EnsureThemekitInstalled.call(@context)
         end
       end
 
       def test_installs_and_makes_executable_if_not_installed
-        File.expects(:exist?).with(EnsureThemekitInstalled::FILENAME).returns(false)
+        File.expects(:exist?).with(Themekit::THEMEKIT).returns(false)
         stub_releases
         stub_themekit_file_write
-        Digest::MD5.expects(:file).with(EnsureThemekitInstalled::FILENAME).returns('boop')
-        FileUtils.expects(:chmod).with('+x', EnsureThemekitInstalled::FILENAME)
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('boop')
+        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT)
 
         EnsureThemekitInstalled.call(@context)
       end
 
       def test_deletes_if_bad_digest
-        File.expects(:exist?).with(EnsureThemekitInstalled::FILENAME).returns(false)
+        File.expects(:exist?).with(Themekit::THEMEKIT).returns(false)
         stub_releases
         stub_themekit_file_write
-        Digest::MD5.expects(:file).with(EnsureThemekitInstalled::FILENAME).returns('mlem')
-        FileUtils.expects(:chmod).with('+x', EnsureThemekitInstalled::FILENAME).never
-        FileUtils.expects(:rm).with(EnsureThemekitInstalled::FILENAME)
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('mlem')
+        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+        FileUtils.expects(:rm).with(Themekit::THEMEKIT)
 
         EnsureThemekitInstalled.call(@context)
       end
 
       def test_fails_gracefully_if_errors
-        File.expects(:exist?).with(EnsureThemekitInstalled::FILENAME).returns(false)
+        File.expects(:exist?).with(Themekit::THEMEKIT).returns(false)
         stub_request(:get, EnsureThemekitInstalled::URL).to_return(status: 504)
         File.expects(:write)
-          .with(EnsureThemekitInstalled::FILENAME, 'this is data').never
-        Digest::MD5.expects(:file).with(EnsureThemekitInstalled::FILENAME).never
-        FileUtils.expects(:chmod).with('+x', EnsureThemekitInstalled::FILENAME).never
-        FileUtils.expects(:rm).with(EnsureThemekitInstalled::FILENAME).never
+          .with(Themekit::THEMEKIT, 'this is data').never
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).never
+        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
 
         assert_nothing_raised do
           EnsureThemekitInstalled.call(@context)
@@ -82,7 +81,7 @@ module Theme
           .to_return(body: 'this is data')
 
         File.expects(:write)
-          .with(EnsureThemekitInstalled::FILENAME, 'this is data')
+          .with(Themekit::THEMEKIT, 'this is data')
       end
     end
   end

--- a/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
+++ b/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
@@ -10,47 +10,87 @@ module Theme
       end
 
       def test_does_nothing_if_themekit_installed
-        File.expects(:exist?).with(Themekit::THEMEKIT).returns(true)
+        stat = mock
+        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(['out', stat])
+        stat.stubs(:success?).returns(true)
+
         assert_nothing_raised do
           EnsureThemekitInstalled.call(@context)
         end
       end
 
       def test_installs_and_makes_executable_if_not_installed
-        File.expects(:exist?).with(Themekit::THEMEKIT).returns(false)
+        stub_check_executable
         stub_releases
         stub_themekit_file_write
+
         Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('boop')
         FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT)
 
         EnsureThemekitInstalled.call(@context)
       end
 
-      def test_deletes_if_bad_digest
-        File.expects(:exist?).with(Themekit::THEMEKIT).returns(false)
+      def test_fails_if_bad_digest
+        stub_check_executable
         stub_releases
         stub_themekit_file_write
+
         Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('mlem')
         FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+        File.expects(:exist?).with(Themekit::THEMEKIT).returns(true)
         FileUtils.expects(:rm).with(Themekit::THEMEKIT)
 
-        EnsureThemekitInstalled.call(@context)
+        assert_raises(ShopifyCli::Abort,
+                      @context.message('theme.tasks.ensure_themekit_installed.errors.digest_fail')) do
+          EnsureThemekitInstalled.call(@context)
+        end
       end
 
-      def test_fails_gracefully_if_errors
-        File.expects(:exist?).with(Themekit::THEMEKIT).returns(false)
+      def test_fails_gracefully_if_network_errors
+        stat = mock
+        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(['out', stat])
+        stat.stubs(:success?).returns(false)
         stub_request(:get, EnsureThemekitInstalled::URL).to_return(status: 504)
-        File.expects(:write)
-          .with(Themekit::THEMEKIT, 'this is data').never
+
+        @context.expects(:capture2e)
+          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
+          .never
         Digest::MD5.expects(:file).with(Themekit::THEMEKIT).never
         FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
 
-        assert_nothing_raised do
+        assert_raises(ShopifyCli::Abort,
+                      @context.message('theme.tasks.ensure_themekit_installed.errors.releases_fail')) do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      def test_fails_if_bad_write
+        stub_check_executable
+        stub_releases
+
+        stat = mock
+        @context.expects(:capture2e)
+          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
+          .returns(['out', stat])
+        stat.stubs(:success?).returns(false)
+
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).never
+        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+        File.expects(:exist?).with(Themekit::THEMEKIT).returns(true)
+        FileUtils.expects(:rm).with(Themekit::THEMEKIT)
+
+        assert_raises(ShopifyCli::Abort, @context.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) do
           EnsureThemekitInstalled.call(@context)
         end
       end
 
       private
+
+      def stub_check_executable
+        stat = mock
+        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(['out', stat])
+        stat.stubs(:success?).returns(false)
+      end
 
       def stub_releases
         stub_request(:get, EnsureThemekitInstalled::URL)
@@ -77,11 +117,11 @@ module Theme
       end
 
       def stub_themekit_file_write
-        stub_request(:get, 'http://www.website.ca')
-          .to_return(body: 'this is data')
-
-        File.expects(:write)
-          .with(Themekit::THEMEKIT, 'this is data')
+        stat = mock
+        @context.expects(:capture2e)
+          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
+          .returns(['out', stat])
+        stat.stubs(:success?).returns(true)
       end
     end
   end

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  class ThemekitTest < MiniTest::Test
+    def test_themekit_install
+      Theme::Tasks::EnsureThemekitInstalled.expects(:call).with(@context)
+      Themekit.ensure_themekit_installed(@context)
+    end
+
+    def test_create_theme_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'new',
+              '--password=boop',
+              '--store=shop.myshopify.com',
+              '--name=My Theme')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.create(context, password: 'boop', store: 'shop.myshopify.com', name: 'My Theme'))
+    end
+
+    def test_create_theme_unsuccessful
+      context = ShopifyCli::Context.new
+      stat = mock
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'new',
+              '--password=boop',
+              '--store=shop.com',
+              '--name=My Theme')
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+      refute(Themekit.create(context, password: 'boop', store: 'shop.com', name: 'My Theme'))
+    end
+  end
+end


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
- If we want to use Themekit on CLI, we must be able to create a new Theme
- Adapter class makes connection between Themekit and CLI much cleaner

### What is this pull request doing? 📋 
- Introduces `create theme` command to create new theme
  - Checks for Themekit executable before attempting to create new theme
  - Shows output from Themekit
- Creates and uses `themekit.rb` adapter class
- Moves and renames `Theme::Tasks::EnsureThemekitInstalled::FILENAME` constant to `Theme::Themekit::THEMEKIT`
- Tests for command, task, and adapter class