### PR TITLE
Fix connect command to write .shopify-cli.yml

### DIFF
--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -13,8 +13,8 @@ module ShopifyCli
         end
 
         org = ShopifyCli::Tasks::EnsureEnv.call(@ctx, regenerate: true)
-        api_key = Project.current.env['api_key']
         write_cli_yml(project_type, org['id']) unless Project.has_current?
+        api_key = Project.current(force_reload: true).env['api_key']
         @ctx.puts(@ctx.message('core.connect.connected', get_app(org['apps'], api_key).first["title"]))
       end
 

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -15,6 +15,10 @@ module ShopifyCli
       # will get an instance of the project that the user is currently operating
       # on. This is used for access to project resources.
       #
+      # #### Parameters
+      #
+      # * `force_reload` - whether to force a reload of the project files
+      #
       # #### Returns
       #
       # * `project` - a Project instance if the user is currently in the project.
@@ -29,8 +33,8 @@ module ShopifyCli
       #
       #   project = ShopifyCli::Project.current
       #
-      def current
-        at(Dir.pwd)
+      def current(force_reload: false)
+        at(Dir.pwd, force_reload: force_reload)
       end
 
       ##
@@ -93,13 +97,17 @@ module ShopifyCli
 
       private
 
-      def directory(dir)
+      def directory(dir, force_reload: false)
+        @dir = nil if force_reload
+
         @dir ||= Hash.new { |h, k| h[k] = __directory(k) }
         @dir[dir]
       end
 
-      def at(dir)
-        proj_dir = directory(dir)
+      def at(dir, force_reload: false)
+        @at = nil if force_reload
+
+        proj_dir = directory(dir, force_reload: force_reload)
         unless proj_dir
           raise(ShopifyCli::Abort, Context.message('core.project.error.not_in_project'))
         end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Currently, if a project has neither `.env` nor `.shopify-cli.yml` (a reasonable expectation for previously non-CLI projects), the `connect` command will write `.env` but fail to write `.shopify-cli.yml` claiming we're not currently in a project dir.

This happened because we store the state of `Project.current` after the first attempt to load it, which would be false in that case. Thus when we checked whether we're in a project before writing the YAML file we failed because the previous state was that no `.env` existed.

### WHAT is this pull request doing?

Forcing a reload of the project state after we write the `.env` and `.shopify-cli.yml` files. The YAML file is only written if the project wasn't a Shopify app before we connected it to an app.