### PR TITLE
Fix tunnel and process supervision on Windows

### DIFF
--- a/lib/project_types/node/commands/deploy/heroku.rb
+++ b/lib/project_types/node/commands/deploy/heroku.rb
@@ -19,10 +19,15 @@ module Node
           end
           spin_group.wait
 
-          spin_group.add(@ctx.message('node.deploy.heroku.installing')) do |spinner|
+          install_message = @ctx.message(
+            @ctx.windows? ? 'node.deploy.heroku.installing_windows' : 'node.deploy.heroku.installing'
+          )
+          spin_group.add(install_message) do |spinner|
             heroku_service.install
             spinner.update_title(@ctx.message('node.deploy.heroku.installed'))
           end
+          spin_group.wait
+
           spin_group.add(@ctx.message('node.deploy.heroku.git.checking')) do |spinner|
             ShopifyCli::Git.init(@ctx)
             spinner.update_title(@ctx.message('node.deploy.heroku.git.initialized'))

--- a/lib/project_types/node/commands/generate/billing.rb
+++ b/lib/project_types/node/commands/generate/billing.rb
@@ -5,8 +5,8 @@ module Node
     class Generate
       class Billing < ShopifyCli::SubCommand
         BILLING_TYPES = {
-          'recurring-billing' => './node_modules/.bin/generate-node-app recurring-billing',
-          'one-time-billing' => './node_modules/.bin/generate-node-app one-time-billing',
+          'recurring-billing' => ['./node_modules/.bin/generate-node-app', 'recurring-billing'],
+          'one-time-billing' => ['./node_modules/.bin/generate-node-app', 'one-time-billing'],
         }
         def call(args, _name)
           selected_type = BILLING_TYPES[args[1]]
@@ -18,11 +18,12 @@ module Node
             end
           end
           billing_type_name = BILLING_TYPES.key(selected_type)
+          selected_type[0] = File.join(ShopifyCli::Project.current.directory, selected_type[0])
+          selected_type = selected_type.join(' ')
+
           spin_group = CLI::UI::SpinGroup.new
           spin_group.add(@ctx.message('node.generate.billing.generating', billing_type_name)) do |spinner|
-            Node::Commands::Generate.run_generate(
-              selected_type, billing_type_name, @ctx
-            )
+            Node::Commands::Generate.run_generate(selected_type, billing_type_name, @ctx)
             spinner.update_title(@ctx.message('node.generate.billing.generated', billing_type_name))
           end
           spin_group.wait

--- a/lib/project_types/node/commands/generate/page.rb
+++ b/lib/project_types/node/commands/generate/page.rb
@@ -5,10 +5,10 @@ module Node
     class Generate
       class Page < ShopifyCli::SubCommand
         PAGE_TYPES = {
-          'empty-state' => './node_modules/.bin/generate-node-app empty-state-page',
-          'two-column' => './node_modules/.bin/generate-node-app two-column-page',
-          'annotated' => './node_modules/.bin/generate-node-app settings-page',
-          'list' => './node_modules/.bin/generate-node-app list-page',
+          'empty-state' => ['./node_modules/.bin/generate-node-app', 'empty-state-page'],
+          'two-column' => ['./node_modules/.bin/generate-node-app', 'two-column-page'],
+          'annotated' => ['./node_modules/.bin/generate-node-app', 'settings-page'],
+          'list' => ['./node_modules/.bin/generate-node-app', 'list-page'],
         }
 
         options do |parser, flags|
@@ -37,9 +37,12 @@ module Node
               end
             end
           end
+          page_type_name = PAGE_TYPES.key(selected_type)
+          selected_type[0] = File.join(ShopifyCli::Project.current.directory, selected_type[0])
+          selected_type = selected_type.join(' ')
 
           spin_group = CLI::UI::SpinGroup.new
-          spin_group.add(@ctx.message('node.generate.page.generating', selected_type)) do |spinner|
+          spin_group.add(@ctx.message('node.generate.page.generating', page_type_name)) do |spinner|
             Node::Commands::Generate.run_generate("#{selected_type} #{name}", name, @ctx)
             spinner.update_title(@ctx.message('node.generate.page.generated', name, name))
           end

--- a/lib/project_types/node/commands/generate/webhook.rb
+++ b/lib/project_types/node/commands/generate/webhook.rb
@@ -15,9 +15,12 @@ module Node
               end
             end
           end
+
+          generate_path = File.join(ShopifyCli::Project.current.directory, "node_modules/.bin/generate-node-app")
+
           spin_group = CLI::UI::SpinGroup.new
           spin_group.add(@ctx.message('node.generate.webhook.generating', selected_type)) do |spinner|
-            Node::Commands::Generate.run_generate("./node_modules/.bin/generate-node-app webhook #{selected_type}",
+            Node::Commands::Generate.run_generate("#{generate_path} webhook #{selected_type}",
               selected_type, @ctx)
             spinner.update_title(@ctx.message('node.generate.webhook.generated', selected_type))
           end

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -54,6 +54,7 @@ module Node
             downloading: "Downloading Heroku CLI…",
             downloaded: "Downloaded Heroku CLI",
             installing: "Installing Heroku CLI…",
+            installing_windows: "Running Heroku CLI install wizard…",
             installed: "Installed Heroku CLI",
             authenticating: "Authenticating with Heroku…",
             authenticated: "{{v}} Authenticated with Heroku",

--- a/lib/shopify-cli/js_deps.rb
+++ b/lib/shopify-cli/js_deps.rb
@@ -69,7 +69,7 @@ module ShopifyCli
       deps = parse_dependencies
       errors = nil
 
-      spinner_title = ctx.message('core.js_deps.installing_deps', deps.size)
+      spinner_title = ctx.message('core.js_deps.installing', @system.package_manager)
       success = CLI::UI::Spinner.spin(spinner_title, auto_debrief: false) do |spinner|
         _, errors, status = CLI::Kit::System.capture3(*cmd, env: @ctx.env, chdir: ctx.root)
         update_spinner_title_and_status(spinner, status, deps)
@@ -81,7 +81,7 @@ module ShopifyCli
 
     def update_spinner_title_and_status(spinner, status, deps)
       if status.success?
-        spinner.update_title(ctx.message('core.js_deps.installed_deps', deps.size))
+        spinner.update_title(ctx.message('core.js_deps.installed', deps.size))
       else
         spinner.update_title(ctx.message('core.js_deps.error.install_spinner_error', deps.size))
         CLI::UI::Spinner::TASK_FAILED

--- a/lib/shopify-cli/process_supervision.rb
+++ b/lib/shopify-cli/process_supervision.rb
@@ -91,8 +91,7 @@ module ShopifyCli
       def stop(identifier)
         process = for_ident(identifier)
         return false unless process
-        ctx = Context.new
-        process.stop(ctx)
+        process.stop
       end
 
       ##
@@ -117,7 +116,6 @@ module ShopifyCli
       @identifier = identifier
       @pid = pid
       @time = time
-
       FileUtils.mkdir_p(ShopifyCli::ProcessSupervision.run_dir)
       @pid_path = File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.pid")
       @log_path = File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.log")
@@ -179,7 +177,7 @@ module ShopifyCli
       end
     rescue Errno::ESRCH
       begin
-        kill(ctx, pid)
+        kill(pid)
       rescue Errno::ESRCH # The process group does not exist, try the pid itself
         # Race condition, process died in the middle
       end

--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -21,6 +21,7 @@ module ShopifyCli
     DOWNLOAD_URLS = {
       mac: 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip',
       linux: 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip',
+      windows: 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip',
     }
 
     NGROK_TUNNELS_URI = URI.parse('http://localhost:4040/api/tunnels')
@@ -122,7 +123,7 @@ module ShopifyCli
     private
 
     def install(ctx)
-      return if File.exist?(File.join(ShopifyCli.cache_dir, 'ngrok'))
+      return if File.exist?(File.join(ShopifyCli.cache_dir, ctx.windows? ? 'ngrok.exe' : 'ngrok'))
       spinner = CLI::UI::SpinGroup.new
       spinner.add('Installing ngrok...') do
         zip_dest = File.join(ShopifyCli.cache_dir, 'ngrok.zip')
@@ -143,7 +144,7 @@ module ShopifyCli
     end
 
     def ngrok_command(port)
-      "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug #{port}"
+      "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -log=stdout -log-level=debug #{port}"
     end
 
     def seconds_to_hm(seconds)

--- a/test/project_types/node/commands/generate/billing_test.rb
+++ b/test/project_types/node/commands/generate/billing_test.rb
@@ -7,16 +7,18 @@ module Node
       class BillingTest < MiniTest::Test
         include TestHelpers::FakeUI
 
+        BIN_REGEX = 'node_modules\/\.bin\/generate-node-app'
+
         def test_recurring_billing
-          CLI::UI::Prompt.expects(:ask).returns('recurring-billing')
-          @context.expects(:system).with('recurring-billing')
+          CLI::UI::Prompt.expects(:ask).returns(Node::Commands::Generate::Billing::BILLING_TYPES['recurring-billing'])
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} recurring-billing$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Billing.new(@context).call([], '')
         end
 
         def test_one_time_billing
-          CLI::UI::Prompt.expects(:ask).returns('one-time-billing')
-          @context.expects(:system).with('one-time-billing')
+          CLI::UI::Prompt.expects(:ask).returns(Node::Commands::Generate::Billing::BILLING_TYPES['one-time-billing'])
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} one-time-billing$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Billing.new(@context).call([], '')
         end

--- a/test/project_types/node/commands/generate/page_test.rb
+++ b/test/project_types/node/commands/generate/page_test.rb
@@ -8,9 +8,13 @@ module Node
         include TestHelpers::Project
         include TestHelpers::FakeUI
 
+        BIN_REGEX = 'node_modules\/\.bin\/generate-node-app'
+
         def test_with_selection
-          CLI::UI::Prompt.expects(:ask).returns('empty-state')
-          @context.expects(:system).with('empty-state name')
+          CLI::UI::Prompt.expects(:ask).returns(Node::Commands::Generate::Page::PAGE_TYPES['empty-state'])
+          @context
+            .expects(:system)
+            .with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} empty-state-page name$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Page.new(@context).call(['name'], '')
         end
@@ -19,7 +23,7 @@ module Node
           CLI::UI::Prompt.expects(:ask).never
           @context
             .expects(:system)
-            .with('./node_modules/.bin/generate-node-app list-page name')
+            .with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} list-page name$")))
             .returns(mock(success?: true))
           command = Node::Commands::Generate::Page.new(@context)
           command.options.flags[:type] = 'list'

--- a/test/project_types/node/commands/generate/webhook_test.rb
+++ b/test/project_types/node/commands/generate/webhook_test.rb
@@ -8,22 +8,24 @@ module Node
         include TestHelpers::FakeUI
         include TestHelpers::Schema
 
+        BIN_REGEX = 'node_modules\/\.bin\/generate-node-app'
+
         def test_with_existing_param
-          @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook APP_UNINSTALLED')
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} webhook APP_UNINSTALLED$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Webhook.new(@context).call(['APP_UNINSTALLED'], '')
         end
 
         def test_with_incorrect_param_expects_ask
           CLI::UI::Prompt.expects(:ask).returns('APP_UNINSTALLED')
-          @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook APP_UNINSTALLED')
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} webhook APP_UNINSTALLED$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Webhook.new(@context).call(['create_webhook_fake'], '')
         end
 
         def test_with_selection
           CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
-          @context.expects(:system).with('./node_modules/.bin/generate-node-app webhook PRODUCT_CREATE')
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} webhook PRODUCT_CREATE$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Webhook.new(@context).call([], '')
         end

--- a/test/shopify-cli/process_supervision_test.rb
+++ b/test/shopify-cli/process_supervision_test.rb
@@ -18,13 +18,13 @@ module ShopifyCli
       process = start
       assert process.alive?
       assert ProcessSupervision.running?('example')
-      process.stop
+      process.stop(@context)
     end
 
     def test_alive
       process = start
       assert process.alive?
-      assert process.stop
+      assert process.stop(@context)
       refute process.alive?
     end
 

--- a/test/shopify-cli/process_supervision_test.rb
+++ b/test/shopify-cli/process_supervision_test.rb
@@ -18,13 +18,13 @@ module ShopifyCli
       process = start
       assert process.alive?
       assert ProcessSupervision.running?('example')
-      process.stop(@context)
+      process.stop
     end
 
     def test_alive
       process = start
       assert process.alive?
-      assert process.stop(@context)
+      assert process.stop
       refute process.alive?
     end
 

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -149,7 +149,7 @@ module ShopifyCli
       process.write
       File.write(process.log_path, File.read(log_path))
       yield
-      process.stop(@context)
+      process.stop
     end
 
     def mock_ngrok_tunnels_http_call(response_body:)

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -26,7 +26,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
         @context.expects(:puts).with(@context.message('core.tunnel.will_timeout', '7 hours 59 minutes'))
@@ -40,7 +40,7 @@ module ShopifyCli
       with_log(time: start_time.to_s) do
         ShopifyCli::ProcessSupervision.expects(:start).twice.with(
           :ngrok,
-          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -log=stdout -log-level=debug 8081"
         ).returns(
           ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000, time: start_time.to_s)
         ).then.returns(
@@ -62,8 +62,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false"\
-          " -log=stdout -log-level=debug #{configured_port}"
+          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -log=stdout -log-level=debug #{configured_port}"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
         @context.expects(:puts).with(@context.message('core.tunnel.will_timeout', '7 hours 59 minutes'))
@@ -77,7 +76,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(
           @context.message('core.tunnel.start_with_account', 'https://example.ngrok.io', 'Tom Cruise')
@@ -91,7 +90,7 @@ module ShopifyCli
       with_log(fixture: 'ngrok_error') do
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         assert_raises ShopifyCli::Tunnel::NgrokError do
           ShopifyCli::Tunnel.start(@context)
@@ -150,7 +149,7 @@ module ShopifyCli
       process.write
       File.write(process.log_path, File.read(log_path))
       yield
-      process.stop
+      process.stop(@context)
     end
 
     def mock_ngrok_tunnels_http_call(response_body:)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

These are the same changes from #764, with the addition of a fix so that `tunnel start / stop` work on Windows as well. This PR means to enable us to run supervised commands on Windows, so that we can continue to work on the features that depend on it (node / rails serve, etc.).

### WHAT is this pull request doing?

* Replace `fork` with `Process.spawn` which is more cross-platform
* Kill the supervised process before deleting its stderr / stdout file, which is a requirement on Windows
* Adapt the Tunnel so that it works both OS