### PR TITLE
Allow any characters in ngrok account names

### DIFF
--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -210,7 +210,7 @@ module ShopifyCli
       end
 
       def parse_account
-        account, timeout, _ = @log.match(/AccountName:([\w\s\d@._\-]*) SessionDuration:([\d]+) PlanName/)&.captures
+        account, timeout, _ = @log.match(/AccountName:(.*)\s+SessionDuration:([\d]+) PlanName/)&.captures
         @account = account&.empty? ? nil : account
         @timeout = timeout&.empty? ? 0 : timeout.to_i
       end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

@saulecabrera and I were debugging a strange issue he was getting, where his `serve` command was failing to start. It turns out that we were incorrectly parsing the ngrok logs, and we were failing to detect the account name because of the accent in his name.

### WHAT is this pull request doing?

We now accept anything as account names, which should ensure that we pick up on all of them. Since we have context both before and after the account name, we can rely on the other markers in the log line and just do a greedy search for the account, which should make this a lot more robust.