### PR TITLE
Fix trailing slash in shop domain

### DIFF
--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -49,7 +49,7 @@ module Script
           resp_hash = script_service_request(
             query_name: query_name,
             api_key: api_key,
-            shop_domain: shop_domain,
+            shop_domain: format_shop_domain(shop_domain),
             variables: variables,
           )
           user_errors = resp_hash["data"]["shopScriptUpdateOrCreate"]["userErrors"]
@@ -76,7 +76,7 @@ module Script
           resp_hash = script_service_request(
             query_name: query_name,
             api_key: api_key,
-            shop_domain: shop_domain,
+            shop_domain: format_shop_domain(shop_domain),
             variables: variables,
           )
           user_errors = resp_hash["data"]["shopScriptDelete"]["userErrors"]
@@ -90,6 +90,10 @@ module Script
         end
 
         private
+
+        def format_shop_domain(shop_domain)
+          shop_domain.delete_suffix("/")
+        end
 
         class ScriptServiceAPI < ShopifyCli::API
           property(:api_key, accepts: String)

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -188,6 +188,7 @@ describe Script::Layers::Infrastructure::ScriptService do
   describe '.enable' do
     let(:api_key) { 'api_key' }
     let(:shop_domain) { 'my.shop.com' }
+    let(:formatted_shop_domain) { 'my.shop.com' }
     let(:configuration) { '{}' }
     let(:extension_point_type) { 'discount' }
     let(:title) { 'title' }
@@ -233,7 +234,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         'script_service_proxy',
         variables: {
           api_key: api_key,
-          shop_domain: shop_domain,
+          shop_domain: formatted_shop_domain,
           variables: {
             extensionPointName: extension_point_type.upcase,
             configuration: configuration,
@@ -253,6 +254,29 @@ describe Script::Layers::Infrastructure::ScriptService do
         extension_point_type: extension_point_type,
         title: title
       )
+    end
+
+    describe 'when shop domain ends with /' do
+      let(:shop_domain) { 'my.shop.com/' }
+      let(:script_service_response) do
+        {
+          "data" => {
+            "shopScriptUpdateOrCreate" => {
+              "shopScript" => {
+                "shopId" => "1",
+                "configuration" => nil,
+                "extensionPointName" => extension_point_type,
+                "title" => "foo2",
+              },
+              "userErrors" => [],
+            },
+          },
+        }
+      end
+
+      it 'should have no errors when shop domain is formatted' do
+        assert_equal(script_service_response, subject)
+      end
     end
 
     describe 'when successful' do
@@ -336,6 +360,7 @@ describe Script::Layers::Infrastructure::ScriptService do
   describe ".disable" do
     let(:extension_point_type) { "DISCOUNT" }
     let(:shop_domain) { 'shop.myshopify.com' }
+    let(:formatted_shop_domain) { 'shop.myshopify.com' }
     let(:api_key) { "fake_key" }
     let(:shop_script_delete) do
       <<~HERE
@@ -371,7 +396,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         'script_service_proxy',
         variables: {
           api_key: api_key,
-          shop_domain: shop_domain,
+          shop_domain: formatted_shop_domain,
           variables: {
             extensionPointName: extension_point_type,
           }.to_json,
@@ -387,6 +412,28 @@ describe Script::Layers::Infrastructure::ScriptService do
         api_key: api_key,
         shop_domain: shop_domain,
       )
+    end
+
+    describe 'when shop domain ends with /' do
+      let(:shop_domain) { 'shop.myshopify.com' }
+      let(:script_service_response) do
+        {
+          "data" => {
+            "shopScriptDelete" => {
+              "shopScript" => {
+                "shopId" => "1",
+                "extensionPointName" => extension_point_type,
+                "title" => "foo2",
+              },
+              "userErrors" => [],
+            },
+          },
+        }
+      end
+
+      it 'should have no errors when shop domain is formatted' do
+        assert_equal(script_service_response, subject)
+      end
     end
 
     describe 'when successful' do


### PR DESCRIPTION
## WHAT is this pull request doing?

If you copy and paste the URL for the shop from a browser it will have a trailing slash (at least in Chrome). This causes an error to be thrown where the domain can't be found.

The screenshot below is a before and after for this change when the .env file has a shop domain with a trailing slash.

<img width="872" alt="Screen Shot 2020-08-18 at 1 54 10 PM" src="https://user-images.githubusercontent.com/64974039/90564501-548c2b80-e15a-11ea-9c9d-01ba57906366.png">
