### PR TITLE
Bump EP packages*

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,24 +1,24 @@
 discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    version: "^0.2.6"
+    version: "^0.2.10"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
-    version: "^0.1.8"
+    version: "^0.1.12"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
-    version: "^0.2.4"
+    version: "^0.2.8"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"
 shipping_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-shipping-filter"
-    version: "^0.2.6"
+    version: "^0.2.10"
     sdk-version: "^6.0.0"
     toolchain-version: "^1.1.0"


### PR DESCRIPTION
### WHY are these changes introduced?

Bump EP packages, which should include the following changes:

* [Set default value and add tests to all builders](https://github.com/Shopify/extension-points/pull/139)
* [Updating EP API docs](https://github.com/Shopify/extension-points/pull/137)
* [Update AS to 0.14.0](https://github.com/Shopify/extension-points/pull/140)


### WHAT is this pull request doing?

