### PR TITLE
Update monorail cli version

### DIFF
--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -99,7 +99,7 @@ module ShopifyCli
               success: err.nil?,
               error_message: err,
               uname: RbConfig::CONFIG["host"],
-              cli_version: ShopifyCli::Git.sha(dir: ShopifyCli::ROOT),
+              cli_version: ShopifyCli::VERSION,
               ruby_version: RUBY_VERSION,
             }.tap do |payload|
               payload[:metadata] = JSON.dump(metadata) unless metadata.empty?

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -6,7 +6,6 @@ module ShopifyCli
     class MonorailTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Git.stubs(:sha).returns("bb6f42193239a248f054e5019e469bc75f3adf1b")
         CLI::UI::Prompt.stubs(:confirm).returns(true)
         ShopifyCli::Core::Monorail.metadata = {}
       end
@@ -66,7 +65,7 @@ module ShopifyCli
                   success: true,
                   error_message: nil,
                   uname: RbConfig::CONFIG["host"],
-                  cli_version: "bb6f42193239a248f054e5019e469bc75f3adf1b",
+                  cli_version: ShopifyCli::VERSION,
                   ruby_version: RUBY_VERSION,
                   metadata: "{\"foo\":\"identifier\"}",
                   api_key: "apikey",
@@ -106,7 +105,7 @@ module ShopifyCli
                   success: false,
                   error_message: 'test error',
                   uname: RbConfig::CONFIG["host"],
-                  cli_version: "bb6f42193239a248f054e5019e469bc75f3adf1b",
+                  cli_version: ShopifyCli::VERSION,
                   ruby_version: RUBY_VERSION,
                   api_key: "apikey",
                   partner_id: 42,


### PR DESCRIPTION
### WHY are these changes introduced?
Right now our opt-in metrics are broken because it is being provided an invalid version value. This value was forgotten during the migration, so this updates that.

### WHAT is this pull request doing?
Switching from `ShopifyCli::Git.sha(dir: ShopifyCli::ROOT)` to `ShopifyCli::VERSION` to provide to monorial.
