### PR TITLE
Remove unnecessary load path manipulation in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,3 @@
-begin
-  addpath = lambda do |p|
-    path = File.expand_path("../../#{p}", __FILE__)
-    $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
-  end
-  addpath.call("lib")
-  addpath.call("vendor/lib")
-end
-
 ENV['RUNNING_SHOPIFY_CLI_TESTS'] = 1.to_s
 
 require 'rubygems'


### PR DESCRIPTION
This was added in #3 when the tests were first set up, but isn't needed.