### PR TITLE
Ensure Stable Data from PartnersAPI::Organizations

### DIFF
--- a/lib/shopify-cli/partners_api/organizations.rb
+++ b/lib/shopify-cli/partners_api/organizations.rb
@@ -4,25 +4,25 @@ module ShopifyCli
       class << self
         def fetch_all(ctx)
           resp = PartnersAPI.query(ctx, 'all_organizations')
-          resp['data']['organizations']['nodes'].map do |org|
-            org['stores'] = org['stores']['nodes']
+          (resp.dig('data', 'organizations', 'nodes') || []).map do |org|
+            org['stores'] = (org.dig('stores', 'nodes') || [])
             org
           end
         end
 
         def fetch(ctx, id:)
           resp = PartnersAPI.query(ctx, 'find_organization', id: id)
-          org = resp['data']['organizations']['nodes'].first
+          org = resp.dig('data', 'organizations', 'nodes').first
           return nil if org.nil?
-          org['stores'] = org['stores']['nodes']
+          org['stores'] = (org.dig('stores', 'nodes') || [])
           org
         end
 
         def fetch_with_app(ctx)
           resp = PartnersAPI.query(ctx, 'all_orgs_with_apps')
-          resp['data']['organizations']['nodes'].map do |org|
-            org['stores'] = org['stores']['nodes']
-            org['apps'] = org['apps']['nodes']
+          (resp.dig('data', 'organizations', 'nodes') || []).map do |org|
+            org['stores'] = (org.dig('stores', 'nodes') || [])
+            org['apps'] = (org.dig('apps', 'nodes') || [])
             org
           end
         end

--- a/test/shopify-cli/partners_api/organizations_test.rb
+++ b/test/shopify-cli/partners_api/organizations_test.rb
@@ -36,6 +36,30 @@ module ShopifyCli
         assert_equal(orgs.first['stores'].first['shopDomain'], 'shopdomain.myshopify.com')
       end
 
+      def test_fetch_all_handles_no_shops
+        stub_partner_req(
+          'all_organizations',
+          resp: {
+            data: { organizations: { nodes: [{ id: 42, stores: { nodes: [] } }] } },
+          }
+        )
+
+        orgs = PartnersAPI::Organizations.fetch_all(@context)
+        assert_equal(orgs.count, 1)
+        assert_equal(orgs.first['id'], 42)
+        assert_equal(orgs.first['stores'].count, 0)
+      end
+
+      def test_fetch_all_handles_no_orgs
+        stub_partner_req(
+          'all_organizations',
+          resp: { data: { organizations: { nodes: [] } } }
+        )
+
+        orgs = PartnersAPI::Organizations.fetch_all(@context)
+        assert_equal(orgs.count, 0)
+      end
+
       def test_fetch_queries_partners
         stub_partner_req(
           'find_organization',
@@ -81,6 +105,29 @@ module ShopifyCli
 
         org = PartnersAPI::Organizations.fetch(@context, id: 42)
         assert_nil(org)
+      end
+
+      def test_fetch_handles_no_shops
+        stub_partner_req(
+          'find_organization',
+          variables: { id: 42 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 42,
+                    stores: { nodes: [] },
+                  },
+                ],
+              },
+            },
+          }
+        )
+
+        org = PartnersAPI::Organizations.fetch(@context, id: 42)
+        assert_equal(org['id'], 42)
+        assert_equal(org['stores'].count, 0)
       end
 
       def test_fetch_org_with_app_info
@@ -135,6 +182,31 @@ module ShopifyCli
         assert_equal(orgs.count, 2)
         assert_equal(orgs.first['id'], 421)
         assert_equal(orgs.first['stores'].first['shopDomain'], 'store.myshopify.com')
+      end
+
+      def test_fetch_org_with_empty_app_info
+        stub_partner_req(
+          'all_orgs_with_apps',
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    'id': 421,
+                    'businessName': "one",
+                    'stores': { 'nodes': [] },
+                    'apps': { nodes: [] },
+                  },
+                ],
+              },
+            },
+          },
+        )
+        orgs = PartnersAPI::Organizations.fetch_with_app(@context)
+        assert_equal(orgs.count, 1)
+        assert_equal(orgs.first['id'], 421)
+        assert_equal(orgs.first['stores'].count, 0)
+        assert_equal(orgs.first['apps'].count, 0)
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #779
fixes #732

Currently if there is an issue fetching organization data from the partners API, we throw an error before we are able to provide the user with helpful output. This PR just makes these API calls more safe by using `dig` instead of direct hash access so it is safer and will return nil if the data does not exist. Then I have wrapped this with a default empty array value so that the value is usable.
