### PR TITLE
Prepare the gem for Windows installation

### DIFF
--- a/ext/shopify-cli/extconf.rb
+++ b/ext/shopify-cli/extconf.rb
@@ -3,25 +3,45 @@ require 'fileutils'
 
 gem = File.expand_path('../../../', __FILE__)
 exe = File.join(gem, 'bin', 'shopify')
-script = exe + '.sh'
-symlink = '/usr/local/bin/shopify'
 
-script_content = <<~SCRIPT
-  #!/usr/bin/env bash
-  #{RbConfig.ruby} --disable=gems -I #{gem} #{exe} $@
-SCRIPT
+if RUBY_PLATFORM.match(/mingw32/)
+  bat_path = File.dirname(RbConfig.ruby)
+  bat = "#{bat_path}\\shopify.bat"
 
-File.write(script, script_content)
-FileUtils.chmod("+x", script)
+  script_content = "#{RbConfig.ruby} --disable=gems -I '#{gem}' '#{exe}' %*"
 
-makefile_content = <<~MAKEFILE
-  .PHONY: clean install
-  
-  clean:
-  \t@sudo rm -f #{symlink}
-  
-  install: clean
-  \t@sudo ln -s #{script} #{symlink}
-MAKEFILE
+  FileUtils.mkdir_p(bat_path)
+  makefile_content = <<~MAKEFILE
+    .PHONY: clean install
+
+    clean:
+    \t rm -f "#{bat}"
+
+    install: clean
+    \t echo "@ECHO OFF"> "#{bat}"
+    \t echo "#{script_content}">> "#{bat}"
+  MAKEFILE
+else
+  script = exe + '.sh'
+  symlink = '/usr/local/bin/shopify'
+
+  script_content = <<~SCRIPT
+    #!/usr/bin/env bash
+    #{RbConfig.ruby} --disable=gems -I #{gem} #{exe} $@
+  SCRIPT
+
+  File.write(script, script_content)
+  FileUtils.chmod("+x", script)
+
+  makefile_content = <<~MAKEFILE
+    .PHONY: clean install
+    
+    clean:
+    \t@sudo rm -f #{symlink}
+    
+    install: clean
+    \t@sudo ln -s #{script} #{symlink}
+  MAKEFILE
+end
 
 File.write('Makefile', makefile_content)

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,17 +1,25 @@
 Gem.post_uninstall do |uninstaller|
   if uninstaller.spec.name == 'shopify-cli'
-    require 'fileutils'
+    if RUBY_PLATFORM.match(/mingw32/)
+      bat_path = File.dirname(RbConfig.ruby)
+      bat = "#{bat_path}\\shopify.bat"
 
-    symlink = '/usr/local/bin/shopify'
+      # delete the auto-generated batch script
+      File.unlink(bat)
+    else
+      require 'fileutils'
 
-    # delete the symbolic link IFF it exists AND it does not point to a file
-    # (i.e., it's been left hanging as a result of the uninstall, as expected)
-    #
-    # if the file still exists, either the uninstall failed (possible but
-    # unlikely) OR
-    # there's another installation of the gem in another ruby folder that has
-    # overwritten it, so leave the symbolic link alone
-    system("sudo rm -f #{symlink}") if File.symlink?(symlink) && !File.exist?(symlink)
+      symlink = '/usr/local/bin/shopify'
+
+      # delete the symbolic link IFF it exists AND it does not point to a file
+      # (i.e., it's been left hanging as a result of the uninstall, as expected)
+      #
+      # if the file still exists, either the uninstall failed (possible but
+      # unlikely) OR
+      # there's another installation of the gem in another ruby folder that has
+      # overwritten it, so leave the symbolic link alone
+      system("sudo rm -f #{symlink}") if File.symlink?(symlink) && !File.exist?(symlink)
+    end
   end
 
   true

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
     %x(git ls-files -z).split("\x0").reject do |f|
       f.match(%r{^(test|spec|features|packaging)/}) ||
-      f.match(%r{^bin/update-deps$})
+      f.match(%r{^bin/(update-deps|shopify.bat)$})
     end
   end
   spec.bindir = "bin"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

With the CLI now working natively on Windows, we needed a way for users to install it.

### WHAT is this pull request doing?

Essentially forking the OS-specific behaviour of the gemspec files so that it works on Windows and UNIX platforms.

Since the Windows PATH env var is limited to 1024 chars (but only when setting it from the command line), using that for our path was not reliable as we could seriously damage 