### PR TITLE
Make EnsureThemekitInstalled a prerequisite task

### DIFF
--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -7,10 +7,12 @@ module Theme
     creator('Theme::Commands::Create')
     connector('Theme::Commands::Connect')
 
-    register_command('Theme::Commands::Deploy', "deploy")
-    register_command('Theme::Commands::Generate', "generate")
-    register_command('Theme::Commands::Push', "push")
-    register_command('Theme::Commands::Serve', "serve")
+    register_command('Theme::Commands::Deploy', 'deploy')
+    register_command('Theme::Commands::Generate', 'generate')
+    register_command('Theme::Commands::Push', 'push')
+    register_command('Theme::Commands::Serve', 'serve')
+
+    register_task('Theme::Tasks::EnsureThemekitInstalled', :ensure_themekit_installed)
 
     require Project.project_filepath('messages/messages')
     register_messages(Theme::Messages::MESSAGES)

--- a/lib/project_types/theme/commands/connect.rb
+++ b/lib/project_types/theme/commands/connect.rb
@@ -2,6 +2,8 @@
 module Theme
   module Commands
     class Connect < ShopifyCli::SubCommand
+      prerequisite_task :ensure_themekit_installed
+
       options do |parser, flags|
         parser.on('--store=STORE') { |url| flags[:store] = url }
         parser.on('--password=PASSWORD') { |p| flags[:password] = p }
@@ -32,10 +34,6 @@ module Theme
       private
 
       def build(store, password, themeid, name, env)
-        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
-          Themekit.ensure_themekit_installed(@ctx)
-        end
-
         if @ctx.dir_exist?(name)
           @ctx.abort(@ctx.message('theme.connect.duplicate'))
         end

--- a/lib/project_types/theme/commands/create.rb
+++ b/lib/project_types/theme/commands/create.rb
@@ -2,6 +2,8 @@
 module Theme
   module Commands
     class Create < ShopifyCli::SubCommand
+      prerequisite_task :ensure_themekit_installed
+
       options do |parser, flags|
         parser.on('--name=NAME') { |t| flags[:title] = t }
         parser.on('--password=PASSWORD') { |p| flags[:password] = p }
@@ -29,10 +31,6 @@ module Theme
 
       def build(name, password, store, env)
         @ctx.abort(@ctx.message('theme.create.duplicate_theme')) if @ctx.dir_exist?(name)
-
-        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
-          Themekit.ensure_themekit_installed(@ctx)
-        end
 
         @ctx.mkdir_p(name)
         @ctx.chdir(name)

--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -2,15 +2,13 @@
 module Theme
   module Commands
     class Deploy < ShopifyCli::Command
+      prerequisite_task :ensure_themekit_installed
+
       options do |parser, flags|
         parser.on('--env=ENV') { |env| flags[:env] = env }
       end
 
       def call(*)
-        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
-          Themekit.ensure_themekit_installed(@ctx)
-        end
-
         CLI::UI::Frame.open(@ctx.message('theme.deploy.deploying')) do
           unless CLI::UI::Prompt.confirm(@ctx.message('theme.deploy.confirmation'))
             @ctx.abort(@ctx.message('theme.deploy.abort'))

--- a/lib/project_types/theme/commands/generate.rb
+++ b/lib/project_types/theme/commands/generate.rb
@@ -4,6 +4,8 @@ require 'shopify_cli'
 module Theme
   module Commands
     class Generate < ShopifyCli::Command
+      prerequisite_task :ensure_themekit_installed
+
       subcommand :Env, 'env', Project.project_filepath('commands/generate/env')
 
       def call(*)

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -2,6 +2,8 @@
 module Theme
   module Commands
     class Push < ShopifyCli::Command
+      prerequisite_task :ensure_themekit_installed
+
       options do |parser, flags|
         parser.on('--remove') { flags['remove'] = true }
         parser.on('--nodelete') { flags['nodelete'] = true }
@@ -22,10 +24,6 @@ module Theme
 
         flags = options.flags.map do |key, _value|
           '--' + key
-        end
-
-        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
-          Themekit.ensure_themekit_installed(@ctx)
         end
 
         if remove

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -2,15 +2,13 @@
 module Theme
   module Commands
     class Serve < ShopifyCli::Command
+      prerequisite_task :ensure_themekit_installed
+
       options do |parser, flags|
         parser.on('--env=ENV') { |env| flags[:env] = env }
       end
 
       def call(*)
-        CLI::UI::Frame.open(@ctx.message('theme.checking_themekit')) do
-          Themekit.ensure_themekit_installed(@ctx)
-        end
-
         CLI::UI::Frame.open(@ctx.message('theme.serve.serve')) do
           Themekit.serve(@ctx, env: options.flags[:env])
         end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -3,7 +3,6 @@ module Theme
   module Messages
     MESSAGES = {
       theme: {
-        checking_themekit: "Verifying Theme Kit",
         connect: {
           duplicate: "Duplicate directory, theme files weren't connected",
           help: <<~HELP,
@@ -130,7 +129,9 @@ module Theme
               update_fail: "Unable to update Theme Kit",
               write_fail: "Unable to download Theme Kit",
             },
+            installing_themekit: "Installing Theme Kit",
             successful: "Theme Kit installed successfully",
+            updating_themekit: "Updating Theme Kit",
             verifying: "Verifying download...",
           },
         },

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -20,7 +20,7 @@ module Theme
         end
 
         now = Time.now.to_i
-        if ShopifyCli::Feature.enabled?(:themekit_auto_update)  # && (time_of_last_check + VERSION_CHECK_INTERVAL) < now
+        if ShopifyCli::Feature.enabled?(:themekit_auto_update) && (time_of_last_check + VERSION_CHECK_INTERVAL) < now
           CLI::UI::Frame.open(ctx.message('theme.tasks.ensure_themekit_installed.updating_themekit')) do
             unless Themekit.update(ctx)
               ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.update_fail'))

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -14,49 +14,57 @@ module Theme
       def call(ctx)
         _out, stat = ctx.capture2e(Themekit::THEMEKIT)
         unless stat.success?
-          require 'json'
-          require 'fileutils'
-          require 'digest'
-          require 'open-uri'
-
-          begin
-            begin
-              releases = JSON.parse(Net::HTTP.get(URI(URL)))
-              release = releases["platforms"].find { |r| r["name"] == OSMAP[ctx.os] }
-            rescue
-              ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.releases_fail'))
-            end
-
-            ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.downloading', releases['version']))
-            _out, stat = ctx.capture2e('curl', '-o', Themekit::THEMEKIT, release["url"])
-            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) unless stat.success?
-
-            ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.verifying'))
-            if Digest::MD5.file(Themekit::THEMEKIT) == release['digest']
-              FileUtils.chmod("+x", Themekit::THEMEKIT)
-              ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.successful'))
-
-              auto = CLI::UI.confirm(ctx.message('theme.tasks.ensure_themekit_installed.auto_update'))
-              ShopifyCli::Feature.set(:themekit_auto_update, auto)
-            else
-              ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.digest_fail'))
-            end
-          rescue StandardError, ShopifyCli::Abort => e
-            FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)
-            raise e
+          CLI::UI::Frame.open(ctx.message('theme.tasks.ensure_themekit_installed.installing_themekit')) do
+            install_themekit(ctx)
           end
         end
 
         now = Time.now.to_i
-        if ShopifyCli::Feature.enabled?(:themekit_auto_update) && (time_of_last_check + VERSION_CHECK_INTERVAL) < now
-          unless Themekit.update(ctx)
-            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.update_fail'))
+        if ShopifyCli::Feature.enabled?(:themekit_auto_update)  # && (time_of_last_check + VERSION_CHECK_INTERVAL) < now
+          CLI::UI::Frame.open(ctx.message('theme.tasks.ensure_themekit_installed.updating_themekit')) do
+            unless Themekit.update(ctx)
+              ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.update_fail'))
+            end
+            update_time_of_last_check(now)
           end
-          update_time_of_last_check(now)
         end
       end
 
       private
+
+      def install_themekit(ctx)
+        require 'json'
+        require 'fileutils'
+        require 'digest'
+        require 'open-uri'
+
+        begin
+          begin
+            releases = JSON.parse(Net::HTTP.get(URI(URL)))
+            release = releases["platforms"].find { |r| r["name"] == OSMAP[ctx.os] }
+          rescue
+            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.releases_fail'))
+          end
+
+          ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.downloading', releases['version']))
+          _out, stat = ctx.capture2e('curl', '-o', Themekit::THEMEKIT, release["url"])
+          ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) unless stat.success?
+
+          ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.verifying'))
+          if Digest::MD5.file(Themekit::THEMEKIT) == release['digest']
+            FileUtils.chmod("+x", Themekit::THEMEKIT)
+            ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.successful'))
+
+            auto = CLI::UI.confirm(ctx.message('theme.tasks.ensure_themekit_installed.auto_update'))
+            ShopifyCli::Feature.set(:themekit_auto_update, auto)
+          else
+            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.digest_fail'))
+          end
+        rescue StandardError, ShopifyCli::Abort => e
+          FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)
+          raise e
+        end
+      end
 
       def time_of_last_check
         (val = ShopifyCli::Config.get(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD)) ? val.to_i : 0

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -34,10 +34,6 @@ module Theme
         stat.success?
       end
 
-      def ensure_themekit_installed(ctx)
-        Tasks::EnsureThemekitInstalled.call(ctx)
-      end
-
       def generate_env(ctx, store:, password:, themeid:, env:)
         command = build_command('configure', env)
         command << "--password=#{password}"

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -81,7 +81,7 @@ module ShopifyCli
 
       def register_task(task, name)
         return if project_load_shallow
-        ShopifyCli::Task.register(task, name)
+        ShopifyCli::Tasks.register(task, name)
       end
 
       def register_messages(messages)

--- a/test/project_types/theme/commands/connect_test.rb
+++ b/test/project_types/theme/commands/connect_test.rb
@@ -25,7 +25,6 @@ module Theme
                                                               name: 'my_theme',
                                                               env: nil }))
 
-          Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(false)
           Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
@@ -53,7 +52,6 @@ module Theme
                                                               name: 'my_theme',
                                                               env: 'test' }))
 
-          Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(false)
           Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: 'test')
@@ -77,7 +75,6 @@ module Theme
           ShopifyCli::Project.expects(:has_current?).returns(true)
 
           Theme::Forms::Connect.expects(:ask).with(context, [], {}).never
-          Themekit.expects(:ensure_themekit_installed).with(context).never
           context.expects(:dir_exist?).with('my_theme').never
           Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
@@ -102,7 +99,6 @@ module Theme
                                                               name: 'my_theme',
                                                               env: nil }))
 
-          Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('my_theme').returns(true)
           Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
@@ -127,7 +123,6 @@ module Theme
                                                               name: 'your_theme',
                                                               env: nil }))
 
-          Themekit.expects(:ensure_themekit_installed).with(context)
           context.expects(:dir_exist?).with('your_theme').returns(false)
           Themekit.expects(:connect)
             .with(context, store: 'shop.myshopify.com', password: 'merp', themeid: '1357', env: nil)

--- a/test/project_types/theme/commands/create_test.rb
+++ b/test/project_types/theme/commands/create_test.rb
@@ -15,7 +15,6 @@ module Theme
       def test_can_create_new_theme
         FakeFS do
           context = ShopifyCli::Context.new
-          Themekit.expects(:ensure_themekit_installed).with(context)
           Theme::Forms::Create.expects(:ask)
             .with(context, [], {})
             .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
@@ -39,7 +38,6 @@ module Theme
       def test_can_specify_env
         FakeFS do
           context = ShopifyCli::Context.new
-          Themekit.expects(:ensure_themekit_installed).with(context)
           Theme::Forms::Create.expects(:ask)
             .with(context, [], { env: 'test' })
             .returns(Theme::Forms::Create.new(context, [], { password: 'boop',

--- a/test/project_types/theme/commands/deploy_test.rb
+++ b/test/project_types/theme/commands/deploy_test.rb
@@ -8,7 +8,6 @@ module Theme
 
       def test_deploy_command
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         CLI::UI::Prompt.expects(:confirm).returns(true)
         Themekit.expects(:deploy).with(context, env: nil).returns(true)
         context.expects(:done).with(context.message('theme.deploy.info.deployed'))
@@ -18,7 +17,6 @@ module Theme
 
       def test_can_specify_env
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         CLI::UI::Prompt.expects(:confirm).returns(true)
         Themekit.expects(:deploy).with(context, env: 'test').returns(true)
         context.expects(:done).with(context.message('theme.deploy.info.deployed'))
@@ -30,7 +28,6 @@ module Theme
 
       def test_aborts_if_not_confirm
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         CLI::UI::Prompt.expects(:confirm).returns(false)
         Themekit.expects(:deploy).with(context, env: nil).never
 
@@ -41,7 +38,6 @@ module Theme
 
       def test_aborts_if_errors
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         CLI::UI::Prompt.expects(:confirm).returns(true)
         Themekit.expects(:deploy).with(context, env: nil).returns(false)
         context.expects(:done).with(context.message('theme.deploy.info.deployed')).never

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -8,7 +8,6 @@ module Theme
 
       def test_can_push_entire_theme
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: nil).returns(true)
         context.expects(:done).with(context.message('theme.push.info.push', context.root))
 
@@ -17,7 +16,6 @@ module Theme
 
       def test_can_push_individual_files
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
           .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: nil, env: nil)
           .returns(true)
@@ -29,7 +27,6 @@ module Theme
       def test_can_remove_files
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
           .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil)
           .returns(true)
@@ -43,7 +40,6 @@ module Theme
       def test_can_abort_remove
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(false)
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
           .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil)
           .never
@@ -57,7 +53,6 @@ module Theme
 
       def test_can_add_flags
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push)
           .with(context, files: ['file.liquid', 'another_file.liquid'], flags: ['--nodelete'], remove: nil, env: nil)
           .returns(true)
@@ -70,7 +65,6 @@ module Theme
 
       def test_can_specify_env
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: 'test')
           .returns(true)
         context.expects(:done).with(context.message('theme.push.info.push', context.root))
@@ -82,7 +76,6 @@ module Theme
 
       def test_aborts_if_push_fails
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: nil).returns(false)
 
         assert_raises CLI::Kit::Abort do

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -8,7 +8,6 @@ module Theme
 
       def test_serve_command
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:serve).with(context, env: nil)
 
         Theme::Commands::Serve.new(context).call
@@ -16,7 +15,6 @@ module Theme
 
       def test_can_specify_env
         context = ShopifyCli::Context.new
-        Themekit.expects(:ensure_themekit_installed).with(context)
         Themekit.expects(:serve).with(context, env: 'test')
 
         command = Theme::Commands::Serve.new(context)

--- a/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
+++ b/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
@@ -4,6 +4,8 @@ require 'project_types/theme/test_helper'
 module Theme
   module Tasks
     class EnsureThemekitInstalledTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
       def setup
         super
         @context = TestHelpers::FakeContext.new

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -10,11 +10,6 @@ module Theme
                 { "id" => 1357,
                   "name" => "your_theme" }] }]
 
-    def test_themekit_install
-      Theme::Tasks::EnsureThemekitInstalled.expects(:call).with(@context)
-      Themekit.ensure_themekit_installed(@context)
-    end
-
     def test_create_theme_successful
       context = ShopifyCli::Context.new
       stat = mock


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
- Need run task before every command so is better to use prerequisite task than explicitly running each time
- Better not to open frame is nothing happening

### What is this pull request doing? 📋 
- Refactor task so only opens frames if running task
- Make into prereq task