### PR TITLE
[script] Bump payment-filter package to 0.6.0

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -13,7 +13,7 @@ unit_limit_per_order:
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
-    version: "^0.5.0"
+    version: "^0.6.0"
     sdk-version: "^7.0.0"
     toolchain-version: "^1.1.0"
 shipping_filter:


### PR DESCRIPTION

### WHY are these changes introduced?

Bump payment-filter package to 0.6.0 to use the new schema, which is updated in https://github.com/Shopify/extension-points/pull/167

### WHAT is this pull request doing?


### Update checklist

I don't see any script related changes in CHANGELOG. I guess it's fine to ignore it.

- [ ] I've added a CHANGELOG entry for this PR
