### PR TITLE
Remove unused session gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :development, :test do
 end
 
 group :test do
-  gem 'session'
   gem 'mocha', require: false
   gem 'minitest', '>= 5.0.0', require: false
   gem 'minitest-reporters', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,6 @@ GEM
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.4)
-    session (3.2.0)
     timecop (0.9.1)
     unicode-display_width (1.7.0)
     webmock (2.3.2)
@@ -69,7 +68,6 @@ DEPENDENCIES
   pry-byebug
   rake
   rubocop
-  session
   timecop
   webmock
 


### PR DESCRIPTION
Originally added in https://github.com/Shopify/shopify-app-cli/pull/3 but currently unused.