### PR TITLE
Ignore git template in tests

### DIFF
--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -110,7 +110,7 @@ module ShopifyCli
     def in_repo
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
-          system('git init > /dev/null')
+          system('git init --template="" > /dev/null')
           yield(dir)
         end
       end


### PR DESCRIPTION
I was commonly have this intermittent failure on my local machine:

```
  1) Error:
ShopifyCli::GitTest#test_head_sha:
Errno::ENOTEMPTY: Directory not empty @ dir_s_rmdir - /var/folders/jp/nw1k8h_n7ygcf_9mw8l_yql80000gn/T/d20201016-11244-1ddcghg
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:1459:in `rmdir'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:1459:in `block in remove_dir1'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:1470:in `platform_support'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:1458:in `remove_dir1'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:1451:in `remove'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:780:in `block in remove_entry'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:1508:in `ensure in postorder_traverse'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:1508:in `postorder_traverse'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/fileutils.rb:778:in `remove_entry'
    /opt/rubies/2.7.1/lib/ruby/2.7.0/tmpdir.rb:97:in `mktmpdir'
    /Users/andyw8/src/github.com/Shopify/shopify-app-cli/test/shopify-cli/git_test.rb:111:in `in_repo'
    /Users/andyw8/src/github.com/Shopify/shopify-app-cli/test/shopify-cli/git_test.rb:72:in `test_head_sha'
```

The file remaining the directory was `.git/tags`. It was generated by a git hook from the dotfiles I use:
https://github.com/thoughtbot/dotfiles/blob/master/git_template/hooks/ctags

By specifying an empty string for `--template` it skips copying over the `~/.git_template` for new repos.