### PR TITLE
Fix outdated packages suggestion message

### DIFF
--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -71,7 +71,7 @@ module Script
           shop_script_undefined_cause: "Script is already turned off in store.",
 
           packages_outdated_cause: "The following npm packages are out of date: %s.",
-          packages_outdated_help: "Run `npm update` to update them.",
+          packages_outdated_help: "Update them by running {{cyan:npm install --save-dev %s}}.",
         },
 
         create: {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -145,7 +145,10 @@ module Script
               'script.error.packages_outdated_cause',
               e.outdated_packages.join(', ')
             ),
-            help_suggestion: ShopifyCli::Context.message('script.error.packages_outdated_help'),
+            help_suggestion: ShopifyCli::Context.message(
+              'script.error.packages_outdated_help',
+              e.outdated_packages.collect { |package| "#{package}@latest" }.join(' ')
+            ),
           }
         end
       end


### PR DESCRIPTION
### WHY are these changes introduced?

To provide a more useful suggestion for what to do when the outdated package check fails.

`npm update` respects semver so running that doesn't actually update the
package enough for the outdated check to pass. Installing the latest
version of the package will.

### WHAT is this pull request doing?

Changes the suggestion message to instruct the user to install the latest EP NPM package.

![New suggestion message](https://user-images.githubusercontent.com/154890/94170160-b593d700-fe5d-11ea-9ecc-71278380f913.png)
