### PR TITLE
Quote commands to handle usernames with spaces

### DIFF
--- a/lib/project_types/node/commands/generate/billing.rb
+++ b/lib/project_types/node/commands/generate/billing.rb
@@ -19,6 +19,7 @@ module Node
           end
           billing_type_name = BILLING_TYPES.key(selected_type)
           selected_type[0] = File.join(ShopifyCli::Project.current.directory, selected_type[0])
+          selected_type[0] = "\"#{selected_type[0]}\""
           selected_type = selected_type.join(' ')
 
           spin_group = CLI::UI::SpinGroup.new

--- a/lib/project_types/node/commands/generate/page.rb
+++ b/lib/project_types/node/commands/generate/page.rb
@@ -39,6 +39,7 @@ module Node
           end
           page_type_name = PAGE_TYPES.key(selected_type)
           selected_type[0] = File.join(ShopifyCli::Project.current.directory, selected_type[0])
+          selected_type[0] = "\"#{selected_type[0]}\""
           selected_type = selected_type.join(' ')
 
           spin_group = CLI::UI::SpinGroup.new

--- a/lib/project_types/node/commands/generate/webhook.rb
+++ b/lib/project_types/node/commands/generate/webhook.rb
@@ -17,6 +17,7 @@ module Node
           end
 
           generate_path = File.join(ShopifyCli::Project.current.directory, "node_modules/.bin/generate-node-app")
+          generate_path = "\"#{generate_path}\""
 
           spin_group = CLI::UI::SpinGroup.new
           spin_group.add(@ctx.message('node.generate.webhook.generating', selected_type)) do |spinner|

--- a/lib/shopify-cli/heroku.rb
+++ b/lib/shopify-cli/heroku.rb
@@ -45,7 +45,7 @@ module ShopifyCli
       return if installed?
 
       result = if @ctx.windows?
-        @ctx.system(download_path)
+        @ctx.system("\"#{download_path}\"")
       else
         @ctx.system('tar', '-xf', download_path, chdir: ShopifyCli.cache_dir)
       end

--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -151,7 +151,7 @@ module ShopifyCli
     end
 
     def ngrok_command(port)
-      "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug #{port}"
+      "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug #{port}"
     end
 
     def seconds_to_hm(seconds)

--- a/test/project_types/node/commands/generate/billing_test.rb
+++ b/test/project_types/node/commands/generate/billing_test.rb
@@ -11,14 +11,14 @@ module Node
 
         def test_recurring_billing
           CLI::UI::Prompt.expects(:ask).returns(Node::Commands::Generate::Billing::BILLING_TYPES['recurring-billing'])
-          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} recurring-billing$")))
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX}\\\" recurring-billing$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Billing.new(@context).call([], '')
         end
 
         def test_one_time_billing
           CLI::UI::Prompt.expects(:ask).returns(Node::Commands::Generate::Billing::BILLING_TYPES['one-time-billing'])
-          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} one-time-billing$")))
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX}\\\" one-time-billing$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Billing.new(@context).call([], '')
         end

--- a/test/project_types/node/commands/generate/page_test.rb
+++ b/test/project_types/node/commands/generate/page_test.rb
@@ -14,7 +14,7 @@ module Node
           CLI::UI::Prompt.expects(:ask).returns(Node::Commands::Generate::Page::PAGE_TYPES['empty-state'])
           @context
             .expects(:system)
-            .with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} empty-state-page name$")))
+            .with(regexp_matches(Regexp.new("^.*#{BIN_REGEX}\\\" empty-state-page name$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Page.new(@context).call(['name'], '')
         end
@@ -23,7 +23,7 @@ module Node
           CLI::UI::Prompt.expects(:ask).never
           @context
             .expects(:system)
-            .with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} list-page name$")))
+            .with(regexp_matches(Regexp.new("^.*#{BIN_REGEX}\\\" list-page name$")))
             .returns(mock(success?: true))
           command = Node::Commands::Generate::Page.new(@context)
           command.options.flags[:type] = 'list'

--- a/test/project_types/node/commands/generate/webhook_test.rb
+++ b/test/project_types/node/commands/generate/webhook_test.rb
@@ -11,21 +11,21 @@ module Node
         BIN_REGEX = 'node_modules\/\.bin\/generate-node-app'
 
         def test_with_existing_param
-          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} webhook APP_UNINSTALLED$")))
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX}\\\" webhook APP_UNINSTALLED$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Webhook.new(@context).call(['APP_UNINSTALLED'], '')
         end
 
         def test_with_incorrect_param_expects_ask
           CLI::UI::Prompt.expects(:ask).returns('APP_UNINSTALLED')
-          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} webhook APP_UNINSTALLED$")))
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX}\\\" webhook APP_UNINSTALLED$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Webhook.new(@context).call(['create_webhook_fake'], '')
         end
 
         def test_with_selection
           CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
-          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX} webhook PRODUCT_CREATE$")))
+          @context.expects(:system).with(regexp_matches(Regexp.new("^.*#{BIN_REGEX}\\\" webhook PRODUCT_CREATE$")))
             .returns(mock(success?: true))
           Node::Commands::Generate::Webhook.new(@context).call([], '')
         end

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -26,7 +26,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
         @context.expects(:puts).with(@context.message('core.tunnel.will_timeout', '7 hours 59 minutes'))
@@ -40,7 +40,7 @@ module ShopifyCli
       with_log(time: start_time.to_s) do
         ShopifyCli::ProcessSupervision.expects(:start).twice.with(
           :ngrok,
-          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(
           ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000, time: start_time.to_s)
         ).then.returns(
@@ -62,7 +62,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false"\
+          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false"\
             " -log=stdout -log-level=debug #{configured_port}"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
@@ -77,7 +77,7 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(
           @context.message('core.tunnel.start_with_account', 'https://example.ngrok.io', 'Tom Cruise')
@@ -91,7 +91,7 @@ module ShopifyCli
       with_log(fixture: 'ngrok_error') do
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "#{File.join(ShopifyCli.cache_dir, 'ngrok')} http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         assert_raises ShopifyCli::Tunnel::NgrokError do
           ShopifyCli::Tunnel.start(@context)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #849 

In some instances, the CLI failed to run external commands on Windows if the current user name has spaces in it. This was due to the commands not being escaped properly.

### WHAT is this pull request doing?

Quoting the external commands that fail if there is a space in the path.