### PR TITLE
Make new instance of `create` when testing

### DIFF
--- a/test/project_types/theme/commands/create_test.rb
+++ b/test/project_types/theme/commands/create_test.rb
@@ -30,9 +30,7 @@ module Theme
                                                       'shop.myshopify.com',
                                                       File.join('', 'my_theme')))
 
-          Theme::Commands::Create.ctx = context
-          Theme::Commands::Create.call([], 'create', nil)
-
+          Theme::Commands::Create.new(context).call([], 'create')
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
       end


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
- Was previously using `call` from `ShopifyCli::Subcommand`, which is not the correct method

### What is this pull request doing? 📋 
- Adds `.new` to the call in `create` test so a new instance of the class is created