### PR TITLE
Use FakeFS for Feature test

### DIFF
--- a/test/shopify-cli/feature_test.rb
+++ b/test/shopify-cli/feature_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module ShopifyCli
   class FeatureTest < MiniTest::Test
+    include TestHelpers::FakeFS
+
     TEST_FEATURE = :feature_set_flag_test
 
     class TestClass


### PR DESCRIPTION
Prevent the real `~/config/shopify/config` being modified during tests.

Closes #915 