### PR TITLE
New scripts use new toolchain and generate metadata

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -2,24 +2,24 @@ discount:
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
     sdk-version: "^7.0.0"
-    toolchain-version: "^2.0.1"
+    toolchain-version: "^3.0.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
     sdk-version: "^7.0.0"
-    toolchain-version: "^2.0.1"
+    toolchain-version: "^3.0.0"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
     sdk-version: "^7.0.0"
-    toolchain-version: "^2.0.1"
+    toolchain-version: "^3.0.0"
 shipping_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-shipping-filter"
     sdk-version: "^7.0.0"
-    toolchain-version: "^2.0.1"
+    toolchain-version: "^3.0.0"
 tax_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-tax-filter"
     sdk-version: "^7.0.0"
-    toolchain-version: "^2.0.1"
+    toolchain-version: "^3.0.0"

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -56,7 +56,7 @@ module Script
               },
               "scripts": {
                 "test": "asp --summary --verbose",
-                "build": "shopify-scripts-toolchain-as build --src src/script.ts --binary build/#{script_name}.wasm -- --lib node_modules --optimize --use Date="
+                "build": "shopify-scripts-toolchain-as build --src src/script.ts --binary build/#{script_name}.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date="
               },
               "engines": {
                 "node": ">=#{MIN_NODE_VERSION}"

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -83,10 +83,10 @@ module Script
           invalid_build_script: "Invalid build script.",
           build_script_not_found: "Build script not found.",
           # rubocop:disable Layout/LineLength
-          build_script_suggestion: "Root package.json needs a script named build, which" \
+          build_script_suggestion: "Root package.json needs a script named build, which " \
             "uses @shopify/scripts-toolchain-as to compile to WebAssembly.\n" \
             "Example:\n" \
-            "build: npx shopify-scripts-toolchain-as build --src src/script.ts --binary <script_name>.wasm -- --lib node_modules --optimize --use Date=",
+            "build: npx shopify-scripts-toolchain-as build --src src/script.ts --binary build/<script_name>.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date=",
 
           web_assembly_binary_not_found: "WebAssembly binary not found.",
           web_assembly_binary_not_found_suggestion: "No WebAssembly binary found." \


### PR DESCRIPTION
Will introduce code in the future to instruct script developers to
migrate their projects to the new toolchain when we start using the
metadata.

### WHY are these changes introduced?

We want to have newly created scripts producing metadata like which version of a schema they are relying on as one of their build artifacts. This involves using a new version of the build toolchain and a new argument flag. We also want error messages providing a suggested build command to include the metadata flag.

I also found a mistake in the existing suggested build command and what appears to be a typo with a missing space which I fixed while I was making these changes.

### WHAT is this pull request doing?

- Update the version of the toolchain new scripts projects are scaffolded with to one that supports producing metadata as a build artifact
- Add the metadata argument flag as part of the scaffolded build command
- Update the missing and invalid build script error messages to include the metadata flag in the suggested build script
- Add a missing space in the suggestion for missing and invalid build script errors
- Fix the location where the binary is being written in the suggested build command in the suggestion for the missing and invalid script errors to match what we output for newly created script projects

Old error message:
![Old error message](https://user-images.githubusercontent.com/154890/101838327-6a10d100-3b0e-11eb-8a95-496ddf63fe7a.png)

New error message:
![New error message](https://user-images.githubusercontent.com/154890/101838222-4188d700-3b0e-11eb-8c10-691a2259658b.png)

Successful push (should be no change):
![Successful push](https://user-images.githubusercontent.com/154890/101838522-c4119680-3b0e-11eb-9872-9545b8298c9f.png)

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
