### PR TITLE
Debug error responses from the API

### DIFF
--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -31,8 +31,9 @@ module ShopifyCli
       )
       ctx.debug(resp)
       resp
-    rescue API::APIRequestServerError, API::APIRequestUnexpectedError
+    rescue API::APIRequestServerError, API::APIRequestUnexpectedError => e
       ctx.puts(ctx.message('core.api.error.internal_server_error'))
+      ctx.debug(ctx.message('core.api.error.internal_server_error_debug', e.message))
     end
 
     protected

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -177,6 +177,7 @@ module ShopifyCli
         api: {
           error: {
             internal_server_error: '{{red:{{x}} An unexpected error occurred on Shopify.}}',
+            internal_server_error_debug: "\n{{red:Response details:}}\n%s\n\n",
           },
         },
 


### PR DESCRIPTION
### WHY are these changes introduced?

Adds information for #900 

When our API requests hit an error on the actual Shopify API, we don't really log any useful information that can help debug our requests, which it makes it hard to discover where certain issues come from.

### WHAT is this pull request doing?

It adds a DEBUG message containing the exception details (in this case, the response code and body) when we hit HTTP 500 / unexpected errors.