### PR TITLE
fix: Improve build script error messages

### DIFF
--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -80,13 +80,13 @@ module Script
           packages_outdated_cause: "These npm packages are out of date: %s.",
           packages_outdated_help: "To update them, run {{cyan:npm install --save-dev %s}}.",
 
-          invalid_build_script: "Invalid build script.",
-          build_script_not_found: "Build script not found.",
+          invalid_build_script: "The root package.json contains an invalid build command that " \
+                                "is needed to compile your script to WebAssembly.",
+          build_script_not_found: "The root package.json is missing the build command that " \
+                                  "is needed to compile your script to WebAssembly.",
           # rubocop:disable Layout/LineLength
-          build_script_suggestion: "Root package.json needs a script named build, which " \
-            "uses @shopify/scripts-toolchain-as to compile to WebAssembly.\n" \
-            "Example:\n" \
-            "build: npx shopify-scripts-toolchain-as build --src src/script.ts --binary build/<script_name>.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date=",
+          build_script_suggestion: "\n\nFor example, your package.json needs the following command:" \
+            "\nbuild: npx shopify-scripts-toolchain-as build --src src/script.ts --binary build/<script_name>.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date=",
 
           web_assembly_binary_not_found: "WebAssembly binary not found.",
           web_assembly_binary_not_found_suggestion: "No WebAssembly binary found." \


### PR DESCRIPTION
### WHY are these changes introduced?

This commit improves error messages when building (pushing) scripts. The intention of this improvement is to make the messages more explicit.


### WHAT is this pull request doing?

Build command not found
<details>
<img width="1151" alt="not found" src="https://user-images.githubusercontent.com/1423601/104362558-f3d30600-54e1-11eb-9a1b-8f21489b8b7c.png">
</details>

Invalid build command
<details>
<img width="1154" alt="invalid" src="https://user-images.githubusercontent.com/1423601/104362644-11a06b00-54e2-11eb-9fe1-ab7e94f71b89.png">
</details>



### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
