### PR TITLE
Add message to user if new version available

### DIFF
--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -28,6 +28,9 @@ module ShopifyCli
             ctx.puts(
               ctx.message('core.warning.development_version', File.join(ShopifyCli::ROOT, 'bin', ShopifyCli::TOOL_NAME))
             )
+          else
+            new_version = ctx.new_version
+            ctx.puts(ctx.message('core.warning.new_version', ShopifyCli::VERSION, new_version)) unless new_version.nil?
           end
 
           ProjectType.load_type(Project.current_project_type)

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -317,7 +317,7 @@ module ShopifyCli
         warning: {
           development_version: <<~DEVELOPMENT,
           {{*}} {{yellow:You are running a development version of the CLI at:}}
-              {{yellow:%s}}
+            {{yellow:%s}}
 
           DEVELOPMENT
 
@@ -326,6 +326,14 @@ module ShopifyCli
 
             Please visit this page for complete instructions:
             {{underline:https://shopify.github.io/shopify-app-cli/migrate/}}
+
+          MESSAGE
+
+          new_version: <<~MESSAGE,
+          {{*}} {{yellow:A new version of the Shopify App CLI is available! You have version %s and the latest version is %s.
+
+            To upgrade, follow the instructions for the package manager you’re using:
+            {{underline:https://shopify.github.io/shopify-app-cli/getting-started/upgrade/}}}}
 
           MESSAGE
         },

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -18,6 +18,7 @@ module Minitest
     def run_cmd(cmd, split_cmd = true)
       stub_prompt_for_cli_updates
       stub_monorail_log_git_sha
+      stub_new_version_check
 
       new_cmd = split_cmd ? cmd.split : cmd
       ShopifyCli::Core::EntryPoint.call(new_cmd, @context)
@@ -52,6 +53,17 @@ module Minitest
 
     def stub_prompt_for_cli_updates
       ShopifyCli::Config.stubs(:get_section).with("autoupdate").returns(stub("key?" => true))
+    end
+
+    def stub_new_version_check
+      stub_request(:get, ShopifyCli::Context::GEM_LATEST_URI)
+        .with(headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host' => 'rubygems.org',
+          'User-Agent' => 'Ruby',
+        })
+        .to_return(status: 200, body: "{\"version\":\"#{ShopifyCli::VERSION}\"}", headers: {})
     end
   end
 end

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -36,5 +36,81 @@ module ShopifyCli
       @ctx.expects(:puts).with(@context.message('core.context.open_url', url))
       @ctx.open_url!(url)
     end
+
+    def test_check_for_new_version_if_no_config_section
+      ShopifyCli::Config
+        .expects(:get)
+        .returns(false)
+      ShopifyCli::Config
+        .expects(:set)
+        .once
+      mock_rubygems_https_call(response_body: "{\"version\":\"99.99.99\"}")
+
+      assert_equal(@ctx.new_version, "99.99.99")
+    end
+
+    def test_no_check_for_new_version_if_config_section_and_interval_not_passed
+      ShopifyCli::Config
+        .expects(:get)
+        .returns(Time.now.to_i - 3600)
+      Net::HTTP
+        .expects(:get_response)
+        .with(ShopifyCli::Context::GEM_LATEST_URI)
+        .never
+
+      refute(@ctx.new_version)
+    end
+
+    def test_check_for_new_version_if_config_section_and_interval_passed
+      ShopifyCli::Config
+        .expects(:get)
+        .returns(Time.now.to_i - 86500)
+      ShopifyCli::Config
+        .expects(:set)
+        .once
+      mock_rubygems_https_call(response_body: "{\"version\":\"99.99.99\"}")
+
+      assert_equal(@ctx.new_version, "99.99.99")
+    end
+
+    def test_check_for_new_version_returns_nil_if_https_call_returns_garbage
+      ShopifyCli::Config
+        .expects(:get)
+        .returns(Time.now.to_i - 86500)
+      ShopifyCli::Config
+        .expects(:set)
+        .once
+      mock_rubygems_https_call(response_body: "ad098q907b\n90979a*(&*^*%klhfadkh}")
+
+      refute(@ctx.new_version)
+    end
+
+    def test_check_for_new_version_returns_nil_if_https_call_times_out
+      ShopifyCli::Config
+        .expects(:get)
+        .returns(Time.now.to_i - 86500)
+      ShopifyCli::Config
+        .expects(:set)
+        .once
+      Net::HTTP
+        .expects(:get_response)
+        .with(ShopifyCli::Context::GEM_LATEST_URI)
+        .raises(Net::ReadTimeout)
+
+      refute(@ctx.new_version)
+    end
+
+    private
+
+    def mock_rubygems_https_call(response_body:)
+      stub_request(:get, ShopifyCli::Context::GEM_LATEST_URI)
+        .with(headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host' => 'rubygems.org',
+          'User-Agent' => 'Ruby',
+        })
+        .to_return(status: 200, body: response_body, headers: {})
+    end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #860

### WHAT is this pull request doing?

Provides a message to the user that a new version of the CLI is available. If there's a new version available, message only appears once every 24 hours.

```
$ shopify
⭑ A new version of the Shopify App CLI is available! You have version 1.1.0 and the latest version is 1.1.1.

  To upgrade, follow the instructions for the package manager you’re using:
  https://shopify.github.io/shopify-app-cli/getting-started/upgrade/

Use shopify help <command> to display detailed information about a specific command.

Available core commands:

connect: Connect (or re-connect) an existing project to a Shopify partner organization and/or a store. Creates or updates the .env file, and creates the .shopify-cli.yml file.
  Usage: shopify connect

create: Create a new project.
  Usage: shopify create [ node | rails | script ]

logout: Log out of a currently authenticated partner organization and store, or clear invalid credentials
  Usage: shopify logout

version: Prints version number.
  Usage: shopify version

$
```