### PR TITLE
Extract HttpRequest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,3 +45,4 @@ Style/MethodCallWithArgsParentheses:
     - assert_equal
     - assert
     - refute
+    - assert_requested # from Webmock

--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -1,5 +1,4 @@
 require 'shopify_cli'
-require 'shopify-cli/http_request'
 
 module ShopifyCli
   class API
@@ -59,6 +58,8 @@ module ShopifyCli
           ctx.abort("Invalid URL: #{graphql_url}")
         end
 
+        # we delay this require so as to avoid a performance hit on starting the CLI
+        require 'shopify-cli/http_request'
         response = HttpRequest.call(uri, body, variables, headers)
 
         case response.code.to_i

--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -1,5 +1,5 @@
 require 'shopify_cli'
-require 'net/http'
+require 'shopify-cli/http_request'
 
 module ShopifyCli
   class API
@@ -58,14 +58,8 @@ module ShopifyCli
         unless uri.is_a?(URI::HTTP)
           ctx.abort("Invalid URL: #{graphql_url}")
         end
-        http = ::Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
 
-        req = ::Net::HTTP::Post.new(uri.request_uri)
-        req.body = JSON.dump(query: body.tr("\n", ""), variables: variables)
-        req['Content-Type'] = 'application/json'
-        headers.each { |header, value| req[header] = value }
-        response = http.request(req)
+        response = HttpRequest.call(uri, body, variables, headers)
 
         case response.code.to_i
         when 200..399

--- a/lib/shopify-cli/http_request.rb
+++ b/lib/shopify-cli/http_request.rb
@@ -1,0 +1,15 @@
+require 'net/http'
+
+module ShopifyCli
+  class HttpRequest
+    def self.call(uri, body, variables, headers)
+      http = ::Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      req = ::Net::HTTP::Post.new(uri.request_uri)
+      req.body = JSON.dump(query: body.tr("\n", ""), variables: variables)
+      req['Content-Type'] = 'application/json'
+      headers.each { |header, value| req[header] = value }
+      http.request(req)
+    end
+  end
+end

--- a/test/fixtures/api/mutation.json
+++ b/test/fixtures/api/mutation.json
@@ -1,1 +1,0 @@
-{"query":"mutation {  fakeMutation(input: {    title: \"fake title\"  }) {    id  }}","variables":{}}

--- a/test/shopify-cli/api_test.rb
+++ b/test/shopify-cli/api_test.rb
@@ -30,21 +30,18 @@ module ShopifyCli
     end
 
     def test_mutation_makes_request_to_shopify
-      stub_request(:post, 'https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json')
-        .with(body: File.read(File.join(FIXTURE_DIR, 'api/mutation.json')).tr("\n", ''),
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} abcde | Mac",
-            'Auth' => 'faketoken',
-          })
-        .to_return(status: 200, body: '{}')
+      headers = {
+        'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} abcde | Mac",
+        'Auth' => 'faketoken',
+      }
+      uri = URI.parse("https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")
+      variables = { var_name: 'var_value' }
       File.stubs(:read)
         .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
-
-      @api.query('api/mutation')
+      response = stub('response', code: '200', body: '{}')
+      HttpRequest.expects(:call).with(uri, @mutation, variables, headers).returns(response)
+      @api.query('api/mutation', variables: variables)
     end
 
     def test_raises_error_with_invalid_url
@@ -64,16 +61,8 @@ module ShopifyCli
     end
 
     def test_query_fails_gracefully_with_internal_server_error
-      stub_request(:post, 'https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json')
-        .with(body: File.read(File.join(FIXTURE_DIR, 'api/mutation.json')).tr("\n", ''),
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} abcde | Mac",
-            'Auth' => 'faketoken',
-          })
-        .to_return(status: 500, body: '{}')
+      response = stub('response', code: '500', body: '{}')
+      HttpRequest.expects(:call).returns(response).times(4)
       File.stubs(:read)
         .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
@@ -87,16 +76,8 @@ module ShopifyCli
     end
 
     def test_query_fails_gracefully_with_unexpected_error
-      stub_request(:post, 'https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json')
-        .with(body: File.read(File.join(FIXTURE_DIR, 'api/mutation.json')).tr("\n", ''),
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} abcde | Mac",
-            'Auth' => 'faketoken',
-          })
-        .to_return(status: 600, body: '{}')
+      response = stub('response', code: '600', body: '{}')
+      HttpRequest.expects(:call).returns(response)
       File.stubs(:read)
         .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)

--- a/test/shopify-cli/http_request_test.rb
+++ b/test/shopify-cli/http_request_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'shopify-cli/http_request'
+
+module ShopifyCli
+  class HttpRequestTest < MiniTest::Test
+    def test_makes_http_request
+      uri = URI.parse("https://example.com")
+      body = "body content"
+      variables = { var_name: "var_value" }
+      headers = { header_name: "header_value" }
+      request = stub_request(:post, "https://example.com/")
+        .with(
+          body: '{"query":"body content","variables":{"var_name":"var_value"}}',
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Ruby',
+            'Header-Name' => 'header_value',
+          }
+        )
+
+      HttpRequest.call(uri, body, variables, headers)
+
+      assert_requested request
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

I'm planning to add some new behaviour to support Employee Authentication and ran into a couple of issues for `api.rb`:

- the current tests were awkward as they stub the HTTP request at a fairly low level, even though those details are mostly incidental to what's being tested
- the `request` method is quite long but has two distinct responsibilities - building the HTTP request and parsing the response.

The request building seems like a cohesive boundary, so I have extracted that out into a new HttpRequest class.

The means the tests can now be simplified, and some duplication removed, as we only need to assert that they send the correct message to `HttpClient.`, rather than using Webmock.

I also found that the single-line `mutation.json` fixture is not needed, as we already have it available as the `@mutation` variable in the test.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
