### PR TITLE
Load project types as symbols consistently

### DIFF
--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -33,7 +33,7 @@ module ShopifyCli
 
       def load_all
         Dir.glob(File.join(ShopifyCli::ROOT, 'lib', 'project_types', '*', 'cli.rb')).map do |filepath|
-          load_type(filepath.split(File::Separator)[-2], true)
+          load_type(filepath.split(File::Separator)[-2].to_sym, true)
         end
       end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When running the overall help command in the CLI, we recently (under #788) started sorting the project types before displaying their help, which works nicely. However, when running a plain `shopify help` command from within a project dir, we ran into an error because the types contained strings and symbols.

The 'default' project load (done in entry_point when inside a project dir) always loaded the type as a symbol, whereas the `ProjectType.load_all` method loaded them as strings. We've been lucky so far that this never caused any issues, but when sorting the project types the comparison function borks.

### WHAT is this pull request doing?

Always load the project types as symbols in `load_all` so our set of types is consistent throughout the code.