### PR TITLE
Detect modifications to local config during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ install:
 - bundle install
 script:
   - bundle exec rake
-  - if [ -f "~/.config/shopify/config" ]; then echo "Found a config file in home directory. This means the tests would modify a developer's local config. Consider using FakeFS"; exit 1; fi

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -85,7 +85,7 @@ module Minitest
     end
 
     def stub_prompt_for_cli_updates
-      ShopifyCli::Config.stubs(:get_section).with("autoupdate").returns(stub("key?" => true))
+      ShopifyCli::Config.stubs(:get_section).with("autoupdate").returns('enabled' => 'true')
     end
 
     def stub_new_version_check

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -182,6 +182,7 @@ module ShopifyCli
       private
 
       def enabled_and_consented(enabled, consented)
+        ShopifyCli::Config.stubs(:get_section).with('analytics').returns({ 'enabled' => consented.to_s })
         ShopifyCli::Context.any_instance.stubs(:system?).returns(enabled)
         ShopifyCli::Config.stubs(:get_bool).with('analytics', 'enabled').returns(consented)
       end

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -17,7 +17,7 @@ module ShopifyCli
 
       def test_log_prompts_for_consent_and_saves_answer
         enabled_and_consented(true, nil)
-        ShopifyCli::Config.expects(:get_section).with('analytics').returns(stub("key?" => false))
+        ShopifyCli::Config.expects(:get_section).with('analytics').returns({})
         CLI::UI::Prompt.expects(:confirm).returns(true)
         ShopifyCli::Config.expects(:set).with('analytics', 'enabled', true)
         Net::HTTP.expects(:start).never
@@ -36,7 +36,7 @@ module ShopifyCli
 
       def test_log_doesnt_prompt_for_consent_if_already_answered
         enabled_and_consented(true, false)
-        ShopifyCli::Config.expects(:get_section).with('analytics').returns(stub("key?" => true))
+        ShopifyCli::Config.expects(:get_section).with('analytics').returns("enabled" => "true")
         CLI::UI::Prompt.expects(:confirm).never
         Net::HTTP.expects(:start).never
 


### PR DESCRIPTION
Similar to #939 but this will also work when running the tests locally. Should help to prevent introducing unstable tests.