### PR TITLE
Add `--env` flag support for commands

### DIFF
--- a/lib/project_types/theme/commands/create.rb
+++ b/lib/project_types/theme/commands/create.rb
@@ -6,13 +6,14 @@ module Theme
         parser.on('--name=NAME') { |t| flags[:title] = t }
         parser.on('--password=PASSWORD') { |p| flags[:password] = p }
         parser.on('--store=STORE') { |url| flags[:store] = url }
+        parser.on('--env=ENV') { |env| flags[:env] = env }
       end
 
       def call(args, _name)
         form = Forms::Create.ask(@ctx, args, options.flags)
         return @ctx.puts(self.class.help) if form.nil?
 
-        build(form.name, form.password, form.store)
+        build(form.name, form.password, form.store, form.env)
         ShopifyCli::Project.write(@ctx,
                                   project_type: 'theme',
                                   organization_id: nil) # private apps are different
@@ -26,7 +27,7 @@ module Theme
 
       private
 
-      def build(name, password, store)
+      def build(name, password, store, env)
         @ctx.abort(@ctx.message('theme.create.duplicate_theme')) if @ctx.dir_exist?(name)
 
         CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
@@ -37,7 +38,7 @@ module Theme
         @ctx.chdir(name)
 
         CLI::UI::Frame.open(@ctx.message('theme.create.creating_theme', name)) do
-          unless Themekit.create(@ctx, name: name, password: password, store: store)
+          unless Themekit.create(@ctx, name: name, password: password, store: store, env: env)
             @ctx.chdir('..')
             @ctx.rm_rf(name)
             @ctx.abort(@ctx.message('theme.create.failed'))

--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -2,6 +2,10 @@
 module Theme
   module Commands
     class Deploy < ShopifyCli::Command
+      options do |parser, flags|
+        parser.on('--env=ENV') { |env| flags[:env] = env }
+      end
+
       def call(*)
         CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
           Themekit.ensure_themekit_installed(@ctx)
@@ -12,7 +16,7 @@ module Theme
             @ctx.abort(@ctx.message('theme.deploy.abort'))
           end
 
-          unless Themekit.deploy(@ctx)
+          unless Themekit.deploy(@ctx, env: options.flags[:env])
             @ctx.abort(@ctx.message('theme.deploy.error'))
           end
         end

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -6,6 +6,7 @@ module Theme
         parser.on('--store=STORE') { |url| flags[:store] = url }
         parser.on('--password=PASSWORD') { |p| flags[:password] = p }
         parser.on('--themeid=THEME_ID') { |id| flags[:themeid] = id }
+        parser.on('--env=ENV') { |env| flags[:env] = env }
       end
 
       def call(args, _name)
@@ -16,7 +17,7 @@ module Theme
         form = Forms::Pull.ask(@ctx, args, options.flags)
         return @ctx.puts(self.class.help) if form.nil?
 
-        build(form.store, form.password, form.themeid, form.name)
+        build(form.store, form.password, form.themeid, form.name, form.env)
         ShopifyCli::Project.write(@ctx,
                                   project_type: 'theme',
                                   organization_id: nil)
@@ -30,7 +31,7 @@ module Theme
 
       private
 
-      def build(store, password, themeid, name)
+      def build(store, password, themeid, name, env)
         CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
           Themekit.ensure_themekit_installed(@ctx)
         end
@@ -43,7 +44,7 @@ module Theme
         @ctx.chdir(name)
 
         CLI::UI::Frame.open(@ctx.message('theme.pull.pull')) do
-          unless Themekit.pull(@ctx, store: store, password: password, themeid: themeid)
+          unless Themekit.pull(@ctx, store: store, password: password, themeid: themeid, env: env)
             @ctx.chdir('..')
             @ctx.rm_rf(name)
             @ctx.abort(@ctx.message('theme.pull.failed'))

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -15,12 +15,13 @@ module Theme
           options.flags.delete('remove')
         end
 
-        flags = options.flags.map do |key, value|
-          flag = '--' + key
-          if value.is_a?(String)
-            flag += '=' + value
-          end
-          flag
+        if options.flags['env']
+          env = options.flags['env']
+          options.flags.delete('env')
+        end
+
+        flags = options.flags.map do |key, _value|
+          '--' + key
         end
 
         CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
@@ -33,7 +34,7 @@ module Theme
               @ctx.abort(@ctx.message('theme.push.remove_abort'))
             end
 
-            unless Themekit.push(@ctx, files: args, flags: flags, remove: remove)
+            unless Themekit.push(@ctx, files: args, flags: flags, remove: remove, env: env)
               @ctx.abort(@ctx.message('theme.push.error.remove_error'))
             end
           end
@@ -41,7 +42,7 @@ module Theme
           @ctx.done(@ctx.message('theme.push.info.remove', @ctx.root))
         else
           CLI::UI::Frame.open(@ctx.message('theme.push.push')) do
-            unless Themekit.push(@ctx, files: args, flags: flags, remove: remove)
+            unless Themekit.push(@ctx, files: args, flags: flags, remove: remove, env: env)
               @ctx.abort(@ctx.message('theme.push.error.push_error'))
             end
           end

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -6,6 +6,7 @@ module Theme
         parser.on('--remove') { flags['remove'] = true }
         parser.on('--nodelete') { flags['nodelete'] = true }
         parser.on('--allow-live') { flags['allow-live'] = true }
+        parser.on('--env=ENV') { |env| flags['env'] = env }
       end
 
       def call(args, _name)
@@ -14,8 +15,12 @@ module Theme
           options.flags.delete('remove')
         end
 
-        flags = options.flags.map do |key, _value|
-          '--' + key
+        flags = options.flags.map do |key, value|
+          flag = '--' + key
+          if value.is_a?(String)
+            flag += '=' + value
+          end
+          flag
         end
 
         CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -2,13 +2,17 @@
 module Theme
   module Commands
     class Serve < ShopifyCli::Command
+      options do |parser, flags|
+        parser.on('--env=ENV') { |env| flags[:env] = env }
+      end
+
       def call(*)
         CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
           Themekit.ensure_themekit_installed(@ctx)
         end
 
         CLI::UI::Frame.open(@ctx.message('theme.serve.serve')) do
-          Themekit.serve(@ctx)
+          Themekit.serve(@ctx, env: options.flags[:env])
         end
       end
 

--- a/lib/project_types/theme/forms/create.rb
+++ b/lib/project_types/theme/forms/create.rb
@@ -2,7 +2,7 @@ module Theme
   module Forms
     class Create < ShopifyCli::Form
       attr_accessor :name
-      flag_arguments :title, :password, :store
+      flag_arguments :title, :password, :store, :env
 
       def ask
         self.store ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_store'), allow_empty: false)

--- a/lib/project_types/theme/forms/pull.rb
+++ b/lib/project_types/theme/forms/pull.rb
@@ -2,7 +2,7 @@ module Theme
   module Forms
     class Pull < ShopifyCli::Form
       attr_accessor :name
-      flag_arguments :themeid, :password, :store
+      flag_arguments :themeid, :password, :store, :env
 
       def ask
         self.store ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_store'), allow_empty: false)

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -42,14 +42,14 @@ module Theme
             ask_title: "Title:",
             private_app: <<~APP,
               To create a new theme, Shopify App CLI needs to connect with a private app installed on your store. Visit {{underline:%s/admin/apps/private}} to create a new API key and password, or retrieve an existing password.
-              If you create a new private app, ensure that it has Read and Write Theme access.,
+              If you create a new private app, ensure that it has Read and Write Theme access.
             APP
           },
           errors: "%s can't be blank",
           pull: {
             private_app: <<~APP,
               To fetch your existing themes, Shopify App CLI needs to connect with your store. Visit {{underline:%s/admin/apps/private}} to create a new API key and password, or retrieve an existing password.
-              If you create a new private app, ensure that it has Read and Write Theme access.,
+              If you create a new private app, ensure that it has Read and Write Theme access.
             APP
           },
         },

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -9,19 +9,18 @@ module Theme
         command << "--store=#{store}"
         command << "--name=#{name}"
 
-        stat = ctx.system(command.join(' '))
+        stat = ctx.system(*command)
         stat.success?
       end
 
       def deploy(ctx, env:)
-        flags = '--env=' + env if env
-        unless push(ctx, flags: flags)
+        unless push(ctx, env: env)
           ctx.abort(ctx.message('theme.deploy.push_fail'))
         end
         ctx.done(ctx.message('theme.deploy.info.pushed'))
 
         command = build_command('publish', env)
-        stat = ctx.system(command.join(' '))
+        stat = ctx.system(*command)
         stat.success?
       end
 
@@ -35,34 +34,34 @@ module Theme
         command << "--store=#{store}"
         command << "--themeid=#{themeid}"
 
-        stat = ctx.system(command.join(' '))
+        stat = ctx.system(*command)
         stat.success?
       end
 
-      def push(ctx, files: nil, flags: nil, remove: false)
-        command = [THEMEKIT, (remove ? 'remove' : 'deploy')]
+      def push(ctx, files: nil, flags: nil, remove: false, env:)
+        action = remove ? 'remove' : 'deploy'
+        command = build_command(action, env)
         (command << flags << files).flatten!
 
-        stat = ctx.system(command.join(' '))
+        stat = ctx.system(*command)
         stat.success?
       end
 
       def serve(ctx, env:)
         command = build_command('open', env)
-
-        out, stat = ctx.capture2e(command.join(' '))
+        out, stat = ctx.capture2e(*command)
         ctx.puts(out)
         ctx.abort(ctx.message('theme.serve.open_fail')) unless stat.success?
 
         command = build_command('watch', env)
-        ctx.system(command.join(' '))
+        ctx.system(*command)
       end
 
       private
 
       def build_command(action, env)
         command = [THEMEKIT, action]
-        command << '--env=' + env if env
+        command << "--env=#{env}" if env
         command
       end
     end

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -44,8 +44,13 @@ module Theme
         stat.success?
       end
 
-      def serve(ctx)
-        out, stat = ctx.capture2e(THEMEKIT, 'open')
+      def serve(ctx, env:)
+        command = [THEMEKIT, 'open']
+        if env
+          command << '--env=' + env
+        end
+
+        out, stat = ctx.capture2e(command.join(' '))
         ctx.puts(out)
         ctx.abort(ctx.message('theme.serve.open_fail')) unless stat.success?
 

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -63,6 +63,7 @@ module Theme
       def build_command(action, env)
         command = [THEMEKIT, action]
         command << '--env=' + env if env
+        command
       end
     end
   end

--- a/test/project_types/theme/commands/create_test.rb
+++ b/test/project_types/theme/commands/create_test.rb
@@ -6,6 +6,13 @@ module Theme
     class CreateTest < MiniTest::Test
       include TestHelpers::FakeUI
 
+      CONFIG_FILE = Regexp.new <<~CONFIG
+        development:
+         password: boop
+         themeid:  "[\d]+"
+         store: shop.myshopify.com 
+      CONFIG
+
       SHOPIFYCLI_FILE = <<~CLI
         ---
         project_type: theme
@@ -21,9 +28,10 @@ module Theme
             .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
                                                              store: 'shop.myshopify.com',
                                                              title: 'My Theme',
-                                                             name: 'my_theme' }))
+                                                             name: 'my_theme',
+                                                             env: nil }))
           Themekit.expects(:create)
-            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme')
+            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme', env: nil)
             .returns(true)
           context.expects(:done).with(context.message('theme.create.info.created',
                                                       'my_theme',
@@ -31,6 +39,34 @@ module Theme
                                                       File.join(context.root, 'my_theme')))
 
           Theme::Commands::Create.new(context).call([], 'create')
+          assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
+        end
+      end
+
+      def test_can_specify_env
+        FakeFS do
+          context = ShopifyCli::Context.new
+          Themekit.expects(:ensure_themekit_installed).with(context)
+          Theme::Forms::Create.expects(:ask)
+            .with(context, [], { env: 'development' })
+            .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
+                                                             store: 'shop.myshopify.com',
+                                                             title: 'My Theme',
+                                                             name: 'my_theme',
+                                                             env: 'development' }))
+          Themekit.expects(:create)
+            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme', env: 'development')
+            .returns(true)
+          context.expects(:done).with(context.message('theme.create.info.created',
+                                                      'my_theme',
+                                                      'shop.myshopify.com',
+                                                      File.join(context.root, 'my_theme')))
+
+          command = Theme::Commands::Create.new(context)
+          command.options.flags[:env] = 'development'
+          command.call([], 'create')
+
+          assert_equal CONFIG_FILE, File.read("config.yml") # TODO: CAN'T FIND FILE
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
       end

--- a/test/project_types/theme/commands/create_test.rb
+++ b/test/project_types/theme/commands/create_test.rb
@@ -6,13 +6,6 @@ module Theme
     class CreateTest < MiniTest::Test
       include TestHelpers::FakeUI
 
-      CONFIG_FILE = Regexp.new <<~CONFIG
-        development:
-         password: boop
-         themeid:  "[\d]+"
-         store: shop.myshopify.com 
-      CONFIG
-
       SHOPIFYCLI_FILE = <<~CLI
         ---
         project_type: theme
@@ -48,14 +41,14 @@ module Theme
           context = ShopifyCli::Context.new
           Themekit.expects(:ensure_themekit_installed).with(context)
           Theme::Forms::Create.expects(:ask)
-            .with(context, [], { env: 'development' })
+            .with(context, [], { env: 'test' })
             .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
                                                              store: 'shop.myshopify.com',
                                                              title: 'My Theme',
                                                              name: 'my_theme',
-                                                             env: 'development' }))
+                                                             env: 'test' }))
           Themekit.expects(:create)
-            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme', env: 'development')
+            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme', env: 'test')
             .returns(true)
           context.expects(:done).with(context.message('theme.create.info.created',
                                                       'my_theme',
@@ -63,10 +56,9 @@ module Theme
                                                       File.join(context.root, 'my_theme')))
 
           command = Theme::Commands::Create.new(context)
-          command.options.flags[:env] = 'development'
+          command.options.flags[:env] = 'test'
           command.call([], 'create')
 
-          assert_equal CONFIG_FILE, File.read("config.yml") # TODO: CAN'T FIND FILE
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
       end

--- a/test/project_types/theme/commands/deploy_test.rb
+++ b/test/project_types/theme/commands/deploy_test.rb
@@ -10,17 +10,29 @@ module Theme
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        Themekit.expects(:deploy).with(context).returns(true)
+        Themekit.expects(:deploy).with(context, env: nil).returns(true)
         context.expects(:done).with(context.message('theme.deploy.info.deployed'))
 
         Theme::Commands::Deploy.new(context).call
+      end
+
+      def test_can_specify_env
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        Themekit.expects(:deploy).with(context, env: 'development').returns(true)
+        context.expects(:done).with(context.message('theme.deploy.info.deployed'))
+
+        command = Theme::Commands::Deploy.new(context)
+        command.options.flags[:env] = 'development'
+        command.call
       end
 
       def test_aborts_if_not_confirm
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
         CLI::UI::Prompt.expects(:confirm).returns(false)
-        Themekit.expects(:deploy).with(context).never
+        Themekit.expects(:deploy).with(context, env: nil).never
 
         assert_raises CLI::Kit::Abort do
           Theme::Commands::Deploy.new(context).call
@@ -31,7 +43,7 @@ module Theme
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        Themekit.expects(:deploy).with(context).returns(false)
+        Themekit.expects(:deploy).with(context, env: nil).returns(false)
         context.expects(:done).with(context.message('theme.deploy.info.deployed')).never
 
         assert_raises CLI::Kit::Abort do

--- a/test/project_types/theme/commands/deploy_test.rb
+++ b/test/project_types/theme/commands/deploy_test.rb
@@ -20,11 +20,11 @@ module Theme
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        Themekit.expects(:deploy).with(context, env: 'development').returns(true)
+        Themekit.expects(:deploy).with(context, env: 'test').returns(true)
         context.expects(:done).with(context.message('theme.deploy.info.deployed'))
 
         command = Theme::Commands::Deploy.new(context)
-        command.options.flags[:env] = 'development'
+        command.options.flags[:env] = 'test'
         command.call
       end
 

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -46,17 +46,17 @@ module Theme
           ShopifyCli::Project.expects(:has_current?).returns(false)
 
           Theme::Forms::Pull.expects(:ask)
-            .with(context, [], { env: 'development' })
+            .with(context, [], { env: 'test' })
             .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
                                                            password: 'boop',
                                                            themeid: '2468',
                                                            name: 'my_theme',
-                                                           env: 'development' }))
+                                                           env: 'test' }))
 
           Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(false)
           Themekit.expects(:pull)
-            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: 'development')
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: 'test')
             .returns(true)
           context.expects(:done).with(context.message('theme.pull.pulled',
                                                       'my_theme',
@@ -64,7 +64,7 @@ module Theme
                                                       File.join(context.root, 'my_theme')))
 
           command = Theme::Commands::Pull.new(context)
-          command.options.flags[:env] = 'development'
+          command.options.flags[:env] = 'test'
           command.call([], 'pull')
 
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -22,12 +22,13 @@ module Theme
             .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
                                                            password: 'boop',
                                                            themeid: '2468',
-                                                           name: 'my_theme' }))
+                                                           name: 'my_theme',
+                                                           env: nil }))
 
           Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(false)
           Themekit.expects(:pull)
-            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468')
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
             .returns(true)
           context.expects(:done).with(context.message('theme.pull.pulled',
                                                       'my_theme',
@@ -35,6 +36,37 @@ module Theme
                                                       File.join(context.root, 'my_theme')))
 
           Theme::Commands::Pull.new(context).call([], 'pull')
+          assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
+        end
+      end
+
+      def test_can_specify_env
+        FakeFS do
+          context = ShopifyCli::Context.new
+          ShopifyCli::Project.expects(:has_current?).returns(false)
+
+          Theme::Forms::Pull.expects(:ask)
+            .with(context, [], { env: 'development' })
+            .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
+                                                           password: 'boop',
+                                                           themeid: '2468',
+                                                           name: 'my_theme',
+                                                           env: 'development' }))
+
+          Themekit.expects(:ensure_themekit_installed).with(context)
+          context.expects(:dir_exist?).with('my_theme').returns(false)
+          Themekit.expects(:pull)
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: 'development')
+            .returns(true)
+          context.expects(:done).with(context.message('theme.pull.pulled',
+                                                      'my_theme',
+                                                      'shop.myshopify.com',
+                                                      File.join(context.root, 'my_theme')))
+
+          command = Theme::Commands::Pull.new(context)
+          command.options.flags[:env] = 'development'
+          command.call([], 'pull')
+
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
       end
@@ -48,7 +80,7 @@ module Theme
           Themekit.expects(:ensure_themekit_installed).with(context).never
           context.expects(:dir_exist?).with('my_theme').never
           Themekit.expects(:pull)
-            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468')
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
             .never
 
           assert_raises CLI::Kit::Abort do
@@ -67,12 +99,13 @@ module Theme
             .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
                                                            password: 'boop',
                                                            themeid: '2468',
-                                                           name: 'my_theme' }))
+                                                           name: 'my_theme',
+                                                           env: nil }))
 
           Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(true)
           Themekit.expects(:pull)
-            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468')
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
             .never
 
           assert_raises CLI::Kit::Abort do
@@ -91,12 +124,13 @@ module Theme
             .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
                                                            password: 'merp',
                                                            themeid: '1357',
-                                                           name: 'your_theme' }))
+                                                           name: 'your_theme',
+                                                           env: nil }))
 
           Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('your_theme').returns(false)
           Themekit.expects(:pull)
-            .with(context, store: 'shop.myshopify.com', password: 'merp', themeid: '1357')
+            .with(context, store: 'shop.myshopify.com', password: 'merp', themeid: '1357', env: nil)
             .returns(false)
 
           assert_raises CLI::Kit::Abort do

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -68,6 +68,17 @@ module Theme
         command.call(['file.liquid', 'another_file.liquid'], 'push')
       end
 
+      def test_can_specify_env
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        Themekit.expects(:push).with(context, files: [], flags: ['--env=development'], remove: nil).returns(true)
+        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+
+        command = Theme::Commands::Push.new(context)
+        command.options.flags['env'] = 'development'
+        command.call([], 'push')
+      end
+
       def test_aborts_if_push_fails
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -9,7 +9,7 @@ module Theme
       def test_can_push_entire_theme
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
-        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil).returns(true)
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: nil).returns(true)
         context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
         Theme::Commands::Push.new(context).call([], 'push')
@@ -19,7 +19,7 @@ module Theme
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
-          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: nil)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: nil, env: nil)
           .returns(true)
         context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
@@ -31,7 +31,7 @@ module Theme
         CLI::UI::Prompt.expects(:confirm).returns(true)
         Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
-          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil)
           .returns(true)
         context.expects(:done).with(context.message('theme.push.info.remove', context.root))
 
@@ -45,7 +45,7 @@ module Theme
         CLI::UI::Prompt.expects(:confirm).returns(false)
         Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
-          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil)
           .never
 
         command = Theme::Commands::Push.new(context)
@@ -59,7 +59,7 @@ module Theme
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
-          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: ['--nodelete'], remove: nil)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: ['--nodelete'], remove: nil, env: nil)
           .returns(true)
         context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
@@ -71,7 +71,8 @@ module Theme
       def test_can_specify_env
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
-        Themekit.expects(:push).with(context, files: [], flags: ['--env=test'], remove: nil).returns(true)
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: 'test')
+          .returns(true)
         context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
         command = Theme::Commands::Push.new(context)
@@ -82,7 +83,7 @@ module Theme
       def test_aborts_if_push_fails
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
-        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil).returns(false)
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: nil).returns(false)
 
         assert_raises CLI::Kit::Abort do
           Theme::Commands::Push.new(context).call([], 'push')

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -71,11 +71,11 @@ module Theme
       def test_can_specify_env
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
-        Themekit.expects(:push).with(context, files: [], flags: ['--env=development'], remove: nil).returns(true)
+        Themekit.expects(:push).with(context, files: [], flags: ['--env=test'], remove: nil).returns(true)
         context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
         command = Theme::Commands::Push.new(context)
-        command.options.flags['env'] = 'development'
+        command.options.flags['env'] = 'test'
         command.call([], 'push')
       end
 

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -17,10 +17,10 @@ module Theme
       def test_can_specify_env
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
-        Themekit.expects(:serve).with(context, env: 'development')
+        Themekit.expects(:serve).with(context, env: 'test')
 
         command = Theme::Commands::Serve.new(context)
-        command.options.flags[:env] = 'development'
+        command.options.flags[:env] = 'test'
         command.call
       end
     end

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -9,9 +9,19 @@ module Theme
       def test_serve_command
         context = ShopifyCli::Context.new
         Themekit.expects(:ensure_themekit_installed).with(context)
-        Themekit.expects(:serve).with(context)
+        Themekit.expects(:serve).with(context, env: nil)
 
         Theme::Commands::Serve.new(context).call
+      end
+
+      def test_can_specify_env
+        context = ShopifyCli::Context.new
+        Themekit.expects(:ensure_themekit_installed).with(context)
+        Themekit.expects(:serve).with(context, env: 'development')
+
+        command = Theme::Commands::Serve.new(context)
+        command.options.flags[:env] = 'development'
+        command.call
       end
     end
   end

--- a/test/project_types/theme/forms/create_test.rb
+++ b/test/project_types/theme/forms/create_test.rb
@@ -12,6 +12,16 @@ module Theme
         assert_equal(form.name, 'my_theme')
       end
 
+      def test_env_can_be_provided_by_flag
+        form = ask(env: 'development')
+        assert_equal(form.env, 'development')
+      end
+
+      def test_env_nil_if_not_provided
+        form = ask
+        assert_nil(form.env)
+      end
+
       def test_store_can_be_provided_by_flag
         form = ask(store: 'shop.myshopify.com')
         assert_equal(form.store, 'shop.myshopify.com')
@@ -63,13 +73,14 @@ module Theme
 
       private
 
-      def ask(title: 'My Theme', password: 'boop', store: 'shop.myshopify.com')
+      def ask(title: 'My Theme', password: 'boop', store: 'shop.myshopify.com', env: nil)
         Create.ask(
           @context,
           [],
           title: title,
           password: password,
-          store: store
+          store: store,
+          env: env
         )
       end
     end

--- a/test/project_types/theme/forms/create_test.rb
+++ b/test/project_types/theme/forms/create_test.rb
@@ -13,8 +13,8 @@ module Theme
       end
 
       def test_env_can_be_provided_by_flag
-        form = ask(env: 'development')
-        assert_equal(form.env, 'development')
+        form = ask(env: 'test')
+        assert_equal(form.env, 'test')
       end
 
       def test_env_nil_if_not_provided

--- a/test/project_types/theme/forms/pull_test.rb
+++ b/test/project_types/theme/forms/pull_test.rb
@@ -13,6 +13,18 @@ module Theme
         assert_equal(form.name, 'my_theme')
       end
 
+      def test_env_can_be_provided_by_flag
+        query_themes
+        form = ask(env: 'development')
+        assert_equal(form.env, 'development')
+      end
+
+      def test_env_nil_if_not_provided
+        query_themes
+        form = ask
+        assert_nil(form.env)
+      end
+
       def test_store_can_be_provided_by_flag
         query_themes
         form = ask(store: 'shop.myshopify.com')
@@ -51,13 +63,14 @@ module Theme
 
       private
 
-      def ask(password: 'boop', store: 'shop.myshopify.com', themeid: '2468')
+      def ask(password: 'boop', store: 'shop.myshopify.com', themeid: '2468', env: nil)
         Pull.ask(
           @context,
           [],
           password: password,
           store: store,
-          themeid: themeid
+          themeid: themeid,
+          env: env
         )
       end
 

--- a/test/project_types/theme/forms/pull_test.rb
+++ b/test/project_types/theme/forms/pull_test.rb
@@ -15,8 +15,8 @@ module Theme
 
       def test_env_can_be_provided_by_flag
         query_themes
-        form = ask(env: 'development')
-        assert_equal(form.env, 'development')
+        form = ask(env: 'test')
+        assert_equal(form.env, 'test')
       end
 
       def test_env_nil_if_not_provided

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -13,11 +13,11 @@ module Theme
       stat = mock
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'new',
-               '--password=boop',
-               '--store=shop.myshopify.com',
-               '--name=My Theme'].join(' '))
+        .with(Themekit::THEMEKIT,
+              'new',
+              '--password=boop',
+              '--store=shop.myshopify.com',
+              '--name=My Theme')
         .returns(stat)
       stat.stubs(:success?).returns(true)
       assert(Themekit.create(context, password: 'boop', store: 'shop.myshopify.com', name: 'My Theme', env: nil))
@@ -28,11 +28,11 @@ module Theme
       stat = mock
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'new',
-               '--password=boop',
-               '--store=shop.com',
-               '--name=My Theme'].join(' '))
+        .with(Themekit::THEMEKIT,
+              'new',
+              '--password=boop',
+              '--store=shop.com',
+              '--name=My Theme')
         .returns(stat)
       stat.stubs(:success?).returns(false)
       refute(Themekit.create(context, password: 'boop', store: 'shop.com', name: 'My Theme', env: nil))
@@ -43,11 +43,11 @@ module Theme
       stat = mock
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'deploy'].join(' '))
+        .with(Themekit::THEMEKIT,
+              'deploy')
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.push(context, files: [], flags: [], remove: nil))
+      assert(Themekit.push(context, files: [], flags: [], remove: nil, env: nil))
     end
 
     def test_push_remove_successful
@@ -55,13 +55,13 @@ module Theme
       stat = mock
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'remove',
-               'file.liquid',
-               'another_file.liquid'].join(' '))
+        .with(Themekit::THEMEKIT,
+              'remove',
+              'file.liquid',
+              'another_file.liquid')
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true))
+      assert(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil))
     end
 
     def test_push_deploy_unsuccessful
@@ -69,11 +69,11 @@ module Theme
       stat = mock
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'deploy'].join(' '))
+        .with(Themekit::THEMEKIT,
+             'deploy')
         .returns(stat)
       stat.stubs(:success?).returns(false)
-      refute(Themekit.push(context, files: [], flags: [], remove: nil))
+      refute(Themekit.push(context, files: [], flags: [], remove: nil, env: nil))
     end
 
     def test_push_remove_unsuccessful
@@ -81,25 +81,25 @@ module Theme
       stat = mock
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'remove',
-               'file.liquid',
-               'another_file.liquid'].join(' '))
+        .with(Themekit::THEMEKIT,
+              'remove',
+              'file.liquid',
+              'another_file.liquid')
         .returns(stat)
       stat.stubs(:success?).returns(false)
-      refute(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true))
+      refute(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil))
     end
 
     def test_deploy_successful
       context = ShopifyCli::Context.new
       stat = mock
 
-      Themekit.expects(:push).with(context, flags: nil).returns(true)
+      Themekit.expects(:push).with(context, env: nil).returns(true)
       context.expects(:done).with(context.message('theme.deploy.info.pushed'))
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'publish'].join(' '))
+        .with(Themekit::THEMEKIT,
+             'publish')
         .returns(stat)
       stat.stubs(:success?).returns(true)
 
@@ -109,7 +109,7 @@ module Theme
     def test_deploy_push_fail
       context = ShopifyCli::Context.new
 
-      Themekit.expects(:push).with(context, flags: nil).returns(false)
+      Themekit.expects(:push).with(context, env: nil).returns(false)
       context.expects(:system).with(Themekit::THEMEKIT, 'publish').never
 
       assert_raises CLI::Kit::Abort do
@@ -121,12 +121,12 @@ module Theme
       context = ShopifyCli::Context.new
       stat = mock
 
-      Themekit.expects(:push).with(context, flags: nil).returns(true)
+      Themekit.expects(:push).with(context, env: nil).returns(true)
       context.expects(:done).with(context.message('theme.deploy.info.pushed'))
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'publish'].join(' '))
+        .with(Themekit::THEMEKIT,
+              'publish')
         .returns(stat)
       stat.stubs(:success?).returns(false)
 
@@ -137,11 +137,11 @@ module Theme
       context = ShopifyCli::Context.new
       stat = mock
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'get',
-               '--password=boop',
-               '--store=shop.com',
-               '--themeid=2468'].join(' '))
+        .with(Themekit::THEMEKIT,
+              'get',
+              '--password=boop',
+              '--store=shop.com',
+              '--themeid=2468')
         .returns(stat)
       stat.stubs(:success?).returns(true)
       assert(Themekit.pull(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
@@ -151,11 +151,11 @@ module Theme
       context = ShopifyCli::Context.new
       stat = mock
       context.expects(:system)
-        .with([Themekit::THEMEKIT,
-               'get',
-               '--password=boop',
-               '--store=shop.com',
-               '--themeid=2468'].join(' '))
+        .with(Themekit::THEMEKIT,
+              'get',
+              '--password=boop',
+              '--store=shop.com',
+              '--themeid=2468')
         .returns(stat)
       stat.stubs(:success?).returns(false)
       refute(Themekit.pull(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
@@ -166,13 +166,13 @@ module Theme
       stat = mock
 
       context.expects(:capture2e)
-        .with([Themekit::THEMEKIT, 'open'].join(' '))
+        .with(Themekit::THEMEKIT, 'open')
         .returns(['out', stat])
       stat.stubs(:success?).returns(true)
       context.expects(:puts).with('out')
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT, 'watch'].join(' '))
+        .with(Themekit::THEMEKIT, 'watch')
 
       Themekit.serve(context, env: nil)
     end
@@ -182,13 +182,13 @@ module Theme
       stat = mock
 
       context.expects(:capture2e)
-        .with([Themekit::THEMEKIT, 'open'].join(' '))
+        .with(Themekit::THEMEKIT, 'open')
         .returns(['out', stat])
       stat.stubs(:success?).returns(false)
       context.expects(:puts).with('out')
 
       context.expects(:system)
-        .with([Themekit::THEMEKIT, 'watch'].join(' '))
+        .with(Themekit::THEMEKIT, 'watch')
         .never
 
       assert_raises(ShopifyCli::Abort) do

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -13,14 +13,14 @@ module Theme
       stat = mock
 
       context.expects(:system)
-        .with(Themekit::THEMEKIT,
-              'new',
-              '--password=boop',
-              '--store=shop.myshopify.com',
-              '--name=My Theme')
+        .with([Themekit::THEMEKIT,
+               'new',
+               '--password=boop',
+               '--store=shop.myshopify.com',
+               '--name=My Theme'].join(' '))
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.create(context, password: 'boop', store: 'shop.myshopify.com', name: 'My Theme'))
+      assert(Themekit.create(context, password: 'boop', store: 'shop.myshopify.com', name: 'My Theme', env: nil))
     end
 
     def test_create_theme_unsuccessful
@@ -28,14 +28,14 @@ module Theme
       stat = mock
 
       context.expects(:system)
-        .with(Themekit::THEMEKIT,
-              'new',
-              '--password=boop',
-              '--store=shop.com',
-              '--name=My Theme')
+        .with([Themekit::THEMEKIT,
+               'new',
+               '--password=boop',
+               '--store=shop.com',
+               '--name=My Theme'].join(' '))
         .returns(stat)
       stat.stubs(:success?).returns(false)
-      refute(Themekit.create(context, password: 'boop', store: 'shop.com', name: 'My Theme'))
+      refute(Themekit.create(context, password: 'boop', store: 'shop.com', name: 'My Theme', env: nil))
     end
 
     def test_push_deploy_successful
@@ -94,26 +94,26 @@ module Theme
       context = ShopifyCli::Context.new
       stat = mock
 
-      Themekit.expects(:push).with(context).returns(true)
+      Themekit.expects(:push).with(context, flags: nil).returns(true)
       context.expects(:done).with(context.message('theme.deploy.info.pushed'))
 
       context.expects(:system)
-        .with(Themekit::THEMEKIT,
-              'publish')
+        .with([Themekit::THEMEKIT,
+               'publish'].join(' '))
         .returns(stat)
       stat.stubs(:success?).returns(true)
 
-      assert(Themekit.deploy(context))
+      assert(Themekit.deploy(context, env: nil))
     end
 
     def test_deploy_push_fail
       context = ShopifyCli::Context.new
 
-      Themekit.expects(:push).with(context).returns(false)
+      Themekit.expects(:push).with(context, flags: nil).returns(false)
       context.expects(:system).with(Themekit::THEMEKIT, 'publish').never
 
       assert_raises CLI::Kit::Abort do
-        Themekit.deploy(context)
+        Themekit.deploy(context, env: nil)
       end
     end
 
@@ -121,44 +121,44 @@ module Theme
       context = ShopifyCli::Context.new
       stat = mock
 
-      Themekit.expects(:push).with(context).returns(true)
+      Themekit.expects(:push).with(context, flags: nil).returns(true)
       context.expects(:done).with(context.message('theme.deploy.info.pushed'))
 
       context.expects(:system)
-        .with(Themekit::THEMEKIT,
-              'publish')
+        .with([Themekit::THEMEKIT,
+               'publish'].join(' '))
         .returns(stat)
       stat.stubs(:success?).returns(false)
 
-      refute(Themekit.deploy(context))
+      refute(Themekit.deploy(context, env: nil))
     end
 
     def test_pull_successful
       context = ShopifyCli::Context.new
       stat = mock
       context.expects(:system)
-        .with(Themekit::THEMEKIT,
-              'get',
-              '--store=shop.com',
-              '--password=boop',
-              '--themeid=2468')
+        .with([Themekit::THEMEKIT,
+               'get',
+               '--password=boop',
+               '--store=shop.com',
+               '--themeid=2468'].join(' '))
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.pull(context, store: 'shop.com', password: 'boop', themeid: '2468'))
+      assert(Themekit.pull(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
     end
 
     def test_pull_unsuccessful
       context = ShopifyCli::Context.new
       stat = mock
       context.expects(:system)
-        .with(Themekit::THEMEKIT,
-              'get',
-              '--store=shop.com',
-              '--password=boop',
-              '--themeid=2468')
+        .with([Themekit::THEMEKIT,
+               'get',
+               '--password=boop',
+               '--store=shop.com',
+               '--themeid=2468'].join(' '))
         .returns(stat)
       stat.stubs(:success?).returns(false)
-      refute(Themekit.pull(context, store: 'shop.com', password: 'boop', themeid: '2468'))
+      refute(Themekit.pull(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
     end
 
     def test_serve_successful
@@ -166,15 +166,15 @@ module Theme
       stat = mock
 
       context.expects(:capture2e)
-        .with(Themekit::THEMEKIT, 'open')
+        .with([Themekit::THEMEKIT, 'open'].join(' '))
         .returns(['out', stat])
       stat.stubs(:success?).returns(true)
       context.expects(:puts).with('out')
 
       context.expects(:system)
-        .with(Themekit::THEMEKIT, 'watch')
+        .with([Themekit::THEMEKIT, 'watch'].join(' '))
 
-      Themekit.serve(context)
+      Themekit.serve(context, env: nil)
     end
 
     def test_aborts_serve_if_open_fails
@@ -182,17 +182,17 @@ module Theme
       stat = mock
 
       context.expects(:capture2e)
-        .with(Themekit::THEMEKIT, 'open')
+        .with([Themekit::THEMEKIT, 'open'].join(' '))
         .returns(['out', stat])
       stat.stubs(:success?).returns(false)
       context.expects(:puts).with('out')
 
       context.expects(:system)
-        .with(Themekit::THEMEKIT, 'watch')
+        .with([Themekit::THEMEKIT, 'watch'].join(' '))
         .never
 
       assert_raises(ShopifyCli::Abort) do
-        Themekit.serve(context)
+        Themekit.serve(context, env: nil)
       end
     end
   end


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
- User may want changes only apply to a certain env

### What is this pull request doing? 📋 
- Adds `--env` flag support to every command + adapter class method + form
  - Changes adapter class command building to private method
- Fixes all related tests