### PR TITLE
[Feature] Theme Kit on CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 1.5.0
 -----
 * [#965](https://github.com/Shopify/shopify-app-cli/pull/965): Remove --no-optional when using npm to create new project
 * [#958](https://github.com/Shopify/shopify-app-cli/pull/958): Split `connect` command into project-specific functionality
+* [#992](https://github.com/Shopify/shopify-app-cli/pull/992): Add Theme Kit functionality to CLI
 
 Version 1.4.1
 ------

--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+module Theme
+  class Project < ShopifyCli::ProjectType
+    hidden_feature
+
+    title('Theme')
+    creator('Theme::Commands::Create')
+    connector('Theme::Commands::Connect')
+
+    register_command('Theme::Commands::Deploy', 'deploy')
+    register_command('Theme::Commands::Generate', 'generate')
+    register_command('Theme::Commands::Push', 'push')
+    register_command('Theme::Commands::Serve', 'serve')
+
+    register_task('Theme::Tasks::EnsureThemekitInstalled', :ensure_themekit_installed)
+
+    require Project.project_filepath('messages/messages')
+    register_messages(Theme::Messages::MESSAGES)
+  end
+
+  module Commands
+    autoload :Connect, Project.project_filepath('commands/connect')
+    autoload :Create, Project.project_filepath('commands/create')
+    autoload :Deploy, Project.project_filepath('commands/deploy')
+    autoload :Generate, Project.project_filepath('commands/generate')
+    autoload :Push, Project.project_filepath('commands/push')
+    autoload :Serve, Project.project_filepath('commands/serve')
+  end
+
+  module Tasks
+    autoload :EnsureThemekitInstalled, Project.project_filepath('tasks/ensure_themekit_installed')
+  end
+
+  module Forms
+    autoload :Create, Project.project_filepath('forms/create')
+    autoload :Connect, Project.project_filepath('forms/connect')
+  end
+
+  autoload :Themekit, Project.project_filepath('themekit')
+end

--- a/lib/project_types/theme/commands/connect.rb
+++ b/lib/project_types/theme/commands/connect.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+module Theme
+  module Commands
+    class Connect < ShopifyCli::SubCommand
+      prerequisite_task :ensure_themekit_installed
+
+      options do |parser, flags|
+        parser.on('--store=STORE') { |url| flags[:store] = url }
+        parser.on('--password=PASSWORD') { |p| flags[:password] = p }
+        parser.on('--themeid=THEME_ID') { |id| flags[:themeid] = id }
+        parser.on('--env=ENV') { |env| flags[:env] = env }
+      end
+
+      def call(args, _name)
+        if ShopifyCli::Project.has_current?
+          @ctx.abort(@ctx.message('theme.connect.inside_project'))
+        end
+
+        form = Forms::Connect.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) if form.nil?
+
+        build(form.store, form.password, form.themeid, form.name, form.env)
+        ShopifyCli::Project.write(@ctx,
+                                  project_type: 'theme',
+                                  organization_id: nil)
+
+        @ctx.done(@ctx.message('theme.connect.connected', form.name, form.store, @ctx.root))
+      end
+
+      def self.help
+        ShopifyCli::Context.message('theme.connect.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+      end
+
+      private
+
+      def build(store, password, themeid, name, env)
+        if @ctx.dir_exist?(name)
+          @ctx.abort(@ctx.message('theme.connect.duplicate'))
+        end
+
+        @ctx.mkdir_p(name)
+        @ctx.chdir(name)
+
+        CLI::UI::Frame.open(@ctx.message('theme.connect.connect')) do
+          unless Themekit.connect(@ctx, store: store, password: password, themeid: themeid, env: env)
+            @ctx.chdir('..')
+            @ctx.rm_rf(name)
+            @ctx.abort(@ctx.message('theme.connect.failed'))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/create.rb
+++ b/lib/project_types/theme/commands/create.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Theme
+  module Commands
+    class Create < ShopifyCli::SubCommand
+      prerequisite_task :ensure_themekit_installed
+
+      options do |parser, flags|
+        parser.on('--name=NAME') { |t| flags[:title] = t }
+        parser.on('--password=PASSWORD') { |p| flags[:password] = p }
+        parser.on('--store=STORE') { |url| flags[:store] = url }
+        parser.on('--env=ENV') { |env| flags[:env] = env }
+      end
+
+      def call(args, _name)
+        form = Forms::Create.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) if form.nil?
+
+        build(form.name, form.password, form.store, form.env)
+        ShopifyCli::Project.write(@ctx,
+                                  project_type: 'theme',
+                                  organization_id: nil) # private apps are different
+
+        @ctx.done(@ctx.message('theme.create.info.created', form.name, form.store, @ctx.root))
+      end
+
+      def self.help
+        ShopifyCli::Context.message('theme.create.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+      end
+
+      private
+
+      def build(name, password, store, env)
+        @ctx.abort(@ctx.message('theme.create.duplicate_theme')) if @ctx.dir_exist?(name)
+
+        @ctx.mkdir_p(name)
+        @ctx.chdir(name)
+
+        CLI::UI::Frame.open(@ctx.message('theme.create.creating_theme', name)) do
+          unless Themekit.create(@ctx, name: name, password: password, store: store, env: env)
+            @ctx.chdir('..')
+            @ctx.rm_rf(name)
+            @ctx.abort(@ctx.message('theme.create.failed'))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module Theme
+  module Commands
+    class Deploy < ShopifyCli::Command
+      prerequisite_task :ensure_themekit_installed
+
+      options do |parser, flags|
+        parser.on('--env=ENV') { |env| flags[:env] = env }
+        parser.on('--allow-live') { flags['allow_live'] = true }
+      end
+
+      def call(*)
+        CLI::UI::Frame.open(@ctx.message('theme.deploy.deploying')) do
+          unless CLI::UI::Prompt.confirm(@ctx.message('theme.deploy.confirmation'))
+            @ctx.abort(@ctx.message('theme.deploy.abort'))
+          end
+
+          if options.flags[:env]
+            env = options.flags[:env]
+            options.flags.delete(:env)
+          end
+
+          flags = Themekit.add_flags(options.flags)
+
+          unless Themekit.deploy(@ctx, flags: flags, env: env)
+            @ctx.abort(@ctx.message('theme.deploy.error'))
+          end
+        end
+
+        @ctx.done(@ctx.message('theme.deploy.info.deployed'))
+      end
+
+      def self.help
+        ShopifyCli::Context.message('theme.deploy.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/generate.rb
+++ b/lib/project_types/theme/commands/generate.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Theme
+  module Commands
+    class Generate < ShopifyCli::Command
+      prerequisite_task :ensure_themekit_installed
+
+      subcommand :Env, 'env', Project.project_filepath('commands/generate/env')
+
+      def call(*)
+        @ctx.puts(self.class.help)
+      end
+
+      def self.help
+        ShopifyCli::Context.message('theme.generate.help', ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/generate/env.rb
+++ b/lib/project_types/theme/commands/generate/env.rb
@@ -1,0 +1,79 @@
+module Theme
+  module Commands
+    class Generate
+      class Env < ShopifyCli::SubCommand
+        options do |parser, flags|
+          parser.on('--store=STORE') { |url| flags[:store] = url }
+          parser.on('--password=PASSWORD') { |p| flags[:password] = p }
+          parser.on('--themeid=THEME_ID') { |id| flags[:themeid] = id }
+          parser.on('--env=ENV') { |env| flags[:env] = env }
+        end
+
+        def call(*)
+          default_store, default_password = fetch_credentials
+          store = ask_store(default_store) || default_store
+          password = ask_password(default_password) || default_password
+          themeid = ask_theme(store: store, password: password)
+          env = options.flags[:env]
+
+          Themekit.generate_env(@ctx, store: store, password: password, themeid: themeid, env: env)
+        end
+
+        def self.help
+          ShopifyCli::Context.message('theme.generate.env.help', ShopifyCli::TOOL_NAME)
+        end
+
+        private
+
+        def fetch_credentials
+          unless File.exist?('config.yml')
+            return nil
+          end
+
+          config = YAML.load_file('config.yml')
+          store = config['development']['store']
+          password = config['development']['password']
+
+          [store, password]
+        end
+
+        def ask_store(default)
+          store = options.flags[:store] ||
+            if default
+              CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_store_default', default))
+            else
+              CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_store'), allow_empty: false)
+            end
+          return nil if store.empty?
+          store
+        end
+
+        def ask_password(default)
+          password = options.flags[:password] ||
+            if default
+              CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_password_default', default))
+            else
+              CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_password'), allow_empty: false)
+            end
+          return nil if password.empty?
+          password
+        end
+
+        def ask_theme(store:, password:)
+          theme = options.flags[:themeid]
+          return theme if theme
+
+          themes = Themekit.query_themes(@ctx, store: store, password: password)
+
+          @ctx.abort(@ctx.message('theme.generate.env.no_themes', ShopifyCli::TOOL_NAME)) if themes.empty?
+
+          CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_theme')) do |handler|
+            themes.each do |name, id|
+              handler.option(name) { id }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+module Theme
+  module Commands
+    class Push < ShopifyCli::Command
+      prerequisite_task :ensure_themekit_installed
+
+      options do |parser, flags|
+        parser.on('--remove') { flags['remove'] = true }
+        parser.on('--nodelete') { flags['nodelete'] = true }
+        parser.on('--allow-live') { flags['allow-live'] = true }
+        parser.on('--env=ENV') { |env| flags[:env] = env }
+      end
+
+      def call(args, _name)
+        if options.flags['remove']
+          remove = true
+          options.flags.delete('remove')
+        end
+
+        if options.flags[:env]
+          env = options.flags[:env]
+          options.flags.delete(:env)
+        end
+
+        flags = Themekit.add_flags(options.flags)
+
+        if remove
+          CLI::UI::Frame.open(@ctx.message('theme.push.remove')) do
+            unless CLI::UI::Prompt.confirm(@ctx.message('theme.push.remove_confirm'))
+              @ctx.abort(@ctx.message('theme.push.remove_abort'))
+            end
+
+            unless Themekit.push(@ctx, files: args, flags: flags, remove: remove, env: env)
+              @ctx.abort(@ctx.message('theme.push.error.remove_error'))
+            end
+          end
+
+          @ctx.done(@ctx.message('theme.push.info.remove', @ctx.root))
+        else
+          CLI::UI::Frame.open(@ctx.message('theme.push.push')) do
+            unless Themekit.push(@ctx, files: args, flags: flags, remove: remove, env: env)
+              @ctx.abort(@ctx.message('theme.push.error.push_error'))
+            end
+          end
+
+          @ctx.done(@ctx.message('theme.push.info.push', @ctx.root))
+        end
+      end
+
+      def self.help
+        ShopifyCli::Context.message('theme.push.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module Theme
+  module Commands
+    class Serve < ShopifyCli::Command
+      prerequisite_task :ensure_themekit_installed
+
+      options do |parser, flags|
+        parser.on('--env=ENV') { |env| flags[:env] = env }
+        parser.on('--allow-live') { flags['allow-live'] = true }
+        parser.on('--notify=FILES') { |files| flags['notify'] = files }
+      end
+
+      def call(*)
+        if options.flags[:env]
+          env = options.flags[:env]
+          options.flags.delete(:env)
+        end
+
+        flags = Themekit.add_flags(options.flags)
+
+        CLI::UI::Frame.open(@ctx.message('theme.serve.serve')) do
+          Themekit.serve(@ctx, flags: flags, env: env)
+        end
+      end
+
+      def self.help
+        ShopifyCli::Context.message('theme.serve.help', ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/forms/connect.rb
+++ b/lib/project_types/theme/forms/connect.rb
@@ -1,0 +1,34 @@
+module Theme
+  module Forms
+    class Connect < ShopifyCli::Form
+      attr_accessor :name
+      flag_arguments :themeid, :password, :store, :env
+
+      def ask
+        self.store ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_store'), allow_empty: false)
+        ctx.puts(ctx.message('theme.forms.connect.private_app', store))
+        self.password ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_password'), allow_empty: false)
+
+        errors = []
+        errors << "store" if store.strip.empty?
+        errors << "password" if password.strip.empty?
+        ctx.abort(ctx.message('theme.forms.errors', errors.join(", ").capitalize)) unless errors.empty?
+
+        self.themeid, self.name = ask_theme(store: store, password: password, themeid: themeid)
+      end
+
+      private
+
+      def ask_theme(store:, password:, themeid:)
+        themes = Themekit.query_themes(@ctx, store: store, password: password)
+
+        themeid ||= CLI::UI::Prompt.ask("Select theme") do |handler|
+          themes.each do |name, id|
+            handler.option(name) { id }
+          end
+        end
+        [themeid, themes.key(themeid.to_i)]
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/forms/create.rb
+++ b/lib/project_types/theme/forms/create.rb
@@ -1,0 +1,22 @@
+module Theme
+  module Forms
+    class Create < ShopifyCli::Form
+      attr_accessor :name
+      flag_arguments :title, :password, :store, :env
+
+      def ask
+        self.store ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_store'), allow_empty: false)
+        ctx.puts(ctx.message('theme.forms.create.private_app', store))
+        self.password ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_password'), allow_empty: false)
+        self.title ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.create.ask_title'), allow_empty: false)
+        self.name = self.title.downcase.split(" ").join("_")
+
+        errors = []
+        errors << "store" if store.strip.empty?
+        errors << "password" if password.strip.empty?
+        errors << "title" if title.strip.empty?
+        ctx.abort(ctx.message('theme.forms.errors', errors.join(", ").capitalize)) unless errors.empty?
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+module Theme
+  module Messages
+    MESSAGES = {
+      theme: {
+        connect: {
+          duplicate: "Duplicate directory, theme files weren't connected",
+          help: <<~HELP,
+            {{command:%s connect theme}}: Connects an existing theme in your store to Shopify App CLI. Downloads a copy of the theme files to your local development environment.
+              Usage: {{command:%s connect theme}}
+              Options:
+                {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
+                {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
+                {{command:--themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
+          HELP
+          inside_project: "You are inside an existing theme, theme files weren't connected",
+          connect: "Downloading theme files...",
+          failed: "Couldn't download theme files from store",
+          connected: "{{green:%s}} files were downloaded from {{underline:%s}} to {{green:%s}}",
+        },
+        create: {
+          creating_theme: "Creating theme %s",
+          duplicate_theme: "Duplicate theme",
+          failed: "Couldn't create the theme",
+          help: <<~HELP,
+            {{command:%s create theme}}: Creates a theme.
+              Usage: {{command:%s create theme}}
+              Options:
+                {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
+                {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
+                {{command:--name=NAME}} Theme name. Any string.
+          HELP
+          info: {
+            created: "{{green:%s}} was created for {{underline:%s}} in {{green:%s}}",
+          },
+        },
+        deploy: {
+          abort: "Theme wasn't deployed",
+          confirmation: "This will change your live theme. Do you wish to proceed?",
+          deploying: "Deploying theme",
+          error: "Theme couldn't be deployed",
+          help: <<~HELP,
+            {{command:%s deploy}}: Uploads your local theme files to Shopify, then sets your theme as the live theme.
+              Usage: {{command:%s deploy}}
+          HELP
+          info: {
+            deployed: "Theme was updated and set as the live theme",
+            pushed: "All theme files were updated",
+          },
+          push_fail: "Theme files couldn't be updated",
+        },
+        forms: {
+          ask_password: "Password:",
+          ask_store: "Store domain:",
+          create: {
+            ask_title: "Title:",
+            private_app: <<~APP,
+              To create a new theme, Shopify App CLI needs to connect with a private app installed on your store. Visit {{underline:%s/admin/apps/private}} to create a new API key and password, or retrieve an existing password.
+              If you create a new private app, ensure that it has Read and Write Theme access.
+            APP
+          },
+          connect: {
+            private_app: <<~APP,
+              To fetch your existing themes, Shopify App CLI needs to connect with your store. Visit {{underline:%s/admin/apps/private}} to create a new API key and password, or retrieve an existing password.
+              If you create a new private app, ensure that it has Read and Write Theme access.
+            APP
+          },
+          errors: "%s can't be blank",
+        },
+        generate: {
+          env: {
+            ask_password: "Password",
+            ask_password_default: "Password (defaults to {{green:%s}})",
+            ask_store: "Store",
+            ask_store_default: "Store (defaults to {{green:%s}})",
+            ask_theme: "Select theme",
+            help: <<~HELP,
+              Create or update configuration file in the current directory.
+                Usage: {{command:%s generate env}}
+                Options:
+                  {{command:--store=MYSHOPIFYDOMAIN}} Store URL. Must be an existing store with private apps enabled.
+                  {{command:--password=PASSWORD}} Private app password. App must have Read and Write Theme access.
+                  {{command:--themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
+            HELP
+            no_themes: "Please create a new theme using %s create theme",
+          },
+          help: <<~HELP,
+            Generate code in your Theme. Currently supports generating new envs.
+              Usage: {{command:%s generate [ env ]}}
+          HELP
+        },
+        push: {
+          remove_abort: "Theme files weren't deleted",
+          remove_confirm: "This will delete the local and remote copies of the theme files. Do you wish to proceed?",
+          error: {
+            push_error: "Theme files couldn't be pushed to Shopify",
+            remove_error: "Theme files couldn't be removed from Shopify",
+          },
+          help: <<~HELP,
+            {{command:%s push}}: Uploads your local theme files to Shopify, overwriting the remote versions. If you specify filenames, separated by a space, only those files will be replaced. Otherwise, the whole theme will be replaced.
+              Usage: {{command:%s push}}
+              Options:
+                {{command:--remove}} Deletes both the local and the remote copies of the specified files. At least one filename must be specified.
+                {{command:--allow-live}} Allows Shopify App CLI to replace files on the store's live production theme.
+                {{command:--nodelete}} Runs the push command without deleting remote files from Shopify.
+          HELP
+          info: {
+            push: "Theme files were pushed from {{green:%s}} to Shopify",
+            remove: "Theme files were deleted from {{green:%s}} and Shopify",
+          },
+          push: "Pushing theme files to Shopify",
+          remove: "Deleting theme files",
+        },
+        serve: {
+          help: <<~HELP,
+            Sync your current changes, then view the active store in your default browser. Any theme edits will continue to update in real time. Also prints the active store's URL in your terminal.
+            Usage: {{command:%s serve}}
+          HELP
+          serve: "Viewing theme...",
+          open_fail: "Couldn't open the theme",
+        },
+        tasks: {
+          ensure_themekit_installed: {
+            auto_update: "Would you like to enable auto-updating?",
+            downloading: "Downloading Theme Kit %s",
+            errors: {
+              digest_fail: "Unable to verify download",
+              releases_fail: "Unable to fetch Theme Kit's list of releases",
+              update_fail: "Unable to update Theme Kit",
+              write_fail: "Unable to download Theme Kit",
+            },
+            installing_themekit: "Installing Theme Kit",
+            successful: "Theme Kit installed successfully",
+            updating_themekit: "Updating Theme Kit",
+            verifying: "Verifying download...",
+          },
+        },
+        themekit: {
+          query_themes: {
+            bad_password: "Bad password",
+            not_connect: "Couldn't connect to given shop",
+          },
+        },
+      },
+    }.freeze
+  end
+end

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -1,0 +1,78 @@
+module Theme
+  module Tasks
+    class EnsureThemekitInstalled < ShopifyCli::Task
+      URL = 'https://shopify-themekit.s3.amazonaws.com/releases/latest.json'
+      OSMAP = {
+        mac: 'darwin-amd64',
+        linux: 'linux-amd64',
+        windows: 'windows-amd64',
+      }
+      VERSION_CHECK_INTERVAL = 604800
+      VERSION_CHECK_SECTION = 'themekit_version_check'
+      LAST_CHECKED_AT_FIELD = 'last_checked_at'
+
+      def call(ctx)
+        _out, stat = ctx.capture2e(Themekit::THEMEKIT)
+        unless stat.success?
+          CLI::UI::Frame.open(ctx.message('theme.tasks.ensure_themekit_installed.installing_themekit')) do
+            install_themekit(ctx)
+          end
+        end
+
+        now = Time.now.to_i
+        if ShopifyCli::Feature.enabled?(:themekit_auto_update) && (time_of_last_check + VERSION_CHECK_INTERVAL) < now
+          CLI::UI::Frame.open(ctx.message('theme.tasks.ensure_themekit_installed.updating_themekit')) do
+            unless Themekit.update(ctx)
+              ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.update_fail'))
+            end
+            update_time_of_last_check(now)
+          end
+        end
+      end
+
+      private
+
+      def install_themekit(ctx)
+        require 'json'
+        require 'fileutils'
+        require 'digest'
+        require 'open-uri'
+
+        begin
+          begin
+            releases = JSON.parse(Net::HTTP.get(URI(URL)))
+            release = releases["platforms"].find { |r| r["name"] == OSMAP[ctx.os] }
+          rescue
+            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.releases_fail'))
+          end
+
+          ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.downloading', releases['version']))
+          _out, stat = ctx.capture2e('curl', '-o', Themekit::THEMEKIT, release["url"])
+          ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) unless stat.success?
+
+          ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.verifying'))
+          if Digest::MD5.file(Themekit::THEMEKIT) == release['digest']
+            FileUtils.chmod("+x", Themekit::THEMEKIT)
+            ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.successful'))
+
+            auto = CLI::UI.confirm(ctx.message('theme.tasks.ensure_themekit_installed.auto_update'))
+            ShopifyCli::Feature.set(:themekit_auto_update, auto)
+          else
+            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.digest_fail'))
+          end
+        rescue StandardError, ShopifyCli::Abort => e
+          FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)
+          raise e
+        end
+      end
+
+      def time_of_last_check
+        (val = ShopifyCli::Config.get(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD)) ? val.to_i : 0
+      end
+
+      def update_time_of_last_check(time)
+        ShopifyCli::Config.set(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD, time)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -1,0 +1,113 @@
+module Theme
+  class Themekit
+    THEMEKIT = File.join(ShopifyCli.cache_dir, "themekit")
+
+    class << self
+      def add_flags(flags)
+        flags.map do |key, value|
+          flag = "--#{key}"
+          flag += "=#{value}" if value.is_a?(String)
+          flag
+        end
+      end
+
+      def connect(ctx, store:, password:, themeid:, env:)
+        command = build_command('get', env)
+        command << "--password=#{password}"
+        command << "--store=#{store}"
+        command << "--themeid=#{themeid}"
+
+        stat = ctx.system(*command)
+        stat.success?
+      end
+
+      def create(ctx, password:, store:, name:, env:)
+        command = build_command('new', env)
+        command << "--password=#{password}"
+        command << "--store=#{store}"
+        command << "--name=#{name}"
+
+        stat = ctx.system(*command)
+        stat.success?
+      end
+
+      def deploy(ctx, flags: nil, env:)
+        unless push(ctx, flags: flags, env: env)
+          ctx.abort(ctx.message('theme.deploy.push_fail'))
+        end
+        ctx.done(ctx.message('theme.deploy.info.pushed'))
+
+        command = build_command('publish', env)
+        (command << flags).compact!
+        command.flatten!
+
+        stat = ctx.system(*command)
+        stat.success?
+      end
+
+      def generate_env(ctx, store:, password:, themeid:, env:)
+        command = build_command('configure', env)
+        command << "--password=#{password}"
+        command << "--store=#{store}"
+        command << "--themeid=#{themeid}"
+
+        stat = ctx.system(*command)
+        stat.success?
+      end
+
+      def push(ctx, files: nil, flags: nil, remove: false, env:)
+        action = remove ? 'remove' : 'deploy'
+        command = build_command(action, env)
+
+        (command << files << flags).compact!
+        command.flatten!
+
+        stat = ctx.system(*command)
+        stat.success?
+      end
+
+      def query_themes(ctx, store:, password:)
+        begin
+          resp = ::ShopifyCli::AdminAPI.rest_request(
+            ctx,
+            shop: store,
+            token: password,
+            path: "themes.json",
+          )
+        rescue ShopifyCli::API::APIRequestUnauthorizedError
+          ctx.abort(ctx.message('theme.themekit.query_themes.bad_password'))
+        rescue StandardError
+          ctx.abort(ctx.message('theme.themekit.query_themes.not_connect'))
+        end
+
+        resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+      end
+
+      def serve(ctx, flags: nil, env:)
+        command = build_command('open', env)
+        out, stat = ctx.capture2e(*command)
+        ctx.puts(out)
+        ctx.abort(ctx.message('theme.serve.open_fail')) unless stat.success?
+
+        command = build_command('watch', env)
+        (command << flags).compact!
+        command.flatten!
+        ctx.system(*command)
+      end
+
+      def update(ctx)
+        command = build_command('update')
+        ctx.system(*command)
+      end
+
+      private
+
+      def build_command(action, env = nil)
+        command = [THEMEKIT, action]
+        command << '--no-update-notifier'
+        command << "--env=#{env}" if env
+        command
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/feature.rb
+++ b/lib/shopify-cli/feature.rb
@@ -87,8 +87,6 @@ module ShopifyCli
         ShopifyCli::Config.get_bool(SECTION, feature.to_s)
       end
 
-      private
-
       def set(feature, value)
         ShopifyCli::Config.set(SECTION, feature.to_s, value)
       end

--- a/lib/shopify-cli/http_request.rb
+++ b/lib/shopify-cli/http_request.rb
@@ -2,14 +2,26 @@ require 'net/http'
 
 module ShopifyCli
   class HttpRequest
-    def self.call(uri, body, variables, headers)
-      http = ::Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      req = ::Net::HTTP::Post.new(uri.request_uri)
-      req.body = JSON.dump(query: body.tr("\n", ""), variables: variables)
-      req['Content-Type'] = 'application/json'
-      headers.each { |header, value| req[header] = value }
-      http.request(req)
+    class << self
+      def post(uri, body, headers)
+        req = ::Net::HTTP::Post.new(uri.request_uri)
+        request(uri, body, headers, req)
+      end
+
+      def get(uri, body, headers)
+        req = ::Net::HTTP::Get.new(uri.request_uri)
+        request(uri, body, headers, req)
+      end
+
+      def request(uri, body, headers, req)
+        http = ::Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        req.body = body unless body.nil?
+        req['Content-Type'] = 'application/json'
+        headers.each { |header, value| req[header] = value }
+        http.request(req)
+      end
     end
   end
 end

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -194,6 +194,7 @@ module ShopifyCli
           error: {
             internal_server_error: '{{red:{{x}} An unexpected error occurred on Shopify.}}',
             internal_server_error_debug: "\n{{red:Response details:}}\n%s\n\n",
+            invalid_url: 'Invalid URL: %s',
           },
         },
 

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -81,7 +81,7 @@ module ShopifyCli
 
       def register_task(task, name)
         return if project_load_shallow
-        ShopifyCli::Task.register(task, name)
+        ShopifyCli::Tasks.register(task, name)
       end
 
       def register_messages(messages)

--- a/test/project_types/theme/commands/connect_test.rb
+++ b/test/project_types/theme/commands/connect_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class ConnectTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      SHOPIFYCLI_FILE = <<~CLI
+        ---
+        project_type: theme
+        organization_id: 0
+      CLI
+
+      def test_can_connect_theme
+        FakeFS do
+          context = ShopifyCli::Context.new
+          ShopifyCli::Project.expects(:has_current?).returns(false).twice
+
+          Theme::Forms::Connect.expects(:ask)
+            .with(context, [], {})
+            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
+                                                              password: 'boop',
+                                                              themeid: '2468',
+                                                              name: 'my_theme',
+                                                              env: nil }))
+
+          context.expects(:dir_exist?).with('my_theme').returns(false)
+          Themekit.expects(:connect)
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
+            .returns(true)
+          context.expects(:done).with(context.message('theme.connect.connected',
+                                                      'my_theme',
+                                                      'shop.myshopify.com',
+                                                      File.join(context.root, 'my_theme')))
+
+          Theme::Commands::Connect.new(context).call([], 'connect')
+          assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
+        end
+      end
+
+      def test_can_specify_env
+        FakeFS do
+          context = ShopifyCli::Context.new
+          ShopifyCli::Project.expects(:has_current?).returns(false).twice
+
+          Theme::Forms::Connect.expects(:ask)
+            .with(context, [], { env: 'test' })
+            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
+                                                              password: 'boop',
+                                                              themeid: '2468',
+                                                              name: 'my_theme',
+                                                              env: 'test' }))
+
+          context.expects(:dir_exist?).with('my_theme').returns(false)
+          Themekit.expects(:connect)
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: 'test')
+            .returns(true)
+          context.expects(:done).with(context.message('theme.connect.connected',
+                                                      'my_theme',
+                                                      'shop.myshopify.com',
+                                                      File.join(context.root, 'my_theme')))
+
+          command = Theme::Commands::Connect.new(context)
+          command.options.flags[:env] = 'test'
+          command.call([], 'connect')
+
+          assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
+        end
+      end
+
+      def test_aborts_if_inside_project
+        FakeFS do
+          context = ShopifyCli::Context.new
+          ShopifyCli::Project.expects(:has_current?).returns(true)
+
+          Theme::Forms::Connect.expects(:ask).with(context, [], {}).never
+          context.expects(:dir_exist?).with('my_theme').never
+          Themekit.expects(:connect)
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
+            .never
+
+          assert_raises CLI::Kit::Abort do
+            Theme::Commands::Connect.new(context).call([], 'connect')
+          end
+        end
+      end
+
+      def test_aborts_if_duplicate_directory
+        FakeFS do
+          context = ShopifyCli::Context.new
+          ShopifyCli::Project.expects(:has_current?).returns(false)
+
+          Theme::Forms::Connect.expects(:ask)
+            .with(context, [], {})
+            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
+                                                              password: 'boop',
+                                                              themeid: '2468',
+                                                              name: 'my_theme',
+                                                              env: nil }))
+
+          context.expects(:dir_exist?).with('my_theme').returns(true)
+          Themekit.expects(:connect)
+            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
+            .never
+
+          assert_raises CLI::Kit::Abort do
+            Theme::Commands::Connect.new(context).call([], 'connect')
+          end
+        end
+      end
+
+      def test_aborts_if_invalid_credentials
+        FakeFS do
+          context = ShopifyCli::Context.new
+          ShopifyCli::Project.expects(:has_current?).returns(false)
+
+          Theme::Forms::Connect.expects(:ask)
+            .with(context, [], {})
+            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
+                                                              password: 'merp',
+                                                              themeid: '1357',
+                                                              name: 'your_theme',
+                                                              env: nil }))
+
+          context.expects(:dir_exist?).with('your_theme').returns(false)
+          Themekit.expects(:connect)
+            .with(context, store: 'shop.myshopify.com', password: 'merp', themeid: '1357', env: nil)
+            .returns(false)
+
+          assert_raises CLI::Kit::Abort do
+            Theme::Commands::Connect.new(context).call([], 'connect')
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/create_test.rb
+++ b/test/project_types/theme/commands/create_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class CreateTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      SHOPIFYCLI_FILE = <<~CLI
+        ---
+        project_type: theme
+        organization_id: 0
+      CLI
+
+      def test_can_create_new_theme
+        FakeFS do
+          context = ShopifyCli::Context.new
+          Theme::Forms::Create.expects(:ask)
+            .with(context, [], {})
+            .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
+                                                             store: 'shop.myshopify.com',
+                                                             title: 'My Theme',
+                                                             name: 'my_theme',
+                                                             env: nil }))
+          Themekit.expects(:create)
+            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme', env: nil)
+            .returns(true)
+          context.expects(:done).with(context.message('theme.create.info.created',
+                                                      'my_theme',
+                                                      'shop.myshopify.com',
+                                                      File.join(context.root, 'my_theme')))
+
+          Theme::Commands::Create.new(context).call([], 'create')
+          assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
+        end
+      end
+
+      def test_can_specify_env
+        FakeFS do
+          context = ShopifyCli::Context.new
+          Theme::Forms::Create.expects(:ask)
+            .with(context, [], { env: 'test' })
+            .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
+                                                             store: 'shop.myshopify.com',
+                                                             title: 'My Theme',
+                                                             name: 'my_theme',
+                                                             env: 'test' }))
+          Themekit.expects(:create)
+            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme', env: 'test')
+            .returns(true)
+          context.expects(:done).with(context.message('theme.create.info.created',
+                                                      'my_theme',
+                                                      'shop.myshopify.com',
+                                                      File.join(context.root, 'my_theme')))
+
+          command = Theme::Commands::Create.new(context)
+          command.options.flags[:env] = 'test'
+          command.call([], 'create')
+
+          assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/deploy_test.rb
+++ b/test/project_types/theme/commands/deploy_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class DeployTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def test_deploy_command
+        context = ShopifyCli::Context.new
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        Themekit.expects(:deploy).with(context, flags: [], env: nil).returns(true)
+        context.expects(:done).with(context.message('theme.deploy.info.deployed'))
+
+        Theme::Commands::Deploy.new(context).call
+      end
+
+      def test_can_specify_env
+        context = ShopifyCli::Context.new
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        Themekit.expects(:deploy).with(context, flags: [], env: 'test').returns(true)
+        context.expects(:done).with(context.message('theme.deploy.info.deployed'))
+
+        command = Theme::Commands::Deploy.new(context)
+        command.options.flags[:env] = 'test'
+        command.call
+      end
+
+      def test_aborts_if_not_confirm
+        context = ShopifyCli::Context.new
+        CLI::UI::Prompt.expects(:confirm).returns(false)
+        Themekit.expects(:deploy).with(context, env: nil).never
+
+        assert_raises CLI::Kit::Abort do
+          Theme::Commands::Deploy.new(context).call
+        end
+      end
+
+      def test_aborts_if_errors
+        context = ShopifyCli::Context.new
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        Themekit.expects(:deploy).with(context, flags: [], env: nil).returns(false)
+        context.expects(:done).with(context.message('theme.deploy.info.deployed')).never
+
+        assert_raises CLI::Kit::Abort do
+          Theme::Commands::Deploy.new(context).call
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/generate/env_test.rb
+++ b/test/project_types/theme/commands/generate/env_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    module GenerateTests
+      class EnvTest < MiniTest::Test
+        include TestHelpers::FakeFS
+
+        resp = [200, { "themes" =>
+                 [{ "id" => 2468, "name" => "my_theme" },
+                  { "id" => 1357, "name" => "your_theme" }] }]
+        THEMES = resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+
+        CONFIG = { "development" =>
+                   { "password" => "boop",
+                     "theme_id" => "2468",
+                     "store" => "shop.myshopify.com" } }
+
+        def test_prompts_for_credentials
+          File.write('config.yml', CONFIG.to_yaml)
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .returns('office.myshopify.com')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .returns('beep')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'office.myshopify.com', password: 'beep')
+            .returns(THEMES)
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .returns('2468')
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  store: 'office.myshopify.com',
+                  password: 'beep',
+                  themeid: '2468',
+                  env: nil)
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.call
+        end
+
+        def test_can_use_default_shop_and_password
+          File.write('config.yml', CONFIG.to_yaml)
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .returns('')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .returns('')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .returns(THEMES)
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .returns('2468')
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  store: 'shop.myshopify.com',
+                  password: 'boop',
+                  themeid: '2468',
+                  env: nil)
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.call
+        end
+
+        def test_can_provide_credentials_with_flags
+          File.write('config.yml', CONFIG.to_yaml)
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .never
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .never
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .never
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .never
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  store: 'office.myshopify.com',
+                  password: 'beep',
+                  themeid: '2468',
+                  env: nil)
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.options.flags[:store] = 'office.myshopify.com'
+          command.options.flags[:password] = 'beep'
+          command.options.flags[:themeid] = '2468'
+          command.call
+        end
+
+        def test_can_use_different_env
+          File.write('config.yml', CONFIG.to_yaml)
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .returns('')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .returns('')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .returns(THEMES)
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .returns('2468')
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  store: 'shop.myshopify.com',
+                  password: 'boop',
+                  themeid: '2468',
+                  env: 'test')
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.options.flags[:env] = 'test'
+          command.call
+        end
+
+        def test_not_allow_empty_if_no_config
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store'), allow_empty: false)
+            .returns('shop.myshopify.com')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password'), allow_empty: false)
+            .returns('boop')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .returns(THEMES)
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_theme'))
+            .returns('2468')
+
+          Themekit.expects(:generate_env)
+            .with(context,
+                  store: 'shop.myshopify.com',
+                  password: 'boop',
+                  themeid: '2468',
+                  env: nil)
+            .returns(true)
+
+          command = Theme::Commands::Generate::Env.new(context)
+          command.call
+        end
+
+        def test_abort_if_no_themes
+          context = ShopifyCli::Context.new
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_store'), allow_empty: false)
+            .returns('shop.myshopify.com')
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(context.message('theme.generate.env.ask_password'), allow_empty: false)
+            .returns('boop')
+
+          Themekit.expects(:query_themes)
+            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .returns({})
+
+          assert_raises CLI::Kit::Abort do
+            command = Theme::Commands::Generate::Env.new(context)
+            command.call
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/generate_test.rb
+++ b/test/project_types/theme/commands/generate_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class GenerateTest < MiniTest::Test
+      def test_puts_help
+        ShopifyCli::Context.expects(:message)
+          .with('theme.generate.help', ShopifyCli::TOOL_NAME)
+
+        Theme::Commands::Generate.new(@context).call
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class PushTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def test_can_push_entire_theme
+        context = ShopifyCli::Context.new
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: nil).returns(true)
+        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+
+        Theme::Commands::Push.new(context).call([], 'push')
+      end
+
+      def test_can_push_individual_files
+        context = ShopifyCli::Context.new
+        Themekit.expects(:push)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: nil, env: nil)
+          .returns(true)
+        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+
+        Theme::Commands::Push.new(context).call(['file.liquid', 'another_file.liquid'], 'push')
+      end
+
+      def test_can_remove_files
+        context = ShopifyCli::Context.new
+        CLI::UI::Prompt.expects(:confirm).returns(true)
+        Themekit.expects(:push)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil)
+          .returns(true)
+        context.expects(:done).with(context.message('theme.push.info.remove', context.root))
+
+        command = Theme::Commands::Push.new(context)
+        command.options.flags['remove'] = true
+        command.call(['file.liquid', 'another_file.liquid'], 'push')
+      end
+
+      def test_can_abort_remove
+        context = ShopifyCli::Context.new
+        CLI::UI::Prompt.expects(:confirm).returns(false)
+        Themekit.expects(:push)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil)
+          .never
+
+        command = Theme::Commands::Push.new(context)
+        command.options.flags['remove'] = true
+        assert_raises CLI::Kit::Abort do
+          command.call(['file.liquid', 'another_file.liquid'], 'push')
+        end
+      end
+
+      def test_can_add_flags
+        context = ShopifyCli::Context.new
+        Themekit.expects(:push)
+          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: ['--nodelete'], remove: nil, env: nil)
+          .returns(true)
+        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+
+        command = Theme::Commands::Push.new(context)
+        command.options.flags['nodelete'] = true
+        command.call(['file.liquid', 'another_file.liquid'], 'push')
+      end
+
+      def test_can_specify_env
+        context = ShopifyCli::Context.new
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: 'test')
+          .returns(true)
+        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+
+        command = Theme::Commands::Push.new(context)
+        command.options.flags[:env] = 'test'
+        command.call([], 'push')
+      end
+
+      def test_aborts_if_push_fails
+        context = ShopifyCli::Context.new
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: nil).returns(false)
+
+        assert_raises CLI::Kit::Abort do
+          Theme::Commands::Push.new(context).call([], 'push')
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Commands
+    class ServeTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def test_serve_command
+        context = ShopifyCli::Context.new
+        Themekit.expects(:serve).with(context, flags: [], env: nil)
+
+        Theme::Commands::Serve.new(context).call
+      end
+
+      def test_can_specify_env
+        context = ShopifyCli::Context.new
+        Themekit.expects(:serve).with(context, flags: [], env: 'test')
+
+        command = Theme::Commands::Serve.new(context)
+        command.options.flags[:env] = 'test'
+        command.call
+      end
+    end
+  end
+end

--- a/test/project_types/theme/forms/connect_test.rb
+++ b/test/project_types/theme/forms/connect_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Forms
+    class ConnectTest < MiniTest::Test
+      resp = [200,
+              { "themes" =>
+               [{ "id" => 2468,
+                  "name" => "my_theme" },
+                { "id" => 1357,
+                  "name" => "your_theme" }] }]
+      THEMES = resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+
+      def test_returns_all_defined_attributes_if_valid
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
+        form = ask
+        assert_equal('shop.myshopify.com', form.store)
+        assert_equal('boop', form.password)
+        assert_equal('2468', form.themeid)
+        assert_equal('my_theme', form.name)
+      end
+
+      def test_env_can_be_provided_by_flag
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
+        form = ask(env: 'test')
+        assert_equal('test', form.env)
+      end
+
+      def test_env_nil_if_not_provided
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
+        form = ask
+        assert_nil(form.env)
+      end
+
+      def test_store_can_be_provided_by_flag
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
+        form = ask(store: 'shop.myshopify.com')
+        assert_equal('shop.myshopify.com', form.store)
+      end
+
+      def test_store_is_prompted
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
+        CLI::UI::Prompt.expects(:ask)
+          .with(@context.message('theme.forms.ask_store'), allow_empty: false)
+          .returns('shop.myshopify.com')
+        ask(store: nil)
+      end
+
+      def test_password_can_be_provided_by_flag
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
+        form = ask(password: 'boop')
+        assert_equal('boop', form.password)
+      end
+
+      def test_password_is_prompted
+        Themekit.expects(:query_themes)
+          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .returns(THEMES)
+
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
+          .returns('boop')
+        ask(password: nil)
+      end
+
+      def test_aborts_if_field_empty
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_store'), allow_empty: false)
+          .returns(' ')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
+          .returns(' ')
+
+        assert_nil(ask(store: nil, password: nil, themeid: nil))
+      end
+
+      private
+
+      def ask(password: 'boop', store: 'shop.myshopify.com', themeid: '2468', env: nil)
+        Connect.ask(
+          @context,
+          [],
+          password: password,
+          store: store,
+          themeid: themeid,
+          env: env
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/theme/forms/create_test.rb
+++ b/test/project_types/theme/forms/create_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Forms
+    class CreateTest < MiniTest::Test
+      def test_returns_all_defined_attributes_if_valid
+        form = ask
+        assert_equal('shop.myshopify.com', form.store)
+        assert_equal('boop', form.password)
+        assert_equal('My Theme', form.title)
+        assert_equal('my_theme', form.name)
+      end
+
+      def test_env_can_be_provided_by_flag
+        form = ask(env: 'test')
+        assert_equal('test', form.env)
+      end
+
+      def test_env_nil_if_not_provided
+        form = ask
+        assert_nil(form.env)
+      end
+
+      def test_store_can_be_provided_by_flag
+        form = ask(store: 'shop.myshopify.com')
+        assert_equal('shop.myshopify.com', form.store)
+      end
+
+      def test_store_is_prompted
+        CLI::UI::Prompt.expects(:ask)
+          .with(@context.message('theme.forms.ask_store'), allow_empty: false)
+          .returns('shop.myshopify.com')
+        ask(store: nil)
+      end
+
+      def test_password_can_be_provided_by_flag
+        form = ask(password: 'boop')
+        assert_equal('boop', form.password)
+      end
+
+      def test_password_is_prompted
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
+          .returns('boop')
+        ask(password: nil)
+      end
+
+      def test_title_can_be_provided_by_flag
+        form = ask(title: 'My Theme')
+        assert_equal('my_theme', form.name)
+        assert_equal('My Theme', form.title)
+      end
+
+      def test_title_is_prompted
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_title'), allow_empty: false)
+          .returns('My Theme')
+        assert_equal('my_theme', ask.name)
+        ask(title: nil)
+      end
+
+      def test_aborts_if_field_empty
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_store'), allow_empty: false)
+          .returns(' ')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
+          .returns(' ')
+        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_title'), allow_empty: false)
+          .returns(' ')
+        @context.expects(:abort)
+          .with(@context.message('theme.forms.errors', 'store, password, title'.capitalize))
+
+        ask(store: nil, password: nil, title: nil)
+      end
+
+      private
+
+      def ask(title: 'My Theme', password: 'boop', store: 'shop.myshopify.com', env: nil)
+        Create.ask(
+          @context,
+          [],
+          title: title,
+          password: password,
+          store: store,
+          env: env
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
+++ b/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  module Tasks
+    class EnsureThemekitInstalledTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        @context = TestHelpers::FakeContext.new
+      end
+
+      def test_does_nothing_if_themekit_installed_and_not_update_time
+        stub_check_executable(true)
+        ShopifyCli::Feature.expects(:enabled?).returns(true)
+        stub_time_check
+        Themekit.expects(:update).with(@context).never
+
+        assert_nothing_raised do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      def test_installs_and_makes_executable_if_not_installed
+        stub_check_executable
+        stub_releases
+        stub_themekit_file_write
+        CLI::UI.expects(:confirm)
+          .with(@context.message('theme.tasks.ensure_themekit_installed.auto_update'))
+          .returns(true)
+        ShopifyCli::Feature.expects(:set).with(:themekit_auto_update, true)
+        stub_time_check
+
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('boop')
+        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT)
+        ShopifyCli::Feature.expects(:enabled?).returns(true)
+
+        EnsureThemekitInstalled.call(@context)
+      end
+
+      def test_fails_if_bad_digest
+        stub_check_executable
+        stub_releases
+        stub_themekit_file_write
+
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('mlem')
+        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+        File.expects(:exist?).with(Themekit::THEMEKIT).returns(true)
+        FileUtils.expects(:rm).with(Themekit::THEMEKIT)
+
+        assert_raises(ShopifyCli::Abort,
+                      @context.message('theme.tasks.ensure_themekit_installed.errors.digest_fail')) do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      def test_fails_gracefully_if_network_errors
+        stat = mock
+        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(['out', stat])
+        stat.stubs(:success?).returns(false)
+        stub_request(:get, EnsureThemekitInstalled::URL).to_return(status: 504)
+
+        @context.expects(:capture2e)
+          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
+          .never
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).never
+        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+
+        assert_raises(ShopifyCli::Abort,
+                      @context.message('theme.tasks.ensure_themekit_installed.errors.releases_fail')) do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      def test_fails_if_bad_write
+        stub_check_executable
+        stub_releases
+
+        stat = mock
+        @context.expects(:capture2e)
+          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
+          .returns(['out', stat])
+        stat.stubs(:success?).returns(false)
+
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).never
+        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+        File.expects(:exist?).with(Themekit::THEMEKIT).returns(true)
+        FileUtils.expects(:rm).with(Themekit::THEMEKIT)
+
+        assert_raises(ShopifyCli::Abort, @context.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      def test_updates_if_has_been_a_week
+        stub_check_executable(true)
+        ShopifyCli::Feature.expects(:enabled?).returns(true)
+        stub_time_check(604801)
+        Themekit.expects(:update).with(@context).returns(true)
+        ShopifyCli::Config
+          .expects(:set)
+          .once
+
+        assert_nothing_raised do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      def test_aborts_if_cannot_update
+        stub_check_executable(true)
+        ShopifyCli::Feature.expects(:enabled?).returns(true)
+        stub_time_check(604801)
+        Themekit.expects(:update).with(@context).returns(false)
+        ShopifyCli::Config
+          .expects(:set)
+          .never
+
+        assert_raises(ShopifyCli::Abort,
+                      @context.message('theme.tasks.ensure_themekit_installed.errors.update_fail')) do
+          EnsureThemekitInstalled.call(@context)
+        end
+      end
+
+      private
+
+      def stub_check_executable(status = false)
+        stat = mock
+        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(['out', stat])
+        stat.stubs(:success?).returns(status)
+      end
+
+      def stub_releases
+        stub_request(:get, EnsureThemekitInstalled::URL)
+          .to_return(body: { "platforms": [
+            {
+              "name": 'darwin-amd64',
+              "version": '123',
+              "url": 'http://www.website.ca',
+              "digest": 'boop',
+            },
+            {
+              "name": 'linux-amd64',
+              "version": '123',
+              "url": 'http://www.website.ca',
+              "digest": 'boop',
+            },
+            {
+              "name": 'windows-amd64',
+              "version": '123',
+              "url": 'http://www.website.ca',
+              "digest": 'boop',
+            },
+          ] }.to_json)
+      end
+
+      def stub_themekit_file_write
+        stat = mock
+        @context.expects(:capture2e)
+          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
+          .returns(['out', stat])
+        stat.stubs(:success?).returns(true)
+      end
+
+      def stub_time_check(ago = 5)
+        ShopifyCli::Config
+          .expects(:get)
+          .returns(Time.now.to_i - ago)
+      end
+    end
+  end
+end

--- a/test/project_types/theme/test_helper.rb
+++ b/test/project_types/theme/test_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+require "test_helper"
+
+ShopifyCli::ProjectType.load_type(:theme)

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -1,0 +1,399 @@
+# frozen_string_literal: true
+require 'project_types/theme/test_helper'
+
+module Theme
+  class ThemekitTest < MiniTest::Test
+    RESP = [200,
+            { "themes" =>
+               [{ "id" => 2468,
+                  "name" => "my_theme" },
+                { "id" => 1357,
+                  "name" => "your_theme" }] }]
+
+    def test_add_flags_successful
+      flags = { 'key': 'value' }
+      assert(Themekit.add_flags(flags), ["--key=value"])
+    end
+
+    def test_create_theme_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'new',
+              '--no-update-notifier',
+              '--password=boop',
+              '--store=shop.myshopify.com',
+              '--name=My Theme')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.create(context, password: 'boop', store: 'shop.myshopify.com', name: 'My Theme', env: nil))
+    end
+
+    def test_create_theme_unsuccessful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'new',
+              '--no-update-notifier',
+              '--password=boop',
+              '--store=shop.com',
+              '--name=My Theme')
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+      refute(Themekit.create(context, password: 'boop', store: 'shop.com', name: 'My Theme', env: nil))
+    end
+
+    def test_push_deploy_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'deploy',
+              '--no-update-notifier')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.push(context, files: [], flags: [], remove: nil, env: nil))
+    end
+
+    def test_push_deploy_successful_with_nil
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'deploy',
+              '--no-update-notifier')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.push(context, files: nil, flags: nil, remove: nil, env: nil))
+    end
+
+    def test_push_remove_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'remove',
+              '--no-update-notifier',
+              'file.liquid',
+              'another_file.liquid')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil))
+    end
+
+    def test_push_successful_with_flags
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'deploy',
+              '--no-update-notifier',
+              '--allow-live')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.push(context, files: [], flags: ['--allow-live'], remove: nil, env: nil))
+    end
+
+    def test_push_deploy_unsuccessful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+             'deploy',
+              '--no-update-notifier')
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+      refute(Themekit.push(context, files: [], flags: [], remove: nil, env: nil))
+    end
+
+    def test_push_remove_unsuccessful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'remove',
+              '--no-update-notifier',
+              'file.liquid',
+              'another_file.liquid')
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+      refute(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil))
+    end
+
+    def test_deploy_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      Themekit.expects(:push).with(context, flags: nil, env: nil).returns(true)
+      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+             'publish',
+              '--no-update-notifier')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+
+      assert(Themekit.deploy(context, env: nil))
+    end
+
+    def test_deploy_with_flags
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      Themekit.expects(:push).with(context, flags: ['--allow-live'], env: nil).returns(true)
+      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+             'publish',
+              '--no-update-notifier',
+             '--allow-live')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+
+      assert(Themekit.deploy(context, flags: ['--allow-live'], env: nil))
+    end
+
+    def test_deploy_push_fail
+      context = ShopifyCli::Context.new
+
+      Themekit.expects(:push).with(context, flags: nil, env: nil).returns(false)
+      context.expects(:system).with(Themekit::THEMEKIT,
+                                    'publish',
+                                    '--no-update-notifier').never
+
+      assert_raises CLI::Kit::Abort do
+        Themekit.deploy(context, env: nil)
+      end
+    end
+
+    def test_deploy_publish_fail
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      Themekit.expects(:push).with(context, flags: nil, env: nil).returns(true)
+      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'publish',
+              '--no-update-notifier')
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+
+      refute(Themekit.deploy(context, env: nil))
+    end
+
+    def test_connect_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'get',
+              '--no-update-notifier',
+              '--password=boop',
+              '--store=shop.com',
+              '--themeid=2468')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+      assert(Themekit.connect(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
+    end
+
+    def test_connect_unsuccessful
+      context = ShopifyCli::Context.new
+      stat = mock
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'get',
+              '--no-update-notifier',
+              '--password=boop',
+              '--store=shop.com',
+              '--themeid=2468')
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+      refute(Themekit.connect(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
+    end
+
+    def test_serve_successful
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:capture2e)
+        .with(Themekit::THEMEKIT,
+              'open',
+              '--no-update-notifier')
+        .returns(['out', stat])
+      stat.stubs(:success?).returns(true)
+      context.expects(:puts).with('out')
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'watch',
+              '--no-update-notifier')
+
+      Themekit.serve(context, env: nil)
+    end
+
+    def test_serve_takes_flags
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:capture2e)
+        .with(Themekit::THEMEKIT,
+              'open',
+              '--no-update-notifier')
+        .returns(['out', stat])
+      stat.stubs(:success?).returns(true)
+      context.expects(:puts).with('out')
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'watch',
+              '--no-update-notifier',
+              '--allow-live')
+
+      Themekit.serve(context, flags: ['--allow-live'], env: nil)
+    end
+
+    def test_aborts_serve_if_open_fails
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:capture2e)
+        .with(Themekit::THEMEKIT,
+              'open',
+              '--no-update-notifier')
+        .returns(['out', stat])
+      stat.stubs(:success?).returns(false)
+      context.expects(:puts).with('out')
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'watch',
+              '--no-update-notifier')
+        .never
+
+      assert_raises(ShopifyCli::Abort) do
+        Themekit.serve(context, env: nil)
+      end
+    end
+
+    def test_can_update
+      context = ShopifyCli::Context.new
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'update',
+              '--no-update-notifier')
+        .returns(true)
+
+      Themekit.update(context)
+    end
+
+    def test_can_generate_env
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'configure',
+              '--no-update-notifier',
+              '--password=boop',
+              '--store=shop.myshopify.com',
+              '--themeid=2468')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+
+      Themekit.generate_env(context, store: 'shop.myshopify.com', password: 'boop', themeid: 2468, env: nil)
+    end
+
+    def test_can_generate_env_with_env_flag
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'configure',
+              '--no-update-notifier',
+              '--env=test',
+              '--password=boop',
+              '--store=shop.myshopify.com',
+              '--themeid=2468')
+        .returns(stat)
+      stat.stubs(:success?).returns(true)
+
+      Themekit.generate_env(context, store: 'shop.myshopify.com', password: 'boop', themeid: 2468, env: 'test')
+    end
+
+    def test_generate_env_returns_false_if_bad_info
+      context = ShopifyCli::Context.new
+      stat = mock
+
+      context.expects(:system)
+        .with(Themekit::THEMEKIT,
+              'configure',
+              '--no-update-notifier',
+              '--password=boop',
+              '--store=shop.myshopify.com',
+              '--themeid=1357')
+        .returns(stat)
+      stat.stubs(:success?).returns(false)
+
+      Themekit.generate_env(context, store: 'shop.myshopify.com', password: 'boop', themeid: 1357, env: nil)
+    end
+
+    def test_can_query_themes
+      context = ShopifyCli::Context.new
+
+      ShopifyCli::AdminAPI.expects(:rest_request)
+        .with(context,
+              shop: 'shop.myshopify.com',
+              token: 'boop',
+              path: 'themes.json')
+        .returns(RESP)
+
+      Themekit.query_themes(context, store: 'shop.myshopify.com', password: 'boop')
+    end
+
+    def test_aborts_query_if_bad_password
+      context = ShopifyCli::Context.new
+
+      ShopifyCli::AdminAPI.expects(:rest_request)
+        .with(context,
+              shop: 'shop.myshopify.com',
+              token: 'meep',
+              path: 'themes.json')
+        .raises(ShopifyCli::API::APIRequestUnauthorizedError)
+
+      assert_raises CLI::Kit::Abort do
+        Themekit.query_themes(context, store: 'shop.myshopify.com', password: 'meep')
+      end
+    end
+
+    def test_querying_handles_errors
+      context = ShopifyCli::Context.new
+
+      ShopifyCli::AdminAPI.expects(:rest_request)
+        .with(context,
+              shop: 'market.myshopify.com',
+              token: 'boop',
+              path: 'themes.json')
+        .raises(StandardError)
+
+      assert_raises CLI::Kit::Abort do
+        Themekit.query_themes(context, store: 'market.myshopify.com', password: 'boop')
+      end
+    end
+  end
+end

--- a/test/shopify-cli/admin_api_test.rb
+++ b/test/shopify-cli/admin_api_test.rb
@@ -44,6 +44,27 @@ module ShopifyCli
       )
     end
 
+    def test_rest_request_calls_admin_api
+      api_stub = stub
+      AdminAPI.expects(:new).with(
+        ctx: @context,
+        auth_header: 'X-Shopify-Access-Token',
+        token: 'boop',
+        url: 'https://shop.myshopify.com/admin/api/unstable/data.json',
+      ).returns(api_stub)
+      api_stub.expects(:request).with(url: 'https://shop.myshopify.com/admin/api/unstable/data.json',
+                                      body: nil,
+                                      method: "GET").returns('response')
+      assert_equal(
+        'response',
+        AdminAPI.rest_request(@context,
+                             shop: 'shop.myshopify.com',
+                             path: 'data.json',
+                             api_version: 'unstable',
+                             token: 'boop'),
+      )
+    end
+
     def test_query_can_reauth
       ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123').twice
       api_stub = stub

--- a/test/shopify-cli/http_request_test.rb
+++ b/test/shopify-cli/http_request_test.rb
@@ -3,10 +3,32 @@ require 'shopify-cli/http_request'
 
 module ShopifyCli
   class HttpRequestTest < MiniTest::Test
-    def test_makes_http_request
+    def test_makes_get_request
       uri = URI.parse("https://example.com")
-      body = "body content"
       variables = { var_name: "var_value" }
+      body = JSON.dump(query: "body content".tr("\n", ""), variables: variables)
+      headers = { header_name: "header_value" }
+      request = stub_request(:get, "https://example.com/")
+        .with(
+          body: '{"query":"body content","variables":{"var_name":"var_value"}}',
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Ruby',
+            'Header-Name' => 'header_value',
+          }
+        )
+
+      HttpRequest.get(uri, body, headers)
+
+      assert_requested request
+    end
+
+    def test_makes_post_request
+      uri = URI.parse("https://example.com")
+      variables = { var_name: "var_value" }
+      body = JSON.dump(query: "body content".tr("\n", ""), variables: variables)
       headers = { header_name: "header_value" }
       request = stub_request(:post, "https://example.com/")
         .with(
@@ -20,7 +42,7 @@ module ShopifyCli
           }
         )
 
-      HttpRequest.call(uri, body, variables, headers)
+      HttpRequest.post(uri, body, headers)
 
       assert_requested request
     end


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
- Centralize development tooling - make Shopify CLI the go-to, rather than having Theme Kit and CLI separately

### What is this pull request doing? 📋 
- Create CLI commands mapped to Theme Kit commands
  - `create theme`
  - `connect theme`
  - `generate env`
  - `serve`
  - `push`
  - `deploy`
- Download or automatically update Theme Kit weekly (as needed)
- Pass important flags to Theme Kit
  - `--allow-live`
  - `--notify`
  - `--env=ENV`
- Refactor code to better support themes
  - `HttpRequest` more specific
  - `rest_request` to query themes

### Update checklist
- [x] I've added a CHANGELOG entry for this PR
