### PR TITLE
Use tmp folder as cache for tests

### DIFF
--- a/lib/shopify-cli/commands/system.rb
+++ b/lib/shopify-cli/commands/system.rb
@@ -36,17 +36,25 @@ module ShopifyCli
         cli_constants_extra = %w(
           PROJECT_TYPES_DIR
           TEMP_DIR
-          CACHE_DIR
-          TOOL_CONFIG_PATH
-          LOG_FILE
-          DEBUG_LOG_FILE
         )
+        cli_path_methods = [
+          :cache_dir,
+          :tool_config_path,
+          :log_file,
+          :debug_log_file,
+        ]
 
         cli_constants += cli_constants_extra if show_all_details
 
         @ctx.puts(@ctx.message('core.system.header'))
         cli_constants.each do |s|
           @ctx.puts("  " + @ctx.message('core.system.const', s, ShopifyCli.const_get(s.to_sym)) + "\n")
+        end
+
+        if show_all_details
+          cli_path_methods.each do |m|
+            @ctx.puts("  " + @ctx.message('core.system.const', m.upcase, ShopifyCli.send(m)) + "\n")
+          end
         end
       end
 
@@ -74,7 +82,7 @@ module ShopifyCli
       end
 
       def display_ngrok
-        ngrok_location = File.join(ShopifyCli::CACHE_DIR, 'ngrok')
+        ngrok_location = File.join(ShopifyCli.cache_dir, 'ngrok')
         if File.exist?(ngrok_location)
           @ctx.puts("  " + @ctx.message('core.system.ngrok_available', ngrok_location))
         else

--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -35,7 +35,7 @@ module ShopifyCli
           task_registry = ShopifyCli::Tasks::Registry
 
           command, command_name, args = ShopifyCli::Resolver.call(args)
-          executor = ShopifyCli::Core::Executor.new(ctx, task_registry, log_file: ShopifyCli::LOG_FILE)
+          executor = ShopifyCli::Core::Executor.new(ctx, task_registry, log_file: ShopifyCli.log_file)
           ShopifyCli::Core::Monorail.log(command_name, args) do
             executor.call(command, command_name, args)
           end

--- a/lib/shopify-cli/db.rb
+++ b/lib/shopify-cli/db.rb
@@ -14,7 +14,7 @@ module ShopifyCli
 
     attr_reader :db # :nodoc:
 
-    def initialize(path: File.join(ShopifyCli::CACHE_DIR, ".db.pstore")) # :nodoc:
+    def initialize(path: File.join(ShopifyCli.cache_dir, ".db.pstore")) # :nodoc:
       @db = PStore.new(path)
     end
 

--- a/lib/shopify-cli/heroku.rb
+++ b/lib/shopify-cli/heroku.rb
@@ -36,7 +36,7 @@ module ShopifyCli
     def download
       return if installed?
 
-      result = @ctx.system('curl', '-o', download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCli::CACHE_DIR)
+      result = @ctx.system('curl', '-o', download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCli.cache_dir)
       @ctx.abort(@ctx.message('core.heroku.error.download')) unless result.success?
       @ctx.abort(@ctx.message('core.heroku.error.download')) unless File.exist?(download_path)
     end
@@ -44,7 +44,7 @@ module ShopifyCli
     def install
       return if installed?
 
-      result = @ctx.system('tar', '-xf', download_path, chdir: ShopifyCli::CACHE_DIR)
+      result = @ctx.system('tar', '-xf', download_path, chdir: ShopifyCli.cache_dir)
       @ctx.abort(@ctx.message('core.heroku.error.install')) unless result.success?
 
       @ctx.rm(download_path)
@@ -70,7 +70,7 @@ module ShopifyCli
     end
 
     def download_path
-      File.join(ShopifyCli::CACHE_DIR, download_filename)
+      File.join(ShopifyCli.cache_dir, download_filename)
     end
 
     def git_remote
@@ -79,7 +79,7 @@ module ShopifyCli
     end
 
     def heroku_command
-      local_path = File.join(ShopifyCli::CACHE_DIR, 'heroku', 'bin', 'heroku').to_s
+      local_path = File.join(ShopifyCli.cache_dir, 'heroku', 'bin', 'heroku').to_s
       if File.exist?(local_path)
         local_path
       else

--- a/lib/shopify-cli/process_supervision.rb
+++ b/lib/shopify-cli/process_supervision.rb
@@ -5,9 +5,6 @@ module ShopifyCli
   # ProcessSupervision wraps a running process spawned by `exec` and keeps track
   # if its `pid` and keeps a log file for it as well
   class ProcessSupervision
-    # is the directory where the pid and logfile are kept
-    RUN_DIR = File.join(ShopifyCli::CACHE_DIR, 'sv')
-
     # a string or a symbol to identify this process by
     attr_reader :identifier
     # process ID for the running process
@@ -20,6 +17,11 @@ module ShopifyCli
     attr_reader :log_path
 
     class << self
+      def run_dir
+        # is the directory where the pid and logfile are kept
+        File.join(ShopifyCli.cache_dir, 'sv')
+      end
+
       ##
       # Will find and create a new instance of ProcessSupervision for a running process
       # if it is currently running. It will return nil if the process is not running.
@@ -34,7 +36,7 @@ module ShopifyCli
       #   will be nil if the process is not running.
       #
       def for_ident(identifier)
-        pid, time = File.read(File.join(RUN_DIR, "#{identifier}.pid")).split(':')
+        pid, time = File.read(File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.pid")).split(':')
         new(identifier, pid: Integer(pid), time: time)
       rescue Errno::ENOENT
         nil
@@ -108,8 +110,8 @@ module ShopifyCli
       @identifier = identifier
       @pid = pid
       @time = time
-      @pid_path = File.join(RUN_DIR, "#{identifier}.pid")
-      @log_path = File.join(RUN_DIR, "#{identifier}.log")
+      @pid_path = File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.pid")
+      @log_path = File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.log")
     end
 
     ##

--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -88,7 +88,7 @@ module ShopifyCli
     #
     def auth(ctx, token)
       install(ctx)
-      ctx.system(File.join(ShopifyCli::CACHE_DIR, 'ngrok'), 'authtoken', token)
+      ctx.system(File.join(ShopifyCli.cache_dir, 'ngrok'), 'authtoken', token)
     end
 
     ##
@@ -122,14 +122,14 @@ module ShopifyCli
     private
 
     def install(ctx)
-      return if File.exist?(File.join(ShopifyCli::CACHE_DIR, 'ngrok'))
+      return if File.exist?(File.join(ShopifyCli.cache_dir, 'ngrok'))
       spinner = CLI::UI::SpinGroup.new
       spinner.add('Installing ngrok...') do
-        zip_dest = File.join(ShopifyCli::CACHE_DIR, 'ngrok.zip')
+        zip_dest = File.join(ShopifyCli.cache_dir, 'ngrok.zip')
         unless File.exist?(zip_dest)
-          ctx.system('curl', '-o', zip_dest, DOWNLOAD_URLS[ctx.os], chdir: ShopifyCli::CACHE_DIR)
+          ctx.system('curl', '-o', zip_dest, DOWNLOAD_URLS[ctx.os], chdir: ShopifyCli.cache_dir)
         end
-        ctx.system('unzip', '-u', zip_dest, chdir: ShopifyCli::CACHE_DIR)
+        ctx.system('unzip', '-u', zip_dest, chdir: ShopifyCli.cache_dir)
         ctx.rm(zip_dest)
       end
       spinner.wait
@@ -143,7 +143,7 @@ module ShopifyCli
     end
 
     def ngrok_command(port)
-      "exec #{File.join(ShopifyCli::CACHE_DIR, 'ngrok')} http -inspect=false -log=stdout -log-level=debug #{port}"
+      "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug #{port}"
     end
 
     def seconds_to_hm(seconds)

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -11,6 +11,8 @@ module Minitest
     include TestHelpers::Project
 
     def setup
+      ENV['RUNNING_SHOPIFY_CLI_TESTS'] = 1.to_s
+
       project_context('project')
       super
     end

--- a/test/shopify-cli/process_supervision_test.rb
+++ b/test/shopify-cli/process_supervision_test.rb
@@ -7,10 +7,10 @@ module ShopifyCli
       assert_equal(1234, process.pid)
       assert_equal('web', process.identifier)
       assert_equal(
-        File.join(ShopifyCli::CACHE_DIR, 'sv/web.pid'), process.pid_path
+        File.join(ShopifyCli.cache_dir, 'sv/web.pid'), process.pid_path
       )
       assert_equal(
-        File.join(ShopifyCli::CACHE_DIR, 'sv/web.log'), process.log_path
+        File.join(ShopifyCli.cache_dir, 'sv/web.log'), process.log_path
       )
     end
 

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -8,7 +8,7 @@ module ShopifyCli
     end
 
     def test_auth_calls_ngrok_authtoken
-      @context.expects(:system).with("#{ShopifyCli::CACHE_DIR}/ngrok", 'authtoken', 'token')
+      @context.expects(:system).with("#{ShopifyCli.cache_dir}/ngrok", 'authtoken', 'token')
       ShopifyCli::Tunnel.auth(@context, 'token')
     end
 
@@ -26,7 +26,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "exec #{File.join(ShopifyCli::CACHE_DIR, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
         @context.expects(:puts).with(@context.message('core.tunnel.will_timeout', '7 hours 59 minutes'))
@@ -40,7 +40,7 @@ module ShopifyCli
       with_log(time: start_time.to_s) do
         ShopifyCli::ProcessSupervision.expects(:start).twice.with(
           :ngrok,
-          "exec #{File.join(ShopifyCli::CACHE_DIR, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(
           ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000, time: start_time.to_s)
         ).then.returns(
@@ -62,7 +62,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "exec #{File.join(ShopifyCli::CACHE_DIR, 'ngrok')} http -inspect=false"\
+          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false"\
           " -log=stdout -log-level=debug #{configured_port}"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
@@ -77,7 +77,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "exec #{File.join(ShopifyCli::CACHE_DIR, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(
           @context.message('core.tunnel.start_with_account', 'https://example.ngrok.io', 'Tom Cruise')
@@ -91,7 +91,7 @@ module ShopifyCli
       with_log(fixture: 'ngrok_error') do
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "exec #{File.join(ShopifyCli::CACHE_DIR, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "exec #{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         assert_raises ShopifyCli::Tunnel::NgrokError do
           ShopifyCli::Tunnel.start(@context)

--- a/test/test_helpers/heroku.rb
+++ b/test/test_helpers/heroku.rb
@@ -56,11 +56,11 @@ module TestHelpers
     def expects_tar_heroku(status:)
       if status.nil?
         @context.expects(:system)
-          .with('tar', '-xf', download_path, chdir: ShopifyCli::CACHE_DIR)
+          .with('tar', '-xf', download_path, chdir: ShopifyCli.cache_dir)
           .never
       else
         @context.expects(:system)
-          .with('tar', '-xf', download_path, chdir: ShopifyCli::CACHE_DIR)
+          .with('tar', '-xf', download_path, chdir: ShopifyCli.cache_dir)
           .returns(status_mock[:"#{status}"])
       end
 
@@ -159,13 +159,13 @@ module TestHelpers
         @context.expects(:system)
           .with('curl', '-o', download_path,
           ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
-          chdir: ShopifyCli::CACHE_DIR)
+          chdir: ShopifyCli.cache_dir)
           .never
       else
         @context.expects(:system)
           .with('curl', '-o', download_path,
             ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
-            chdir: ShopifyCli::CACHE_DIR)
+            chdir: ShopifyCli.cache_dir)
           .returns(status_mock[:"#{status}"])
       end
     end
@@ -207,13 +207,13 @@ module TestHelpers
     end
 
     def download_path
-      File.join(ShopifyCli::CACHE_DIR, download_filename)
+      File.join(ShopifyCli.cache_dir, download_filename)
     end
 
     def heroku_command(full_path: false)
       if full_path
         File.stubs(:exist?).returns(true)
-        File.join(ShopifyCli::CACHE_DIR, 'heroku', 'bin', 'heroku').to_s
+        File.join(ShopifyCli.cache_dir, 'heroku', 'bin', 'heroku').to_s
       else
         'heroku'
       end


### PR DESCRIPTION
### WHY are these changes introduced?

This PR attempts to improve the CLI tests, which are failing intermittently when trying to touch the `.db.pstore` file. After the changes to run the CLI natively, we changed the db from `TMP_DIR` to `CACHE_DIR`, which means that the tests run on the same .db.pstore file that the production CLI runs on. We don't want that.

### WHAT is this pull request doing?

By moving the tests back to using `TMP_DIR`, we ensure they run on a clean(er) db file, since it only exists in the context of the current repo's test runs. Even though I can't explain exactly why this improves the test stability, it makes sense in any case to run it in a contained environment. Empirically, this change made 10/10 test runs pass whereas 7/10 (or less, based on manual runs where I got 4+ fails in a row) passed without it, so there does seem to be some correlation between the two.

What I am **not** sure though is whether the is the optimal way of replacing the const. I'd be glad to hear if there's a cleaner way of doing this.