### PR TITLE
Keep script dir if created with same name

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -26,6 +26,8 @@ module Script
           extension_point_type: form.extension_point
         )
         @ctx.puts(@ctx.message('script.create.change_directory_notice', project.script_name))
+      rescue Script::Errors::ScriptProjectAlreadyExistsError => e
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.create.error.operation_failed'))
       rescue StandardError => e
         ScriptProject.cleanup(ctx: @ctx, script_name: form.name, root_dir: cur_dir) if form
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.create.error.operation_failed'))

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -78,6 +78,28 @@ module Script
         refute @context.dir_exist?(@script_name)
       end
 
+      def test_directory_already_exists
+        error = Script::Errors::ScriptProjectAlreadyExistsError.new
+        Dir.mktmpdir(@script_name)
+        Layers::Application::CreateScript.expects(:call).with(
+          ctx: @context,
+          language: @language,
+          script_name: @script_name,
+          extension_point_type: @ep_type
+        ).raises(error)
+
+        UI::ErrorHandler.expects(:pretty_print_and_raise).with(
+          error,
+          failed_op: @context.message('script.create.error.operation_failed')
+        )
+
+        ScriptProject.expects(:cleanup).never
+
+        capture_io do
+          perform_command
+        end
+      end
+
       private
 
       def perform_command


### PR DESCRIPTION
## WHAT is this pull request doing?

In the case of a runtime error during `shopify create script`, the partially created directory is removed. This PR solves a bug in the case that a directory is created that has a name as one that already exists, because previously both would be deleted.

**This is what would happen before this fix** (I try to create a script called `erik2` when a directory with that name previously existed
<img width="845" alt="Screen Shot 2020-07-29 at 11 19 56 PM" src="https://user-images.githubusercontent.com/64974039/88891626-59fbf300-d1f8-11ea-8889-c3e567746d6c.png">

