### PR TITLE
Check for dir before creating rails projects

### DIFF
--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -114,6 +114,9 @@ module Rails
         @ctx.abort(@ctx.message('rails.create.error.install_failure', 'bundler ~>2.0')) unless
           install_gem('bundler', '~>2.0')
 
+        full_path = File.join(@ctx.root, name)
+        @ctx.abort(@ctx.message('rails.create.error.dir_exists', name)) if Dir.exist?(full_path)
+
         CLI::UI::Frame.open(@ctx.message('rails.create.generating_app', name)) do
           new_command = %w(rails new)
           new_command += DEFAULT_RAILS_FLAGS
@@ -124,7 +127,7 @@ module Rails
           syscall(new_command)
         end
 
-        @ctx.root = File.join(@ctx.root, name)
+        @ctx.root = full_path
 
         File.open(File.join(@ctx.root, '.gitignore'), 'a') { |f| f.write('.env') }
 

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -36,6 +36,7 @@ module Rails
             See {{underline:https://github.com/Shopify/shopify-app-cli/blob/master/docs/installing-ruby.md}}
             for our recommended method of installing ruby.
             MSG
+            dir_exists: "Project directory %s already exists. Please use a different name.",
             install_failure: "Error installing %s gem",
             node_required: "node is required to create a rails project. Download at https://nodejs.org/en/download.",
             node_version_failure: "Failed to get the current node version. Please make sure it is installed as " \


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #800 <!-- link to issue if one exists -->

If one attempts to create a new rails project with the CLI, and the project dir already exists, `rails new` won't fail, but will instead try to update the project files. We should avoid that situation by making sure we don't overwrite an existing dir with a new project.

### WHAT is this pull request doing?

This PR makes sure that the `create` command fails if the project dir already exists by looking for the dir before running any actual commands.
