### PR TITLE
Reorganize `connect` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ------
 * [#965](https://github.com/Shopify/shopify-app-cli/pull/965): Remove --no-optional when using npm to create new project
+* [#958](https://github.com/Shopify/shopify-app-cli/pull/958): Split `connect` command into project-specific functionality
 
 Version 1.4.1
 ------

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -3,7 +3,8 @@
 module Extension
   class Project < ShopifyCli::ProjectType
     hidden_feature
-    creator 'App Extension', 'Extension::Commands::Create'
+    title('App Extension')
+    creator('Extension::Commands::Create')
 
     register_command('Extension::Commands::Build', "build")
     register_command('Extension::Commands::Register', "register")

--- a/lib/project_types/node/cli.rb
+++ b/lib/project_types/node/cli.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 module Node
   class Project < ShopifyCli::ProjectType
-    creator 'Node.js App', 'Node::Commands::Create'
+    title('Node.js App')
+    creator('Node::Commands::Create')
+    connector('Node::Commands::Connect')
 
     register_command('Node::Commands::Deploy', "deploy")
     register_command('Node::Commands::Generate', "generate")
@@ -17,6 +19,7 @@ module Node
 
   # define/autoload project specific Commands
   module Commands
+    autoload :Connect, Project.project_filepath('commands/connect')
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')
     autoload :Generate, Project.project_filepath('commands/generate')

--- a/lib/project_types/node/commands/connect.rb
+++ b/lib/project_types/node/commands/connect.rb
@@ -4,17 +4,11 @@ module Node
     class Connect < ShopifyCli::SubCommand
       def call(*)
         if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
-          @ctx.puts(@ctx.message('core.connect.production_warning'))
+          @ctx.puts(@ctx.message('node.connect.production_warning'))
         end
 
-        org, api_key = ShopifyCli::Commands::Connect.default_connect('node')
-        @ctx.done(@ctx.message('core.connect.connected', get_app(org['apps'], api_key).first["title"]))
-      end
-
-      private
-
-      def get_app(apps, api_key)
-        apps.select { |app| app["apiKey"] == api_key }
+        app = ShopifyCli::Commands::Connect.new.default_connect('node')
+        @ctx.done(@ctx.message('node.connect.connected', app))
       end
     end
   end

--- a/lib/project_types/node/commands/connect.rb
+++ b/lib/project_types/node/commands/connect.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Node
+  module Commands
+    class Connect < ShopifyCli::SubCommand
+      def call(*)
+        if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
+          @ctx.puts(@ctx.message('core.connect.production_warning'))
+        end
+
+        org, api_key = ShopifyCli::Commands::Connect.default_connect('node')
+        @ctx.done(@ctx.message('core.connect.connected', get_app(org['apps'], api_key).first["title"]))
+      end
+
+      private
+
+      def get_app(apps, api_key)
+        apps.select { |app| app["apiKey"] == api_key }
+      end
+    end
+  end
+end

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -8,6 +8,13 @@ module Node
           generic: "Error",
         },
 
+        connect: {
+          connected: "Project now connected to {{green:%s}}",
+          production_warning: <<~MESSAGE,
+          {{yellow:! Warning: if you have connected to an {{bold:app in production}}, running {{command:serve}} may update the app URL and cause an outage.
+          MESSAGE
+        },
+
         create: {
           help: <<~HELP,
           {{command:%s create node}}: Creates an embedded nodejs app.

--- a/lib/project_types/rails/cli.rb
+++ b/lib/project_types/rails/cli.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 module Rails
   class Project < ShopifyCli::ProjectType
-    creator 'Ruby on Rails App', 'Rails::Commands::Create'
+    title('Ruby on Rails App')
+    creator('Rails::Commands::Create')
+    connector('Rails::Commands::Connect')
 
     register_command('Rails::Commands::Deploy', "deploy")
     register_command('Rails::Commands::Generate', "generate")
@@ -17,6 +19,7 @@ module Rails
 
   # define/autoload project specific Commands
   module Commands
+    autoload :Connect, Project.project_filepath('commands/connect')
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')
     autoload :Generate, Project.project_filepath('commands/generate')

--- a/lib/project_types/rails/commands/connect.rb
+++ b/lib/project_types/rails/commands/connect.rb
@@ -4,17 +4,11 @@ module Rails
     class Connect < ShopifyCli::SubCommand
       def call(*)
         if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
-          @ctx.puts(@ctx.message('core.connect.production_warning'))
+          @ctx.puts(@ctx.message('rails.connect.production_warning'))
         end
 
-        org, api_key = ShopifyCli::Commands::Connect.default_connect('rails')
-        @ctx.done(@ctx.message('core.connect.connected', get_app(org['apps'], api_key).first["title"]))
-      end
-
-      private
-
-      def get_app(apps, api_key)
-        apps.select { |app| app["apiKey"] == api_key }
+        app = ShopifyCli::Commands::Connect.new.default_connect('rails')
+        @ctx.done(@ctx.message('rails.connect.connected', app))
       end
     end
   end

--- a/lib/project_types/rails/commands/connect.rb
+++ b/lib/project_types/rails/commands/connect.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Rails
+  module Commands
+    class Connect < ShopifyCli::SubCommand
+      def call(*)
+        if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
+          @ctx.puts(@ctx.message('core.connect.production_warning'))
+        end
+
+        org, api_key = ShopifyCli::Commands::Connect.default_connect('rails')
+        @ctx.done(@ctx.message('core.connect.connected', get_app(org['apps'], api_key).first["title"]))
+      end
+
+      private
+
+      def get_app(apps, api_key)
+        apps.select { |app| app["apiKey"] == api_key }
+      end
+    end
+  end
+end

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -17,6 +17,13 @@ module Rails
           setting_gem_path: "GEM_PATH being set to %s",
         },
 
+        connect: {
+          connected: "Project now connected to {{green:%s}}",
+          production_warning: <<~MESSAGE,
+          {{yellow:! Warning: if you have connected to an {{bold:app in production}}, running {{command:serve}} may update the app URL and cause an outage.
+          MESSAGE
+        },
+
         create: {
           help: <<~HELP,
           {{command:%s create rails}}: Creates a ruby on rails app.

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -3,7 +3,8 @@
 module Script
   class Project < ShopifyCli::ProjectType
     hidden_feature(feature_set: :script_project)
-    creator 'Script', 'Script::Commands::Create'
+    title('Script')
+    creator('Script::Commands::Create')
 
     register_command('Script::Commands::Push', 'push')
     register_command('Script::Commands::Disable', 'disable')

--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -9,42 +9,27 @@ module ShopifyCli
           super
         end
 
-        def default_connect(project_type)
-          org = ShopifyCli::Tasks::EnsureEnv.call(@ctx, regenerate: true)
-          write_cli_yml(project_type, org['id']) unless Project.has_current?
-          api_key = Project.current(force_reload: true).env['api_key']
-          [org, api_key]
-        end
-
-        def write_cli_yml(project_type, org_id)
-          ShopifyCli::Project.write(
-            @ctx,
-            project_type: project_type,
-            organization_id: org_id,
-          )
-          @ctx.done(@ctx.message('core.connect.cli_yml_saved'))
-        end
-
         def help
           ShopifyCli::Context.message('core.connect.help', ShopifyCli::TOOL_NAME)
         end
       end
 
       def call(args, command_name)
-        if Project.has_current? && Project.current && Project.current.env
+        if Project.current&.env
           @ctx.puts(@ctx.message('core.connect.already_connected_warning'))
         end
 
         project_type = ask_project_type
 
-        klass = ProjectType.load_type(project_type).connect_command
-        klass.ctx = @ctx
+        klass = ProjectType.load_type(project_type)&.connect_command
+
         if klass
+          klass.ctx = @ctx
           klass.call(args, command_name, 'connect')
         else
-          org, api_key = default_connect(project_type)
+          app = default_connect(project_type)
+          @ctx.done(@ctx.message('core.connect.connected', app))
         end
-        [org, api_key]
       end
 
       def ask_project_type
@@ -53,6 +38,26 @@ module ShopifyCli
             handler.option(type.project_name) { type.project_type }
           end
         end
+      end
+
+      def default_connect(project_type)
+        org = ShopifyCli::Tasks::EnsureEnv.call(@ctx, regenerate: true)
+        write_cli_yml(project_type, org['id']) unless Project.has_current?
+        api_key = Project.current(force_reload: true).env['api_key']
+        get_app(org['apps'], api_key).first['title']
+      end
+
+      def write_cli_yml(project_type, org_id)
+        ShopifyCli::Project.write(
+          @ctx,
+          project_type: project_type,
+          organization_id: org_id,
+        )
+        @ctx.done(@ctx.message('core.connect.cli_yml_saved'))
+      end
+
+      def get_app(apps, api_key)
+        apps.select { |app| app["apiKey"] == api_key }
       end
     end
   end

--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -3,23 +3,48 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Connect < ShopifyCli::Command
-      def call(*)
-        project_type = ask_project_type unless Project.has_current?
-
-        if Project.has_current? && Project.current && Project.current.env
-          @ctx.puts @ctx.message('core.connect.already_connected_warning')
-          prod_warning = @ctx.message('core.connect.production_warning')
-          @ctx.puts prod_warning if [:rails, :node].include?(Project.current_project_type)
+      class << self
+        def call(args, command_name)
+          ProjectType.load_type(args[0]) unless args.empty?
+          super
         end
 
-        org = ShopifyCli::Tasks::EnsureEnv.call(@ctx, regenerate: true)
-        write_cli_yml(project_type, org['id']) unless Project.has_current?
-        api_key = Project.current(force_reload: true).env['api_key']
-        @ctx.puts(@ctx.message('core.connect.connected', get_app(org['apps'], api_key).first["title"]))
+        def default_connect(project_type)
+          org = ShopifyCli::Tasks::EnsureEnv.call(@ctx, regenerate: true)
+          write_cli_yml(project_type, org['id']) unless Project.has_current?
+          api_key = Project.current(force_reload: true).env['api_key']
+          [org, api_key]
+        end
+
+        def write_cli_yml(project_type, org_id)
+          ShopifyCli::Project.write(
+            @ctx,
+            project_type: project_type,
+            organization_id: org_id,
+          )
+          @ctx.done(@ctx.message('core.connect.cli_yml_saved'))
+        end
+
+        def help
+          ShopifyCli::Context.message('core.connect.help', ShopifyCli::TOOL_NAME)
+        end
       end
 
-      def get_app(apps, api_key)
-        apps.select { |app| app["apiKey"] == api_key }
+      def call(args, command_name)
+        if Project.has_current? && Project.current && Project.current.env
+          @ctx.puts(@ctx.message('core.connect.already_connected_warning'))
+        end
+
+        project_type = ask_project_type
+
+        klass = ProjectType.load_type(project_type).connect_command
+        klass.ctx = @ctx
+        if klass
+          klass.call(args, command_name, 'connect')
+        else
+          org, api_key = default_connect(project_type)
+        end
+        [org, api_key]
       end
 
       def ask_project_type
@@ -28,19 +53,6 @@ module ShopifyCli
             handler.option(type.project_name) { type.project_type }
           end
         end
-      end
-
-      def write_cli_yml(project_type, org_id)
-        ShopifyCli::Project.write(
-          @ctx,
-          project_type: project_type,
-          organization_id: org_id,
-        )
-        @ctx.done(@ctx.message('core.connect.cli_yml_saved'))
-      end
-
-      def self.help
-        ShopifyCli::Context.message('core.connect.help', ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -14,7 +14,7 @@ module ShopifyCli
           {{yellow:! Warning: if you have connected to an {{bold:app in production}}, running {{command:serve}} may update the app URL and cause an outage.
           MESSAGE
           already_connected_warning: "{{yellow:! This app appears to be already connected}}",
-          connected: "{{v}} Project now connected to {{green:%s}}",
+          connected: "Project now connected to {{green:%s}}",
           project_type_select: "What type of project would you like to connect?",
           cli_yml_saved: ".shopify-cli.yml saved to project root",
         },

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -10,11 +10,7 @@ module ShopifyCli
             Usage: {{command:%s connect}}
           HELP
 
-          production_warning: <<~MESSAGE,
-          {{yellow:! Warning: if you have connected to an {{bold:app in production}}, running {{command:serve}} may update the app URL and cause an outage.
-          MESSAGE
           already_connected_warning: "{{yellow:! This app appears to be already connected}}",
-          connected: "Project now connected to {{green:%s}}",
           project_type_select: "What type of project would you like to connect?",
           cli_yml_saved: ".shopify-cli.yml saved to project root",
         },

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -45,14 +45,26 @@ module ShopifyCli
         File.join(ShopifyCli::PROJECT_TYPES_DIR, project_type.to_s, path)
       end
 
-      def creator(name, command_const)
+      def title(name)
         @project_name = name
+      end
+
+      def creator(command_const)
         @project_creator_command_class = command_const
         ShopifyCli::Commands::Create.subcommand(command_const, @project_type)
       end
 
       def create_command
         const_get(@project_creator_command_class)
+      end
+
+      def connector(command_const)
+        @project_connector_command_class = command_const
+        ShopifyCli::Commands::Connect.subcommand(command_const, @project_type)
+      end
+
+      def connect_command
+        const_get(@project_connector_command_class)
       end
 
       def register_command(const, cmd)

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -64,7 +64,11 @@ module ShopifyCli
       end
 
       def connect_command
-        const_get(@project_connector_command_class)
+        if @project_connector_command_class.nil?
+          nil
+        else
+          const_get(@project_connector_command_class)
+        end
       end
 
       def register_command(const, cmd)

--- a/test/project_types/node/commands/connect_test.rb
+++ b/test/project_types/node/commands/connect_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'project_types/node/test_helper'
+
+module Node
+  module Commands
+    class CreateTest < MiniTest::Test
+      include TestHelpers::Partners
+
+      ORG = { 'id' => '620',
+              'businessName' => 'idk',
+              'stores' => [{
+                'shopId' => '420',
+                'shopDomain' => 'shop.myshopify.com',
+                'shopName' => 'My Shop',
+              }],
+              'apps' => [{
+                'id' => '80',
+                'title' => 'node-app',
+                'apiKey' => 'bomk',
+                'apiSecretKeys' => [{ 'secret' => 'boop' }],
+              }] }
+
+      def test_can_connect
+        context = ShopifyCli::Context.new
+
+        ShopifyCli::Project.expects(:has_current?).returns(false)
+        ShopifyCli::Commands::Connect.expects(:default_connect)
+          .with('node')
+          .returns([ORG, 'bomk'])
+        context.expects(:done)
+          .with(context.message('core.connect.connected', 'node-app'))
+
+        Node::Commands::Connect.new(context).call
+      end
+
+      def test_warns_if_in_production
+        context = ShopifyCli::Context.new
+
+        ShopifyCli::Project.stubs(:current_project_type).returns(:node)
+        context.expects(:puts)
+          .with(context.message('core.connect.production_warning'))
+        ShopifyCli::Commands::Connect.expects(:default_connect)
+          .with('node')
+          .returns([ORG, 'bomk'])
+        context.expects(:done)
+          .with(context.message('core.connect.connected', 'node-app'))
+
+        Node::Commands::Connect.new(context).call
+      end
+    end
+  end
+end

--- a/test/project_types/node/commands/connect_test.rb
+++ b/test/project_types/node/commands/connect_test.rb
@@ -3,32 +3,19 @@ require 'project_types/node/test_helper'
 
 module Node
   module Commands
-    class CreateTest < MiniTest::Test
+    class ConnectTest < MiniTest::Test
       include TestHelpers::Partners
-
-      ORG = { 'id' => '620',
-              'businessName' => 'idk',
-              'stores' => [{
-                'shopId' => '420',
-                'shopDomain' => 'shop.myshopify.com',
-                'shopName' => 'My Shop',
-              }],
-              'apps' => [{
-                'id' => '80',
-                'title' => 'node-app',
-                'apiKey' => 'bomk',
-                'apiSecretKeys' => [{ 'secret' => 'boop' }],
-              }] }
+      include TestHelpers::FakeUI
 
       def test_can_connect
         context = ShopifyCli::Context.new
 
-        ShopifyCli::Project.expects(:has_current?).returns(false)
-        ShopifyCli::Commands::Connect.expects(:default_connect)
+        ShopifyCli::Project.stubs(:has_current?).returns(false)
+        ShopifyCli::Commands::Connect.any_instance.expects(:default_connect)
           .with('node')
-          .returns([ORG, 'bomk'])
+          .returns('node-app')
         context.expects(:done)
-          .with(context.message('core.connect.connected', 'node-app'))
+          .with(context.message('node.connect.connected', 'node-app'))
 
         Node::Commands::Connect.new(context).call
       end
@@ -36,14 +23,13 @@ module Node
       def test_warns_if_in_production
         context = ShopifyCli::Context.new
 
-        ShopifyCli::Project.stubs(:current_project_type).returns(:node)
         context.expects(:puts)
-          .with(context.message('core.connect.production_warning'))
-        ShopifyCli::Commands::Connect.expects(:default_connect)
+          .with(context.message('node.connect.production_warning'))
+        ShopifyCli::Commands::Connect.any_instance.expects(:default_connect)
           .with('node')
-          .returns([ORG, 'bomk'])
+          .returns('node-app')
         context.expects(:done)
-          .with(context.message('core.connect.connected', 'node-app'))
+          .with(context.message('node.connect.connected', 'node-app'))
 
         Node::Commands::Connect.new(context).call
       end

--- a/test/project_types/rails/commands/connect_test.rb
+++ b/test/project_types/rails/commands/connect_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'project_types/rails/test_helper'
+
+module Rails
+  module Commands
+    class CreateTest < MiniTest::Test
+      include TestHelpers::Partners
+
+      ORG = { 'id' => '620',
+              'businessName' => 'idk',
+              'stores' => [{
+                'shopId' => '420',
+                'shopDomain' => 'shop.myshopify.com',
+                'shopName' => 'My Shop',
+              }],
+              'apps' => [{
+                'id' => '80',
+                'title' => 'rails-app',
+                'apiKey' => 'bomk',
+                'apiSecretKeys' => [{ 'secret' => 'boop' }],
+              }] }
+
+      def test_can_connect
+        context = ShopifyCli::Context.new
+
+        ShopifyCli::Project.expects(:has_current?).returns(false)
+        ShopifyCli::Commands::Connect.expects(:default_connect)
+          .with('rails')
+          .returns([ORG, 'bomk'])
+        context.expects(:done)
+          .with(context.message('core.connect.connected', 'rails-app'))
+
+        Rails::Commands::Connect.new(context).call
+      end
+
+      def test_warns_if_in_production
+        context = ShopifyCli::Context.new
+
+        ShopifyCli::Project.stubs(:current_project_type).returns(:rails)
+        context.expects(:puts)
+          .with(context.message('core.connect.production_warning'))
+        ShopifyCli::Commands::Connect.expects(:default_connect)
+          .with('rails')
+          .returns([ORG, 'bomk'])
+        context.expects(:done)
+          .with(context.message('core.connect.connected', 'rails-app'))
+
+        Rails::Commands::Connect.new(context).call
+      end
+    end
+  end
+end

--- a/test/project_types/rails/commands/connect_test.rb
+++ b/test/project_types/rails/commands/connect_test.rb
@@ -3,32 +3,19 @@ require 'project_types/rails/test_helper'
 
 module Rails
   module Commands
-    class CreateTest < MiniTest::Test
+    class ConnectTest < MiniTest::Test
       include TestHelpers::Partners
-
-      ORG = { 'id' => '620',
-              'businessName' => 'idk',
-              'stores' => [{
-                'shopId' => '420',
-                'shopDomain' => 'shop.myshopify.com',
-                'shopName' => 'My Shop',
-              }],
-              'apps' => [{
-                'id' => '80',
-                'title' => 'rails-app',
-                'apiKey' => 'bomk',
-                'apiSecretKeys' => [{ 'secret' => 'boop' }],
-              }] }
+      include TestHelpers::FakeUI
 
       def test_can_connect
         context = ShopifyCli::Context.new
 
         ShopifyCli::Project.expects(:has_current?).returns(false)
-        ShopifyCli::Commands::Connect.expects(:default_connect)
+        ShopifyCli::Commands::Connect.any_instance.expects(:default_connect)
           .with('rails')
-          .returns([ORG, 'bomk'])
+          .returns('rails-app')
         context.expects(:done)
-          .with(context.message('core.connect.connected', 'rails-app'))
+          .with(context.message('rails.connect.connected', 'rails-app'))
 
         Rails::Commands::Connect.new(context).call
       end
@@ -38,12 +25,12 @@ module Rails
 
         ShopifyCli::Project.stubs(:current_project_type).returns(:rails)
         context.expects(:puts)
-          .with(context.message('core.connect.production_warning'))
-        ShopifyCli::Commands::Connect.expects(:default_connect)
+          .with(context.message('rails.connect.production_warning'))
+        ShopifyCli::Commands::Connect.any_instance.expects(:default_connect)
           .with('rails')
-          .returns([ORG, 'bomk'])
+          .returns('rails-app')
         context.expects(:done)
-          .with(context.message('core.connect.connected', 'rails-app'))
+          .with(context.message('rails.connect.connected', 'rails-app'))
 
         Rails::Commands::Connect.new(context).call
       end

--- a/test/shopify-cli/commands/connect_test.rb
+++ b/test/shopify-cli/commands/connect_test.rb
@@ -5,6 +5,23 @@ module ShopifyCli
     class ConnectTest < MiniTest::Test
       include TestHelpers::Partners
 
+      def test_runs_project_type_connect_if_exists
+        ShopifyCli::Project.stubs(:has_current?).returns(false)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
+        Node::Commands::Connect.expects(:call)
+          .with([], 'connect', 'connect')
+
+        run_cmd('connect')
+      end
+
+      def test_can_take_arg
+        ShopifyCli::Project.stubs(:has_current?).returns(false)
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).never
+        ::Node::Commands::Connect.expects(:call)
+
+        ShopifyCli::Commands::Connect.call(['node'], 'connect')
+      end
+
       def test_connect_asks_project_type_and_writes_yml_when_no_project_exists
         ShopifyCli::Project.stubs(:has_current?).returns(false)
         CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
@@ -14,21 +31,21 @@ module ShopifyCli
       end
 
       def test_connect_doesnt_write_yml_when_current_project_exists
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).never
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
         ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
         ShopifyCli::Project.expects(:write).never
         run_cmd('connect')
       end
 
       def test_connect_outputs_warnings_if_already_connected
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).never
+        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
         ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
         ShopifyCli::Project.expects(:write).never
         ShopifyCli::Project.stubs(:current_project_type).returns(:rails)
 
         @context.expects(:puts).with(@context.message('core.connect.already_connected_warning'))
         @context.expects(:puts).with(@context.message('core.connect.production_warning'))
-        @context.expects(:puts).with(@context.message('core.connect.connected', 'app'))
+        @context.expects(:done).with(@context.message('core.connect.connected', 'app'))
 
         run_cmd('connect')
       end


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
* "Fixes" #614 
* Allows for greater flexibility depending on behaviour of project types

### What is this pull request doing? 📋 
* Splits `connect` command into subcommands for each project type (similar to `create`)
* Default fallback behaviour if `connect` not implemented for that project type

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR
