### PR TITLE
Refactor shopifolk test

### DIFF
--- a/test/shopify-cli/shopifolk_test.rb
+++ b/test/shopify-cli/shopifolk_test.rb
@@ -8,12 +8,15 @@ module ShopifyCli
       File.stubs(:exist?).with("/opt/dev/bin/dev").returns(true)
       File.stubs(:exist?).with("/opt/dev/.shopify-build").returns(true)
       stub_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
+
       ShopifyCli::Shopifolk.check
+
       assert ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
     def test_feature_always_returns_true
       ShopifyCli::Feature.enable('shopifolk')
+
       assert ShopifyCli::Shopifolk.check
     end
 
@@ -21,7 +24,9 @@ module ShopifyCli
       ShopifyCli::Feature.enable('shopifolk')
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       File.expects(:exist?).with(File.expand_path('~/.config/gcloud/configurations/config_default')).returns(false)
+
       ShopifyCli::Shopifolk.check
+
       refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
@@ -29,7 +34,9 @@ module ShopifyCli
       ShopifyCli::Feature.enable('shopifolk')
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_ini({ "account" => "test@shopify.com", "project" => "shopify-dev" })
+
       ShopifyCli::Shopifolk.check
+
       refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
@@ -37,7 +44,9 @@ module ShopifyCli
       ShopifyCli::Feature.enable('shopifolk')
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_ini({ "[core]" => { "project" => "shopify-dev" } })
+
       ShopifyCli::Shopifolk.check
+
       refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
@@ -45,7 +54,9 @@ module ShopifyCli
       ShopifyCli::Feature.enable('shopifolk')
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_ini({ "[core]" => { "account" => "test@test.com", "project" => "shopify-dev" } })
+
       ShopifyCli::Shopifolk.check
+
       refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
@@ -54,7 +65,9 @@ module ShopifyCli
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       File.stubs(:exist?).with("/opt/dev/bin/dev").returns(false)
       stub_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
+
       ShopifyCli::Shopifolk.check
+
       refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 

--- a/test/shopify-cli/shopifolk_test.rb
+++ b/test/shopify-cli/shopifolk_test.rb
@@ -3,66 +3,65 @@ require 'fileutils'
 
 module ShopifyCli
   class ShopifolkTest < MiniTest::Test
-    FEATURE_NAME = "shopifolk"
     def test_correct_features_is_shopifolk
-      ShopifyCli::Feature.disable(FEATURE_NAME)
-      File.stubs(:exist?).with("#{::ShopifyCli::Shopifolk::DEV_PATH}/bin/dev").returns(true)
-      File.stubs(:exist?).with("#{::ShopifyCli::Shopifolk::DEV_PATH}/.shopify-build").returns(true)
+      ShopifyCli::Feature.disable('shopifolk')
+      File.stubs(:exist?).with("/opt/dev/bin/dev").returns(true)
+      File.stubs(:exist?).with("/opt/dev/.shopify-build").returns(true)
       stub_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
       ShopifyCli::Shopifolk.check
-      assert ShopifyCli::Config.get_bool(Feature::SECTION, FEATURE_NAME)
+      assert ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
     def test_feature_always_returns_true
-      ShopifyCli::Feature.enable(FEATURE_NAME)
+      ShopifyCli::Feature.enable('shopifolk')
       assert ShopifyCli::Shopifolk.check
     end
 
     def test_no_gcloud_config_disables_shopifolk_feature
-      ShopifyCli::Feature.enable(FEATURE_NAME)
-      ShopifyCli::Feature.stubs(:enabled?).with(FEATURE_NAME).returns(false)
-      File.expects(:exist?).with(::ShopifyCli::Shopifolk::GCLOUD_CONFIG_FILE).returns(false)
+      ShopifyCli::Feature.enable('shopifolk')
+      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
+      File.expects(:exist?).with(File.expand_path('~/.config/gcloud/configurations/config_default')).returns(false)
       ShopifyCli::Shopifolk.check
-      refute ShopifyCli::Config.get_bool(Feature::SECTION, FEATURE_NAME)
+      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
     def test_no_section_in_gcloud_config_disables_shopifolk_feature
-      ShopifyCli::Feature.enable(FEATURE_NAME)
-      ShopifyCli::Feature.stubs(:enabled?).with(FEATURE_NAME).returns(false)
+      ShopifyCli::Feature.enable('shopifolk')
+      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_ini({ "account" => "test@shopify.com", "project" => "shopify-dev" })
       ShopifyCli::Shopifolk.check
-      refute ShopifyCli::Config.get_bool(Feature::SECTION, FEATURE_NAME)
+      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
     def test_no_account_in_gcloud_config_disables_shopifolk_feature
-      ShopifyCli::Feature.enable(FEATURE_NAME)
-      ShopifyCli::Feature.stubs(:enabled?).with(FEATURE_NAME).returns(false)
+      ShopifyCli::Feature.enable('shopifolk')
+      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_ini({ "[core]" => { "project" => "shopify-dev" } })
       ShopifyCli::Shopifolk.check
-      refute ShopifyCli::Config.get_bool(Feature::SECTION, FEATURE_NAME)
+      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
     def test_incorrect_email_in_gcloud_config_disables_shopifolk_feature
-      ShopifyCli::Feature.enable(FEATURE_NAME)
-      ShopifyCli::Feature.stubs(:enabled?).with(FEATURE_NAME).returns(false)
+      ShopifyCli::Feature.enable('shopifolk')
+      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_ini({ "[core]" => { "account" => "test@test.com", "project" => "shopify-dev" } })
       ShopifyCli::Shopifolk.check
-      refute ShopifyCli::Config.get_bool(Feature::SECTION, FEATURE_NAME)
+      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
     def test_incorrect_dev_path_disables_dev_shopifolk_feature
-      ShopifyCli::Feature.enable(FEATURE_NAME)
-      ShopifyCli::Feature.stubs(:enabled?).with(FEATURE_NAME).returns(false)
-      File.stubs(:exist?).with("#{::ShopifyCli::Shopifolk::DEV_PATH}/bin/dev").returns(false)
+      ShopifyCli::Feature.enable('shopifolk')
+      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
+      File.stubs(:exist?).with("/opt/dev/bin/dev").returns(false)
       stub_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
       ShopifyCli::Shopifolk.check
-      refute ShopifyCli::Config.get_bool(Feature::SECTION, FEATURE_NAME)
+      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
     end
 
     private
 
     def stub_ini(ret_val)
-      File.stubs(:exist?).with(::ShopifyCli::Shopifolk::GCLOUD_CONFIG_FILE).returns(true)
+      File.stubs(:exist?).with(File.expand_path('~/.config/gcloud/configurations/config_default')).returns(true)
       ini = CLI::Kit::Ini.new
       ini.expects(:parse).returns(ini)
       ini.expects(:ini).returns(ret_val)

--- a/test/shopify-cli/shopifolk_test.rb
+++ b/test/shopify-cli/shopifolk_test.rb
@@ -7,7 +7,7 @@ module ShopifyCli
       ShopifyCli::Feature.disable('shopifolk')
       File.stubs(:exist?).with("/opt/dev/bin/dev").returns(true)
       File.stubs(:exist?).with("/opt/dev/.shopify-build").returns(true)
-      stub_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
+      stub_gcloud_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
 
       ShopifyCli::Shopifolk.check
 
@@ -33,7 +33,7 @@ module ShopifyCli
     def test_no_section_in_gcloud_config_disables_shopifolk_feature
       ShopifyCli::Feature.enable('shopifolk')
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
-      stub_ini({ "account" => "test@shopify.com", "project" => "shopify-dev" })
+      stub_gcloud_ini({ "account" => "test@shopify.com", "project" => "shopify-dev" })
 
       ShopifyCli::Shopifolk.check
 
@@ -43,7 +43,7 @@ module ShopifyCli
     def test_no_account_in_gcloud_config_disables_shopifolk_feature
       ShopifyCli::Feature.enable('shopifolk')
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
-      stub_ini({ "[core]" => { "project" => "shopify-dev" } })
+      stub_gcloud_ini({ "[core]" => { "project" => "shopify-dev" } })
 
       ShopifyCli::Shopifolk.check
 
@@ -53,7 +53,7 @@ module ShopifyCli
     def test_incorrect_email_in_gcloud_config_disables_shopifolk_feature
       ShopifyCli::Feature.enable('shopifolk')
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
-      stub_ini({ "[core]" => { "account" => "test@test.com", "project" => "shopify-dev" } })
+      stub_gcloud_ini({ "[core]" => { "account" => "test@test.com", "project" => "shopify-dev" } })
 
       ShopifyCli::Shopifolk.check
 
@@ -64,7 +64,7 @@ module ShopifyCli
       ShopifyCli::Feature.enable('shopifolk')
       ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       File.stubs(:exist?).with("/opt/dev/bin/dev").returns(false)
-      stub_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
+      stub_gcloud_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
 
       ShopifyCli::Shopifolk.check
 
@@ -73,7 +73,7 @@ module ShopifyCli
 
     private
 
-    def stub_ini(ret_val)
+    def stub_gcloud_ini(ret_val)
       File.stubs(:exist?).with(File.expand_path('~/.config/gcloud/configurations/config_default')).returns(true)
       ini = CLI::Kit::Ini.new
       ini.expects(:parse).returns(ini)


### PR DESCRIPTION
Since we deal with a number of different config paths, I found it a little confusing to keep track of each while reading the tests. I've replaced the references to constants with literals. Although this might seem like a form of duplication, in general we should aim for tests that are easy to read and understand.

Update:

I've also updated the test to use `FakeFS`. This will prevent the same problem as in #930, and also prevents state leaking between tests.