### PR TITLE
Update Travis Ruby versions and fix Ruby 2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
- - 2.4.7
- - 2.5.1
+ - 2.5.8
+ - 2.6.6
+ - 2.7.1
 before_install:
 - gem install bundler -v '1.17.3'
 cache:

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'mocha', require: false
   gem 'minitest', '>= 5.0.0', require: false
   gem 'minitest-reporters', require: false
-  gem 'fakefs', require: false
+  gem 'fakefs', '>= 1.0', require: false
   gem 'webmock', require: false
   gem 'timecop', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,11 +6,11 @@ GEM
     ansi (1.5.0)
     ast (2.4.0)
     builder (3.2.3)
-    byebug (8.2.2)
+    byebug (8.2.5)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    fakefs (0.20.0)
+    fakefs (1.2.2)
     hashdiff (0.3.2)
     metaclass (0.0.4)
     method_source (0.9.2)
@@ -62,7 +62,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  fakefs
+  fakefs (>= 1.0)
   minitest (>= 5.0.0)
   minitest-reporters
   mocha

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -20,7 +20,7 @@ module Extension
           extension_context: extension_context,
         }
 
-        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
+        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
         context.abort(context.message('tasks.errors.parse_error')) if response.nil?
 
         abort_if_user_errors(context, response)

--- a/lib/project_types/extension/tasks/get_app.rb
+++ b/lib/project_types/extension/tasks/get_app.rb
@@ -12,7 +12,7 @@ module Extension
       def call(context:, api_key:)
         input = { api_key: api_key }
 
-        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
+        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
         context.abort(context.message('tasks.errors.parse_error')) if response.nil?
 
         Converters::AppConverter.from_hash(response.dig(APP_FIELD))

--- a/lib/project_types/extension/tasks/update_draft.rb
+++ b/lib/project_types/extension/tasks/update_draft.rb
@@ -18,7 +18,7 @@ module Extension
           config: JSON.generate(config),
           extension_context: extension_context,
         }
-        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
+        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
         context.abort(context.message('tasks.errors.parse_error')) if response.nil?
 
         abort_if_user_errors(context, response)

--- a/lib/shopify-cli/core/executor.rb
+++ b/lib/shopify-cli/core/executor.rb
@@ -3,10 +3,10 @@ require 'shopify_cli'
 module ShopifyCli
   module Core
     class Executor < CLI::Kit::Executor
-      def initialize(ctx, task_registry, *args)
+      def initialize(ctx, task_registry, *args, **kwargs)
         @ctx = ctx || ShopifyCli::Context.new
         @task_registry = task_registry || ShopifyCli::Tasks::TaskRegistry.new
-        super(*args)
+        super(*args, **kwargs)
       end
 
       def call(command, command_name, args)

--- a/lib/shopify-cli/task.rb
+++ b/lib/shopify-cli/task.rb
@@ -2,9 +2,9 @@ require 'shopify_cli'
 
 module ShopifyCli
   class Task
-    def self.call(*args)
+    def self.call(*args, **kwargs)
       task = new
-      task.call(*args)
+      task.call(*args, **kwargs)
     end
   end
 end

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -24,7 +24,7 @@ module Extension
 
         def stub_create_extension_success(**args)
           registration_id = rand(9999)
-          stub_create_extension(args) do |title, type|
+          stub_create_extension(**args) do |title, type|
             {
               extensionCreate: {
                 extensionRegistration: {
@@ -43,7 +43,7 @@ module Extension
         end
 
         def stub_create_extension_failure(userErrors:, **args) # rubocop:disable Naming/VariableName
-          stub_create_extension(args) do
+          stub_create_extension(**args) do
             {
               extensionCreate: {
                 userErrors: userErrors, # rubocop:disable Naming/VariableName

--- a/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
@@ -20,7 +20,7 @@ module Extension
         end
 
         def stub_update_draft_success(**args)
-          stub_update_draft(args) do |registration_id, _config, extension_context|
+          stub_update_draft(**args) do |registration_id, _config, extension_context|
             {
               extensionUpdateDraft: {
                 extensionVersion: {
@@ -36,7 +36,7 @@ module Extension
         end
 
         def stub_update_draft_failure(errors:, **args)
-          stub_update_draft(args) do
+          stub_update_draft(**args) do
             {
               extensionUpdateDraft: {
                 Tasks::UserErrors::USER_ERRORS_FIELD => errors,

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -24,7 +24,7 @@ module Script
       end
 
       def test_calls_push_script
-        ShopifyCli::Tasks::EnsureEnv.any_instance.expects(:call).with(@context).returns({
+        ShopifyCli::Tasks::EnsureEnv.any_instance.expects(:call).returns({
           api_key: @api_key,
         })
         Layers::Application::PushScript.expects(:call).with(
@@ -44,7 +44,7 @@ module Script
       end
 
       def test_returns_help_if_language_is_not_supported
-        ShopifyCli::Tasks::EnsureEnv.any_instance.expects(:call).with(@context).returns({
+        ShopifyCli::Tasks::EnsureEnv.any_instance.expects(:call).returns({
           api_key: @api_key,
         })
         @script_project.stubs(:language).returns('invalid')

--- a/test/project_types/script/layers/domain/domain_package_test.rb
+++ b/test/project_types/script/layers/domain/domain_package_test.rb
@@ -33,7 +33,7 @@ describe Script::Layers::Domain::PushPackage do
     subject { push_package.push(script_service, api_key, force) }
 
     it "should open write to build file and push" do
-      script_service.expect(:push, nil) do |**kwargs|
+      script_service.expect(:push, nil) do |kwargs|
         kwargs[:extension_point_type] == extension_point_type &&
           kwargs[:script_name] == script_name &&
           kwargs[:script_content] == script_content &&


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

After we released v1.0.0 of the CLI, we updated the Ruby dependency to >= 2.5, but our Travis builds still ran only 2.4 and 2.5, which don't necessarily cover the scenarios we would expect to see in real life any more.

### WHAT is this pull request doing?

Changing the Travis configs so we run the tests with Ruby 2.5, 2.6, 2.7.