### PR TITLE
Revert "Revert "read and push post purchase config""

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -53,6 +53,7 @@ module Extension
     autoload :ArgoSetupStep, Project.project_filepath('features/argo_setup_step')
     autoload :ArgoSetupSteps, Project.project_filepath('features/argo_setup_steps')
     autoload :ArgoDependencies, Project.project_filepath('features/argo_dependencies')
+    autoload :ArgoConfig, Project.project_filepath('features/argo_config')
   end
 
   module Models

--- a/lib/project_types/extension/features/argo_config.rb
+++ b/lib/project_types/extension/features/argo_config.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Extension
+  module Features
+    class ArgoConfig
+      CONFIG_FILE_NAME = 'extension.config.yml'
+
+      class << self
+        def parse_yaml(context, permitted_keys = [])
+          file_name = File.join(context.root, CONFIG_FILE_NAME)
+
+          return {} unless File.size?(file_name)
+
+          require 'yaml' # takes 20ms, so deferred as late as possible.
+          begin
+            config = YAML.load_file(file_name)
+
+            # `YAML.load_file` returns nil if the file is not empty
+            # but does not contain any parsable yml data, e.g. only comments
+            # We consider this valid
+            return {} if config.nil?
+
+            unless config.is_a?(Hash)
+              raise ShopifyCli::Abort, ShopifyCli::Context.message('core.yaml.error.not_hash', CONFIG_FILE_NAME)
+            end
+
+            config.transform_keys!(&:to_sym)
+            assert_valid_config(config, permitted_keys) unless permitted_keys.empty?
+
+            config
+          rescue Psych::SyntaxError => e
+            raise(
+              ShopifyCli::Abort,
+              ShopifyCli::Context.message('core.yaml.error.invalid', CONFIG_FILE_NAME, e.message)
+            )
+          end
+        end
+
+        private
+
+        def assert_valid_config(config, permitted_keys)
+          unpermitted_keys = config.keys.select do |k|
+            !permitted_keys.include?(k)
+          end
+
+          unless unpermitted_keys.empty?
+            raise(
+              ShopifyCli::Abort,
+              ShopifyCli::Context.message(
+                'features.argo.config.unpermitted_keys',
+                CONFIG_FILE_NAME,
+                unpermitted_keys.map { |k| "\n- #{k}" }.join
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -96,6 +96,9 @@ module Extension
               version_too_low: 'Your node version %s does not meet the minimum required version %s',
             },
           },
+          config: {
+            unpermitted_keys: '`%s` contains the following unpermitted keys: %s',
+          },
         },
       },
       tasks: {

--- a/lib/project_types/extension/models/types/checkout_post_purchase.rb
+++ b/lib/project_types/extension/models/types/checkout_post_purchase.rb
@@ -6,13 +6,16 @@ module Extension
     module Types
       class CheckoutPostPurchase < Models::Type
         IDENTIFIER = 'CHECKOUT_POST_PURCHASE'
-
+        PERMITTED_CONFIG_KEYS = [:metafields]
         def create(directory_name, context)
           Features::Argo.checkout.create(directory_name, IDENTIFIER, context)
         end
 
         def config(context)
-          Features::Argo.checkout.config(context)
+          {
+            **Features::ArgoConfig.parse_yaml(context, PERMITTED_CONFIG_KEYS),
+            **Features::Argo.checkout.config(context),
+          }
         end
       end
     end

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -184,11 +184,14 @@ module ShopifyCli
             {{x}} You are not in a Shopify app project
             {{yellow:{{*}}}}{{reset: Run}}{{cyan: shopify create}}{{reset: to create your app}}
             MESSAGE
-            cli_yaml: {
-              not_hash: "{{x}} .shopify-cli.yml was not a proper YAML file. Expecting a hash.",
-              invalid: "{{x}} %s contains invalid YAML: %s",
-              not_found: "{{x}} %s not found",
-            },
+          },
+        },
+
+        yaml: {
+          error: {
+            not_hash: "{{x}} %s was not a proper YAML file. Expecting a hash.",
+            invalid: "{{x}} %s contains invalid YAML: %s",
+            not_found: "{{x}} %s not found",
           },
         },
 

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -166,7 +166,7 @@ module ShopifyCli
       @config ||= begin
         config = load_yaml_file('.shopify-cli.yml')
         unless config.is_a?(Hash)
-          raise ShopifyCli::Abort, Context.message('core.project.error.cli_yaml.not_hash')
+          raise ShopifyCli::Abort, Context.message('core.yaml.error.not_hash', '.shopify-cli.yml')
         end
 
         # The app_type key was deprecated in favour of project_type, so replace it
@@ -187,12 +187,12 @@ module ShopifyCli
       begin
         YAML.load_file(f)
       rescue Psych::SyntaxError => e
-        raise(ShopifyCli::Abort, Context.message('core.project.error.cli_yaml.invalid', relative_path, e.message))
+        raise(ShopifyCli::Abort, Context.message('core.yaml.error.invalid', relative_path, e.message))
       # rescue Errno::EACCES => e
       # TODO
       #   Dev::Helpers::EaccesHandler.diagnose_and_raise(f, e, mode: :read)
       rescue Errno::ENOENT
-        raise ShopifyCli::Abort, Context.message('core.project.error.cli_yaml.not_found', f)
+        raise ShopifyCli::Abort, Context.message('core.yaml.error.not_found', f)
       end
     end
   end

--- a/test/project_types/extension/features/argo_config_test.rb
+++ b/test/project_types/extension/features/argo_config_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Features
+    class ArgoConfigTest < MiniTest::Test
+      def setup
+        super
+        File.stubs(:size?).returns(true)
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_parses_and_symbolizes_yaml_hash
+        value = {}
+        another_value = 10
+        yml = { "value": value, "another_value": another_value }
+        YAML.stubs(:load_file).returns(yml)
+
+        parsed_config = ArgoConfig.parse_yaml(@context, [:value, :another_value])
+
+        assert_equal(value, parsed_config[:value])
+        assert_equal(another_value, parsed_config[:another_value])
+      end
+
+      def test_aborts_when_yaml_is_invalid
+        Psych::SyntaxError.any_instance.stubs(:initialize)
+        YAML.stubs(:load_file).raises(Psych::SyntaxError)
+
+        assert_raises(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context) }
+      end
+
+      def test_aborts_when_yaml_is_not_a_hash
+        YAML.stubs(:load_file).returns(false)
+
+        assert_raises(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context) }
+      end
+
+      def test_returns_empty_hash_when_file_not_found_or_empty
+        File.stubs(:size?).returns(false)
+
+        assert_equal({}, ArgoConfig.parse_yaml(@context))
+      end
+
+      def test_returns_empty_hash_when_file_contains_no_parsable_yaml_data
+        YAML.stubs(:load_file).returns(nil)
+
+        assert_equal({}, ArgoConfig.parse_yaml(@context))
+      end
+
+      def test_aborts_when_yaml_contains_unpermitted_keys
+        permitted_keys = [:a, :b]
+
+        YAML.stubs(:load_file).returns({ "a" => 1, "c" => 1 })
+
+        assert_raises(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context, permitted_keys) }
+      end
+
+      def test_does_not_abort_when_yaml_contains_no_unpermitted_keys
+        permitted_keys = [:a, :b]
+
+        YAML.stubs(:load_file).returns({ "a" => 1, "b" => 1 })
+
+        assert_nothing_raised(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context, permitted_keys) }
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/types/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/models/types/checkout_post_purchase_test.rb
@@ -7,7 +7,11 @@ module Extension
       class CheckoutPostPurchaseTest < MiniTest::Test
         def setup
           super
+          YAML.stubs(:load_file).returns({})
           ShopifyCli::ProjectType.load_type(:extension)
+          Features::Argo.checkout.stubs(:config).returns({})
+          Features::ArgoConfig.stubs(:parse_yaml).returns({})
+
           @checkout_post_purchase = Models::Type.load_type(CheckoutPostPurchase::IDENTIFIER)
         end
 
@@ -23,8 +27,29 @@ module Extension
         end
 
         def test_config_uses_standard_argo_config_implementation
-          Features::Argo.checkout.expects(:config).with(@context).once
+          Features::Argo.checkout.expects(:config).with(@context).once.returns({})
+          @checkout_post_purchase.config(@context)
+        end
 
+        def test_config_merges_with_standard_argo_config_implementation
+          script_content = "alert(true)"
+          metafields = [{ key: 'a-key', namespace: 'a-namespace' }]
+
+          initial_config = { script_content: script_content }
+          yaml_config = { "metafields": metafields }
+
+          Features::Argo.checkout.expects(:config).with(@context).once.returns(initial_config)
+          Features::ArgoConfig.stubs(:parse_yaml).returns(yaml_config)
+
+          config = @checkout_post_purchase.config(@context)
+
+          assert_equal(metafields, config[:metafields])
+          assert_equal(script_content, config[:script_content])
+        end
+
+        def test_config_passes_allowed_keys
+          Features::Argo.checkout.stubs(:config).returns({})
+          Features::ArgoConfig.expects(:parse_yaml).with(@context, [:metafields]).once.returns({})
           @checkout_post_purchase.config(@context)
         end
       end


### PR DESCRIPTION
Reverts Shopify/shopify-app-cli#874

Basically https://github.com/Shopify/shopify-app-cli/pull/857 which I merged to soon and had to revert.

This needs to wait for the counterpart in core to be live.