### PR TITLE
Fix unhandled empty response error in script_service.rb

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -9,6 +9,7 @@ module Script
         class AppScriptUndefinedError < ScriptProjectError; end
         class BuildError < ScriptProjectError; end
         class DependencyInstallError < ScriptProjectError; end
+        class EmptyResponseError < ScriptProjectError; end
         class ForbiddenError < ScriptProjectError; end
         class GraphqlError < ScriptProjectError
           attr_reader :errors

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -146,6 +146,8 @@ module Script
         end
 
         def raise_if_graphql_failed(response)
+          raise Errors::EmptyResponseError if response.nil?
+
           return unless response.key?('errors')
           case error_code(response['errors'])
           when 'forbidden'

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -57,6 +57,9 @@ module Script
           dependency_install_cause: "Something went wrong while installing the dependencies that are needed.",
           dependency_install_help: "Correct the errors and try again.",
 
+          failed_api_request_cause: "Something went wrong while communicating with Shopify.",
+          failed_api_request_help: "Try again.",
+
           forbidden_error_cause: "You do not have permission to do this action.",
 
           graphql_error_cause: "An error was returned: %s.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -116,6 +116,11 @@ module Script
             cause_of_error: ShopifyCli::Context.message('script.error.dependency_install_cause'),
             help_suggestion: ShopifyCli::Context.message('script.error.dependency_install_help'),
           }
+        when Layers::Infrastructure::Errors::EmptyResponseError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.failed_api_request_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.failed_api_request_help'),
+          }
         when Layers::Infrastructure::Errors::ForbiddenError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.forbidden_error_cause'),

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -182,6 +182,14 @@ describe Script::Layers::Infrastructure::ScriptService do
           assert_raises(Script::Layers::Infrastructure::Errors::ScriptRepushError) { subject }
         end
       end
+
+      describe "when response is empty" do
+        let(:response) { nil }
+
+        it "should raise EmptyResponseError error" do
+          assert_raises(Script::Layers::Infrastructure::Errors::EmptyResponseError) { subject }
+        end
+      end
     end
   end
 

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -188,6 +188,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when EmptyResponseError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::EmptyResponseError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when ForbiddenError" do
         let(:err) { Script::Layers::Infrastructure::Errors::ForbiddenError.new }
         it "should call display_and_raise" do


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/1845

If theres a server error in one of our APIs, the API class will print a failure message and return nil. We don't currently check if it is nil which means we run into a messy stacktrace later on that is unhelpful to debug.

### WHAT is this pull request doing?

Checks if the response is nil, and raises an exception & print a helpful error if it is. 

Settled on the following content with @kwringe the other day:
![image](https://user-images.githubusercontent.com/28009669/98260422-51326000-1f51-11eb-8835-62fe4aba7b44.png)

