### PR TITLE
Print correct env values for connect

### DIFF
--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -13,6 +13,7 @@ module ShopifyCli
         end
 
         org = ShopifyCli::Tasks::EnsureEnv.call(@ctx, regenerate: true)
+        Project.current.clear_env
         api_key = Project.current.env['api_key']
         write_cli_yml(project_type, org['id']) unless Project.has_current?
         @ctx.puts(@ctx.message('core.connect.connected', get_app(org['apps'], api_key).first["title"]))

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -138,6 +138,10 @@ module ShopifyCli
                end
     end
 
+    def clear_env
+      @env = nil
+    end
+
     ##
     # will read, parse and return the .shopify-cli.yml for the project
     #

--- a/test/shopify-cli/commands/connect_test.rb
+++ b/test/shopify-cli/commands/connect_test.rb
@@ -9,6 +9,7 @@ module ShopifyCli
         ShopifyCli::Project.stubs(:has_current?).returns(false)
         CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
         ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
+        ShopifyCli::Project.any_instance.expects(:clear_env)
         ShopifyCli::Project.expects(:write)
         run_cmd('connect')
       end
@@ -16,6 +17,7 @@ module ShopifyCli
       def test_connect_doesnt_write_yml_when_current_project_exists
         CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).never
         ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
+        ShopifyCli::Project.any_instance.expects(:clear_env)
         ShopifyCli::Project.expects(:write).never
         run_cmd('connect')
       end
@@ -23,6 +25,7 @@ module ShopifyCli
       def test_connect_outputs_warnings_if_already_connected
         CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).never
         ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
+        ShopifyCli::Project.any_instance.expects(:clear_env)
         ShopifyCli::Project.expects(:write).never
         ShopifyCli::Project.stubs(:current_project_type).returns(:rails)
 


### PR DESCRIPTION

### WHAT is this pull request doing?

fixes #825

When connecting an existing app, `shopify connect` uses the previous env values when informing the user what they selected. However, the values could have changed during the command when EnsureEnv is called. This PR fixes that issue which was that the env values were cached when `Project.current .env` was first called.

