### PR TITLE
Automatically update Theme Kit weekly

### DIFF
--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -104,6 +104,7 @@ module Theme
             errors: {
               digest_fail: "Unable to verify download",
               releases_fail: "Unable to fetch Theme Kit's list of releases",
+              update_fail: "Unable to update Theme Kit",
               write_fail: "Unable to download Theme Kit",
             },
             successful: "Theme Kit installed successfully",

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -100,6 +100,7 @@ module Theme
         },
         tasks: {
           ensure_themekit_installed: {
+            auto_update: "Would you like to enable auto-updating?",
             downloading: "Downloading Theme Kit %s",
             errors: {
               digest_fail: "Unable to verify download",

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -7,37 +7,57 @@ module Theme
         linux: 'linux-amd64',
         windows: 'windows-amd64',
       }
+      VERSION_CHECK_INTERVAL = 604800
+      VERSION_CHECK_SECTION = 'themekitversioncheck'
+      LAST_CHECKED_AT_FIELD = 'last_checked_at'
 
       def call(ctx)
         _out, stat = ctx.capture2e(Themekit::THEMEKIT)
-        return if stat.success?
+        unless stat.success?
+          require 'json'
+          require 'fileutils'
+          require 'digest'
+          require 'open-uri'
 
-        require 'json'
-        require 'fileutils'
-        require 'digest'
-        require 'open-uri'
+          begin
+            begin
+              releases = JSON.parse(Net::HTTP.get(URI(URL)))
+              release = releases["platforms"].find { |r| r["name"] == OSMAP[ctx.os] }
+            rescue
+              ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.releases_fail'))
+            end
 
-        begin
-          releases = JSON.parse(Net::HTTP.get(URI(URL)))
-          release = releases["platforms"].find { |r| r["name"] == OSMAP[ctx.os] }
-        rescue
-          ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.releases_fail'))
+            ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.downloading', releases['version']))
+            _out, stat = ctx.capture2e('curl', '-o', Themekit::THEMEKIT, release["url"])
+            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) unless stat.success?
+
+            ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.verifying'))
+            if Digest::MD5.file(Themekit::THEMEKIT) == release['digest']
+              FileUtils.chmod("+x", Themekit::THEMEKIT)
+              ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.successful'))
+            else
+              ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.digest_fail'))
+            end
+          rescue StandardError, ShopifyCli::Abort => e
+            FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)
+            raise e
+          end
         end
 
-        ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.downloading', releases['version']))
-        _out, stat = ctx.capture2e('curl', '-o', Themekit::THEMEKIT, release["url"])
-        ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) unless stat.success?
-
-        ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.verifying'))
-        if Digest::MD5.file(Themekit::THEMEKIT) == release['digest']
-          FileUtils.chmod("+x", Themekit::THEMEKIT)
-          ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.successful'))
-        else
-          ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.digest_fail'))
+        if (time_of_last_check + VERSION_CHECK_INTERVAL) < (now = Time.now.to_i)
+          update_time_of_last_check(now)
+          unless Themekit.update(ctx)
+            ctx.abort('Unable to update Theme Kit')
+          end
         end
-      rescue StandardError, ShopifyCli::Abort => e
-        FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)
-        raise e
+      end
+
+      def time_of_last_check
+        (val = ShopifyCli::Config.get(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD)) ? val.to_i : 0
+      end
+
+      def update_time_of_last_check(time)
+        ShopifyCli::Config.set(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD, time)
       end
     end
   end

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -45,12 +45,14 @@ module Theme
         end
 
         if (time_of_last_check + VERSION_CHECK_INTERVAL) < (now = Time.now.to_i)
-          update_time_of_last_check(now)
           unless Themekit.update(ctx)
-            ctx.abort('Unable to update Theme Kit')
+            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.update_fail'))
           end
+          update_time_of_last_check(now)
         end
       end
+
+      private
 
       def time_of_last_check
         (val = ShopifyCli::Config.get(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD)) ? val.to_i : 0

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -59,9 +59,14 @@ module Theme
         ctx.system(*command)
       end
 
+      def update(ctx)
+        command = build_command('update')
+        ctx.system(*command)
+      end
+
       private
 
-      def build_command(action, env)
+      def build_command(action, env = nil)
         command = [THEMEKIT, action]
         command << "--env=#{env}" if env
         command

--- a/lib/shopify-cli/feature.rb
+++ b/lib/shopify-cli/feature.rb
@@ -87,8 +87,6 @@ module ShopifyCli
         ShopifyCli::Config.get_bool(SECTION, feature.to_s)
       end
 
-      private
-
       def set(feature, value)
         ShopifyCli::Config.set(SECTION, feature.to_s, value)
       end

--- a/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
+++ b/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
@@ -11,6 +11,7 @@ module Theme
 
       def test_does_nothing_if_themekit_installed_and_not_update_time
         stub_check_executable(true)
+        ShopifyCli::Feature.expects(:enabled?).returns(true)
         stub_time_check
         Themekit.expects(:update).with(@context).never
 
@@ -23,10 +24,15 @@ module Theme
         stub_check_executable
         stub_releases
         stub_themekit_file_write
+        CLI::UI.expects(:confirm)
+          .with(@context.message('theme.tasks.ensure_themekit_installed.auto_update'))
+          .returns(true)
+        ShopifyCli::Feature.expects(:set).with(:themekit_auto_update, true)
         stub_time_check
 
         Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('boop')
         FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT)
+        ShopifyCli::Feature.expects(:enabled?).returns(true)
 
         EnsureThemekitInstalled.call(@context)
       end
@@ -87,6 +93,7 @@ module Theme
 
       def test_updates_if_has_been_a_week
         stub_check_executable(true)
+        ShopifyCli::Feature.expects(:enabled?).returns(true)
         stub_time_check(604801)
         Themekit.expects(:update).with(@context).returns(true)
         ShopifyCli::Config
@@ -100,6 +107,7 @@ module Theme
 
       def test_aborts_if_cannot_update
         stub_check_executable(true)
+        ShopifyCli::Feature.expects(:enabled?).returns(true)
         stub_time_check(604801)
         Themekit.expects(:update).with(@context).returns(false)
         ShopifyCli::Config

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -207,5 +207,15 @@ module Theme
         Themekit.serve(context, env: nil)
       end
     end
+
+    def test_can_update
+      context = ShopifyCli::Context.new
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT, 'update')
+        .returns(true)
+
+      Themekit.update(context)
+    end
   end
 end


### PR DESCRIPTION
### Why are these changes introduced? 🤔
* Having most up-to-date Theme Kit version is good but not always desirable
* If Theme Kit has an update it will prompt the user to type `theme update`, which will not work

### What is this pull request doing? 📋
* When downloading Theme Kit, prompts for autoupdate
* Checks if it has been a week since the last update
* If so, runs `theme update`
