### PR TITLE
Require `HttpRequest` in test

### DIFF
--- a/test/shopify-cli/api_test.rb
+++ b/test/shopify-cli/api_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'shopify-cli/http_request'
 
 module ShopifyCli
   class APITest < MiniTest::Test


### PR DESCRIPTION
Since we now lazy-load in the implementation, this test was passing as part
of the whole suite but failing when run in isolation.