### PR TITLE
apply_gem_home uses output from 'gem env home'

### DIFF
--- a/lib/project_types/rails/commands/serve.rb
+++ b/lib/project_types/rails/commands/serve.rb
@@ -26,7 +26,6 @@ module Rails
             @ctx.open_url!("#{project.env.host}/login?shop=#{project.env.shop}")
           end
         end
-        Gem.gem_home(@ctx)
         CLI::UI::Frame.open(@ctx.message('rails.serve.running_server')) do
           env = ShopifyCli::Project.current.env.to_h
           env.delete('HOST')

--- a/lib/project_types/rails/gem.rb
+++ b/lib/project_types/rails/gem.rb
@@ -34,7 +34,14 @@ module Rails
       private
 
       def apply_gem_home(ctx)
-        path = File.join(ctx.getenv('HOME'), '.gem', 'ruby', RUBY_VERSION)
+        path = ''
+        # extract GEM_HOME from `gem environment home` command
+        out, stat = ctx.capture2e('gem', 'environment', 'home')
+        path = out&.empty? ? '' : out.strip if stat.success?
+        # fallback if return from `gem environment home` is empty (somewhat unlikely)
+        path = fallback_gem_home_path(ctx) if path.empty?
+        # fallback if path isn't writable (if using a system installed ruby)
+        path = fallback_gem_home_path(ctx) unless File.writable?(path)
         ctx.mkdir_p(path) unless Dir.exist?(path)
         ctx.debug(ctx.message('rails.gem.setting_gem_home', path))
         ctx.setenv('GEM_HOME', path)
@@ -42,32 +49,29 @@ module Rails
 
       def apply_gem_path(ctx)
         path = ''
-        out, stat = ctx.capture2('gem', 'environment', 'path')
-        if stat
-          path = out&.empty? ? '' : out.strip
-        end
+        out, stat = ctx.capture2e('gem', 'environment', 'path')
+        path = out&.empty? ? '' : out.strip if stat.success?
+        # usually GEM_PATH already contains GEM_HOME
+        # if gem_home() falls back to our fallback path, we need to add it
+        path = gem_home(ctx) + File::PATH_SEPARATOR + path unless path.include?(gem_home(ctx))
         ctx.debug(ctx.message('rails.gem.setting_gem_path', path))
         ctx.setenv('GEM_PATH', path)
+      end
+
+      def fallback_gem_home_path(ctx)
+        File.join(ctx.getenv('HOME'), '.gem', 'ruby', RUBY_VERSION)
       end
     end
 
     def installed?
-      ctx.debug(
-        ctx.message('rails.gem.checking_installation_path', "#{self.class.gem_home(ctx)}/gems/", name)
-      )
-      found = !!Dir.glob("#{self.class.gem_home(ctx)}/gems/#{name}-*").detect do |f|
-        gem_satisfies_version?(f)
-      end
-      unless found
-        # not found in GEM_HOME, check directories of GEM_PATH
-        paths = self.class.gem_path(ctx).split(File::PATH_SEPARATOR)
-        paths.each do |path|
-          ctx.debug(ctx.message('rails.gem.checking_installation_path', "#{path}/gems/", name))
-          found = !!Dir.glob("#{path}/gems/#{name}-*").detect do |f|
-            gem_satisfies_version?(f)
-          end
-          break if found
+      found = false
+      paths = self.class.gem_path(ctx).split(File::PATH_SEPARATOR)
+      paths.each do |path|
+        ctx.debug(ctx.message('rails.gem.checking_installation_path', "#{path}/gems/", name))
+        found = !!Dir.glob("#{path}/gems/#{name}-*").detect do |f|
+          gem_satisfies_version?(f)
         end
+        break if found
       end
       found
     end
@@ -95,8 +99,8 @@ module Rails
         # there was a specific version given during new(), so
         # check version of gem found to determine match
         require 'semantic/semantic'
-        found_version = %r{/#{Regexp.quote(name)}-([\d\.]+)}.match(path)[1]
-        Semantic::Version.new(found_version).satisfies?(version)
+        found_version, _ = path.match(%r{/#{Regexp.quote(name)}-([\d\.]+)})&.captures
+        found_version.nil? ? false : Semantic::Version.new(found_version).satisfies?(version)
       else
         # otherwise ignore the actual version number,
         # just check there's an initial digit

--- a/test/project_types/rails/gem_test.rb
+++ b/test/project_types/rails/gem_test.rb
@@ -13,6 +13,7 @@ module Rails
 
     def teardown
       @context.setenv('GEM_HOME', nil)
+      @context.setenv('GEM_PATH', nil)
     end
 
     def test_install_installs_with_gem_home_unpopulated
@@ -33,6 +34,7 @@ module Rails
 
     def test_install_does_not_install_if_installed
       @context.setenv('GEM_HOME', "#{@home}/.gem/ruby/#{RUBY_VERSION}")
+      @context.setenv('GEM_PATH', "")
       Dir.expects(:glob).with("#{@home}/.gem/ruby/#{RUBY_VERSION}/gems/mygem-*").returns([
         "#{@home}/.gem/ruby/#{RUBY_VERSION}/gems/mygem-1.0.0",
       ]).at_least_once
@@ -41,7 +43,22 @@ module Rails
     end
 
     def test_gem_home_returns_proper_path
+      @context.expects(:capture2e).with('gem', 'environment', 'home').returns(
+        ["#{@home}/.gem/ruby/#{RUBY_VERSION}\n", mock(success?: true)]
+      )
       assert_equal("#{@home}/.gem/ruby/#{RUBY_VERSION}", Gem.gem_home(@context))
+    end
+
+    def test_gem_path_returns_proper_path
+      tmpdir1 = Dir.mktmpdir
+      tmpdir2 = Dir.mktmpdir
+      @context.expects(:capture2e).with('gem', 'environment', 'home').returns(
+        ["#{@home}/.gem/ruby/#{RUBY_VERSION}\n", mock(success?: true)]
+      )
+      @context.expects(:capture2e).with('gem', 'environment', 'path').returns(
+        ["#{tmpdir1}:#{tmpdir2}\n", mock(success?: true)]
+      )
+      assert_equal("#{@home}/.gem/ruby/#{RUBY_VERSION}:#{tmpdir1}:#{tmpdir2}", Gem.gem_path(@context))
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #809

If `GEM_HOME` isn't set in the environment, we (internally, for the CLI during execution) set it to `$HOME/.gem/ruby/x.y.z`, where `x.y.z` is the full version of the ruby used to run the CLI.

Typically this isn't a problem, as `chruby` and `rvm` environments will set the `GEM_HOME` (and `GEM_PATH`) for the user.  Likewise, if a user exclusively uses the CLI to install the required gems, the CLI will find them where it installed them.  

However, in `rbenv` environments, `GEM_HOME` and `GEM_PATH` are NOT set by `rbenv`, and what we choose as the default is typically not on the expected path for `ruby` or `gem`.  For example:
```
$ gem environment home
/home/vagrant/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0
$ gem environment path
/home/vagrant/.gem/ruby/2.6.0:/home/vagrant/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0
$
```
In this example, we would default to `/home/vagrant/.gem/ruby/2.6.6` which isn't anywhere on the path.

### WHAT is this pull request doing?

If `GEM_HOME` isn't set, we set it from the output of `gem environment home`, which will ensure any subsequent calls to `bin/rails`, etc. will find the gems the CLI installed on the users behalf.  Likewise, if the user has already installed the gems (say, installing `rails` before using the CLI), the CLI can now find them.

We default to `$HOME/.gem/ruby/x.y.z` as a last resort only if:
- in the case of system rubies, where the path returned by `gem environment home` may not be writable, or,
- in the unlikely case that `gem environment home` fails 
