### PR TITLE
Fix Ruby 2.7 kwargs warning

### DIFF
--- a/lib/shopify-cli/admin_api/populate_resource_command.rb
+++ b/lib/shopify-cli/admin_api/populate_resource_command.rb
@@ -118,7 +118,7 @@ module ShopifyCli
         kwargs = { input: data }
         kwargs[:shop] = @shop
         resp = AdminAPI.query(
-          @ctx, "create_#{snake_case_resource_type}", kwargs
+          @ctx, "create_#{snake_case_resource_type}", **kwargs
         )
         @ctx.abort(resp['errors']) if resp['errors']
         @ctx.done(message(resp['data'])) unless @silent


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Ruby 2.7 mandates that keyword args are always passed in with `**`, and this call didn't do that.

### WHAT is this pull request doing?

Pass in `**kwargs` rather than `kwargs` so Ruby doesn't complain.