### PR TITLE
Command to push Theme files to Shopify

### DIFF
--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -3,6 +3,7 @@ module Theme
   class Project < ShopifyCli::ProjectType
     hidden_feature
     creator 'Theme App', 'Theme::Commands::Create'
+    register_command('Theme::Commands::Push', "push")
     register_command('Theme::Commands::Serve', "serve")
 
     require Project.project_filepath('messages/messages')
@@ -11,6 +12,7 @@ module Theme
 
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
+    autoload :Push, Project.project_filepath('commands/push')
     autoload :Serve, Project.project_filepath('commands/serve')
   end
 

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -12,9 +12,6 @@ module Theme
         if options.flags['remove']
           remove = true
           options.flags.delete('remove')
-          action = 'remov'
-        else
-          action = 'push'
         end
 
         flags = options.flags.map do |key, _value|
@@ -25,13 +22,27 @@ module Theme
           Themekit.ensure_themekit_installed(@ctx)
         end
 
-        CLI::UI::Frame.open(@ctx.message("theme.push.#{action}ing")) do
-          unless Themekit.push(@ctx, files: args, flags: flags, remove: remove)
-            @ctx.abort(@ctx.message("theme.push.error.#{action}ing_error"))
-          end
-        end
+        if remove
+          CLI::UI::Frame.open(@ctx.message('theme.push.remove')) do
+            unless CLI::UI::Prompt.confirm(@ctx.message('theme.push.remove_confirm'))
+              @ctx.abort(@ctx.message('theme.push.remove_abort'))
+            end
 
-        @ctx.done(@ctx.message("theme.push.info.#{action}ed", @ctx.root))
+            unless Themekit.push(@ctx, files: args, flags: flags, remove: remove)
+              @ctx.abort(@ctx.message('theme.push.error.remove_error'))
+            end
+          end
+
+          @ctx.done(@ctx.message('theme.push.info.remove', @ctx.root))
+        else
+          CLI::UI::Frame.open(@ctx.message('theme.push.push')) do
+            unless Themekit.push(@ctx, files: args, flags: flags, remove: remove)
+              @ctx.abort(@ctx.message('theme.push.error.push_error'))
+            end
+          end
+
+          @ctx.done(@ctx.message('theme.push.info.push', @ctx.root))
+        end
       end
 
       def self.help

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Theme
+  module Commands
+    class Push < ShopifyCli::Command
+      options do |parser, flags|
+        parser.on('--remove') { flags['remove'] = true }
+        parser.on('--nodelete') { flags['nodelete'] = true }
+        parser.on('--allow-live') { flags['allow-live'] = true }
+      end
+
+      def call(args, _name)
+        if options.flags['remove']
+          remove = true
+          options.flags.delete('remove')
+        end
+
+        flags = options.flags.map do |key, _value|
+          '--' + key
+        end
+
+        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
+          Themekit.ensure_themekit_installed(@ctx)
+        end
+
+        CLI::UI::Frame.open(@ctx.message('theme.push.pushing')) do
+          unless Themekit.push(@ctx, files: args, flags: flags, remove: remove)
+            @ctx.abort(@ctx.message('theme.push.error'))
+          end
+        end
+
+        @ctx.done(@ctx.message('theme.push.pushed', @ctx.root))
+      end
+
+      def self.help
+        ShopifyCli::Context.message('theme.push.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -12,6 +12,9 @@ module Theme
         if options.flags['remove']
           remove = true
           options.flags.delete('remove')
+          action = 'remov'
+        else
+          action = 'push'
         end
 
         flags = options.flags.map do |key, _value|
@@ -22,13 +25,13 @@ module Theme
           Themekit.ensure_themekit_installed(@ctx)
         end
 
-        CLI::UI::Frame.open(@ctx.message('theme.push.pushing')) do
+        CLI::UI::Frame.open(@ctx.message("theme.push.#{action}ing")) do
           unless Themekit.push(@ctx, files: args, flags: flags, remove: remove)
-            @ctx.abort(@ctx.message('theme.push.error'))
+            @ctx.abort(@ctx.message("theme.push.error.#{action}ing_error"))
           end
         end
 
-        @ctx.done(@ctx.message('theme.push.pushed', @ctx.root))
+        @ctx.done(@ctx.message("theme.push.info.#{action}ed", @ctx.root))
       end
 
       def self.help

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -32,6 +32,19 @@ module Theme
             APP
           },
         },
+        push: {
+          error: "Theme could not be pushed to Shopify",
+          help: <<~HELP,
+            {{command:%s push}}: Replaces theme files on Shopify with those in your directory. If filenames are provided, only those files will be replaced; otherwise, the whole theme is replaced.
+              Usage: {{command:%s push}}
+              Options:
+                {{command:--remove}} Removes, rather than replaces, both local and Shopify copies of theme files. At least one file must be specified.
+                {{command:--allow-live}} Allows Shopify App CLI to replace a file on the currently live theme.
+                {{command:--nodelete}} Runs push without removing files from Shopify.
+          HELP
+          pushed: "Pushed files from %s to Shopify",
+          pushing: "Pushing files to Shopify",
+        },
         serve: {
           help: <<~HELP,
             Sync your current changes, then view the active store in your default browser. Any theme edits will continue to update in real time. Also prints the active store's URL in your terminal.

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -33,7 +33,10 @@ module Theme
           },
         },
         push: {
-          error: "Theme could not be pushed to Shopify",
+          error: {
+            pushing_error: "Theme files couldn't be pushed to Shopify",
+            removing_error: "Theme files couldn't be removed from Shopify",
+          },
           help: <<~HELP,
             {{command:%s push}}: Replaces theme files on Shopify with those in your directory. If filenames are provided, only those files will be replaced; otherwise, the whole theme is replaced.
               Usage: {{command:%s push}}
@@ -42,8 +45,12 @@ module Theme
                 {{command:--allow-live}} Allows Shopify App CLI to replace a file on the currently live theme.
                 {{command:--nodelete}} Runs push without removing files from Shopify.
           HELP
-          pushed: "Pushed files from %s to Shopify",
-          pushing: "Pushing files to Shopify",
+          info: {
+            pushed: "Theme files were pushed from %s to Shopify",
+            removed: "Theme files were removed from %s and Shopify",
+          },
+          pushing: "Pushing theme files to Shopify",
+          removing: "Removing theme files from Shopify",
         },
         serve: {
           help: <<~HELP,

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -33,24 +33,26 @@ module Theme
           },
         },
         push: {
+          remove_abort: 'Your theme files were not deleted',
+          remove_confirm: 'Are you sure you want to delete the local and remote copies of the specified theme files?',
           error: {
-            pushing_error: "Theme files couldn't be pushed to Shopify",
-            removing_error: "Theme files couldn't be removed from Shopify",
+            push_error: "Theme files couldn't be pushed to Shopify",
+            remove_error: "Theme files couldn't be removed from Shopify",
           },
           help: <<~HELP,
-            {{command:%s push}}: Replaces theme files on Shopify with those in your directory. If filenames are provided, only those files will be replaced; otherwise, the whole theme is replaced.
+            {{command:%s push}}: Uploads your local theme files to Shopify, overwriting the remote versions. If you specify filenames, separated by a space, only those files will be replaced. Otherwise, the whole theme will be replaced.
               Usage: {{command:%s push}}
               Options:
-                {{command:--remove}} Removes, rather than replaces, both local and Shopify copies of theme files. At least one file must be specified.
-                {{command:--allow-live}} Allows Shopify App CLI to replace a file on the currently live theme.
-                {{command:--nodelete}} Runs push without removing files from Shopify.
+                {{command:--remove}} Deletes both the local and the remote copies of the specified files. At least one filename must be specified.
+                {{command:--allow-live}} Allows Shopify App CLI to replace files on the store's live production theme.
+                {{command:--nodelete}} Runs the push command without deleting remote files from Shopify.
           HELP
           info: {
-            pushed: "Theme files were pushed from %s to Shopify",
-            removed: "Theme files were removed from %s and Shopify",
+            push: "Theme files were pushed from {{green:%s}} to Shopify",
+            remove: "Theme files were deleted from {{green:%s}} and Shopify",
           },
-          pushing: "Pushing theme files to Shopify",
-          removing: "Removing theme files from Shopify",
+          push: "Pushing theme files to Shopify",
+          remove: "Deleting theme files",
         },
         serve: {
           help: <<~HELP,

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -25,7 +25,7 @@ module Theme
         command << (remove ? 'remove' : 'deploy')
         (command << flags << files).flatten!
 
-        stat = ctx.system(command.join(" "))
+        stat = ctx.system(command.join(' '))
         stat.success?
       end
 

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -20,6 +20,15 @@ module Theme
         ctx.system(THEMEKIT, "watch")
       end
 
+      def push(ctx, files: nil, flags: nil, remove: false)
+        command = [THEMEKIT]
+        command << (remove ? 'remove' : 'deploy')
+        (command << flags << files).flatten!
+
+        stat = ctx.system(command.join(" "))
+        stat.success?
+      end
+
       def ensure_themekit_installed(ctx)
         Tasks::EnsureThemekitInstalled.call(ctx)
       end

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -10,7 +10,7 @@ module Theme
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push).with(context, files: [], flags: [], remove: nil).returns(true)
-        context.expects(:done).with(context.message('theme.push.info.pushed', context.root))
+        context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
         Theme::Commands::Push.new(context).call([], 'push')
       end
@@ -21,22 +21,38 @@ module Theme
         Themekit.expects(:push)
           .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: nil)
           .returns(true)
-        context.expects(:done).with(context.message('theme.push.info.pushed', context.root))
+        context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
         Theme::Commands::Push.new(context).call(['file.liquid', 'another_file.liquid'], 'push')
       end
 
       def test_can_remove_files
         context = ShopifyCli::Context.new
+        CLI::UI::Prompt.expects(:confirm).returns(true)
         Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
           .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true)
           .returns(true)
-        context.expects(:done).with(context.message('theme.push.info.removed', context.root))
+        context.expects(:done).with(context.message('theme.push.info.remove', context.root))
 
         command = Theme::Commands::Push.new(context)
         command.options.flags['remove'] = true
         command.call(['file.liquid', 'another_file.liquid'], 'push')
+      end
+
+      def test_can_abort_remove
+        context = ShopifyCli::Context.new
+        CLI::UI::Prompt.expects(:confirm).returns(false)
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        Themekit.expects(:push)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true)
+          .never
+
+        command = Theme::Commands::Push.new(context)
+        command.options.flags['remove'] = true
+        assert_raises CLI::Kit::Abort do
+          command.call(['file.liquid', 'another_file.liquid'], 'push')
+        end
       end
 
       def test_can_add_flags
@@ -45,7 +61,7 @@ module Theme
         Themekit.expects(:push)
           .with(context, files: ['file.liquid', 'another_file.liquid'], flags: ['--nodelete'], remove: nil)
           .returns(true)
-        context.expects(:done).with(context.message('theme.push.info.pushed', context.root))
+        context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
         command = Theme::Commands::Push.new(context)
         command.options.flags['nodelete'] = true

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class PushTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def test_can_push_entire_theme
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil).returns(true)
+        context.expects(:done).with(context.message('theme.push.info.pushed', context.root))
+
+        Theme::Commands::Push.new(context).call([], 'push')
+      end
+
+      def test_can_push_individual_files
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        Themekit.expects(:push)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: nil)
+          .returns(true)
+        context.expects(:done).with(context.message('theme.push.info.pushed', context.root))
+
+        Theme::Commands::Push.new(context).call(['file.liquid', 'another_file.liquid'], 'push')
+      end
+
+      def test_can_remove_files
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        Themekit.expects(:push)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true)
+          .returns(true)
+        context.expects(:done).with(context.message('theme.push.info.removed', context.root))
+
+        command = Theme::Commands::Push.new(context)
+        command.options.flags['remove'] = true
+        command.call(['file.liquid', 'another_file.liquid'], 'push')
+      end
+
+      def test_can_add_flags
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        Themekit.expects(:push)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: ['--nodelete'], remove: nil)
+          .returns(true)
+        context.expects(:done).with(context.message('theme.push.info.pushed', context.root))
+
+        command = Theme::Commands::Push.new(context)
+        command.options.flags['nodelete'] = true
+        command.call(['file.liquid', 'another_file.liquid'], 'push')
+      end
+
+      def test_aborts_if_push_fails
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil).returns(false)
+
+        assert_raises CLI::Kit::Abort do
+          Theme::Commands::Push.new(context).call([], 'push')
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -11,6 +11,7 @@ module Theme
     def test_create_theme_successful
       context = ShopifyCli::Context.new
       stat = mock
+
       context.expects(:system)
         .with(Themekit::THEMEKIT,
               'new',
@@ -25,6 +26,7 @@ module Theme
     def test_create_theme_unsuccessful
       context = ShopifyCli::Context.new
       stat = mock
+
       context.expects(:system)
         .with(Themekit::THEMEKIT,
               'new',
@@ -34,6 +36,58 @@ module Theme
         .returns(stat)
       stat.stubs(:success?).returns(false)
       refute(Themekit.create(context, password: 'boop', store: 'shop.com', name: 'My Theme'))
+    end
+
+    def test_push_deploy_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with([Themekit::THEMEKIT,
+               'deploy'].join(' '))
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.push(context, files: [], flags: [], remove: nil))
+    end
+
+    def test_push_remove_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with([Themekit::THEMEKIT,
+               'remove',
+               'file.liquid',
+               'another_file.liquid'].join(' '))
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true))
+    end
+
+    def test_push_deploy_unsuccessful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with([Themekit::THEMEKIT,
+               'deploy'].join(' '))
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+      refute(Themekit.push(context, files: [], flags: [], remove: nil))
+    end
+
+    def test_push_remove_unsuccessful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with([Themekit::THEMEKIT,
+               'remove',
+               'file.liquid',
+               'another_file.liquid'].join(' '))
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+      refute(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true))
     end
 
     def test_serve_successful


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
- Need to be able to push theme to Shopify once changed
- Would be good to have a way of deleting theme files

### What is this pull request doing? 📋 
- Uses `theme deploy` command to replace theme files on shop
- `--remove` flag to remove files instead of replacing them (`theme remove`)
- Tests for command and adapter class

##### Addition of `--env` flag will be done in another PR, in bulk with other commands in need of this flag