### PR TITLE
[scripts] shipping-filter version bump

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -19,6 +19,6 @@ payment_filter:
 shipping_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-shipping-filter"
-    version: "^0.2.2"
+    version: "^0.2.3"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"


### PR DESCRIPTION
This merely updated to the latest shipping-filter ep

### WHY are these changes introduced?

There was a bug in the TestHelper for the `Address` type. This fixes it
