### PR TITLE
Add Shopify org indicator for new project config

### DIFF
--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -88,8 +88,10 @@ module ShopifyCli
         content = Hash[{ project_type: project_type, organization_id: organization_id.to_i }
           .merge(identifiers)
           .collect { |k, v| [k.to_s, v] }]
+        content['shopify_organization'] = true if Shopifolk.acting_as_shopify_organization?
 
         ctx.write('.shopify-cli.yml', YAML.dump(content))
+        clear
       end
 
       def project_name

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -31,14 +31,32 @@ module ShopifyCli
     def test_write_writes_yaml
       Dir.stubs(:pwd).returns(@context.root)
       FileUtils.touch(".shopify-cli.yml")
+      Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
       assert_equal :node, Project.current.config['project_type']
       assert_equal 42, Project.current.config['organization_id']
     end
 
+    def test_write_writes_yaml_with_shopify_organization_field
+      Dir.stubs(:pwd).returns(@context.root)
+      FileUtils.touch(".shopify-cli.yml")
+      Shopifolk.stubs(:acting_as_shopify_organization?).returns(true)
+      ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
+      assert Project.current.config['shopify_organization']
+    end
+
+    def test_write_writes_yaml_without_shopify_organization_field
+      Dir.stubs(:pwd).returns(@context.root)
+      FileUtils.touch(".shopify-cli.yml")
+      Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
+      ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
+      refute Project.current.config['shopify_organization']
+    end
+
     def test_write_includes_identifiers
       Dir.stubs(:pwd).returns(@context.root)
       FileUtils.touch(".shopify-cli.yml")
+      Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       ShopifyCli::Project.write(
         @context,
         project_type: :node,

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -29,8 +29,7 @@ module ShopifyCli
     end
 
     def test_write_writes_yaml
-      Dir.stubs(:pwd).returns(@context.root)
-      FileUtils.touch(".shopify-cli.yml")
+      create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
       assert_equal :node, Project.current.config['project_type']
@@ -38,24 +37,21 @@ module ShopifyCli
     end
 
     def test_write_writes_yaml_with_shopify_organization_field
-      Dir.stubs(:pwd).returns(@context.root)
-      FileUtils.touch(".shopify-cli.yml")
+      create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(true)
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
       assert Project.current.config['shopify_organization']
     end
 
     def test_write_writes_yaml_without_shopify_organization_field
-      Dir.stubs(:pwd).returns(@context.root)
-      FileUtils.touch(".shopify-cli.yml")
+      create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
       refute Project.current.config['shopify_organization']
     end
 
     def test_write_includes_identifiers
-      Dir.stubs(:pwd).returns(@context.root)
-      FileUtils.touch(".shopify-cli.yml")
+      create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       ShopifyCli::Project.write(
         @context,
@@ -107,6 +103,13 @@ module ShopifyCli
         File.write(File.join(dir, '.env'), content)
         refute_nil(Project.current.env)
       end
+    end
+
+    private
+
+    def create_empty_config
+      Dir.stubs(:pwd).returns(@context.root)
+      FileUtils.touch(".shopify-cli.yml")
     end
   end
 end


### PR DESCRIPTION
When creating a new project, a Shopify employee will be prompted whether they want to act on behalf of the Shopify organization or not. If they do, we want to persist that in the project's configuration. This will then be read by project commands to determine whether to send the Shopify employee HTTP header or not.