### PR TITLE
[scripts] Fix inconsistent node version warning

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -11,6 +11,7 @@ module Script
         property! :path_to_project, accepts: String
 
         BOOTSTRAP = "npx --no-install shopify-scripts-toolchain-as bootstrap --from %{extension_point} --dest %{base}"
+        MIN_NODE_VERSION = "14.5.0"
 
         def setup_dependencies
           write_npmrc
@@ -58,7 +59,7 @@ module Script
                 "build": "shopify-scripts-toolchain-as build --src src/script.ts --binary #{script_name}.wasm -- --lib node_modules --optimize --use Date="
               },
               "engines": {
-                "node": ">=14.5"
+                "node": ">=#{MIN_NODE_VERSION}"
               }
             }
           HERE

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -46,8 +46,10 @@ module Script
 
           require 'semantic/semantic'
           version = ::Semantic::Version.new(output[1..-1])
-          unless version >= ::Semantic::Version.new("12.16.0")
-            raise Errors::DependencyInstallError, "Node version must be >= v12.16.0. Current version: #{output.strip}."
+          unless version >= ::Semantic::Version.new(AssemblyScriptProjectCreator::MIN_NODE_VERSION)
+            raise Errors::DependencyInstallError,
+                  "Node version must be >= v#{AssemblyScriptProjectCreator::MIN_NODE_VERSION}. "\
+                  "Current version: #{output.strip}."
           end
         end
 

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -181,21 +181,37 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
   describe ".install_dependencies" do
     subject { as_task_runner.install_dependencies }
 
-    it "should install using npm" do
-      ctx.expects(:capture2e)
-        .with("node", "--version")
-        .returns(["v12.16.1", mock(success?: true)])
-      ctx.expects(:capture2e)
-        .with("npm", "install", "--no-audit", "--no-optional", "--loglevel error")
-        .returns([nil, mock(success?: true)])
-      subject
+    describe "when node version is above minimum" do
+      it "should install using npm" do
+        ctx.expects(:capture2e)
+          .with("node", "--version")
+          .returns(["v14.5.1", mock(success?: true)])
+        ctx.expects(:capture2e)
+          .with("npm", "install", "--no-audit", "--no-optional", "--loglevel error")
+          .returns([nil, mock(success?: true)])
+        subject
+      end
     end
 
-    it "should raise error on failure" do
-      msg = 'error message'
-      ctx.expects(:capture2e).returns([msg, mock(success?: false)])
-      assert_raises Script::Layers::Infrastructure::Errors::DependencyInstallError, msg do
-        subject
+    describe "when node version is below minimum" do
+      it "should raise error" do
+        ctx.expects(:capture2e)
+          .with("node", "--version")
+          .returns(["v14.4.0", mock(success?: true)])
+
+        assert_raises Script::Layers::Infrastructure::Errors::DependencyInstallError do
+          subject
+        end
+      end
+    end
+
+    describe "when capture2e fails" do
+      it "should raise error" do
+        msg = 'error message'
+        ctx.expects(:capture2e).returns([msg, mock(success?: false)])
+        assert_raises Script::Layers::Infrastructure::Errors::DependencyInstallError, msg do
+          subject
+        end
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/1795

Previously, we had multiple locations that checks the current node version. The version they required were different and led to different behaviour. 

### WHAT is this pull request doing?

Uses a single `MIN_NODE_VERSION` constant that each place can reference to check what version we need to use.

![image](https://user-images.githubusercontent.com/28009669/100284040-8a506580-2f3c-11eb-9dac-8ab73044ef0c.png)



### Update checklist
- [ ] I've added a CHANGELOG entry for this PR
