### PR TITLE
Make ngrok account regex more lenient

### DIFF
--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -195,7 +195,7 @@ module ShopifyCli
       end
 
       def parse_account
-        account, timeout, _ = @log.match(/AccountName:([\w\s]*) SessionDuration:([\d]+) PlanName/)&.captures
+        account, timeout, _ = @log.match(/AccountName:([\w\s\d@._\-]*) SessionDuration:([\d]+) PlanName/)&.captures
         @account = account&.empty? ? nil : account
         @timeout = timeout&.empty? ? 0 : timeout.to_i
       end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

It seems that our log parsing was not able to properly detect ngrok tunnel accounts: with my account, `AccountName` in the logs were my email address and therefore did not match the `\w\s` regex we were using - because of that, we somehow ended up thinking that a tunnel was already up and tried to stop it, which failed.

### WHAT is this pull request doing?

Allowing some email address characters (`.`, `@`, `_`, `-` and digits) to be part of the regex. I didn't make the regex enforce proper email format because the previous code seems to indicate that it's possible that `AccountName` is an actual name (letters and spaces).