### PR TITLE
Add beta setting for Employee authentication

### DIFF
--- a/lib/shopify-cli/commands/config.rb
+++ b/lib/shopify-cli/commands/config.rb
@@ -7,6 +7,7 @@ module ShopifyCli
 
       subcommand :Feature, 'feature'
       subcommand :Analytics, 'analytics'
+      subcommand :ShopifolkBeta, 'shopifolk-beta'
 
       def call(*)
         @ctx.puts(self.class.help)
@@ -68,6 +69,29 @@ module ShopifyCli
             @ctx.puts(@ctx.message('core.config.analytics.is_enabled'))
           else
             @ctx.puts(@ctx.message('core.config.analytics.is_disabled'))
+          end
+        end
+      end
+
+      class ShopifolkBeta < ShopifyCli::SubCommand
+        options do |parser, flags|
+          parser.on('--enable') { flags[:action] = 'enable' }
+          parser.on('--disable') { flags[:action] = 'disable' }
+          parser.on('--status') { flags[:action] = 'status' }
+        end
+
+        def call(_args, _name)
+          is_enabled = ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
+          if options.flags[:action] == 'disable' && is_enabled
+            ShopifyCli::Config.set('shopifolk-beta', 'enabled', false)
+            @ctx.puts(@ctx.message('core.config.shopifolk-beta.disabled'))
+          elsif options.flags[:action] == 'enable' && !is_enabled
+            ShopifyCli::Config.set('shopifolk-beta', 'enabled', true)
+            @ctx.puts(@ctx.message('core.config.shopifolk-beta.enabled'))
+          elsif is_enabled
+            @ctx.puts(@ctx.message('core.config.shopifolk-beta.is_enabled'))
+          else
+            @ctx.puts(@ctx.message('core.config.shopifolk-beta.is_disabled'))
           end
         end
       end

--- a/lib/shopify-cli/commands/config.rb
+++ b/lib/shopify-cli/commands/config.rb
@@ -84,14 +84,14 @@ module ShopifyCli
           is_enabled = ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
           if options.flags[:action] == 'disable' && is_enabled
             ShopifyCli::Config.set('shopifolk-beta', 'enabled', false)
-            @ctx.puts(@ctx.message('core.config.shopifolk-beta.disabled'))
+            @ctx.puts(@ctx.message('core.config.shopifolk_beta.disabled'))
           elsif options.flags[:action] == 'enable' && !is_enabled
             ShopifyCli::Config.set('shopifolk-beta', 'enabled', true)
-            @ctx.puts(@ctx.message('core.config.shopifolk-beta.enabled'))
+            @ctx.puts(@ctx.message('core.config.shopifolk_beta.enabled'))
           elsif is_enabled
-            @ctx.puts(@ctx.message('core.config.shopifolk-beta.is_enabled'))
+            @ctx.puts(@ctx.message('core.config.shopifolk_beta.is_enabled'))
           else
-            @ctx.puts(@ctx.message('core.config.shopifolk-beta.is_disabled'))
+            @ctx.puts(@ctx.message('core.config.shopifolk_beta.is_disabled'))
           end
         end
       end

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -76,6 +76,16 @@ module ShopifyCli
             is_enabled: "{{v}} analytics are currently enabled",
             is_disabled: "{{v}} analytics are currently disabled",
           },
+          shopifolk_beta: {
+            help: <<~HELP,
+            Opt in/out of shopifolk beta
+              Usage: {{command:%s config [ analytics ] }}
+            HELP
+            enabled: "{{v}} shopifolk-beta has been enabled",
+            disabled: "{{v}} shopifolk-beta has been disabled",
+            is_enabled: "{{v}} shopifolk-beta is currently enabled",
+            is_disabled: "{{v}} shopifolk-beta is currently disabled",
+          },
         },
 
         git: {

--- a/lib/shopify-cli/shopifolk.rb
+++ b/lib/shopify-cli/shopifolk.rb
@@ -25,6 +25,7 @@ module ShopifyCli
       #     ShopifyCli::Shopifolk.check
       #
       def check
+        return false unless Feature.enabled?('shopifolk-beta')
         ShopifyCli::Shopifolk.new.shopifolk?
       end
 
@@ -50,7 +51,9 @@ module ShopifyCli
     # a valid google cloud config file with email ending in "@shopify.com"
     #
     def shopifolk?
+      return false unless Feature.enabled?('shopifolk-beta')
       return true if Feature.enabled?(FEATURE_NAME)
+
       if shopifolk_by_gcloud? && shopifolk_by_dev?
         ShopifyCli::Feature.enable(FEATURE_NAME)
         true

--- a/test/shopify-cli/commands/config_test.rb
+++ b/test/shopify-cli/commands/config_test.rb
@@ -62,6 +62,18 @@ module ShopifyCli
         run_cmd("config analytics --disable")
         refute ShopifyCli::Config.get_bool('analytics', 'enabled')
       end
+
+      def test_will_enable_shopifolk_beta_that_is_disabled
+        ShopifyCli::Config.set('shopifolk-beta', 'enabled', false)
+        run_cmd("config shopifolk-beta --enable")
+        assert ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
+      end
+
+      def test_will_disable_shopifolk_beta_that_is_enabled
+        ShopifyCli::Config.set('shopifolk-beta', 'enabled', true)
+        run_cmd("config shopifolk-beta --disable")
+        refute ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
+      end
     end
   end
 end

--- a/test/shopify-cli/shopifolk_test.rb
+++ b/test/shopify-cli/shopifolk_test.rb
@@ -5,8 +5,13 @@ module ShopifyCli
   class ShopifolkTest < MiniTest::Test
     include TestHelpers::FakeFS
 
-    def test_correct_features_is_shopifolk
+    def setup
+      super
+      ShopifyCli::Feature.enable('shopifolk-beta')
       ShopifyCli::Feature.disable('shopifolk')
+    end
+
+    def test_correct_features_is_shopifolk
       FileUtils.mkdir_p("/opt/dev/bin")
       FileUtils.touch("/opt/dev/bin/dev")
       FileUtils.touch("/opt/dev/.shopify-build")
@@ -24,8 +29,7 @@ module ShopifyCli
     end
 
     def test_no_gcloud_config_disables_shopifolk_feature
-      ShopifyCli::Feature.enable('shopifolk')
-      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
+      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
 
       ShopifyCli::Shopifolk.check
 
@@ -33,8 +37,6 @@ module ShopifyCli
     end
 
     def test_no_section_in_gcloud_config_disables_shopifolk_feature
-      ShopifyCli::Feature.enable('shopifolk')
-      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_gcloud_ini({ "account" => "test@shopify.com", "project" => "shopify-dev" })
 
       ShopifyCli::Shopifolk.check
@@ -43,8 +45,6 @@ module ShopifyCli
     end
 
     def test_no_account_in_gcloud_config_disables_shopifolk_feature
-      ShopifyCli::Feature.enable('shopifolk')
-      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_gcloud_ini({ "[core]" => { "project" => "shopify-dev" } })
 
       ShopifyCli::Shopifolk.check
@@ -53,8 +53,6 @@ module ShopifyCli
     end
 
     def test_incorrect_email_in_gcloud_config_disables_shopifolk_feature
-      ShopifyCli::Feature.enable('shopifolk')
-      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_gcloud_ini({ "[core]" => { "account" => "test@test.com", "project" => "shopify-dev" } })
 
       ShopifyCli::Shopifolk.check
@@ -63,8 +61,6 @@ module ShopifyCli
     end
 
     def test_incorrect_dev_path_disables_dev_shopifolk_feature
-      ShopifyCli::Feature.enable('shopifolk')
-      ShopifyCli::Feature.stubs(:enabled?).with('shopifolk').returns(false)
       stub_gcloud_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
 
       ShopifyCli::Shopifolk.check


### PR DESCRIPTION
### WHY are these changes introduced?

This will allow Shopify employees to opt-in to the Employee Authentication beta by running:

`shopify config shopifolk-beta --enable`

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ Not public facing
