### PR TITLE
Fix broken code of conduct link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Shopify App CLI is an open source project. We want to make it as easy and transp
 
 ## Code of conduct
 
-We expect all participants to read our [code of conduct](https://github.com/Shopify/shopify-app-cli/.github/CODE_OF_CONDUCT.md) to understand which actions are and aren’t tolerated.
+We expect all participants to read our [code of conduct](https://github.com/Shopify/shopify-app-cli/blob/master/.github/CODE_OF_CONDUCT.md) to understand which actions are and aren’t tolerated.
 
 ## Open development
 


### PR DESCRIPTION
### WHY are these changes introduced?
The link to the `code of conduct README` was not correctly linked in the `CONTRIBUTING.md` file.


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This change correctly links the `code of conduct README`.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
