### PR TITLE
Show options in help for create command

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -32,12 +32,8 @@ module Script
       end
 
       def self.help
-        ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME)
-      end
-
-      def self.extended_help
         allowed_values = Script::Layers::Application::ExtensionPoints.types.map { |type| "{{cyan:#{type}}}" }
-        ShopifyCli::Context.message('script.create.extended_help', ShopifyCli::TOOL_NAME, allowed_values.join(', '))
+        ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME, allowed_values.join(', '))
       end
     end
   end

--- a/lib/project_types/script/commands/enable.rb
+++ b/lib/project_types/script/commands/enable.rb
@@ -40,10 +40,6 @@ module Script
         ShopifyCli::Context.message('script.enable.help', ShopifyCli::TOOL_NAME)
       end
 
-      def self.extended_help
-        ShopifyCli::Context.message('script.enable.extended_help', ShopifyCli::TOOL_NAME)
-      end
-
       private
 
       def acquire_configuration(config_file: nil, config_props: nil)

--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -31,10 +31,6 @@ module Script
       def self.help
         ShopifyCli::Context.message('script.push.help', ShopifyCli::TOOL_NAME)
       end
-
-      def self.extended_help
-        ShopifyCli::Context.message('script.push.extended_help', ShopifyCli::TOOL_NAME)
-      end
     end
   end
 end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -72,11 +72,9 @@ module Script
           help: <<~HELP,
           {{command:%1$s create script}}: Creates a script project.
             Usage: {{command:%1$s create script}}
-          HELP
-          extended_help: <<~HELP,
-            \s\sOptions:
-              \s\s{{command:--name=NAME}} Script project name. Use any string.
-              \s\s{{command:--extension_point=TYPE}} Extension point name. Allowed values: %2$s.
+            Options:
+              {{command:--name=NAME}} Script project name. Use any string.
+              {{command:--extension_point=TYPE}} Extension point name. Allowed values: %2$s.
           HELP
 
           error: {
@@ -92,10 +90,8 @@ module Script
           help: <<~HELP,
           Build the script and put it into production. If you've already pushed a script with the same extension point, use --force to replace the current script with the newest one.
             Usage: {{command:%s push}}
-          HELP
-          extended_help: <<~HELP,
-            \s\sOptions:
-              \s\s{{command:[--force]}} Forces the script to be overwritten if an instance of it already exists.
+            Options:
+              {{command:[--force]}} Forces the script to be overwritten if an instance of it already exists.
           HELP
 
           error: {
@@ -122,11 +118,9 @@ module Script
           help: <<~HELP,
           Turn on script in development store.
             Usage: {{command:%s enable}}
-          HELP
-          extended_help: <<~HELP,
-            \s\sOptions:
-              \s\s{{command:--config_props='name1:value1, name2:value2'}} Optional. Define the configuration of your script by passing individual name and value pairs. If used with --config_file, then matching values in --config_props will override those set in the file.
-              \s\s{{command:--config_file=<path/to/YAMLFilename>}} Optional. Define the configuration of your script using a YAML formatted file. --config_props values override properties in this file.
+            Options:
+              {{command:--config_props='name1:value1, name2:value2'}} Optional. Define the configuration of your script by passing individual name and value pairs. If used with --config_file, then matching values in --config_props will override those set in the file.
+              {{command:--config_file=<path/to/YAMLFilename>}} Optional. Define the configuration of your script using a YAML formatted file. --config_props values override properties in this file.
           HELP
 
           info: "{{*}} A script always remains enabled until you disable it - even after pushing "\

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -32,7 +32,7 @@ module ShopifyCli
       end
 
       def self.help
-        project_types = all_visible_type.map(&:project_type).join(" | ")
+        project_types = all_visible_type.map(&:project_type).sort.join(" | ")
         ShopifyCli::Context.message('core.create.help', ShopifyCli::TOOL_NAME, project_types)
       end
 

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -69,7 +69,7 @@ module Extension
         end
 
         output = io.join
-        refute_match('extension', output)
+        refute_match(' extension ', output)
       end
 
       private

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -40,18 +40,11 @@ module Script
       end
 
       def test_help
-        ShopifyCli::Context
-          .expects(:message)
-          .with('script.create.help', ShopifyCli::TOOL_NAME)
-        Script::Commands::Create.help
-      end
-
-      def test_extended_help
         Script::Layers::Application::ExtensionPoints.expects(:types).returns(%w(ep1 ep2))
         ShopifyCli::Context
           .expects(:message)
-          .with('script.create.extended_help', ShopifyCli::TOOL_NAME, '{{cyan:ep1}}, {{cyan:ep2}}')
-        Script::Commands::Create.extended_help
+          .with('script.create.help', ShopifyCli::TOOL_NAME, '{{cyan:ep1}}, {{cyan:ep2}}')
+        Script::Commands::Create.help
       end
 
       def test_cleanup_after_error

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -59,13 +59,6 @@ module Script
         Script::Commands::Push.help
       end
 
-      def test_extended_help
-        ShopifyCli::Context
-          .expects(:message)
-          .with('script.push.extended_help', ShopifyCli::TOOL_NAME)
-        Script::Commands::Push.extended_help
-      end
-
       private
 
       def perform_command


### PR DESCRIPTION
### WHAT is this pull request doing?

Scripts seem to be inconsistent with other project types in the CLI because we aren’t displaying options in `shopify create --help` since scripts only displays them in extended help, whereas other project types seem to have them in help. We want to look consistent for the preview.

As per the related ticket, we are looking at removing all extended help in script commands for consistency and moving options back to help.

This ticket also changes the ordering in help (`[node|rails|script]`)

**This is what it looked like before this change:**

<img width="1100" alt="Screen Shot 2020-07-21 at 10 12 11 AM" src="https://user-images.githubusercontent.com/64974039/88224150-6a6f0500-cc1d-11ea-8222-80a3931c75a0.png">

**This is what it looks like after this change:**

<img width="1092" alt="Screen Shot 2020-08-03 at 9 31 16 PM" src="https://user-images.githubusercontent.com/64974039/89254597-5db2bf80-d5d4-11ea-8e65-373c117a6119.png">


