### PR TITLE
Adding CHANGELOG notice to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,11 @@ Fixes #0000 <!-- link to issue if one exists -->
   Summary of the changes committed.
   Before / after screenshots appreciated for UI changes.
 -->
+
+### Update checklist
+<!--
+  Ideally, CHANGELOG entries should be in the format
+  `* [#PR](PR URL): Message`. You should consider adding your PR
+  and then making the CHANGELOG update once you know the PR number.
+-->
+- [ ] I've added a CHANGELOG entry for this PR


### PR DESCRIPTION
This PR simply adds a checklist to the PR template as a reminder for contributors to update the CHANGELOG with the changes they're making, so we don't need to come up with messages at realize time and can expedite the release process.