### PR TITLE
Fix shopifolk-beta flag location

### DIFF
--- a/lib/shopify-cli/shopifolk.rb
+++ b/lib/shopify-cli/shopifolk.rb
@@ -25,7 +25,8 @@ module ShopifyCli
       #     ShopifyCli::Shopifolk.check
       #
       def check
-        return false unless Feature.enabled?('shopifolk-beta')
+        return false unless ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
+
         ShopifyCli::Shopifolk.new.shopifolk?
       end
 
@@ -51,7 +52,7 @@ module ShopifyCli
     # a valid google cloud config file with email ending in "@shopify.com"
     #
     def shopifolk?
-      return false unless Feature.enabled?('shopifolk-beta')
+      return false unless ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
       return true if Feature.enabled?(FEATURE_NAME)
 
       if shopifolk_by_gcloud? && shopifolk_by_dev?

--- a/test/shopify-cli/shopifolk_test.rb
+++ b/test/shopify-cli/shopifolk_test.rb
@@ -7,7 +7,7 @@ module ShopifyCli
 
     def setup
       super
-      ShopifyCli::Feature.enable('shopifolk-beta')
+      ShopifyCli::Config.set('shopifolk-beta', 'enabled', true)
       ShopifyCli::Feature.disable('shopifolk')
     end
 


### PR DESCRIPTION
'shopifolk' is treated as a feature, but `shopifolk-beta` is considered to be separate setting.

I had changed this previously but missed a couple of places.