### PR TITLE
Send Shopify header for employees

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :test do
   gem 'mocha', require: false
   gem 'minitest', '>= 5.0.0', require: false
   gem 'minitest-reporters', require: false
+  gem 'minitest-fail-fast', require: false
   gem 'fakefs', '>= 1.0', require: false
   gem 'webmock', require: false
   gem 'timecop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,8 @@ GEM
     hashdiff (1.0.1)
     method_source (1.0.0)
     minitest (5.14.2)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
     minitest-reporters (1.4.2)
       ansi
       builder
@@ -63,6 +65,7 @@ DEPENDENCIES
   byebug
   fakefs (>= 1.0)
   minitest (>= 5.0.0)
+  minitest-fail-fast
   minitest-reporters
   mocha
   pry-byebug

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -40,11 +40,11 @@ module Node
           scopes: 'write_products,write_customers,write_draft_orders',
         ).write(@ctx)
 
-        partners_url = "#{partners_endpoint}/#{form.organization_id}/apps/#{api_client['id']}"
+        partners_url = partners_url_for(form.organization_id, api_client['id'])
 
-        @ctx.puts(@ctx.message('node.create.info.created', form.title, partners_url))
-        @ctx.puts(@ctx.message('node.create.info.serve', form.name, ShopifyCli::TOOL_NAME))
-        @ctx.puts(@ctx.message('node.create.info.install', partners_url, form.title))
+        @ctx.puts(@ctx.message('apps.create.info.created', form.title, partners_url))
+        @ctx.puts(@ctx.message('apps.create.info.serve', form.name, ShopifyCli::TOOL_NAME))
+        @ctx.puts(@ctx.message('apps.create.info.install', partners_url, form.title))
       end
 
       def self.help
@@ -113,9 +113,20 @@ module Node
         end
       end
 
+      def partners_url_for(organization_id, api_client_id)
+        if ShopifyCli::Shopifolk.acting_as_shopify_organization?
+          organization_id = 'internal'
+        end
+        "#{partners_endpoint}/#{organization_id}/apps/#{api_client_id}"
+      end
+
       def partners_endpoint
-        return 'https://partners.myshopify.io' if @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
-        'https://partners.shopify.com'
+        domain = if @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
+          'partners.myshopify.io'
+        else
+          'partners.shopify.com'
+        end
+        "https://#{domain}"
       end
     end
   end

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -40,7 +40,7 @@ module Node
           scopes: 'write_products,write_customers,write_draft_orders',
         ).write(@ctx)
 
-        partners_url = partners_url_for(form.organization_id, api_client['id'])
+        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client['id'], local_debug?)
 
         @ctx.puts(@ctx.message('apps.create.info.created', form.title, partners_url))
         @ctx.puts(@ctx.message('apps.create.info.serve', form.name, ShopifyCli::TOOL_NAME))
@@ -113,20 +113,8 @@ module Node
         end
       end
 
-      def partners_url_for(organization_id, api_client_id)
-        if ShopifyCli::Shopifolk.acting_as_shopify_organization?
-          organization_id = 'internal'
-        end
-        "#{partners_endpoint}/#{organization_id}/apps/#{api_client_id}"
-      end
-
-      def partners_endpoint
-        domain = if @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
-          'partners.myshopify.io'
-        else
-          'partners.shopify.com'
-        end
-        "https://#{domain}"
+      def local_debug?
+        @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
       end
     end
   end

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -26,12 +26,6 @@ module Node
             npm_version_failure: "Failed to get the current npm version. Please make sure it is installed as per " \
               "the instructions at https://www.npmjs.com/get-npm.",
           },
-          info: {
-            created: "{{v}} {{green:%s}} was created in your Partner Dashboard {{underline:%s}}",
-            serve: "{{*}} Change directories to your new project folder {{green:%s}} and run {{command:%s serve}} " \
-              "to start a local server",
-            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
-          },
           node_version: "node %s",
           npm_version: "npm %s",
         },

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -55,11 +55,11 @@ module Rails
           scopes: 'write_products,write_customers,write_draft_orders',
         ).write(@ctx)
 
-        partners_url = "#{partners_endpoint}/#{form.organization_id}/apps/#{api_client['id']}"
+        partners_url = partners_url_for(form.organization_id, api_client['id'])
 
-        @ctx.puts(@ctx.message('rails.create.info.created', form.title, partners_url))
-        @ctx.puts(@ctx.message('rails.create.info.serve', form.name, ShopifyCli::TOOL_NAME))
-        @ctx.puts(@ctx.message('rails.create.info.install', partners_url, form.title))
+        @ctx.puts(@ctx.message('apps.create.info.created', form.title, partners_url))
+        @ctx.puts(@ctx.message('apps.create.info.serve', form.name, ShopifyCli::TOOL_NAME))
+        @ctx.puts(@ctx.message('apps.create.info.install', partners_url, form.title))
       end
 
       def self.help
@@ -173,9 +173,20 @@ module Rails
         Gem.install(@ctx, name, version)
       end
 
+      def partners_url_for(organization_id, api_client_id)
+        if ShopifyCli::Shopifolk.acting_as_shopify_organization?
+          organization_id = 'internal'
+        end
+        "#{partners_endpoint}/#{organization_id}/apps/#{api_client_id}"
+      end
+
       def partners_endpoint
-        return 'https://partners.myshopify.io' if @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
-        'https://partners.shopify.com'
+        domain = if @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
+          'partners.myshopify.io'
+        else
+          'partners.shopify.com'
+        end
+        "https://#{domain}"
       end
     end
   end

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -55,7 +55,7 @@ module Rails
           scopes: 'write_products,write_customers,write_draft_orders',
         ).write(@ctx)
 
-        partners_url = partners_url_for(form.organization_id, api_client['id'])
+        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client['id'], local_debug?)
 
         @ctx.puts(@ctx.message('apps.create.info.created', form.title, partners_url))
         @ctx.puts(@ctx.message('apps.create.info.serve', form.name, ShopifyCli::TOOL_NAME))
@@ -173,20 +173,8 @@ module Rails
         Gem.install(@ctx, name, version)
       end
 
-      def partners_url_for(organization_id, api_client_id)
-        if ShopifyCli::Shopifolk.acting_as_shopify_organization?
-          organization_id = 'internal'
-        end
-        "#{partners_endpoint}/#{organization_id}/apps/#{api_client_id}"
-      end
-
-      def partners_endpoint
-        domain = if @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
-          'partners.myshopify.io'
-        else
-          'partners.shopify.com'
-        end
-        "https://#{domain}"
+      def local_debug?
+        @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
       end
     end
   end

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -48,10 +48,6 @@ module Rails
           },
 
           info: {
-            created: "{{v}} {{green:%s}} was created in your Partner Dashboard {{underline:%s}}",
-            serve: "{{*}} Change directories to your new project folder {{green:%s}} and run {{command:%s serve}} " \
-              "to start a local server",
-            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
             open_new_shell: "{{*}} {{yellow:After installing %s, please open a new Command Prompt or PowerShell " \
               "window to continue.}}",
           },

--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -91,7 +91,9 @@ module ShopifyCli
     def default_headers
       {
         'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} #{current_sha} | #{ctx.uname}",
-      }.merge(auth_headers(token))
+      }.tap do |headers|
+        headers['X-Shopify-Cli-Employee'] = '1' if Shopifolk.acting_as_shopify_organization?
+      end.merge(auth_headers(token))
     end
 
     def auth_headers(token)

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -3,6 +3,16 @@
 module ShopifyCli
   module Messages
     MESSAGES = {
+      apps: {
+        create: {
+          info: {
+            created: "{{v}} {{green:%s}} was created in the organization's Partner Dashboard {{underline:%s}}",
+            serve: "{{*}} Change directories to your new project folder {{green:%s}} and run {{command:%s serve}} " \
+            "to start a local server",
+            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
+          },
+        },
+      },
       core: {
         connect: {
           help: <<~HELP,
@@ -300,6 +310,8 @@ module ShopifyCli
               organization_not_found: "Cannot find a partner organization with that ID",
               partners_notice: "Please visit https://partners.shopify.com/ to create a partners account",
             },
+            first_party: "Are you working on a 1P (1st Party) app?",
+            identified_as_shopify: "We've identified you as a {{green:Shopify}} employee.",
             organization: "Partner organization {{green:%s (%s)}}",
             organization_select: "Select partner organization",
           },

--- a/lib/shopify-cli/partners_api.rb
+++ b/lib/shopify-cli/partners_api.rb
@@ -27,7 +27,7 @@ module ShopifyCli
       # #### Parameters
       # - `ctx`: running context from your command
       # - `query_name`: name of the query you want to use, loaded from the `lib/graphql` directory.
-      # - `**variable`: a hash of variables to be supplied to the query ro mutation
+      # - `**variables`: a hash of variables to be supplied to the query or mutation
       #
       # #### Raises
       #

--- a/lib/shopify-cli/partners_api.rb
+++ b/lib/shopify-cli/partners_api.rb
@@ -50,6 +50,13 @@ module ShopifyCli
         end
       end
 
+      def partners_url_for(organization_id, api_client_id, local_debug)
+        if ShopifyCli::Shopifolk.acting_as_shopify_organization?
+          organization_id = 'internal'
+        end
+        "#{partners_endpoint(local_debug)}/#{organization_id}/apps/#{api_client_id}"
+      end
+
       private
 
       def authenticated_req(ctx)
@@ -104,6 +111,15 @@ module ShopifyCli
       def endpoint
         return 'https://partners.shopify.com' if ENV[LOCAL_DEBUG].nil?
         'https://partners.myshopify.io/'
+      end
+
+      def partners_endpoint(local_debug)
+        domain = if local_debug
+          'partners.myshopify.io'
+        else
+          'partners.shopify.com'
+        end
+        "https://#{domain}"
       end
     end
 

--- a/lib/shopify-cli/task.rb
+++ b/lib/shopify-cli/task.rb
@@ -6,5 +6,13 @@ module ShopifyCli
       task = new
       task.call(*args, **kwargs)
     end
+
+    private
+
+    def wants_to_run_against_shopify_org?
+      @ctx.puts(@ctx.message('core.tasks.select_org_and_shop.identified_as_shopify'))
+      message = @ctx.message('core.tasks.select_org_and_shop.first_party')
+      CLI::UI::Prompt.confirm(message, default: false)
+    end
   end
 end

--- a/lib/shopify-cli/tasks/create_api_client.rb
+++ b/lib/shopify-cli/tasks/create_api_client.rb
@@ -17,6 +17,15 @@ module ShopifyCli
           redir: [OAuth::REDIRECT_HOST]
         )
 
+        unless resp
+          ctx.abort("Error - empty response")
+        end
+
+        errors = resp.dig("errors")
+        if !errors.nil? && errors.any?
+          ctx.abort(errors.map { |err| "#{err['field']} #{err['message']}" }.join(", "))
+        end
+
         user_errors = resp.dig("data", "appCreate", "userErrors")
         if !user_errors.nil? && user_errors.any?
           ctx.abort(user_errors.map { |err| "#{err['field']} #{err['message']}" }.join(", "))

--- a/lib/shopify-cli/tasks/ensure_env.rb
+++ b/lib/shopify-cli/tasks/ensure_env.rb
@@ -22,6 +22,9 @@ module ShopifyCli
       private
 
       def fetch_org
+        if Shopifolk.check && wants_to_run_against_shopify_org?
+          Shopifolk.act_as_shopify_organization
+        end
         orgs = PartnersAPI::Organizations.fetch_with_app(@ctx)
         org_id = if orgs.count == 1
           orgs.first["id"]

--- a/lib/shopify-cli/tasks/select_org_and_shop.rb
+++ b/lib/shopify-cli/tasks/select_org_and_shop.rb
@@ -8,6 +8,9 @@ module ShopifyCli
       def call(ctx, organization_id: nil, shop_domain: nil)
         @ctx = ctx
         return response(organization_id.to_i, shop_domain) unless organization_id.nil? || shop_domain.nil?
+        if Shopifolk.check && wants_to_run_against_shopify_org?
+          Shopifolk.act_as_shopify_organization
+        end
         org = get_organization(organization_id)
         shop_domain ||= get_shop_domain(org)
         ShopifyCli::Core::Monorail.metadata[:organization_id] = org["id"].to_i

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -22,6 +22,7 @@ module Minitest
     end
 
     def teardown
+      ShopifyCli::Shopifolk.reset
       # Some tests stub the File class, but we need to call the real methods when checking if the config file has
       # changed.
       #

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -12,6 +12,7 @@ module Extension
       FileUtils.cd(new_context.root)
 
       ExtensionProject.write_cli_file(context: new_context, type: @test_extension_type.identifier)
+      ::ShopifyCli::Project.clear
 
       assert File.exist?('.shopify-cli.yml')
       assert_equal :extension, ShopifyCli::Project.current_project_type

--- a/test/project_types/node/forms/create_test.rb
+++ b/test/project_types/node/forms/create_test.rb
@@ -8,6 +8,8 @@ module Node
 
       def setup
         super
+        stub_shopify_org_confirmation
+        ShopifyCli::Shopifolk.stubs(:check)
         ShopifyCli::ProjectType.load_type(:node)
       end
 

--- a/test/project_types/rails/forms/create_test.rb
+++ b/test/project_types/rails/forms/create_test.rb
@@ -6,6 +6,12 @@ module Rails
     class CreateTest < MiniTest::Test
       include TestHelpers::Partners
 
+      def setup
+        super
+        ShopifyCli::Shopifolk.stubs(:check)
+        stub_shopify_org_confirmation
+      end
+
       def test_returns_all_defined_attributes_if_valid
         form = ask
         assert_equal('test_app', form.name)

--- a/test/shopify-cli/api_test.rb
+++ b/test/shopify-cli/api_test.rb
@@ -139,5 +139,18 @@ module ShopifyCli
       File.expects(:read).with(expected_path).returns('content')
       assert_equal('content', new_api.call_load_query('my_query'))
     end
+
+    def test_include_shopify_cli_header_if_acting_as_shopify_organization
+      Shopifolk.act_as_shopify_organization
+      File.stubs(:read)
+        .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
+        .returns(@mutation)
+      response = stub('response', code: '200', body: '{}')
+      HttpRequest
+        .expects(:call)
+        .with(anything, @mutation, {}, has_entry({ 'X-Shopify-Cli-Employee' => '1' }))
+        .returns(response)
+      @api.query('api/mutation')
+    end
   end
 end

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -6,7 +6,7 @@ module ShopifyCli
     class MonorailTest < MiniTest::Test
       def setup
         super
-        CLI::UI::Prompt.stubs(:confirm).returns(true)
+        stub_shopify_org_confirmation
         ShopifyCli::Core::Monorail.metadata = {}
       end
 
@@ -189,6 +189,13 @@ module ShopifyCli
         ShopifyCli::Config.stubs(:get_section).with('analytics').returns({ 'enabled' => consented.to_s })
         ShopifyCli::Context.any_instance.stubs(:system?).returns(enabled)
         ShopifyCli::Config.stubs(:get_bool).with('analytics', 'enabled').returns(consented)
+      end
+
+      def stub_shopify_org_confirmation(response: true)
+        CLI::UI::Prompt
+          .stubs(:confirm)
+          .with(includes("Are you working a 1P (1st Party) app?"), anything)
+          .returns(response)
       end
     end
   end

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -31,7 +31,6 @@ module ShopifyCli
     def test_write_writes_yaml
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       Dir.stubs(:pwd).returns(@context.root)
-      FileUtils.touch(".shopify-cli.yml")
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
       assert_equal :node, Project.current.config['project_type']
       assert_equal 42, Project.current.config['organization_id']

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -53,7 +53,7 @@ module ShopifyCli
 
     def test_write_includes_identifiers
       create_empty_config
-      File.write(".shopify-cli.yml", YAML.dump({}))
+      Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       ShopifyCli::Project.write(
         @context,
         project_type: :node,

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -29,11 +29,13 @@ module ShopifyCli
     end
 
     def test_write_writes_yaml
-      create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
+      Dir.stubs(:pwd).returns(@context.root)
+      FileUtils.touch(".shopify-cli.yml")
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
       assert_equal :node, Project.current.config['project_type']
       assert_equal 42, Project.current.config['organization_id']
+      refute Project.current.config['shopify_organization']
     end
 
     def test_write_writes_yaml_with_shopify_organization_field
@@ -52,13 +54,14 @@ module ShopifyCli
 
     def test_write_includes_identifiers
       create_empty_config
-      Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
+      File.write(".shopify-cli.yml", YAML.dump({}))
       ShopifyCli::Project.write(
         @context,
         project_type: :node,
         organization_id: 42,
         other_option: true,
       )
+      Project.clear
       assert Project.current.config['other_option']
     end
 

--- a/test/shopify-cli/tasks/create_api_client_test.rb
+++ b/test/shopify-cli/tasks/create_api_client_test.rb
@@ -44,6 +44,34 @@ module ShopifyCli
         assert_equal("newapikey", ShopifyCli::Core::Monorail.metadata[:api_key])
       end
 
+      def test_call_will_return_any_general_errors
+        stub_partner_req(
+          'create_app',
+          variables: {
+            org: 42,
+            title: 'Test app',
+            type: 'public',
+            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            redir: ["http://127.0.0.1:3456"],
+          },
+          resp: {
+            'errors': [
+              { 'field': 'title', 'message': 'is not a valid title' },
+            ],
+          }
+        )
+
+        err = assert_raises ShopifyCli::Abort do
+          Tasks::CreateApiClient.call(
+            @context,
+            org_id: 42,
+            title: 'Test app',
+            type: 'public',
+          )
+        end
+        assert_equal("{{x}} title is not a valid title", err.message)
+      end
+
       def test_call_will_return_any_user_errors
         stub_partner_req(
           'create_app',

--- a/test/shopify-cli/tasks/ensure_env_test.rb
+++ b/test/shopify-cli/tasks/ensure_env_test.rb
@@ -12,6 +12,7 @@ module ShopifyCli
         Project.write(@context, project_type: :fake, organization_id: 42)
         FileUtils.cd(@context.root)
         ShopifyCli::Tunnel.stubs(:start)
+        Shopifolk.stubs(:check)
       end
 
       def test_create_new_app_if_none_available

--- a/test/shopify-cli/tasks/select_org_and_shop_test.rb
+++ b/test/shopify-cli/tasks/select_org_and_shop_test.rb
@@ -8,6 +8,7 @@ module ShopifyCli
       def setup
         super
         stub_shopify_org_confirmation
+        Shopifolk.stubs(:check).returns(false) # note that we re-stub this in some tests below
       end
 
       def teardown
@@ -31,7 +32,6 @@ module ShopifyCli
             ],
           },
         ])
-        Shopifolk.expects(:check)
         CLI::UI::Prompt.expects(:ask)
           .with(@context.message('core.tasks.select_org_and_shop.organization_select'))
           .returns(431)
@@ -53,7 +53,7 @@ module ShopifyCli
             },
           ]
         )
-        Shopifolk.expects(:check)
+
         io = capture_io do
           form = call(org_id: nil, shop: nil)
           assert_equal(421, form[:organization_id])
@@ -74,7 +74,6 @@ module ShopifyCli
             ],
           }
         )
-        Shopifolk.expects(:check)
         form = call(org_id: 123, shop: nil)
         assert_equal(123, form[:organization_id])
         assert_equal('shopdomain.myshopify.com', form[:shop_domain])
@@ -82,7 +81,6 @@ module ShopifyCli
 
       def test_it_will_fail_if_no_orgs_are_available
         ShopifyCli::PartnersAPI::Organizations.expects(:fetch_all).with(@context).returns([])
-        Shopifolk.expects(:check)
 
         assert_raises ShopifyCli::Abort do
           io = capture_io do
@@ -99,7 +97,6 @@ module ShopifyCli
         ShopifyCli::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
           { "id" => 123, "stores" => [] },
         )
-        Shopifolk.expects(:check)
 
         io = capture_io do
           form = call(org_id: 123, shop: nil)
@@ -119,8 +116,6 @@ module ShopifyCli
             ],
           }
         )
-        Shopifolk.expects(:check)
-
         io = capture_io do
           form = call(org_id: 123, shop: nil)
           assert_equal('shopdomain.myshopify.com', form[:shop_domain])
@@ -141,7 +136,6 @@ module ShopifyCli
             ],
           }
         )
-        Shopifolk.expects(:check)
 
         CLI::UI::Prompt.expects(:ask)
           .with(
@@ -162,7 +156,7 @@ module ShopifyCli
         })
 
         stub_shopify_org_confirmation(response: true)
-        ShopifyCli::Feature.expects(:enabled?).with('shopifolk').returns(true)
+        Shopifolk.stubs(:check).returns(true)
         call(org_id: 123, shop: nil)
 
         assert(Shopifolk.acting_as_shopify_organization?)
@@ -176,7 +170,7 @@ module ShopifyCli
           ],
         })
         stub_shopify_org_confirmation(response: false)
-        ShopifyCli::Feature.expects(:enabled?).with('shopifolk').returns(true)
+        Shopifolk.stubs(:check).returns(true)
         call(org_id: 123, shop: nil)
 
         refute(Shopifolk.acting_as_shopify_organization?)

--- a/test/test_helpers/partners.rb
+++ b/test/test_helpers/partners.rb
@@ -21,5 +21,12 @@ module TestHelpers
         variables: variables,
       }.to_json).to_return(status: status, body: resp.to_json)
     end
+
+    def stub_shopify_org_confirmation(response: false)
+      CLI::UI::Prompt
+        .stubs(:confirm)
+        .with(includes("Are you working on a 1P (1st Party) app?"), anything)
+        .returns(response)
+    end
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?




<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

* We previously added behaviour to detect if someone is a Shopify employee. Now, for certain tasks, they will be prompted `Are you working on a 1P (1st Party) app?`. If they reply yes, this sends an additional header in the request which alters the behaviour in the partner app (that PR is currently in review).
* Not essential to the PR, but I've also added [minitest-fail-fast](https://github.com/teoljungberg/minitest-fail-fast) – it was useful when working to troubleshooting some kinds of noisy failures (it's inactive by default).
* See GitHub comments for further notes.
