### PR TITLE
Remove Ctrl-T from serve and always print URLs

### DIFF
--- a/lib/project_types/node/commands/serve.rb
+++ b/lib/project_types/node/commands/serve.rb
@@ -20,12 +20,12 @@ module Node
           url: url,
           callback_url: "/auth/callback",
         )
-        if @ctx.mac? && project.env.shop
-          @ctx.puts(@ctx.message('node.serve.open_info', project.env.shop))
-          @ctx.on_siginfo do
-            @ctx.open_url!("#{project.env.host}/auth?shop=#{project.env.shop}")
-          end
+
+        if project.env.shop
+          project_url = "#{project.env.host}/auth?shop=#{project.env.shop}"
+          @ctx.puts("\n" + @ctx.message('node.serve.open_info', project_url) + "\n")
         end
+
         CLI::UI::Frame.open(@ctx.message('node.serve.running_server')) do
           env = project.env.to_h
           env['PORT'] = ShopifyCli::Tunnel::PORT.to_s

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -202,7 +202,10 @@ module Node
             host_must_be_https: "HOST must be a HTTPS url.",
           },
 
-          open_info: "{{*}} Press {{yellow: Control-T}} to open this project in {{green:%s}} ",
+          open_info: <<~MESSAGE,
+            {{*}} To install and start using your app, open this URL in your browser:
+            {{green:%s}}
+          MESSAGE
           running_server: "Running server...",
         },
 

--- a/lib/project_types/rails/commands/serve.rb
+++ b/lib/project_types/rails/commands/serve.rb
@@ -20,12 +20,12 @@ module Rails
           url: url,
           callback_url: "/auth/shopify/callback",
         )
-        if @ctx.mac? && project.env.shop
-          @ctx.puts(@ctx.message('rails.serve.open_info', project.env.shop))
-          @ctx.on_siginfo do
-            @ctx.open_url!("#{project.env.host}/login?shop=#{project.env.shop}")
-          end
+
+        if project.env.shop
+          project_url = "#{project.env.host}/login?shop=#{project.env.shop}"
+          @ctx.puts("\n" + @ctx.message('rails.serve.open_info', project_url) + "\n")
         end
+
         CLI::UI::Frame.open(@ctx.message('rails.serve.running_server')) do
           env = ShopifyCli::Project.current.env.to_h
           env.delete('HOST')

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -219,7 +219,10 @@ module Rails
             host_must_be_https: "{{red:HOST must be a HTTPS url.}}",
           },
 
-          open_info: "{{*}} Press {{yellow: Control-T}} to open this project in {{green:%s}} ",
+          open_info: <<~MESSAGE,
+            {{*}} To install and start using your app, open this URL in your browser:
+            {{green:%s}}
+          MESSAGE
           running_server: "Running server...",
         },
 

--- a/test/project_types/node/commands/serve_test.rb
+++ b/test/project_types/node/commands/serve_test.rb
@@ -53,15 +53,15 @@ module Node
       end
 
       def test_open_while_run
-        ShopifyCli::Context.any_instance.stubs(:on_siginfo).yields
         ShopifyCli::Tunnel.stubs(:start).returns('https://example.com')
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
           @context, :host, 'https://example.com'
         )
-        ShopifyCli::Context.any_instance.stubs(:mac?).returns(true)
-        ShopifyCli::Context.any_instance.expects(:open_url!).with(
-          'https://example.com/auth?shop=my-test-shop.myshopify.com'
+        @context.expects(:puts).with(
+          "\n" +
+          @context.message('node.serve.open_info', 'https://example.com/auth?shop=my-test-shop.myshopify.com') +
+          "\n"
         )
         run_cmd('serve')
       end

--- a/test/project_types/rails/commands/serve_test.rb
+++ b/test/project_types/rails/commands/serve_test.rb
@@ -54,15 +54,15 @@ module Rails
       end
 
       def test_open_while_run
-        ShopifyCli::Context.any_instance.stubs(:on_siginfo).yields
         ShopifyCli::Tunnel.stubs(:start).returns('https://example.com')
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
           @context, :host, 'https://example.com'
         )
-        ShopifyCli::Context.any_instance.stubs(:mac?).returns(true)
-        ShopifyCli::Context.any_instance.expects(:open_url!).with(
-          'https://example.com/login?shop=my-test-shop.myshopify.com'
+        @context.expects(:puts).with(
+          "\n" +
+          @context.message('rails.serve.open_info', 'https://example.com/login?shop=my-test-shop.myshopify.com') +
+          "\n"
         )
         Rails::Commands::Serve.new(@context).call
       end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #769 <!-- link to issue if one exists -->

Currently, the `serve` command only prints out the login URL for the app when the developer presses `Ctrl-T`. However, that approach has two main flaws:
* Not all OSs support Ctrl-T (SIGINFO)
* In the case of rails, the URL is printed along with the stack trace for all of the Puma threads, which makes it very hard to find

### WHAT is this pull request doing?

In order to make it easier for the developer to find the login URL (aside from running `open` in a different window), this PR prints out the URL prior to starting the server. Since that doesn't depend on any signals, it also does this on any OS.

CC @attaboy @gfscott 

Before:
![before](https://user-images.githubusercontent.com/64600052/92155984-472b9e00-edf6-11ea-898a-8ccde5e24e90.gif)

After:
![after](https://user-images.githubusercontent.com/64600052/92156005-4bf05200-edf6-11ea-9f00-31cca398337a.gif)
