### PR TITLE
Command to generate new envs

### DIFF
--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -8,6 +8,7 @@ module Theme
     connector('Theme::Commands::Connect')
 
     register_command('Theme::Commands::Deploy', "deploy")
+    register_command('Theme::Commands::Generate', "generate")
     register_command('Theme::Commands::Push', "push")
     register_command('Theme::Commands::Serve', "serve")
 
@@ -19,6 +20,7 @@ module Theme
     autoload :Connect, Project.project_filepath('commands/connect')
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')
+    autoload :Generate, Project.project_filepath('commands/generate')
     autoload :Push, Project.project_filepath('commands/push')
     autoload :Serve, Project.project_filepath('commands/serve')
   end

--- a/lib/project_types/theme/commands/generate.rb
+++ b/lib/project_types/theme/commands/generate.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Theme
+  module Commands
+    class Generate < ShopifyCli::Command
+      subcommand :Env, 'env', Project.project_filepath('commands/generate/env')
+
+      def call(*)
+        @ctx.puts(self.class.help)
+      end
+
+      def self.help
+        ShopifyCli::Context.message('theme.generate.help', ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/generate/env.rb
+++ b/lib/project_types/theme/commands/generate/env.rb
@@ -1,0 +1,63 @@
+module Theme
+  module Commands
+    class Generate
+      class Env < ShopifyCli::SubCommand
+        options do |parser, flags|
+          parser.on('--store=STORE') { |url| flags[:store] = url }
+          parser.on('--password=PASSWORD') { |p| flags[:password] = p }
+          parser.on('--themeid=THEME_ID') { |id| flags[:themeid] = id }
+          parser.on('--env=ENV') { |env| flags[:env] = env }
+        end
+
+        def call(*)
+          default_store, default_password = fetch_credentials
+          store = ask_store(default_store) || default_store
+          password = ask_password(default_password) || default_password
+          themeid = ask_theme(store: store, password: password)
+          env = options.flags[:env]
+
+          Themekit.generate_env(@ctx, store: store, password: password, themeid: themeid, env: env)
+        end
+
+        def self.help
+          ShopifyCli::Context.message('theme.generate.env.help', ShopifyCli::TOOL_NAME)
+        end
+
+        private
+
+        def fetch_credentials
+          config = YAML.load_file('config.yml')
+          store = config['development']['store']
+          password = config['development']['password']
+          [store, password]
+        end
+
+        def ask_store(default)
+          store = options.flags[:store] ||
+            CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_store', default))
+          return nil if store.empty?
+          store
+        end
+
+        def ask_password(default)
+          password = options.flags[:password] ||
+            CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_password', default))
+          return nil if password.empty?
+          password
+        end
+
+        def ask_theme(store:, password:)
+          themes = Themekit.query_themes(@ctx, store: store, password: password)
+
+          theme = options.flags[:themeid] ||
+            CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_theme')) do |handler|
+              themes.each do |name, id|
+                handler.option(name) { id }
+              end
+            end
+          theme
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/generate/env.rb
+++ b/lib/project_types/theme/commands/generate/env.rb
@@ -65,12 +65,13 @@ module Theme
 
           themes = Themekit.query_themes(@ctx, store: store, password: password)
 
-          theme = CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_theme')) do |handler|
+          @ctx.abort(@ctx.message('theme.generate.env.no_themes', ShopifyCli::TOOL_NAME)) if themes.empty?
+
+          CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_theme')) do |handler|
             themes.each do |name, id|
               handler.option(name) { id }
             end
           end
-          theme
         end
       end
     end

--- a/lib/project_types/theme/forms/connect.rb
+++ b/lib/project_types/theme/forms/connect.rb
@@ -14,15 +14,15 @@ module Theme
         errors << "password" if password.strip.empty?
         ctx.abort(ctx.message('theme.forms.errors', errors.join(", ").capitalize)) unless errors.empty?
 
-        self.themeid, self.name = ask_theme(store: store, password: password)
+        self.themeid, self.name = ask_theme(store: store, password: password, themeid: themeid)
       end
 
       private
 
-      def ask_theme(store:, password:)
+      def ask_theme(store:, password:, themeid:)
         themes = Themekit.query_themes(@ctx, store: store, password: password)
 
-        themeid = CLI::UI::Prompt.ask("Select theme") do |handler|
+        themeid ||= CLI::UI::Prompt.ask("Select theme") do |handler|
           themes.each do |name, id|
             handler.option(name) { id }
           end

--- a/lib/project_types/theme/forms/connect.rb
+++ b/lib/project_types/theme/forms/connect.rb
@@ -14,36 +14,20 @@ module Theme
         errors << "password" if password.strip.empty?
         ctx.abort(ctx.message('theme.forms.errors', errors.join(", ").capitalize)) unless errors.empty?
 
-        themes = query_themes(store, password)
-        self.themeid ||= ask_theme(themes)
-        self.name = themes.key(themeid.to_i)
+        self.themeid, self.name = ask_theme(store: store, password: password)
       end
 
       private
 
-      def ask_theme(themes)
-        CLI::UI::Prompt.ask("Select theme") do |handler|
+      def ask_theme(store:, password:)
+        themes = Themekit.query_themes(@ctx, store: store, password: password)
+
+        themeid = CLI::UI::Prompt.ask("Select theme") do |handler|
           themes.each do |name, id|
             handler.option(name) { id }
           end
         end
-      end
-
-      def query_themes(store, password)
-        begin
-          resp = ::ShopifyCli::AdminAPI.rest_request(
-            @ctx,
-            shop: store,
-            token: password,
-            path: "themes.json",
-          )
-        rescue ShopifyCli::API::APIRequestUnauthorizedError
-          ctx.abort('bad password')
-        rescue StandardError
-          ctx.abort('could not connect to given shop')
-        end
-
-        resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+        [themeid, themes.key(themeid.to_i)]
       end
     end
   end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -67,19 +67,6 @@ module Theme
             APP
           },
           errors: "%s can't be blank",
-          duplicate: "Duplicate directory, theme files weren't pulled",
-          help: <<~HELP,
-            {{command:%s pull}}: Connects an existing theme in your store to Shopify App CLI. Downloads a copy of the theme files to your local development environment.
-              Usage: {{command:%s pull}}
-              Options:
-                {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
-                {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
-                {{command:--themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
-          HELP
-          inside_project: "You are inside an existing theme, theme files weren't pulled",
-          pull: "Pulling theme files...",
-          failed: "Couldn't pull theme files from store",
-          pulled: "{{green:%s}} files were pulled from {{underline:%s}} to {{green:%s}}",
         },
         generate: {
           env: {

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -67,6 +67,38 @@ module Theme
             APP
           },
           errors: "%s can't be blank",
+          duplicate: "Duplicate directory, theme files weren't pulled",
+          help: <<~HELP,
+            {{command:%s pull}}: Connects an existing theme in your store to Shopify App CLI. Downloads a copy of the theme files to your local development environment.
+              Usage: {{command:%s pull}}
+              Options:
+                {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
+                {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
+                {{command:--themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
+          HELP
+          inside_project: "You are inside an existing theme, theme files weren't pulled",
+          pull: "Pulling theme files...",
+          failed: "Couldn't pull theme files from store",
+          pulled: "{{green:%s}} files were pulled from {{underline:%s}} to {{green:%s}}",
+        },
+        generate: {
+          env: {
+            ask_password: "Password (defaults to {{green:%s}})",
+            ask_store: "Store (defaults to {{green:%s}})",
+            ask_theme: "Select theme",
+            help: <<~HELP,
+              Generate a new env in {{green:config.yml}}.
+                Usage: {{command:%s generate env}}
+                Options:
+                  {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
+                  {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
+                  {{command:--themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
+            HELP
+          },
+          help: <<~HELP,
+            Generate code in your Theme. Currently supports generating new envs.
+              Usage: {{command:%s generate [ env ]}}
+          HELP
         },
         push: {
           remove_abort: "Theme files weren't deleted",
@@ -110,6 +142,12 @@ module Theme
             },
             successful: "Theme Kit installed successfully",
             verifying: "Verifying download...",
+          },
+        },
+        themekit: {
+          query_themes: {
+            bad_password: "Bad password",
+            not_connect: "Couldn't connect to given shop",
           },
         },
       },

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -70,17 +70,20 @@ module Theme
         },
         generate: {
           env: {
-            ask_password: "Password (defaults to {{green:%s}})",
-            ask_store: "Store (defaults to {{green:%s}})",
+            ask_password: "Password",
+            ask_password_default: "Password (defaults to {{green:%s}})",
+            ask_store: "Store",
+            ask_store_default: "Store (defaults to {{green:%s}})",
             ask_theme: "Select theme",
             help: <<~HELP,
-              Generate a new env in {{green:config.yml}}.
+              Create or update configuration file in the current directory.
                 Usage: {{command:%s generate env}}
                 Options:
                   {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
                   {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
                   {{command:--themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
             HELP
+            no_themes: "Please create a new theme using %s create theme",
           },
           help: <<~HELP,
             Generate code in your Theme. Currently supports generating new envs.

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -3,6 +3,16 @@ module Theme
     THEMEKIT = File.join(ShopifyCli.cache_dir, "themekit")
 
     class << self
+      def connect(ctx, store:, password:, themeid:, env:)
+        command = build_command('get', env)
+        command << "--password=#{password}"
+        command << "--store=#{store}"
+        command << "--themeid=#{themeid}"
+
+        stat = ctx.system(*command)
+        stat.success?
+      end
+
       def create(ctx, password:, store:, name:, env:)
         command = build_command('new', env)
         command << "--password=#{password}"
@@ -28,8 +38,8 @@ module Theme
         Tasks::EnsureThemekitInstalled.call(ctx)
       end
 
-      def connect(ctx, store:, password:, themeid:, env:)
-        command = build_command('get', env)
+      def generate_env(ctx, store:, password:, themeid:, env:)
+        command = build_command('configure', env)
         command << "--password=#{password}"
         command << "--store=#{store}"
         command << "--themeid=#{themeid}"
@@ -47,6 +57,23 @@ module Theme
 
         stat = ctx.system(*command)
         stat.success?
+      end
+
+      def query_themes(ctx, store:, password:)
+        begin
+          resp = ::ShopifyCli::AdminAPI.rest_request(
+            ctx,
+            shop: store,
+            token: password,
+            path: "themes.json",
+          )
+        rescue ShopifyCli::API::APIRequestUnauthorizedError
+          ctx.abort(ctx.message('theme.themekit.query_themes.bad_password'))
+        rescue StandardError
+          ctx.abort(ctx.message('theme.themekit.query_themes.not_connect'))
+        end
+
+        resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
       end
 
       def serve(ctx, env:)

--- a/test/project_types/theme/commands/generate/env_test.rb
+++ b/test/project_types/theme/commands/generate/env_test.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    module GenerateTests
+      class EnvTest < MiniTest::Test
+        include TestHelpers::FakeFS
+
+        resp = [200, { "themes" =>
+                 [{ "id" => 2468, "name" => "my_theme" },
+                  { "id" => 1357, "name" => "your_theme" }] }]
+        THEMES = resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+
+        CONFIG = { "development" =>
+                   { "password" => "boop",
+                     "theme_id" => "2468",
+                     "store" => "shop.myshopify.com" } }
+
+        def test_prompts_for_credentials
+          File.write('config.yml', CONFIG.to_yaml)
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .returns('office.myshopify.com')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .returns('beep')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'office.myshopify.com', password: 'beep')
+            .returns(THEMES)
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .returns('2468')
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  password: 'beep',
+                  themeid: '2468',
+                  store: 'office.myshopify.com',
+                  env: nil)
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.call
+        end
+
+        def test_can_use_default_shop_and_password
+          File.write('config.yml', CONFIG.to_yaml)
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .returns('')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .returns('')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .returns(THEMES)
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .returns('2468')
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  password: 'boop',
+                  themeid: '2468',
+                  store: 'shop.myshopify.com',
+                  env: nil)
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.call
+        end
+
+        def test_can_provide_credentials_with_flags
+          File.write('config.yml', CONFIG.to_yaml)
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .never
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .never
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .never
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .never
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  password: 'beep',
+                  themeid: '2468',
+                  store: 'office.myshopify.com',
+                  env: nil)
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.options.flags[:store] = 'office.myshopify.com'
+          command.options.flags[:password] = 'beep'
+          command.options.flags[:themeid] = '2468'
+          command.call
+        end
+
+        def test_can_use_different_env
+          File.write('config.yml', CONFIG.to_yaml)
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .returns('')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .returns('')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .returns(THEMES)
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .returns('2468')
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  password: 'boop',
+                  themeid: '2468',
+                  store: 'shop.myshopify.com',
+                  env: 'test')
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.options.flags[:env] = 'test'
+          command.call
+        end
+
+        def test_not_allow_empty_if_no_config
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store'), allow_empty: false)
+            .returns('shop.myshopify.com')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password'), allow_empty: false)
+            .returns('boop')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .returns(THEMES)
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .returns('2468')
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  password: 'boop',
+                  themeid: '2468',
+                  store: 'shop.myshopify.com',
+                  env: nil)
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.call
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/generate/env_test.rb
+++ b/test/project_types/theme/commands/generate/env_test.rb
@@ -38,9 +38,9 @@ module Theme
 
           Themekit.expects(:generate_env)
             .with(context,
+                  store: 'office.myshopify.com',
                   password: 'beep',
                   themeid: '2468',
-                  store: 'office.myshopify.com',
                   env: nil)
             .returns(true)
 
@@ -69,9 +69,9 @@ module Theme
 
           Themekit.expects(:generate_env)
             .with(context,
+                  store: 'shop.myshopify.com',
                   password: 'boop',
                   themeid: '2468',
-                  store: 'shop.myshopify.com',
                   env: nil)
             .returns(true)
 
@@ -100,9 +100,9 @@ module Theme
 
           Themekit.expects(:generate_env)
             .with(context,
+                  store: 'office.myshopify.com',
                   password: 'beep',
                   themeid: '2468',
-                  store: 'office.myshopify.com',
                   env: nil)
             .returns(true)
 
@@ -134,9 +134,9 @@ module Theme
 
           Themekit.expects(:generate_env)
             .with(context,
+                  store: 'shop.myshopify.com',
                   password: 'boop',
                   themeid: '2468',
-                  store: 'shop.myshopify.com',
                   env: 'test')
             .returns(true)
 
@@ -165,14 +165,35 @@ module Theme
 
           Themekit.expects(:generate_env)
             .with(context,
+                  store: 'shop.myshopify.com',
                   password: 'boop',
                   themeid: '2468',
-                  store: 'shop.myshopify.com',
                   env: nil)
             .returns(true)
 
           command = Theme::Commands::Generate::Env.new(context)
           command.call
+        end
+
+        def test_abort_if_no_themes
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store'), allow_empty: false)
+            .returns('shop.myshopify.com')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password'), allow_empty: false)
+            .returns('boop')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .returns({})
+
+          assert_raises CLI::Kit::Abort do
+            command = Theme::Commands::Generate::Env.new(context)
+            command.call
+          end
         end
       end
     end

--- a/test/project_types/theme/commands/generate_test.rb
+++ b/test/project_types/theme/commands/generate_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class GenerateTest < MiniTest::Test
+      def test_puts_help
+        ShopifyCli::Context.expects(:message)
+          .with('theme.generate.help', ShopifyCli::TOOL_NAME)
+
+        Theme::Commands::Generate.new(@context).call
+      end
+    end
+  end
+end

--- a/test/project_types/theme/forms/connect_test.rb
+++ b/test/project_types/theme/forms/connect_test.rb
@@ -73,24 +73,6 @@ module Theme
           env: env
         )
       end
-
-      def query_themes
-        resp = [200,
-                { "themes" =>
-                   [{ "id" => 2468,
-                      "name" => "my_theme" },
-                    { "id" => 1357,
-                      "name" => "your_theme" }] }]
-
-        ShopifyCli::AdminAPI.expects(:rest_request)
-          .with(@context,
-                shop: 'shop.myshopify.com',
-                token: 'boop',
-                path: 'themes.json')
-          .returns(resp)
-
-        @themes = resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
-      end
     end
   end
 end

--- a/test/project_types/theme/forms/connect_test.rb
+++ b/test/project_types/theme/forms/connect_test.rb
@@ -3,9 +3,24 @@ require 'project_types/theme/test_helper'
 
 module Theme
   module Forms
+<<<<<<< HEAD:test/project_types/theme/forms/connect_test.rb
     class ConnectTest < MiniTest::Test
+=======
+    class PullTest < MiniTest::Test
+      resp = [200,
+              { "themes" =>
+               [{ "id" => 2468,
+                  "name" => "my_theme" },
+                { "id" => 1357,
+                  "name" => "your_theme" }] }]
+      THEMES = resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+
+>>>>>>> 58d1e78... Add tests:test/project_types/theme/forms/pull_test.rb
       def test_returns_all_defined_attributes_if_valid
-        query_themes
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
         form = ask
         assert_equal('shop.myshopify.com', form.store)
         assert_equal('boop', form.password)
@@ -14,25 +29,37 @@ module Theme
       end
 
       def test_env_can_be_provided_by_flag
-        query_themes
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
         form = ask(env: 'test')
         assert_equal('test', form.env)
       end
 
       def test_env_nil_if_not_provided
-        query_themes
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
         form = ask
         assert_nil(form.env)
       end
 
       def test_store_can_be_provided_by_flag
-        query_themes
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
         form = ask(store: 'shop.myshopify.com')
         assert_equal('shop.myshopify.com', form.store)
       end
 
       def test_store_is_prompted
-        query_themes
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
         CLI::UI::Prompt.expects(:ask)
           .with(@context.message('theme.forms.ask_store'), allow_empty: false)
           .returns('shop.myshopify.com')
@@ -40,13 +67,19 @@ module Theme
       end
 
       def test_password_can_be_provided_by_flag
-        query_themes
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
         form = ask(password: 'boop')
         assert_equal('boop', form.password)
       end
 
       def test_password_is_prompted
-        query_themes
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
         CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
           .returns('boop')
         ask(password: nil)
@@ -63,6 +96,7 @@ module Theme
 
       private
 
+<<<<<<< HEAD:test/project_types/theme/forms/connect_test.rb
       def ask(password: 'boop', store: 'shop.myshopify.com', themeid: '2468', env: nil)
         Connect.ask(
           @context,
@@ -72,6 +106,15 @@ module Theme
           themeid: themeid,
           env: env
         )
+=======
+      def ask(password: 'boop', store: 'shop.myshopify.com', themeid: 2468, env: nil)
+        Pull.ask(@context,
+                 [],
+                 password: password,
+                 store: store,
+                 themeid: themeid,
+                 env: env)
+>>>>>>> 58d1e78... Add tests:test/project_types/theme/forms/pull_test.rb
       end
     end
   end

--- a/test/project_types/theme/forms/connect_test.rb
+++ b/test/project_types/theme/forms/connect_test.rb
@@ -3,10 +3,7 @@ require 'project_types/theme/test_helper'
 
 module Theme
   module Forms
-<<<<<<< HEAD:test/project_types/theme/forms/connect_test.rb
     class ConnectTest < MiniTest::Test
-=======
-    class PullTest < MiniTest::Test
       resp = [200,
               { "themes" =>
                [{ "id" => 2468,
@@ -15,7 +12,6 @@ module Theme
                   "name" => "your_theme" }] }]
       THEMES = resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
 
->>>>>>> 58d1e78... Add tests:test/project_types/theme/forms/pull_test.rb
       def test_returns_all_defined_attributes_if_valid
         Themekit.expects(:query_themes)
           .with(@context, store: 'shop.myshopify.com', password: 'boop')
@@ -96,7 +92,6 @@ module Theme
 
       private
 
-<<<<<<< HEAD:test/project_types/theme/forms/connect_test.rb
       def ask(password: 'boop', store: 'shop.myshopify.com', themeid: '2468', env: nil)
         Connect.ask(
           @context,
@@ -106,15 +101,6 @@ module Theme
           themeid: themeid,
           env: env
         )
-=======
-      def ask(password: 'boop', store: 'shop.myshopify.com', themeid: 2468, env: nil)
-        Pull.ask(@context,
-                 [],
-                 password: password,
-                 store: store,
-                 themeid: themeid,
-                 env: env)
->>>>>>> 58d1e78... Add tests:test/project_types/theme/forms/pull_test.rb
       end
     end
   end


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
* Harder to mess up `config.yml` if generating envs rather than typing them yourself
* Different envs for more flexibility on each theme

### What is this pull request doing? 📋 
* Adds `generate` command and `env` subcommand
* Moves `query_themes` to adapter class
* Get store and password for user from existing config file as default
