### PR TITLE
[Scripts] Remove ScriptRepository#with_temp_build_context

### DIFF
--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -9,7 +9,9 @@ module Script
             CLI::UI::Frame.open(ctx.message('script.application.building')) do
               begin
                 UI::StrictSpinner.spin(ctx.message('script.application.building_script')) do |spinner|
-                  build(ctx, task_runner, script)
+                  Infrastructure::PushPackageRepository
+                    .new(ctx: ctx)
+                    .create_push_package(script, task_runner.build, task_runner.compiled_type)
                   spinner.update_title(ctx.message('script.application.built'))
                 end
               rescue StandardError => e
@@ -26,17 +28,6 @@ module Script
                 raise
               end
             end
-          end
-
-          private
-
-          def build(ctx, task_runner, script)
-            script_repo = Infrastructure::ScriptRepository.new(ctx: ctx)
-            script_content = script_repo.with_temp_build_context do
-              task_runner.build
-            end
-            Infrastructure::PushPackageRepository.new(ctx: ctx)
-              .create_push_package(script, script_content, task_runner.compiled_type)
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/script_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_repository.rb
@@ -16,18 +16,6 @@ module Script
           Domain::Script.new(script_id(language), script_name, extension_point_type, language)
         end
 
-        def with_temp_build_context
-          prev_dir = Dir.pwd
-          temp_dir = "#{project_base}/temp"
-          ctx.mkdir_p(temp_dir)
-          FileUtils.cp_r(Dir['**'].reject { |f| f == 'temp' }, temp_dir)
-          ctx.chdir(temp_dir)
-          yield
-        ensure
-          ctx.chdir(prev_dir)
-          ctx.rm_rf(temp_dir)
-        end
-
         def relative_path_to_src
           "src"
         end

--- a/test/project_types/script/layers/infrastructure/script_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_repository_test.rb
@@ -52,46 +52,4 @@ describe Script::Layers::Infrastructure::ScriptRepository do
       end
     end
   end
-
-  describe ".with_temp_build_context" do
-    let(:script_file) { "script.#{language}" }
-    let(:helper_file) { "helper.#{language}" }
-
-    before do
-      context.mkdir_p(script_source_base)
-      Dir.chdir(script_source_base)
-      context.root = script_source_base
-      context.write(script_file, "//run code")
-    end
-
-    it "should go to a tempdir with all its files" do
-      context.write(helper_file, "//helper code")
-      context.mkdir_p("other_dir")
-
-      script_repository.with_temp_build_context do
-        refute_equal script_source_base, Dir.pwd
-        assert context.file_exist?(script_file)
-        assert context.file_exist?(helper_file)
-      end
-    end
-
-    it "should create temp directory in the script root" do
-      nested_dir = "#{script_folder_base}/some/nested/directory"
-      context.mkdir_p(nested_dir)
-      context.chdir(nested_dir)
-
-      temp_dir = "#{script_folder_base}/temp"
-      script_repository.with_temp_build_context do
-        assert_equal Dir.pwd, temp_dir
-      end
-    end
-
-    it "should delete the script root temp directory afterwards" do
-      temp_dir = "#{script_folder_base}/temp"
-      script_repository.with_temp_build_context do
-        assert context.dir_exist?(temp_dir)
-      end
-      refute context.dir_exist?(temp_dir)
-    end
-  end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

We no longer need to create a temporary build context when building the script. When building, we should have the exact same side effects as running `npm run build` directly.

### WHAT is this pull request doing?

Removes the `get_temp_build_context` method from the ScriptRepository. 

![image](https://user-images.githubusercontent.com/28009669/101384870-045fe300-3889-11eb-9fac-7a2c6386ef8c.png)

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
