### PR TITLE
Remove nil values from `command` array

### DIFF
--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -41,7 +41,9 @@ module Theme
       def push(ctx, files: nil, flags: nil, remove: false, env:)
         action = remove ? 'remove' : 'deploy'
         command = build_command(action, env)
-        (command << files << flags).flatten!.compact!
+
+        (command << files << flags).compact!
+        command.flatten!
 
         stat = ctx.system(*command)
         stat.success?

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -41,9 +41,7 @@ module Theme
       def push(ctx, files: nil, flags: nil, remove: false, env:)
         action = remove ? 'remove' : 'deploy'
         command = build_command(action, env)
-        command << flags if flags
-        command << files if files
-        command.flatten!
+        (command << files << flags).flatten!.compact!
 
         stat = ctx.system(*command)
         stat.success?

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -41,7 +41,9 @@ module Theme
       def push(ctx, files: nil, flags: nil, remove: false, env:)
         action = remove ? 'remove' : 'deploy'
         command = build_command(action, env)
-        (command << flags << files).flatten!
+        command << flags if flags
+	command << files if files
+	command.flatten!
 
         stat = ctx.system(*command)
         stat.success?

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -42,8 +42,8 @@ module Theme
         action = remove ? 'remove' : 'deploy'
         command = build_command(action, env)
         command << flags if flags
-	command << files if files
-	command.flatten!
+        command << files if files
+        command.flatten!
 
         stat = ctx.system(*command)
         stat.success?

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -47,7 +47,7 @@ module Theme
               'deploy')
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.push(context, files: nil, flags: nil, remove: nil, env: nil))
+      assert(Themekit.push(context, files: [], flags: [], remove: nil, env: nil))
     end
 
     def test_push_deploy_successful_with_nil

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -47,7 +47,19 @@ module Theme
               'deploy')
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.push(context, files: [], flags: [], remove: nil, env: nil))
+      assert(Themekit.push(context, files: nil, flags: nil, remove: nil, env: nil))
+    end
+
+    def test_push_deploy_successful_with_nil
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'deploy')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.push(context, files: nil, flags: nil, remove: nil, env: nil))
     end
 
     def test_push_remove_successful


### PR DESCRIPTION
Done in conjunction with @carmelal 

### WHY are these changes introduced?
When we wanted to use `system`, it was raising an error. This was because some values that were being put into the `command` array (specifically, files and flags) were sometimes nil, and the splat operator could not change nil into a string. All nil values from the `command` array need to be removed.

### WHAT is this pull request doing?
To remove nil values, we first add files and flags to the `command` array, and then use `.compact` to remove any nil values from the array. Then, we `.flatten` the array to ensure it isn't multidimensional. 🥳