### PR TITLE
Enable mocha checks

### DIFF
--- a/test/shopify-cli/admin_api_test.rb
+++ b/test/shopify-cli/admin_api_test.rb
@@ -5,7 +5,7 @@ module ShopifyCli
     include TestHelpers::Project
 
     def test_latest_api_version
-      unstable_stub = Object.new
+      unstable_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
         auth_header: 'X-Shopify-Access-Token',
@@ -17,7 +17,7 @@ module ShopifyCli
         .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'api/versions.json'))))
 
       ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123').twice
-      api_stub = Object.new
+      api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
         auth_header: 'X-Shopify-Access-Token',
@@ -30,7 +30,7 @@ module ShopifyCli
 
     def test_query_calls_admin_api
       ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123')
-      api_stub = Object.new
+      api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
         auth_header: 'X-Shopify-Access-Token',
@@ -46,7 +46,7 @@ module ShopifyCli
 
     def test_query_can_reauth
       ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123').twice
-      api_stub = Object.new
+      api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
         auth_header: 'X-Shopify-Access-Token',
@@ -56,7 +56,7 @@ module ShopifyCli
       api_stub.expects(:query).with('query', variables: {}).returns('response')
       api_stub.expects(:query).raises(API::APIRequestUnauthorizedError)
 
-      @oauth_client = Object.new
+      @oauth_client = mock
       ShopifyCli::OAuth
         .expects(:new)
         .with(
@@ -77,7 +77,7 @@ module ShopifyCli
 
     def test_query_calls_admin_api_with_different_shop
       ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123')
-      api_stub = Object.new
+      api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
         auth_header: 'X-Shopify-Access-Token',

--- a/test/shopify-cli/core/entry_point_test.rb
+++ b/test/shopify-cli/core/entry_point_test.rb
@@ -5,11 +5,6 @@ module ShopifyCli
     class EntryPointTest < MiniTest::Test
       include TestHelpers::Project
 
-      def setup
-        super
-        ShopifyCli::Core::EntryPoint.stubs(:before_resolve)
-      end
-
       def test_calls_executor_with_args
         args = %w(help argone argtwo)
 

--- a/test/shopify-cli/oauth/servlet_test.rb
+++ b/test/shopify-cli/oauth/servlet_test.rb
@@ -52,7 +52,7 @@ module ShopifyCli
       private
 
       def new_server
-        server = Object.new
+        server = mock
         server.stubs(:[])
         server.expects(:shutdown)
         server

--- a/test/shopify-cli/oauth_test.rb
+++ b/test/shopify-cli/oauth_test.rb
@@ -279,7 +279,7 @@ module ShopifyCli
     end
 
     def stub_server(client, resp)
-      server = Object.new
+      server = mock
       client.stubs(:server).returns(server)
       server.expects(:start)
       client.response_query = resp

--- a/test/shopify-cli/partners_api_test.rb
+++ b/test/shopify-cli/partners_api_test.rb
@@ -6,7 +6,7 @@ module ShopifyCli
 
     def test_query_calls_partners_api
       ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns('token123')
-      api_stub = Object.new
+      api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
         token: 'token123',
@@ -19,7 +19,7 @@ module ShopifyCli
     def test_query_can_reauth
       ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns('token123').twice
 
-      api_stub = Object.new
+      api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
         token: 'token123',
@@ -28,7 +28,7 @@ module ShopifyCli
       api_stub.expects(:query).with('query', variables: {}).returns('response')
       api_stub.expects(:query).raises(API::APIRequestUnauthorizedError)
 
-      @oauth_client = Object.new
+      @oauth_client = mock
       ShopifyCli::OAuth
         .expects(:new)
         .with(
@@ -47,7 +47,7 @@ module ShopifyCli
 
     def test_query_fails_gracefully_without_partners_account
       ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns('token123')
-      api_stub = Object.new
+      api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
         token: 'token123',
@@ -60,7 +60,7 @@ module ShopifyCli
 
     def test_query
       ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns('token123')
-      api_stub = Object.new
+      api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
         token: 'token123',

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -87,7 +87,6 @@ module ShopifyCli
     end
 
     def test_start_raises_error_on_ngrok_failure
-      Tunnel.any_instance.stubs(:running?).returns(false)
       with_log(fixture: 'ngrok_error') do
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,3 +14,8 @@ require 'fakefs/safe'
 require 'webmock/minitest'
 
 require 'mocha/minitest'
+
+Mocha.configure do |c|
+  c.stubbing_non_existent_method = :prevent
+  c.stubbing_method_on_nil = :prevent
+end


### PR DESCRIPTION
Mocha has a couple of configuration options to detect stubbing on `nil` or of non-existing methods.