### PR TITLE
Add command to deploy Theme

### DIFF
--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -3,6 +3,7 @@ module Theme
   class Project < ShopifyCli::ProjectType
     hidden_feature
     creator 'Theme App', 'Theme::Commands::Create'
+    register_command('Theme::Commands::Deploy', "deploy")
     register_command('Theme::Commands::Push', "push")
     register_command('Theme::Commands::Serve', "serve")
 
@@ -12,6 +13,7 @@ module Theme
 
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
+    autoload :Deploy, Project.project_filepath('commands/deploy')
     autoload :Push, Project.project_filepath('commands/push')
     autoload :Serve, Project.project_filepath('commands/serve')
   end

--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Theme
+  module Commands
+    class Deploy < ShopifyCli::Command
+      def call(*)
+        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
+          Themekit.ensure_themekit_installed(@ctx)
+        end
+
+        CLI::UI::Frame.open(@ctx.message('theme.deploy.deploying')) do
+          unless CLI::UI::Prompt.confirm(@ctx.message('theme.deploy.confirmation'))
+            @ctx.abort(@ctx.message('theme.deploy.abort'))
+          end
+
+          unless Themekit.deploy(@ctx)
+            @ctx.abort(@ctx.message('theme.deploy.error'))
+          end
+        end
+
+        @ctx.done(@ctx.message('theme.deploy.info.deployed'))
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -19,6 +19,10 @@ module Theme
 
         @ctx.done(@ctx.message('theme.deploy.info.deployed'))
       end
+
+      def self.help
+        ShopifyCli::Context.message('theme.deploy.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+      end
     end
   end
 end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -25,6 +25,10 @@ module Theme
           confirmation: "This will change your live theme. Do you wish to proceed?",
           deploying: "Deploying theme",
           error: "Theme couldn't be deployed",
+          help: <<~HELP,
+            {{command:%s deploy}}: Uploads your local theme files to Shopify, then sets your theme as the live theme.
+              Usage: {{command:%s deploy}}
+          HELP
           info: {
             deployed: "Theme was updated and set as the live theme",
             pushed: "All theme files were updated",

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -20,6 +20,17 @@ module Theme
             created: "{{green:%s}} was created for {{underline:%s}} in {{green:%s}}",
           },
         },
+        deploy: {
+          abort: "Theme wasn't deployed",
+          confirmation: "This will change your live theme. Do you wish to proceed?",
+          deploying: "Deploying theme",
+          error: "Theme couldn't be deployed",
+          info: {
+            deployed: "Theme was updated and set as the live theme",
+            pushed: "All theme files were updated",
+          },
+          push_fail: "Theme files couldn't be updated",
+        },
         forms: {
           create: {
             ask_password: "Password:",
@@ -33,8 +44,8 @@ module Theme
           },
         },
         push: {
-          remove_abort: 'Your theme files were not deleted',
-          remove_confirm: 'Are you sure you want to delete the local and remote copies of the specified theme files?',
+          remove_abort: "Theme files weren't deleted",
+          remove_confirm: "This will delete the local and remote copies of the theme files. Do you wish to proceed?",
           error: {
             push_error: "Theme files couldn't be pushed to Shopify",
             remove_error: "Theme files couldn't be removed from Shopify",

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -13,7 +13,7 @@ module Theme
       end
 
       def deploy(ctx)
-        unless push(ctx, files: nil, flags: nil, remove: false)
+        unless push(ctx)
           ctx.abort(ctx.message('theme.deploy.push_fail'))
         end
         ctx.done(ctx.message('theme.deploy.info.pushed'))

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -5,19 +5,29 @@ module Theme
     class << self
       def create(ctx, password:, store:, name:)
         stat = ctx.system(THEMEKIT,
-                          "new",
+                          'new',
                           "--password=#{password}",
                           "--store=#{store}",
                           "--name=#{name}")
         stat.success?
       end
 
+      def deploy(ctx)
+        unless push(ctx, files: nil, flags: nil, remove: false)
+          ctx.abort(ctx.message('theme.deploy.push_fail'))
+        end
+        ctx.done(ctx.message('theme.deploy.info.pushed'))
+
+        stat = ctx.system(THEMEKIT, 'publish')
+        stat.success?
+      end
+
       def serve(ctx)
-        out, stat = ctx.capture2e(THEMEKIT, "open")
+        out, stat = ctx.capture2e(THEMEKIT, 'open')
         ctx.puts(out)
         ctx.abort(ctx.message('theme.serve.open_fail')) unless stat.success?
 
-        ctx.system(THEMEKIT, "watch")
+        ctx.system(THEMEKIT, 'watch')
       end
 
       def push(ctx, files: nil, flags: nil, remove: false)

--- a/test/project_types/theme/commands/create_test.rb
+++ b/test/project_types/theme/commands/create_test.rb
@@ -28,7 +28,7 @@ module Theme
           context.expects(:done).with(context.message('theme.create.info.created',
                                                       'my_theme',
                                                       'shop.myshopify.com',
-                                                      File.join('', 'my_theme')))
+                                                      File.join(context.root, 'my_theme')))
 
           Theme::Commands::Create.new(context).call([], 'create')
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")

--- a/test/project_types/theme/commands/deploy_test.rb
+++ b/test/project_types/theme/commands/deploy_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class DeployTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def test_deploy_command
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        Themekit.expects(:deploy).with(context).returns(true)
+        context.expects(:done).with(context.message('theme.deploy.info.deployed'))
+
+        Theme::Commands::Deploy.new(context).call
+      end
+
+      def test_aborts_if_not_confirm
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        CLI::UI::Prompt.expects(:confirm).returns(false)
+        Themekit.expects(:deploy).with(context).never
+
+        assert_raises CLI::Kit::Abort do
+          Theme::Commands::Deploy.new(context).call
+        end
+      end
+
+      def test_aborts_if_errors
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        Themekit.expects(:deploy).with(context).returns(false)
+        context.expects(:done).with(context.message('theme.deploy.info.deployed')).never
+
+        assert_raises CLI::Kit::Abort do
+          Theme::Commands::Deploy.new(context).call
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -90,6 +90,49 @@ module Theme
       refute(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true))
     end
 
+    def test_deploy_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      Themekit.expects(:push).with(context).returns(true)
+      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'publish')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+
+      assert(Themekit.deploy(context))
+    end
+
+    def test_deploy_push_fail
+      context = ShopifyCli::Context.new
+
+      Themekit.expects(:push).with(context).returns(false)
+      context.expects(:system).with(Themekit::THEMEKIT, 'publish').never
+
+      assert_raises CLI::Kit::Abort do
+        Themekit.deploy(context)
+      end
+    end
+
+    def test_deploy_publish_fail
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      Themekit.expects(:push).with(context).returns(true)
+      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'publish')
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+
+      refute(Themekit.deploy(context))
+    end
+
     def test_serve_successful
       context = ShopifyCli::Context.new
       stat = mock


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
* Efficient to be able to change the live theme from command line

### What is this pull request doing? 📋 
* Combines `push` command from previous PR and `theme publish` to push all changes and then set theme as live theme
* Tests for command and `themekit.rb` method

##### `--env` flag support will be added in separate PR in bulk