### PR TITLE
Add APIClient and OrgID to monorail in create actions

### DIFF
--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -81,7 +81,6 @@ module ShopifyCli
               post.body = JSON.dump(payload)
               http.request(post)
             end
-          rescue
             # silently fail on errors, fire-and-forget approach
           end
         end
@@ -102,13 +101,15 @@ module ShopifyCli
               cli_version: ShopifyCli::VERSION,
               ruby_version: RUBY_VERSION,
             }.tap do |payload|
-              payload[:metadata] = JSON.dump(metadata) unless metadata.empty?
-
               if Project.has_current?
-                project = Project.current
+                project = Project.current(force_reload: true)
                 payload[:api_key] = project.env&.api_key
                 payload[:partner_id] = project.config['organization_id']
+              else
+                payload[:api_key] = metadata.delete(:api_key)
+                payload[:partner_id] = metadata.delete(:organization_id)
               end
+              payload[:metadata] = JSON.dump(metadata) unless metadata.empty?
             end,
           }
         end

--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -102,13 +102,12 @@ module ShopifyCli
               cli_version: ShopifyCli::VERSION,
               ruby_version: RUBY_VERSION,
             }.tap do |payload|
+              payload[:api_key] = metadata.delete(:api_key)
+              payload[:partner_id] = metadata.delete(:organization_id)
               if Project.has_current?
                 project = Project.current(force_reload: true)
                 payload[:api_key] = project.env&.api_key
                 payload[:partner_id] = project.config['organization_id']
-              else
-                payload[:api_key] = metadata.delete(:api_key)
-                payload[:partner_id] = metadata.delete(:organization_id)
               end
               payload[:metadata] = JSON.dump(metadata) unless metadata.empty?
             end,

--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -81,6 +81,7 @@ module ShopifyCli
               post.body = JSON.dump(payload)
               http.request(post)
             end
+          rescue
             # silently fail on errors, fire-and-forget approach
           end
         end

--- a/lib/shopify-cli/tasks/create_api_client.rb
+++ b/lib/shopify-cli/tasks/create_api_client.rb
@@ -17,12 +17,14 @@ module ShopifyCli
           redir: [OAuth::REDIRECT_HOST]
         )
 
-        user_errors = resp["data"]["appCreate"]["userErrors"]
+        user_errors = resp.dig("data", "appCreate", "userErrors")
         if !user_errors.nil? && user_errors.any?
           ctx.abort(user_errors.map { |err| "#{err['field']} #{err['message']}" }.join(", "))
         end
 
-        resp["data"]["appCreate"]["app"]
+        ShopifyCli::Core::Monorail.metadata[:api_key] = resp.dig("data", "appCreate", "app", "apiKey")
+
+        resp.dig("data", "appCreate", "app")
       end
     end
   end

--- a/lib/shopify-cli/tasks/select_org_and_shop.rb
+++ b/lib/shopify-cli/tasks/select_org_and_shop.rb
@@ -10,6 +10,7 @@ module ShopifyCli
         return response(organization_id.to_i, shop_domain) unless organization_id.nil? || shop_domain.nil?
         org = get_organization(organization_id)
         shop_domain ||= get_shop_domain(org)
+        ShopifyCli::Core::Monorail.metadata[:organization_id] = org["id"].to_i
         response(org["id"].to_i, shop_domain)
       end
 

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -67,9 +67,9 @@ module ShopifyCli
                   uname: RbConfig::CONFIG["host"],
                   cli_version: ShopifyCli::VERSION,
                   ruby_version: RUBY_VERSION,
-                  metadata: "{\"foo\":\"identifier\"}",
                   api_key: "apikey",
                   partner_id: 42,
+                  metadata: "{\"foo\":\"identifier\"}",
                 },
               })
             )

--- a/test/shopify-cli/tasks/create_api_client_test.rb
+++ b/test/shopify-cli/tasks/create_api_client_test.rb
@@ -5,6 +5,10 @@ module ShopifyCli
     class CreateApiClientTest < MiniTest::Test
       include TestHelpers::Partners
 
+      def teardown
+        ShopifyCli::Core::Monorail.metadata = {}
+      end
+
       def test_call_will_query_partners_dashboard
         stub_partner_req(
           'create_app',
@@ -36,6 +40,7 @@ module ShopifyCli
 
         refute_nil(api_client)
         assert_equal('newapikey', api_client['apiKey'])
+        assert_equal("newapikey", ShopifyCli::Core::Monorail.metadata[:api_key])
       end
 
       def test_call_will_return_any_user_errors

--- a/test/shopify-cli/tasks/select_org_and_shop_test.rb
+++ b/test/shopify-cli/tasks/select_org_and_shop_test.rb
@@ -5,6 +5,10 @@ module ShopifyCli
     class SelectOrgAndShopTest < MiniTest::Test
       include TestHelpers::Partners
 
+      def teardown
+        ShopifyCli::Core::Monorail.metadata = {}
+      end
+
       def test_user_will_be_prompted_if_more_than_one_organization
         stub_partner_req(
           'all_organizations',
@@ -36,6 +40,7 @@ module ShopifyCli
           .with(@context.message('core.tasks.select_org_and_shop.organization_select'))
           .returns(431)
         form = call(org_id: nil, shop: nil)
+        assert_equal(431, ShopifyCli::Core::Monorail.metadata[:organization_id])
         assert_equal(431, form[:organization_id])
         assert_equal('other.myshopify.com', form[:shop_domain])
       end


### PR DESCRIPTION
### WHY are these changes introduced?
To be able to track which apps are created with the CLI, this adds the api key data into the original creation payload. This will allow us to track the process from start to completion

### WHAT is this pull request doing?
- Change `SelectOrgAndShop` to set partner id metadata
- Change `CreateApiClient` to set api key metadata.
