### PR TITLE
Fix system command ngrok check on Windows

### DIFF
--- a/lib/shopify-cli/commands/system.rb
+++ b/lib/shopify-cli/commands/system.rb
@@ -83,7 +83,7 @@ module ShopifyCli
       end
 
       def display_ngrok
-        ngrok_location = File.join(ShopifyCli.cache_dir, 'ngrok')
+        ngrok_location = File.join(ShopifyCli.cache_dir, @ctx.windows? ? 'ngrok.exe' : 'ngrok')
         if File.exist?(ngrok_location)
           @ctx.puts("  " + @ctx.message('core.system.ngrok_available', ngrok_location))
         else


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This fixes an issue where `system` claims that ngrok is not installed, because it's not looking for the right file.

### WHAT is this pull request doing?

Changing the check for Windows so that it looks for `ngrok.exe` rather than `ngrok`.