### PR TITLE
Added checks for curl, unzip/tar before install of ngrok

### DIFF
--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -289,6 +289,8 @@ module ShopifyCli
           error: {
             stop: "ngrok tunnel could not be stopped. Try running {{command:killall -9 ngrok}}",
             url_fetch_failure: "Unable to fetch external url",
+            prereq_command_required: "%1$s is required for installing ngrok. Please install %1$s using the appropriate"\
+              " package manager for your system.",
           },
 
           not_running: "{{green:x}} ngrok tunnel not running",
@@ -302,6 +304,7 @@ module ShopifyCli
           stopped: "{{green:x}} ngrok tunnel stopped",
           timed_out: "{{x}} ngrok tunnel has timed out, restarting ...",
           will_timeout: "{{*}} This tunnel will timeout in {{red:%s}}",
+          prereq_command_location: "%s @ %s",
         },
 
         version: {

--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -124,6 +124,8 @@ module ShopifyCli
 
     def install(ctx)
       return if File.exist?(File.join(ShopifyCli.cache_dir, ctx.windows? ? 'ngrok.exe' : 'ngrok'))
+      check_prereq_command(ctx, 'curl')
+      check_prereq_command(ctx, ctx.linux? ? 'unzip' : 'tar')
       spinner = CLI::UI::SpinGroup.new
       spinner.add('Installing ngrok...') do
         zip_dest = File.join(ShopifyCli.cache_dir, 'ngrok.zip')
@@ -169,6 +171,13 @@ module ShopifyCli
       end
       start_ngrok(ctx, port)
     end
+
+    def check_prereq_command(ctx, command)
+      cmd_path = ctx.which(command)
+      ctx.abort(ctx.message('core.tunnel.error.prereq_command_required', command)) if cmd_path.nil?
+      ctx.done(ctx.message('core.tunnel.prereq_command_location', command, cmd_path))
+    end
+
     class LogParser # :nodoc:
       TIMEOUT = 10
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #425 

### WHAT is this pull request doing?

Checks to see if `curl`, for downloading `ngrok`, and either `unzip` on Linux or `tar` on macOS/Windows (for decompressing the downloaded file) are present on the system before attempting install of `ngrok`

Tophatted on macOS Catalina, Ubuntu 20.04, Windows 10