### PR TITLE
Bump Scripts EP and SDK versions

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,24 +1,24 @@
 discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    version: "^0.2.10"
-    sdk-version: "^6.0.0"
+    version: "^0.3.0"
+    sdk-version: "^7.0.0"
     toolchain-version: "^1.1.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
-    version: "^0.1.12"
-    sdk-version: "^6.0.0"
+    version: "^0.2.0"
+    sdk-version: "^7.0.0"
     toolchain-version: "^1.1.0"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
-    version: "^0.2.8"
-    sdk-version: "^6.0.0"
+    version: "^0.5.0"
+    sdk-version: "^7.0.0"
     toolchain-version: "^1.1.0"
 shipping_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-shipping-filter"
-    version: "^0.2.10"
-    sdk-version: "^6.0.0"
+    version: "^0.3.0"
+    sdk-version: "^7.0.0"
     toolchain-version: "^1.1.0"


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/2082

### WHAT is this pull request doing?

Bumps the Scripts extension point and SDK package version numbers.
