### PR TITLE
Support important flags

### DIFF
--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -20,9 +20,7 @@ module Theme
             options.flags.delete(:env)
           end
 
-          flags = options.flags.map do |key, _value|
-            '--' + key
-          end
+          flags = Themekit.add_flags(options.flags)
 
           unless Themekit.deploy(@ctx, flags: flags, env: env)
             @ctx.abort(@ctx.message('theme.deploy.error'))

--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -15,9 +15,9 @@ module Theme
             @ctx.abort(@ctx.message('theme.deploy.abort'))
           end
 
-          if options.flags['env']
-            env = options.flags['env']
-            options.flags.delete('env')
+          if options.flags[:env]
+            env = options.flags[:env]
+            options.flags.delete(:env)
           end
 
           flags = options.flags.map do |key, _value|

--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -6,6 +6,7 @@ module Theme
 
       options do |parser, flags|
         parser.on('--env=ENV') { |env| flags[:env] = env }
+        parser.on('--allow-live') { flags['allow_live'] = true }
       end
 
       def call(*)
@@ -14,7 +15,16 @@ module Theme
             @ctx.abort(@ctx.message('theme.deploy.abort'))
           end
 
-          unless Themekit.deploy(@ctx, env: options.flags[:env])
+          if options.flags['env']
+            env = options.flags['env']
+            options.flags.delete('env')
+          end
+
+          flags = options.flags.map do |key, _value|
+            '--' + key
+          end
+
+          unless Themekit.deploy(@ctx, flags: flags, env: env)
             @ctx.abort(@ctx.message('theme.deploy.error'))
           end
         end

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -8,7 +8,7 @@ module Theme
         parser.on('--remove') { flags['remove'] = true }
         parser.on('--nodelete') { flags['nodelete'] = true }
         parser.on('--allow-live') { flags['allow-live'] = true }
-        parser.on('--env=ENV') { |env| flags['env'] = env }
+        parser.on('--env=ENV') { |env| flags[:env] = env }
       end
 
       def call(args, _name)
@@ -17,9 +17,9 @@ module Theme
           options.flags.delete('remove')
         end
 
-        if options.flags['env']
-          env = options.flags['env']
-          options.flags.delete('env')
+        if options.flags[:env]
+          env = options.flags[:env]
+          options.flags.delete(:env)
         end
 
         flags = options.flags.map do |key, _value|

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -22,9 +22,7 @@ module Theme
           options.flags.delete(:env)
         end
 
-        flags = options.flags.map do |key, _value|
-          '--' + key
-        end
+        flags = Themekit.add_flags(options.flags)
 
         if remove
           CLI::UI::Frame.open(@ctx.message('theme.push.remove')) do

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -6,11 +6,26 @@ module Theme
 
       options do |parser, flags|
         parser.on('--env=ENV') { |env| flags[:env] = env }
+        parser.on('--allow-live') { flags['allow-live'] = true }
+        parser.on('--notify') { flags['notify'] = true }
       end
 
       def call(*)
+        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
+          Themekit.ensure_themekit_installed(@ctx)
+        end
+
+        if options.flags['env']
+          env = options.flags['env']
+          options.flags.delete('env')
+        end
+
+        flags = options.flags.map do |key, _value|
+          '--' + key
+        end
+
         CLI::UI::Frame.open(@ctx.message('theme.serve.serve')) do
-          Themekit.serve(@ctx, env: options.flags[:env])
+          Themekit.serve(@ctx, flags: flags, env: env)
         end
       end
 

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -11,13 +11,9 @@ module Theme
       end
 
       def call(*)
-        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
-          Themekit.ensure_themekit_installed(@ctx)
-        end
-
-        if options.flags['env']
-          env = options.flags['env']
-          options.flags.delete('env')
+        if options.flags[:env]
+          env = options.flags[:env]
+          options.flags.delete(:env)
         end
 
         flags = options.flags.map do |key, _value|

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -7,7 +7,7 @@ module Theme
       options do |parser, flags|
         parser.on('--env=ENV') { |env| flags[:env] = env }
         parser.on('--allow-live') { flags['allow-live'] = true }
-        parser.on('--notify') { flags['notify'] = true }
+        parser.on('--notify=FILES') { |files| flags['notify'] = files }
       end
 
       def call(*)
@@ -16,9 +16,7 @@ module Theme
           options.flags.delete(:env)
         end
 
-        flags = options.flags.map do |key, _value|
-          '--' + key
-        end
+        flags = Themekit.add_flags(options.flags)
 
         CLI::UI::Frame.open(@ctx.message('theme.serve.serve')) do
           Themekit.serve(@ctx, flags: flags, env: env)

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -3,6 +3,14 @@ module Theme
     THEMEKIT = File.join(ShopifyCli.cache_dir, "themekit")
 
     class << self
+      def add_flags(flags)
+        flags.map do |key, value|
+          flag = "--#{key}"
+          flag += "=#{value}" if value.is_a? String
+          flag
+        end
+      end
+
       def connect(ctx, store:, password:, themeid:, env:)
         command = build_command('get', env)
         command << "--password=#{password}"

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -23,13 +23,16 @@ module Theme
         stat.success?
       end
 
-      def deploy(ctx, env:)
-        unless push(ctx, env: env)
+      def deploy(ctx, flags: nil, env:)
+        unless push(ctx, flags: flags, env: env)
           ctx.abort(ctx.message('theme.deploy.push_fail'))
         end
         ctx.done(ctx.message('theme.deploy.info.pushed'))
 
         command = build_command('publish', env)
+        (command << flags).compact!
+        command.flatten!
+
         stat = ctx.system(*command)
         stat.success?
       end
@@ -72,13 +75,16 @@ module Theme
         resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
       end
 
-      def serve(ctx, env:)
+      def serve(ctx, flags: nil, env:)
         command = build_command('open', env)
         out, stat = ctx.capture2e(*command)
         ctx.puts(out)
         ctx.abort(ctx.message('theme.serve.open_fail')) unless stat.success?
 
         command = build_command('watch', env)
+        (command << flags).compact!
+        command.flatten!
+        p command
         ctx.system(*command)
       end
 

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -84,7 +84,6 @@ module Theme
         command = build_command('watch', env)
         (command << flags).compact!
         command.flatten!
-        p command
         ctx.system(*command)
       end
 

--- a/test/project_types/theme/commands/deploy_test.rb
+++ b/test/project_types/theme/commands/deploy_test.rb
@@ -9,7 +9,7 @@ module Theme
       def test_deploy_command
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        Themekit.expects(:deploy).with(context, env: nil).returns(true)
+        Themekit.expects(:deploy).with(context, flags: [], env: nil).returns(true)
         context.expects(:done).with(context.message('theme.deploy.info.deployed'))
 
         Theme::Commands::Deploy.new(context).call
@@ -18,7 +18,7 @@ module Theme
       def test_can_specify_env
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        Themekit.expects(:deploy).with(context, env: 'test').returns(true)
+        Themekit.expects(:deploy).with(context, flags: [], env: 'test').returns(true)
         context.expects(:done).with(context.message('theme.deploy.info.deployed'))
 
         command = Theme::Commands::Deploy.new(context)
@@ -39,7 +39,7 @@ module Theme
       def test_aborts_if_errors
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        Themekit.expects(:deploy).with(context, env: nil).returns(false)
+        Themekit.expects(:deploy).with(context, flags: [], env: nil).returns(false)
         context.expects(:done).with(context.message('theme.deploy.info.deployed')).never
 
         assert_raises CLI::Kit::Abort do

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -70,7 +70,7 @@ module Theme
         context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
         command = Theme::Commands::Push.new(context)
-        command.options.flags['env'] = 'test'
+        command.options.flags[:env] = 'test'
         command.call([], 'push')
       end
 

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -8,14 +8,14 @@ module Theme
 
       def test_serve_command
         context = ShopifyCli::Context.new
-        Themekit.expects(:serve).with(context, env: nil)
+        Themekit.expects(:serve).with(context, flags: [], env: nil)
 
         Theme::Commands::Serve.new(context).call
       end
 
       def test_can_specify_env
         context = ShopifyCli::Context.new
-        Themekit.expects(:serve).with(context, env: 'test')
+        Themekit.expects(:serve).with(context, flags: [], env: 'test')
 
         command = Theme::Commands::Serve.new(context)
         command.options.flags[:env] = 'test'

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -78,6 +78,19 @@ module Theme
       assert(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil))
     end
 
+    def test_push_successful_with_flags
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'deploy',
+              '--allow-live')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.push(context, files: [], flags: ['--allow-live'], remove: nil, env: nil))
+    end
+
     def test_push_deploy_unsuccessful
       context = ShopifyCli::Context.new
       stat = mock
@@ -108,7 +121,7 @@ module Theme
       context = ShopifyCli::Context.new
       stat = mock
 
-      Themekit.expects(:push).with(context, env: nil).returns(true)
+      Themekit.expects(:push).with(context, flags: nil, env: nil).returns(true)
       context.expects(:done).with(context.message('theme.deploy.info.pushed'))
 
       context.expects(:system)
@@ -120,10 +133,27 @@ module Theme
       assert(Themekit.deploy(context, env: nil))
     end
 
+    def test_deploy_with_flags
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      Themekit.expects(:push).with(context, flags: ['--allow-live'], env: nil).returns(true)
+      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+             'publish',
+             '--allow-live')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+
+      assert(Themekit.deploy(context, flags: ['--allow-live'], env: nil))
+    end
+
     def test_deploy_push_fail
       context = ShopifyCli::Context.new
 
-      Themekit.expects(:push).with(context, env: nil).returns(false)
+      Themekit.expects(:push).with(context, flags: nil, env: nil).returns(false)
       context.expects(:system).with(Themekit::THEMEKIT, 'publish').never
 
       assert_raises CLI::Kit::Abort do
@@ -135,7 +165,7 @@ module Theme
       context = ShopifyCli::Context.new
       stat = mock
 
-      Themekit.expects(:push).with(context, env: nil).returns(true)
+      Themekit.expects(:push).with(context, flags: nil, env: nil).returns(true)
       context.expects(:done).with(context.message('theme.deploy.info.pushed'))
 
       context.expects(:system)
@@ -189,6 +219,22 @@ module Theme
         .with(Themekit::THEMEKIT, 'watch')
 
       Themekit.serve(context, env: nil)
+    end
+
+    def test_serve_takes_flags
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:capture2e)
+        .with(Themekit::THEMEKIT, 'open')
+        .returns(['out', stat])
+      stat.stubs(:success?).returns(true)
+      context.expects(:puts).with('out')
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT, 'watch', '--allow-live')
+
+      Themekit.serve(context, flags: ['--allow-live'], env: nil)
     end
 
     def test_aborts_serve_if_open_fails

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -10,6 +10,11 @@ module Theme
                 { "id" => 1357,
                   "name" => "your_theme" }] }]
 
+    def test_add_flags_successful
+      flags = { 'key': 'value' }
+      assert(Themekit.add_flags(flags), ["--key=value"])
+    end
+
     def test_create_theme_successful
       context = ShopifyCli::Context.new
       stat = mock

--- a/test/shopify-cli/admin_api_test.rb
+++ b/test/shopify-cli/admin_api_test.rb
@@ -45,7 +45,7 @@ module ShopifyCli
     end
 
     def test_rest_request_calls_admin_api
-      api_stub = Object.new
+      api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
         auth_header: 'X-Shopify-Access-Token',


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
- Certain commands require flags to function (`--allow-live`)
- Some commonly used flags in Theme Kit should also be in CLI

### What is this pull request doing? 📋 
- Add support for:
  - `--allow-live`
  - `--notify`
