### PR TITLE
Command to connect Theme

### DIFF
--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -2,21 +2,23 @@
 module Theme
   class Project < ShopifyCli::ProjectType
     hidden_feature
+
     title('Theme')
     creator('Theme::Commands::Create')
+    connector('Theme::Commands::Connect')
+
     register_command('Theme::Commands::Deploy', "deploy")
     register_command('Theme::Commands::Push', "push")
     register_command('Theme::Commands::Serve', "serve")
-    register_command('Theme::Commands::Pull', "pull")
 
     require Project.project_filepath('messages/messages')
     register_messages(Theme::Messages::MESSAGES)
   end
 
   module Commands
+    autoload :Connect, Project.project_filepath('commands/connect')
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Deploy, Project.project_filepath('commands/deploy')
-    autoload :Pull, Project.project_filepath('commands/pull')
     autoload :Push, Project.project_filepath('commands/push')
     autoload :Serve, Project.project_filepath('commands/serve')
   end
@@ -27,7 +29,7 @@ module Theme
 
   module Forms
     autoload :Create, Project.project_filepath('forms/create')
-    autoload :Pull, Project.project_filepath('forms/pull')
+    autoload :Connect, Project.project_filepath('forms/connect')
   end
 
   autoload :Themekit, Project.project_filepath('themekit')

--- a/lib/project_types/theme/commands/connect.rb
+++ b/lib/project_types/theme/commands/connect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Theme
   module Commands
-    class Pull < ShopifyCli::Command
+    class Connect < ShopifyCli::SubCommand
       options do |parser, flags|
         parser.on('--store=STORE') { |url| flags[:store] = url }
         parser.on('--password=PASSWORD') { |p| flags[:password] = p }
@@ -11,10 +11,10 @@ module Theme
 
       def call(args, _name)
         if ShopifyCli::Project.has_current?
-          @ctx.abort(@ctx.message('theme.pull.inside_project'))
+          @ctx.abort(@ctx.message('theme.connect.inside_project'))
         end
 
-        form = Forms::Pull.ask(@ctx, args, options.flags)
+        form = Forms::Connect.ask(@ctx, args, options.flags)
         return @ctx.puts(self.class.help) if form.nil?
 
         build(form.store, form.password, form.themeid, form.name, form.env)
@@ -22,11 +22,11 @@ module Theme
                                   project_type: 'theme',
                                   organization_id: nil)
 
-        @ctx.done(@ctx.message('theme.pull.pulled', form.name, form.store, @ctx.root))
+        @ctx.done(@ctx.message('theme.connect.connected', form.name, form.store, @ctx.root))
       end
 
       def self.help
-        ShopifyCli::Context.message('theme.pull.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message('theme.connect.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
       end
 
       private
@@ -37,17 +37,17 @@ module Theme
         end
 
         if @ctx.dir_exist?(name)
-          @ctx.abort(@ctx.message('theme.pull.duplicate'))
+          @ctx.abort(@ctx.message('theme.connect.duplicate'))
         end
 
         @ctx.mkdir_p(name)
         @ctx.chdir(name)
 
-        CLI::UI::Frame.open(@ctx.message('theme.pull.pull')) do
-          unless Themekit.pull(@ctx, store: store, password: password, themeid: themeid, env: env)
+        CLI::UI::Frame.open(@ctx.message('theme.connect.connect')) do
+          unless Themekit.connect(@ctx, store: store, password: password, themeid: themeid, env: env)
             @ctx.chdir('..')
             @ctx.rm_rf(name)
-            @ctx.abort(@ctx.message('theme.pull.failed'))
+            @ctx.abort(@ctx.message('theme.connect.failed'))
           end
         end
       end

--- a/lib/project_types/theme/forms/connect.rb
+++ b/lib/project_types/theme/forms/connect.rb
@@ -1,12 +1,12 @@
 module Theme
   module Forms
-    class Pull < ShopifyCli::Form
+    class Connect < ShopifyCli::Form
       attr_accessor :name
       flag_arguments :themeid, :password, :store, :env
 
       def ask
         self.store ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_store'), allow_empty: false)
-        ctx.puts(ctx.message('theme.forms.pull.private_app', store))
+        ctx.puts(ctx.message('theme.forms.connect.private_app', store))
         self.password ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_password'), allow_empty: false)
 
         errors = []

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -4,6 +4,21 @@ module Theme
     MESSAGES = {
       theme: {
         checking_themekit: "Verifying Theme Kit",
+        connect: {
+          duplicate: "Duplicate directory, theme files weren't connected",
+          help: <<~HELP,
+            {{command:%s connect theme}}: Connects an existing theme in your store to Shopify App CLI. Downloads a copy of the theme files to your local development environment.
+              Usage: {{command:%s connect theme}}
+              Options:
+                {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
+                {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
+                {{command:--themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
+          HELP
+          inside_project: "You are inside an existing theme, theme files weren't connected",
+          connect: "Downloading theme files...",
+          failed: "Couldn't download theme files from store",
+          connected: "{{green:%s}} files were downloaded from {{underline:%s}} to {{green:%s}}",
+        },
         create: {
           creating_theme: "Creating theme %s",
           duplicate_theme: "Duplicate theme",
@@ -45,28 +60,13 @@ module Theme
               If you create a new private app, ensure that it has Read and Write Theme access.
             APP
           },
-          errors: "%s can't be blank",
-          pull: {
+          connect: {
             private_app: <<~APP,
               To fetch your existing themes, Shopify App CLI needs to connect with your store. Visit {{underline:%s/admin/apps/private}} to create a new API key and password, or retrieve an existing password.
               If you create a new private app, ensure that it has Read and Write Theme access.
             APP
           },
-        },
-        pull: {
-          duplicate: "Duplicate directory, theme files weren't pulled",
-          help: <<~HELP,
-            {{command:%s pull}}: Connects an existing theme in your store to Shopify App CLI. Downloads a copy of the theme files to your local development environment.
-              Usage: {{command:%s pull}}
-              Options:
-                {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
-                {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
-                {{command:--themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
-          HELP
-          inside_project: "You are inside an existing theme, theme files weren't pulled",
-          pull: "Pulling theme files...",
-          failed: "Couldn't pull theme files from store",
-          pulled: "{{green:%s}} files were pulled from {{underline:%s}} to {{green:%s}}",
+          errors: "%s can't be blank",
         },
         push: {
           remove_abort: "Theme files weren't deleted",

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -28,7 +28,7 @@ module Theme
         Tasks::EnsureThemekitInstalled.call(ctx)
       end
 
-      def pull(ctx, store:, password:, themeid:, env:)
+      def connect(ctx, store:, password:, themeid:, env:)
         command = build_command('get', env)
         command << "--password=#{password}"
         command << "--store=#{store}"

--- a/test/project_types/theme/commands/connect_test.rb
+++ b/test/project_types/theme/commands/connect_test.rb
@@ -3,7 +3,7 @@ require 'project_types/theme/test_helper'
 
 module Theme
   module Commands
-    class PullTest < MiniTest::Test
+    class ConnectTest < MiniTest::Test
       include TestHelpers::FakeUI
 
       SHOPIFYCLI_FILE = <<~CLI
@@ -12,30 +12,30 @@ module Theme
         organization_id: 0
       CLI
 
-      def test_can_pull_theme
+      def test_can_connect_theme
         FakeFS do
           context = ShopifyCli::Context.new
           ShopifyCli::Project.expects(:has_current?).returns(false).twice
 
-          Theme::Forms::Pull.expects(:ask)
+          Theme::Forms::Connect.expects(:ask)
             .with(context, [], {})
-            .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
-                                                           password: 'boop',
-                                                           themeid: '2468',
-                                                           name: 'my_theme',
-                                                           env: nil }))
+            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
+                                                              password: 'boop',
+                                                              themeid: '2468',
+                                                              name: 'my_theme',
+                                                              env: nil }))
 
           Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(false)
-          Themekit.expects(:pull)
+          Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
             .returns(true)
-          context.expects(:done).with(context.message('theme.pull.pulled',
+          context.expects(:done).with(context.message('theme.connect.connected',
                                                       'my_theme',
                                                       'shop.myshopify.com',
                                                       File.join(context.root, 'my_theme')))
 
-          Theme::Commands::Pull.new(context).call([], 'pull')
+          Theme::Commands::Connect.new(context).call([], 'connect')
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
       end
@@ -45,27 +45,27 @@ module Theme
           context = ShopifyCli::Context.new
           ShopifyCli::Project.expects(:has_current?).returns(false).twice
 
-          Theme::Forms::Pull.expects(:ask)
+          Theme::Forms::Connect.expects(:ask)
             .with(context, [], { env: 'test' })
-            .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
-                                                           password: 'boop',
-                                                           themeid: '2468',
-                                                           name: 'my_theme',
-                                                           env: 'test' }))
+            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
+                                                              password: 'boop',
+                                                              themeid: '2468',
+                                                              name: 'my_theme',
+                                                              env: 'test' }))
 
           Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(false)
-          Themekit.expects(:pull)
+          Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: 'test')
             .returns(true)
-          context.expects(:done).with(context.message('theme.pull.pulled',
+          context.expects(:done).with(context.message('theme.connect.connected',
                                                       'my_theme',
                                                       'shop.myshopify.com',
                                                       File.join(context.root, 'my_theme')))
 
-          command = Theme::Commands::Pull.new(context)
+          command = Theme::Commands::Connect.new(context)
           command.options.flags[:env] = 'test'
-          command.call([], 'pull')
+          command.call([], 'connect')
 
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
@@ -76,15 +76,15 @@ module Theme
           context = ShopifyCli::Context.new
           ShopifyCli::Project.expects(:has_current?).returns(true)
 
-          Theme::Forms::Pull.expects(:ask).with(context, [], {}).never
+          Theme::Forms::Connect.expects(:ask).with(context, [], {}).never
           Themekit.expects(:ensure_themekit_installed).with(context).never
           context.expects(:dir_exist?).with('my_theme').never
-          Themekit.expects(:pull)
+          Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
             .never
 
           assert_raises CLI::Kit::Abort do
-            Theme::Commands::Pull.new(context).call([], 'pull')
+            Theme::Commands::Connect.new(context).call([], 'connect')
           end
         end
       end
@@ -94,22 +94,22 @@ module Theme
           context = ShopifyCli::Context.new
           ShopifyCli::Project.expects(:has_current?).returns(false)
 
-          Theme::Forms::Pull.expects(:ask)
+          Theme::Forms::Connect.expects(:ask)
             .with(context, [], {})
-            .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
-                                                           password: 'boop',
-                                                           themeid: '2468',
-                                                           name: 'my_theme',
-                                                           env: nil }))
+            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
+                                                              password: 'boop',
+                                                              themeid: '2468',
+                                                              name: 'my_theme',
+                                                              env: nil }))
 
           Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(true)
-          Themekit.expects(:pull)
+          Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
             .never
 
           assert_raises CLI::Kit::Abort do
-            Theme::Commands::Pull.new(context).call([], 'pull')
+            Theme::Commands::Connect.new(context).call([], 'connect')
           end
         end
       end
@@ -119,22 +119,22 @@ module Theme
           context = ShopifyCli::Context.new
           ShopifyCli::Project.expects(:has_current?).returns(false)
 
-          Theme::Forms::Pull.expects(:ask)
+          Theme::Forms::Connect.expects(:ask)
             .with(context, [], {})
-            .returns(Theme::Forms::Pull.new(context, [], { store: 'shop.myshopify.com',
-                                                           password: 'merp',
-                                                           themeid: '1357',
-                                                           name: 'your_theme',
-                                                           env: nil }))
+            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
+                                                              password: 'merp',
+                                                              themeid: '1357',
+                                                              name: 'your_theme',
+                                                              env: nil }))
 
           Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('your_theme').returns(false)
-          Themekit.expects(:pull)
+          Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'merp', themeid: '1357', env: nil)
             .returns(false)
 
           assert_raises CLI::Kit::Abort do
-            Theme::Commands::Pull.new(context).call([], 'pull')
+            Theme::Commands::Connect.new(context).call([], 'connect')
           end
         end
       end

--- a/test/project_types/theme/forms/connect_test.rb
+++ b/test/project_types/theme/forms/connect_test.rb
@@ -3,7 +3,7 @@ require 'project_types/theme/test_helper'
 
 module Theme
   module Forms
-    class PullTest < MiniTest::Test
+    class ConnectTest < MiniTest::Test
       def test_returns_all_defined_attributes_if_valid
         query_themes
         form = ask
@@ -64,7 +64,7 @@ module Theme
       private
 
       def ask(password: 'boop', store: 'shop.myshopify.com', themeid: '2468', env: nil)
-        Pull.ask(
+        Connect.ask(
           @context,
           [],
           password: password,

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -145,7 +145,7 @@ module Theme
       refute(Themekit.deploy(context, env: nil))
     end
 
-    def test_pull_successful
+    def test_connect_successful
       context = ShopifyCli::Context.new
       stat = mock
       context.expects(:system)
@@ -156,10 +156,10 @@ module Theme
               '--themeid=2468')
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.pull(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
+      assert(Themekit.connect(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
     end
 
-    def test_pull_unsuccessful
+    def test_connect_unsuccessful
       context = ShopifyCli::Context.new
       stat = mock
       context.expects(:system)
@@ -170,7 +170,7 @@ module Theme
               '--themeid=2468')
         .returns(stat)
       stat.stubs(:success?).returns(false)
-      refute(Themekit.pull(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
+      refute(Themekit.connect(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
     end
 
     def test_serve_successful


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
* Currently the `pull` command can't be used outside a project, but can't be used inside a project either

### What is this pull request doing? 📋 
* Makes `pull` into `connect theme`, a subcommand from `connect`, by renaming and moving files