### PR TITLE
Ignore readline.so error on Windows

### DIFF
--- a/bin/shopify
+++ b/bin/shopify
@@ -8,6 +8,8 @@ module Kernel
   def require(name)
     original_require(name)
   rescue LoadError => e
+    # Special case for readline.so, which fails harmlessly on Windows
+    raise if (name == "readline.so") && ShopifyCli::Context.new.windows?
     # Special case for psych (yaml), which rescues this itself
     raise if name == "#{RUBY_VERSION[/\d+\.\d+/]}/psych.so"
     STDERR.puts "[Note] You cannot use gems with Shopify App CLI."


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Our code to prevent loading gems on the CLI is running into a bit of trouble on Windows: when the `readline` gem is loaded, it tries to load a `readline.so` file which is not there.

However, the gem itself is loaded just fine and works as expected, it is only used when prompting for project names or such other open inputs. Those work, so the error itself appears to be harmless, possibly an oversight in the gem code to ignore that file.

### WHAT is this pull request doing?

Ignore errors when attempting to load a missing `readline.so` file on Windows only.