### PR TITLE
Improve error handling when passing config file

### DIFF
--- a/lib/project_types/script/commands/enable.rb
+++ b/lib/project_types/script/commands/enable.rb
@@ -32,6 +32,8 @@ module Script
           title: project.script_name
         ))
         @ctx.puts(@ctx.message('script.enable.info'))
+      rescue Errors::InvalidConfigYAMLError => e
+        UI::ErrorHandler.pretty_print_and_raise(e)
       rescue StandardError => e
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.enable.error.operation_failed'))
       end
@@ -59,6 +61,8 @@ module Script
           })
         end
         configuration
+      rescue Errno::ENOENT, Psych::SyntaxError
+        raise Errors::InvalidConfigYAMLError, options.flags[:config_file]
       end
 
       # No slice pre Ruby 2.5 so roll our own

--- a/lib/project_types/script/errors.rb
+++ b/lib/project_types/script/errors.rb
@@ -13,5 +13,11 @@ module Script
       end
     end
     class ScriptProjectAlreadyExistsError < ScriptProjectError; end
+    class InvalidConfigYAMLError < ScriptProjectError
+      attr_reader :config_file
+      def initialize(config_file)
+        @config_file = config_file
+      end
+    end
   end
 end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -38,6 +38,9 @@ module Script
           invalid_extension_cause: "Invalid extension point %s",
           invalid_extension_help: "Allowed values: %s.",
 
+          invalid_config: "Can't change the configuration values because %1$s is missing or "\
+                          "it is not formatted properly.",
+
           script_not_found_cause: "Couldn't find script %s for extension point %s",
 
           app_not_installed_cause: "App not installed on development store.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -44,6 +44,10 @@ module Script
             cause_of_error: ShopifyCli::Context.message('script.error.invalid_context_cause'),
             help_suggestion: ShopifyCli::Context.message('script.error.invalid_context_help'),
           }
+        when Errors::InvalidConfigYAMLError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.invalid_config', e.config_file),
+          }
         when Errors::InvalidScriptNameError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.invalid_script_name_cause'),


### PR DESCRIPTION
### WHAT is this pull request doing?

When passing in a configuration file or configuration properties to `enable` that cannot be parsed, we let the errors bubble up which are currently not user friendly in the case of a missing configuration file or one with improper syntax.

There is one error for both of these cases and it looks like the image below:

<img width="1414" alt="Screen Shot 2020-08-04 at 7 44 02 AM" src="https://user-images.githubusercontent.com/64974039/89308505-2faa9b00-d627-11ea-819d-404f031f5ad7.png">



