### PR TITLE
Fix Layout/EmptyLineBetweenDefs rubocop violation

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -47,8 +47,10 @@ module Script
             @outdated_packages = outdated_packages
           end
         end
+
         class BuildScriptNotFoundError < ScriptProjectError; end
         class InvalidBuildScriptError < ScriptProjectError; end
+
         class WebAssemblyBinaryNotFoundError < ScriptProjectError
           def initialize
             super("WebAssembly binary not found")


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/shopify-app-cli/pull/995 changed cop rules that https://github.com/Shopify/shopify-app-cli/pull/979 violates, but https://github.com/Shopify/shopify-app-cli/pull/979 was merged before https://github.com/Shopify/shopify-app-cli/pull/995

### WHAT is this pull request doing?

Appeases rubocop failures

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
