### PR TITLE
Use latest stable extension points

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,24 +1,20 @@
 discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    version: "^0.4.0"
     sdk-version: "^7.0.0"
     toolchain-version: "^2.0.1"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
-    version: "^0.3.0"
     sdk-version: "^7.0.0"
     toolchain-version: "^2.0.1"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
-    version: "^0.7.0"
     sdk-version: "^7.0.0"
     toolchain-version: "^2.0.1"
 shipping_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-shipping-filter"
-    version: "^0.4.0"
     sdk-version: "^7.0.0"
     toolchain-version: "^2.0.1"

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -19,7 +19,6 @@ module Script
 
         def initialize(config)
           @package = config["package"]
-          @version = config["version"]
           @sdk_version = config["sdk-version"]
           @toolchain_version = config["toolchain-version"]
         end

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -34,6 +34,12 @@ module Script
           )
         end
 
+        def extension_point_version
+          out, status = ctx.capture2e("npm show #{extension_point.sdks[:ts].package} version --json")
+          raise Domain::Errors::ServiceFailureError, out unless status.success?
+          JSON.parse(out)
+        end
+
         def write_package_json
           package_json = <<~HERE
             {
@@ -42,7 +48,7 @@ module Script
               "devDependencies": {
                 "@shopify/scripts-sdk-as": "#{extension_point.sdks[:ts].sdk_version}",
                 "@shopify/scripts-toolchain-as": "#{extension_point.sdks[:ts].toolchain_version}",
-                "#{extension_point.sdks[:ts].package}": "#{extension_point.sdks[:ts].version}",
+                "#{extension_point.sdks[:ts].package}": "^#{extension_point_version}",
                 "@as-pect/cli": "4.0.0",
                 "as-wasi": "^0.2.1",
                 "assemblyscript": "^0.14.0"
@@ -56,7 +62,6 @@ module Script
               }
             }
           HERE
-
           ctx.write("package.json", package_json)
         end
       end

--- a/test/project_types/script/layers/domain/extension_point_test.rb
+++ b/test/project_types/script/layers/domain/extension_point_test.rb
@@ -8,7 +8,6 @@ describe Script::Layers::Domain::ExtensionPoint do
     {
       "assemblyscript" => {
         "package" => "@shopify/extension-point-as-fake",
-        "version" => "*",
         "sdk-version" => "*",
         "toolchain-version" => "*",
       },
@@ -23,7 +22,6 @@ describe Script::Layers::Domain::ExtensionPoint do
 
       sdk = extension_point.sdks[:ts]
       refute_nil sdk.package
-      refute_nil sdk.version
       refute_nil sdk.sdk_version
       refute_nil sdk.toolchain_version
     end

--- a/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
@@ -14,7 +14,6 @@ describe Script::Layers::Infrastructure::ExtensionPointRepository do
           extension_point = subject.get_extension_point(extension_point_type)
           assert_equal extension_point_type, extension_point.type
           refute_nil extension_point.sdks[:ts].package
-          refute_nil extension_point.sdks[:ts].version
           refute_nil extension_point.sdks[:ts].sdk_version
         end
       end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/1249
To be merged after https://github.com/Shopify/shopify-app-cli/pull/979

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This pull request ensures that at script creation time, the latest stable release of each extension point is used. This change will remove some friction for the extension point authoring process, from this point on, no updates to the CLI will be needed. An update to the CLI will be needed only when new extension points are introduced. 

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR
