### PR TITLE
Fix message for the org prompt in connect

### DIFF
--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -45,7 +45,7 @@ module ShopifyCli
           CLI::UI::Prompt.ask(@ctx.message('core.connect.organization_select')) do |handler|
             orgs.each do |org|
               handler.option(
-                ctx.message('core.partners_api.org_name_and_id', org['businessName'], org['id'])
+                @ctx.message('core.partners_api.org_name_and_id', org['businessName'], org['id'])
               ) { org["id"] }
             end
           end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When showing the prompt to select one of multiple organizations in `connect`, we were failing to get the CLI message by using an invalid variable `ctx` (it should be `@ctx`).

### WHAT is this pull request doing?

Fixing the variable name in the call.