### PR TITLE
[Fix] Remove --no-optional when running npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ------
-* Remove --no-optional when using npm to create new extension
+* [#965](https://github.com/Shopify/shopify-app-cli/pull/965): Remove --no-optional when using npm to create new extension
 
 Version 1.4.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ------
-* [#965](https://github.com/Shopify/shopify-app-cli/pull/965): Remove --no-optional when using npm to create new extension
+* [#965](https://github.com/Shopify/shopify-app-cli/pull/965): Remove --no-optional when using npm to create new project
 
 Version 1.4.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* Remove --no-optional when using npm to create new extension
 
 Version 1.4.1
 ------

--- a/lib/shopify-cli/js_deps.rb
+++ b/lib/shopify-cli/js_deps.rb
@@ -59,7 +59,7 @@ module ShopifyCli
     end
 
     def npm(verbose = false)
-      cmd = %w(npm install --no-audit --no-optional)
+      cmd = %w(npm install --no-audit)
       cmd << '--quiet' unless verbose
 
       run_install_command(cmd)

--- a/test/shopify-cli/js_deps_test.rb
+++ b/test/shopify-cli/js_deps_test.rb
@@ -12,7 +12,7 @@ module ShopifyCli
     def test_installs_with_npm_and_returns_true
       JsSystem.any_instance.stubs(:yarn?).returns(false)
       mock_install_call(
-        command: %w(npm install --no-audit --no-optional --quiet),
+        command: %w(npm install --no-audit --quiet),
         returns: ['', '', mock(success?: true)]
       )
 
@@ -28,7 +28,7 @@ module ShopifyCli
     def test_install_with_npm_outputs_an_error_message_if_install_fails_and_returns_false
       JsSystem.any_instance.stubs(:yarn?).returns(false)
       mock_install_call(
-        command: %w(npm install --no-audit --no-optional --quiet),
+        command: %w(npm install --no-audit --quiet),
         returns: ['', mock(lines: ['error message']), mock(success?: false)]
       )
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-extension-libs/issues/1112

This PR fixes `shopify serve` issue when running Argo extension. `chokidar ` is an optional dependency that webpack uses for Argo. Considering Shopify cli is for development, it makes sense to not use `--no-optional` option.

### WHAT is this pull request doing?

- Remove `--no-optional` and fix test.


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR

### How to 🎩 
- Do 
```
dev cd shopify-app-cli
./bin/shopify create extension
```
- Follow the steps to create new Argo Admin Extension
- Go to new extension directory and point to correct local shopify-app-cli
```
../bin/shopify-app-cli/bin/shopify serve
```
- Verify that extension is served correctly without having to do `npm install` again.