### PR TITLE
Catch entire git stderr when cloning

### DIFF
--- a/lib/shopify-cli/git.rb
+++ b/lib/shopify-cli/git.rb
@@ -125,13 +125,13 @@ module ShopifyCli
 
           success = Open3.popen3('git', *git_command, '--progress') do |_stdin, _stdout, stderr, thread|
             while (line = stderr.gets)
+              msg << line.chomp
               next unless line.strip.start_with?('Receiving objects:')
               percent = (line.match(/Receiving objects:\s+(\d+)/)[1].to_f / 100).round(2)
               bar.tick(set_percent: percent)
               next
             end
 
-            msg << stderr
             thread.value
           end.success?
 


### PR DESCRIPTION
### WHY are these changes introduced?

Issue #821 shows that we are not properly reporting git errors when it fails to clone the App repository. The code was previously catching the stderr object rather than its output to show as the error message, which led to the very confusing message displayed in the issue. This PR addresses that by showing the entire Git stderr contents when the command fails.

### WHAT is this pull request doing?

This PR stores each stderr line we fetch in our failure message so we don't miss any of them.