### PR TITLE
Use draft PR instead of WIP indicator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
   - Prefix it with [Feature] (if applicable)
   - Start with a verb, for example: Add, Delete, Improve, Fix…
   - Give as much context as necessary and as little as possible
-  - Prefix it with [WIP] while it’s a work in progress
+  - Use a draft PR while it’s a work in progress
 -->
 
 ### WHY are these changes introduced?


### PR DESCRIPTION
Using a draft PR better conveys the intention of something being a work in progress, and protects against accidental merges.