### PR TITLE
Change script project codeowners from scripts to scripts-experience

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 *       @shopify/platform-dev-tools-education
 
-/lib/project_types/script/ @shopify/scripts
-/test/project_types/script/ @shopify/scripts
+/lib/project_types/script/ @shopify/scripts-experience
+/test/project_types/script/ @shopify/scripts-experience


### PR DESCRIPTION
### WHY are these changes introduced?

The `scripts` team has split into subteams and `scripts-experience` will primarily be the ones owning the CLI changes. 

### WHAT is this pull request doing?

Changes the codeowners of the script project type from `scripts` to `scripts-experience`.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
