### PR TITLE
Update packages to enable WASI for script

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,24 +1,24 @@
 discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    version: "^0.2.3"
+    version: "^0.2.4"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
-    version: "^0.1.4"
+    version: "^0.1.6"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
-    version: "^0.2.1"
+    version: "^0.2.2"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"
 shipping_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-shipping-filter"
-    version: "^0.2.3"
+    version: "^0.2.4"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -86,14 +86,14 @@ module Script
                 "@shopify/scripts-toolchain-as": "#{extension_point.sdks[:ts].toolchain_version}",
                 "#{extension_point.sdks[:ts].package}": "#{extension_point.sdks[:ts].version}",
                 "@as-pect/cli": "4.0.0",
-                "as-wasi": "^0.0.1",
+                "as-wasi": "^0.2.0",
                 "assemblyscript": "^0.12.0"
               },
               "scripts": {
                 "test": "asp --config test/as-pect.config.js --summary --verbose"
               },
               "engines": {
-                "node": ">=12.16"
+                "node": ">=14.5"
               }
             }
           HERE

--- a/lib/project_types/script/templates/ts/as-pect.config.js
+++ b/lib/project_types/script/templates/ts/as-pect.config.js
@@ -17,5 +17,11 @@ module.exports = {
         reportMax: false,
         reportMin: false,
     },
+    wasi: {
+      args: [],
+      env: process.env,
+      preopens: {},
+      returnOnExit: false,
+    },
     outputBinary: false,
 };


### PR DESCRIPTION
### WHY are these changes introduced?

Ticket: https://github.com/Shopify/script-service/issues/948
After https://github.com/Shopify/extension-points/pull/120 gets deployed, we should make use of it in CLI. 

### WHAT is this pull request doing?

Update script related package versions to enable WASI support.
