### PR TITLE
Fix config prop parsing in Script::Commands::Enable

### DIFF
--- a/lib/project_types/script/errors.rb
+++ b/lib/project_types/script/errors.rb
@@ -14,6 +14,7 @@ module Script
       end
     end
     class ScriptProjectAlreadyExistsError < ScriptProjectError; end
+    class InvalidConfigProps < ScriptProjectError; end
     class InvalidConfigYAMLError < ScriptProjectError
       attr_reader :config_file
       def initialize(config_file)

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -18,6 +18,10 @@ module Script
           invalid_context_cause: "Your .shopify-cli.yml file is not correct.",
           invalid_context_help: "See https://help.shopify.com",
 
+          invalid_config_props_cause: "The provided {{command:--config_props}} argument is invalid.",
+          invalid_config_props_help: "Try again using the following format: "\
+                                     "{{cyan:--config_props='name1:value1, name2:value2'}}",
+
           invalid_script_name_cause: "Invalid script name.",
           invalid_script_name_help: "Replace or remove unsupported characters. Valid characters "\
                                     "are numbers, letters, hyphens, or underscores.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -18,8 +18,8 @@ module Script
           invalid_context_cause: "Your .shopify-cli.yml file is not correct.",
           invalid_context_help: "See https://help.shopify.com",
 
-          invalid_config_props_cause: "The provided {{command:--config_props}} argument is invalid.",
-          invalid_config_props_help: "Try again using the following format: "\
+          invalid_config_props_cause: "{{command:--config_props}} is formatted incorrectly.",
+          invalid_config_props_help: "Try again using this format: "\
                                      "{{cyan:--config_props='name1:value1, name2:value2'}}",
 
           invalid_script_name_cause: "Invalid script name.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -44,6 +44,11 @@ module Script
             cause_of_error: ShopifyCli::Context.message('script.error.invalid_context_cause'),
             help_suggestion: ShopifyCli::Context.message('script.error.invalid_context_help'),
           }
+        when Errors::InvalidConfigProps
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.invalid_config_props_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.invalid_config_props_help'),
+          }
         when Errors::InvalidConfigYAMLError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.invalid_config', e.config_file),

--- a/test/project_types/script/commands/enable_test.rb
+++ b/test/project_types/script/commands/enable_test.rb
@@ -122,9 +122,10 @@ module Script
       end
 
       def test_should_call_error_handler_when_given_invalid_config_props
-        Script::UI::ErrorHandler
-          .expects(:pretty_print_and_raise)
-          .with { |e| e.is_a?(Errors::InvalidConfigProps) }
+        Script::UI::ErrorHandler.expects(:pretty_print_and_raise).with(
+          instance_of(Errors::InvalidConfigProps),
+          failed_op: @context.message('script.enable.error.operation_failed')
+        )
 
         capture_io do
           perform_command(config_props: "key1:value1:value2")
@@ -180,7 +181,7 @@ module Script
 
         Script::UI::ErrorHandler
           .expects(:pretty_print_and_raise)
-          .with { |e| e.is_a?(Errors::InvalidConfigYAMLError) }
+          .with(instance_of(Errors::InvalidConfigYAMLError))
 
         capture_io do
           perform_command(config_file_path: "enable_config_file.yml")
@@ -190,7 +191,7 @@ module Script
       def test_calls_application_enable_with_missing_configuration_file
         Script::UI::ErrorHandler
           .expects(:pretty_print_and_raise)
-          .with { |e| e.is_a?(Errors::InvalidConfigYAMLError) }
+          .with(instance_of(Errors::InvalidConfigYAMLError))
 
         capture_io do
           perform_command(config_file_path: "enable_config_file.yml")

--- a/test/project_types/script/commands/enable_test.rb
+++ b/test/project_types/script/commands/enable_test.rb
@@ -28,28 +28,8 @@ module Script
         ShopifyCli::Tasks::EnsureEnv
           .any_instance.expects(:call)
           .with(@context, required: [:api_key, :secret, :shop])
-        Script::Layers::Application::EnableScript.expects(:call).with(
-          ctx: @context,
-          api_key: @api_key,
-          shop_domain: @shop_domain,
-          configuration: @configuration,
-          extension_point_type: @ep_type,
-          title: @script_name
-        )
 
-        @context
-          .expects(:puts)
-          .with(@context.message(
-            'script.enable.script_enabled',
-            api_key: @api_key,
-            shop_domain: @shop_domain,
-            type: @ep_type.capitalize,
-            title: @script_name
-          ))
-
-        @context
-          .expects(:puts)
-          .with(@context.message('script.enable.info'))
+        expect_successful_enable(@configuration)
 
         capture_io do
           perform_command
@@ -112,28 +92,8 @@ module Script
             },
           ],
         }
-        Script::Layers::Application::EnableScript.expects(:call).with(
-          ctx: @context,
-          api_key: @api_key,
-          shop_domain: @shop_domain,
-          configuration: expected_configuration,
-          extension_point_type: @ep_type,
-          title: @script_name
-        )
 
-        @context
-          .expects(:puts)
-          .with(@context.message(
-            'script.enable.script_enabled',
-            api_key: @api_key,
-            shop_domain: @shop_domain,
-            type: @ep_type.capitalize,
-            title: @script_name
-          ))
-
-        @context
-          .expects(:puts)
-          .with(@context.message('script.enable.info'))
+        expect_successful_enable(expected_configuration)
 
         capture_io do
           perform_command(config_props: "key1:value1,key2:value2")
@@ -154,28 +114,9 @@ module Script
             },
           ],
         }
-        Script::Layers::Application::EnableScript.expects(:call).with(
-          ctx: @context,
-          api_key: @api_key,
-          shop_domain: @shop_domain,
-          configuration: expected_configuration,
-          extension_point_type: @ep_type,
-          title: @script_name
-        )
 
-        @context
-          .expects(:puts)
-          .with(@context.message(
-            'script.enable.script_enabled',
-            api_key: @api_key,
-            shop_domain: @shop_domain,
-            type: @ep_type.capitalize,
-            title: @script_name
-          ))
+        expect_successful_enable(expected_configuration)
 
-        @context
-          .expects(:puts)
-          .with(@context.message('script.enable.info'))
         capture_io do
           perform_command(config_file_path: "enable_config_file.yml")
         end
@@ -195,28 +136,8 @@ module Script
             },
           ],
         }
-        Script::Layers::Application::EnableScript.expects(:call).with(
-          ctx: @context,
-          api_key: @api_key,
-          shop_domain: @shop_domain,
-          configuration: expected_configuration,
-          extension_point_type: @ep_type,
-          title: @script_name
-        )
 
-        @context
-          .expects(:puts)
-          .with(@context.message(
-            'script.enable.script_enabled',
-            api_key: @api_key,
-            shop_domain: @shop_domain,
-            type: @ep_type.capitalize,
-            title: @script_name
-          ))
-
-        @context
-          .expects(:puts)
-          .with(@context.message('script.enable.info'))
+        expect_successful_enable(expected_configuration)
 
         capture_io do
           perform_command(config_props: "key1:overriddenValue", config_file_path: "enable_config_file.yml")
@@ -246,6 +167,31 @@ module Script
       end
 
       private
+
+      def expect_successful_enable(configuration)
+        Script::Layers::Application::EnableScript.expects(:call).with(
+          ctx: @context,
+          api_key: @api_key,
+          shop_domain: @shop_domain,
+          configuration: configuration,
+          extension_point_type: @ep_type,
+          title: @script_name
+        )
+
+        @context
+          .expects(:puts)
+          .with(@context.message(
+            'script.enable.script_enabled',
+            api_key: @api_key,
+            shop_domain: @shop_domain,
+            type: @ep_type.capitalize,
+            title: @script_name
+          ))
+
+        @context
+          .expects(:puts)
+          .with(@context.message('script.enable.info'))
+      end
 
       def perform_command(config_props: nil, config_file_path: nil)
         env_contents = "SHOPIFY_API_KEY=apikey\n" \

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -104,6 +104,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when InvalidConfigProps" do
+        let(:err) { Script::Errors::InvalidConfigProps.new('') }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when InvalidScriptNameError" do
         let(:err) { Script::Errors::InvalidScriptNameError.new }
         it "should call display_and_raise" do


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/1757

Enabling a script with specific `config_props` currently has a couple of bugs:
1. `key1:a, key2:b` is parsed as `{"key1": "a", " key2": "b"}` (`key2` has an extra space in the key).
2. `key1:a:invalid_action` raises an ugly error

### WHAT is this pull request doing?

Fixes the two bugs above by validating the config_props. If invalid, it raises the following error:

![image](https://user-images.githubusercontent.com/28009669/98014375-8e6be600-1dc9-11eb-9f76-0b39269b66c4.png)

@kwringe please let me know if you have a better error message 🙂 