### PR TITLE
Remove 'z' flag from initial tar command

### DIFF
--- a/packaging/homebrew/shopify-cli.base.rb
+++ b/packaging/homebrew/shopify-cli.base.rb
@@ -15,7 +15,7 @@ class ShopifyCli < Formula
   depends_on 'git' => '2.13'
 
   def install
-    system 'tar', '-xzf', cached_download, '--directory', buildpath
+    system 'tar', '-xf', cached_download, '--directory', buildpath
 
     (buildpath/'src').mkpath
     (buildpath/'symlink').mkpath


### PR DESCRIPTION
### WHY are these changes introduced?

This PR fixes #814 for future generated releases of CLI.
PR [#180](https://github.com/Shopify/homebrew-shopify/pull/180) on the `Shopify/homebrew-shopify` repo fixes it for the current release.

### WHAT is this pull request doing?

While `tar -xzf` works on macOS even if the given file is not compressed, on Linux it will complain and abort.

Since the `.gem` file is really an uncompressed tarball, `tar -xf` will work on both macOS and Linux as the first command of the install formula.

🎩 Tophatted on macOS Catalina and Ubuntu 20.04