### PR TITLE
Update script build option

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -6,7 +6,7 @@ module Script
       class AssemblyScriptTaskRunner
         BYTECODE_FILE = "%{name}.wasm"
         SCRIPT_SDK_BUILD = "npx --no-install shopify-scripts-build --src=../%{source} --binary=#{BYTECODE_FILE} "\
-                           "-- --lib=../node_modules --validate --optimize"
+                           "-- --lib=../node_modules --optimize --use Date="
 
         attr_reader :ctx, :script_name, :script_source_file
 


### PR DESCRIPTION
### WHY are these changes introduced?

Ticket: https://github.com/Shopify/script-service/issues/592

* remove `--validate` as AS enables validation by default https://github.com/AssemblyScript/assemblyscript/pull/1258
* add `--use Date=` to get `Date` usage caught at AS compile time.

### WHAT is this pull request doing?

Before: no compilation errors with `Date.now()` usage
After:

<img width="1261" alt="Screen Shot 2020-07-23 at 4 27 10 PM" src="https://user-images.githubusercontent.com/1019171/88335496-65838180-cd01-11ea-8176-c49e3e138a68.png">


