### PR TITLE
[tests] Simplify log stubbing

### DIFF
--- a/test/shopify-cli/commands/config_test.rb
+++ b/test/shopify-cli/commands/config_test.rb
@@ -7,86 +7,60 @@ module ShopifyCli
 
       TEST_FEATURE = :feature_flag_test
 
+      def setup
+        super
+        ShopifyCli::Core::Monorail.stubs(:log).yields
+      end
+
       def test_help_argument_calls_help
-        with_logging_stubbed_out do
-          @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
-          run_cmd('config help')
-        end
+        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        run_cmd('config help')
       end
 
       def test_feature_help_argument_calls_help
-        with_logging_stubbed_out do
-          @context.expects(:puts).with(ShopifyCli::Commands::Config::Feature.help)
-          run_cmd('config feature --help')
-        end
+        @context.expects(:puts).with(ShopifyCli::Commands::Config::Feature.help)
+        run_cmd('config feature --help')
       end
 
       def test_analytics_help_argument_calls_help
-        with_logging_stubbed_out do
-          @context.expects(:puts).with(ShopifyCli::Commands::Config::Analytics.help)
-          run_cmd('config analytics --help')
-        end
+        @context.expects(:puts).with(ShopifyCli::Commands::Config::Analytics.help)
+        run_cmd('config analytics --help')
       end
 
       def test_no_arguments_calls_help
-        with_logging_stubbed_out do
-          @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
-          run_cmd('config')
-        end
+        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        run_cmd('config')
       end
 
       def test_no_feature_calls_help
-        with_logging_stubbed_out do
-          @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
-          run_cmd('config feature')
-        end
+        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        run_cmd('config feature')
       end
 
       def test_will_enable_a_feature_that_is_disabled
-        with_logging_stubbed_out do
-          ShopifyCli::Feature.disable(TEST_FEATURE)
-          @context.expects(:puts).with(@context.message('core.config.feature.enabled', TEST_FEATURE))
-          run_cmd("config feature #{TEST_FEATURE} --enable")
-          assert ShopifyCli::Feature.enabled?(TEST_FEATURE)
-        end
+        ShopifyCli::Feature.disable(TEST_FEATURE)
+        @context.expects(:puts).with(@context.message('core.config.feature.enabled', TEST_FEATURE))
+        run_cmd("config feature #{TEST_FEATURE} --enable")
+        assert ShopifyCli::Feature.enabled?(TEST_FEATURE)
       end
 
       def test_will_disable_a_feature_that_is_enabled
-        with_logging_stubbed_out do
-          ShopifyCli::Feature.enable(TEST_FEATURE)
-          @context.expects(:puts).with(@context.message('core.config.feature.disabled', TEST_FEATURE))
-          run_cmd("config feature #{TEST_FEATURE} --disable")
-          refute ShopifyCli::Feature.enabled?(TEST_FEATURE)
-        end
+        ShopifyCli::Feature.enable(TEST_FEATURE)
+        @context.expects(:puts).with(@context.message('core.config.feature.disabled', TEST_FEATURE))
+        run_cmd("config feature #{TEST_FEATURE} --disable")
+        refute ShopifyCli::Feature.enabled?(TEST_FEATURE)
       end
 
       def test_will_enable_analytics_that_is_disabled
-        with_logging_stubbed_out do
-          ShopifyCli::Config.set('analytics', 'enabled', false)
-          run_cmd("config analytics --enable")
-          assert ShopifyCli::Config.get_bool('analytics', 'enabled')
-        end
+        ShopifyCli::Config.set('analytics', 'enabled', false)
+        run_cmd("config analytics --enable")
+        assert ShopifyCli::Config.get_bool('analytics', 'enabled')
       end
 
       def test_will_disable_analytics_that_is_enabled
-        with_logging_stubbed_out do
-          ShopifyCli::Config.set('analytics', 'enabled', true)
-          run_cmd("config analytics --disable")
-          refute ShopifyCli::Config.get_bool('analytics', 'enabled')
-        end
-      end
-
-      private
-
-      # NOTE: This is using minitest's own mocking rather than Mocha, as Mocha
-      # doesn't appear to provide a way to swap out a method's implementation
-      def with_logging_stubbed_out(&test_block)
-        ShopifyCli::Core::Monorail.stub(
-          :log,
-          ->(*_args, &block) { block.call },
-        ) do
-          test_block.call
-        end
+        ShopifyCli::Config.set('analytics', 'enabled', true)
+        run_cmd("config analytics --disable")
+        refute ShopifyCli::Config.get_bool('analytics', 'enabled')
       end
     end
   end


### PR DESCRIPTION
After #938 I found a simpler way. We also use it here:

https://github.com/Shopify/shopify-app-cli/blame/dcfccb5a8d5808477a15ab16e6477d396e818ea7/test/project_types/script/commands/enable_test.rb#L259