### PR TITLE
Fix test warnings

### DIFF
--- a/test/project_types/extension/features/argo_config_test.rb
+++ b/test/project_types/extension/features/argo_config_test.rb
@@ -24,9 +24,7 @@ module Extension
       end
 
       def test_aborts_when_yaml_is_invalid
-        Psych::SyntaxError.any_instance.stubs(:initialize)
-        YAML.stubs(:load_file).raises(Psych::SyntaxError)
-
+        YAML.stubs(:load_file).raises(Psych::SyntaxError.new(nil, 1, 1, nil, nil, nil))
         assert_raises(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context) }
       end
 


### PR DESCRIPTION
Prevent this warning when running tests:

```
/Users/andyw8/.gem/ruby/2.5.1/gems/mocha-1.7.0/lib/mocha/mock.rb:351: warning: undefining `initialize' may cause serious problems
/Users/andyw8/.gem/ruby/2.5.1/gems/mocha-1.7.0/lib/mocha/any_instance_method.rb:44: warning: removing `initialize' may cause serious problems
```