### PR TITLE
[Fix] Fix argo admin identifier

### DIFF
--- a/lib/project_types/extension/models/types/product_subscription.rb
+++ b/lib/project_types/extension/models/types/product_subscription.rb
@@ -12,7 +12,7 @@ module Extension
         end
 
         def create(directory_name, context)
-          Features::Argo::Admin.new.create(directory_name, graphql_identifier, context)
+          Features::Argo::Admin.new.create(directory_name, IDENTIFIER, context)
         end
 
         def config(context)

--- a/test/project_types/extension/models/types/product_subscription_test.rb
+++ b/test/project_types/extension/models/types/product_subscription_test.rb
@@ -16,7 +16,7 @@ module Extension
 
           Features::Argo::Admin.any_instance
             .expects(:create)
-            .with(directory_name, @product_subscription.graphql_identifier, @context)
+            .with(directory_name, ProductSubscription::IDENTIFIER, @context)
             .once
 
           @product_subscription.create(directory_name, @context)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-extension-libs/issues/1012

This PR fixes argo admin identifier. Argo-Admin-Template is using `PRODUCT_SUBSCRIPTION` type https://github.com/Shopify/argo-admin-template/blob/master/README.md#from-github

### WHAT is this pull request doing?

Change to correct identifier and fix test. 

### How to test this?
- Checkout this PR
- Run 
```
./bin/shopify create extension
```
- Verify that PRODUCT_SUBSCRIPTION extension is created successfully.
- Go to the extension folder that you just create.
- Try to register and push it
```
../bin/shopify register
../bin/shopify push
```
- Verify the extension is pushed successfully. 
- Go to app in partner dash and try to publish it. 

Note: 
- Make sure your test app has `product_subscription_extension` beta flag. 
