### PR TITLE
Prevent new tests from modifying the real Shopify config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ install:
 - bundle install
 script:
   - bundle exec rake
+  - if [ -f "~/.config/shopify/config" ]; then echo "Found a config file in home directory. This means the tests would modify a developer's local config. Consider using FakeFS"; exit 1; fi


### PR DESCRIPTION
This is to protect against adding tests which hit the real filesystem and modify a developer's `.config/shopify/config`, e.g. 
#942