### PR TITLE
[tests] Add missing calls to `super` in `setup` and `teardown` methods

### DIFF
--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -11,8 +11,18 @@ module Minitest
     include TestHelpers::Project
 
     def setup
+      @minitest_ext_setup_called = true
       project_context('project')
       ::ShopifyCli::Project.clear
+      super
+    end
+
+    def teardown
+      unless @minitest_ext_setup_called
+        raise "teardown called without setup - you may have forgotten to call `super`"
+      end
+
+      @minitest_ext_setup_called = nil
       super
     end
 

--- a/test/project_types/rails/gem_test.rb
+++ b/test/project_types/rails/gem_test.rb
@@ -14,6 +14,7 @@ module Rails
     def teardown
       @context.setenv('GEM_HOME', nil)
       @context.setenv('GEM_PATH', nil)
+      super
     end
 
     def test_install_installs_with_gem_home_unpopulated

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -6,6 +6,7 @@ module Script
   module Commands
     class PushTest < MiniTest::Test
       def setup
+        super
         @context = TestHelpers::FakeContext.new
         @language = 'ts'
         @script_name = 'name'

--- a/test/project_types/script/script_project_test.rb
+++ b/test/project_types/script/script_project_test.rb
@@ -5,6 +5,7 @@ require 'project_types/script/test_helper'
 module Script
   class ScriptProjectTest < MiniTest::Test
     def setup
+      super
       @context = TestHelpers::FakeContext.new
       @script_name = 'name'
       @extension_point_type = 'ep_type'

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -12,6 +12,7 @@ module ShopifyCli
 
       def teardown
         ShopifyCli::Core::Monorail.metadata = {}
+        super
       end
 
       def test_log_prompts_for_consent_and_saves_answer

--- a/test/shopify-cli/js_deps_test.rb
+++ b/test/shopify-cli/js_deps_test.rb
@@ -4,6 +4,7 @@ require 'project_types/node/test_helper'
 module ShopifyCli
   class JsDepsTest < MiniTest::Test
     def setup
+      super
       project_context('app_types', 'node')
       @node_fixture_dependencies = 37
     end

--- a/test/shopify-cli/js_system_test.rb
+++ b/test/shopify-cli/js_system_test.rb
@@ -4,6 +4,7 @@ require 'project_types/node/test_helper'
 module ShopifyCli
   class JsSystemTest < MiniTest::Test
     def setup
+      super
       project_context('app_types', 'node')
       @system = JsSystem.new(ctx: @context)
 

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 module ShopifyCli
   class ProjectTest < MiniTest::Test
     def setup
+      super
       @context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
       FileUtils.cd(@context.root)
     end

--- a/test/shopify-cli/tasks/create_api_client_test.rb
+++ b/test/shopify-cli/tasks/create_api_client_test.rb
@@ -7,6 +7,7 @@ module ShopifyCli
 
       def teardown
         ShopifyCli::Core::Monorail.metadata = {}
+        super
       end
 
       def test_call_will_query_partners_dashboard

--- a/test/shopify-cli/tasks/select_org_and_shop_test.rb
+++ b/test/shopify-cli/tasks/select_org_and_shop_test.rb
@@ -7,6 +7,7 @@ module ShopifyCli
 
       def teardown
         ShopifyCli::Core::Monorail.metadata = {}
+        super
       end
 
       def test_user_will_be_prompted_if_more_than_one_organization


### PR DESCRIPTION
This can lead to intermittent failures depending on the order tests are run in.