### PR TITLE
Deprecate Discounts EP

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,4 +1,5 @@
 discount:
+  deprecated: true
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
     sdk-version: "^7.0.0"

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -15,7 +15,7 @@ module Script
       def ask_extension_point
         CLI::UI::Prompt.ask(
           @ctx.message('script.forms.create.select_extension_point'),
-          options: Script::Layers::Application::ExtensionPoints.types
+          options: Script::Layers::Application::ExtensionPoints.non_deprecated_types
         )
       end
 

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -11,6 +11,12 @@ module Script
         def self.types
           Infrastructure::ExtensionPointRepository.new.extension_point_types
         end
+
+        def self.non_deprecated_types
+          Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
+            !ep.deprecated?
+          end.map(&:type)
+        end
       end
     end
   end

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -4,13 +4,18 @@ module Script
   module Layers
     module Domain
       class ExtensionPoint
-        attr_reader :type, :sdks
+        attr_reader :type, :deprecated, :sdks
 
         def initialize(type, config)
           @type = type
+          @deprecated = config["deprecated"] || false
           @sdks = {
             ts: ExtensionPointAssemblyScriptSDK.new(config["assemblyscript"]),
           }
+        end
+
+        def deprecated?
+          @deprecated
         end
       end
 

--- a/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
@@ -8,18 +8,24 @@ module Script
           Domain::ExtensionPoint.new(type, fetch_extension_point(type))
         end
 
+        def extension_points
+          extension_point_configs.map do |type, extension_point_data|
+            Domain::ExtensionPoint.new(type, extension_point_data)
+          end
+        end
+
         def extension_point_types
-          extension_points.keys
+          extension_point_configs.keys
         end
 
         private
 
         def fetch_extension_point(type)
-          raise Domain::Errors::InvalidExtensionPointError, type unless extension_points[type]
-          extension_points[type]
+          raise Domain::Errors::InvalidExtensionPointError, type unless extension_point_configs[type]
+          extension_point_configs[type]
         end
 
-        def extension_points
+        def extension_point_configs
           @extension_points ||= begin
             require 'yaml'
             YAML.load_file(Project.project_filepath('config/extension_points.yml'))

--- a/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
@@ -9,8 +9,8 @@ module Script
         end
 
         def extension_points
-          extension_point_configs.map do |type, extension_point_data|
-            Domain::ExtensionPoint.new(type, extension_point_data)
+          extension_point_configs.map do |type, extension_point_config|
+            Domain::ExtensionPoint.new(type, extension_point_config)
           end
         end
 

--- a/test/project_types/script/forms/create_test.rb
+++ b/test/project_types/script/forms/create_test.rb
@@ -23,7 +23,7 @@ module Script
 
       def test_asks_extension_point_if_no_flag
         eps = ['discount', 'another']
-        Layers::Application::ExtensionPoints.stubs(:types).returns(eps)
+        Layers::Application::ExtensionPoints.stubs(:non_deprecated_types).returns(eps)
         CLI::UI::Prompt.expects(:ask).with(
           @context.message('script.forms.create.select_extension_point'),
           options: eps

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -9,11 +9,13 @@ describe Script::Layers::Application::ExtensionPoints do
   let(:language) { 'ts' }
   let(:script_name) { 'name' }
   let(:extension_point_type) { 'discount' }
+  let(:deprecated_extension_point_type) { 'unit_limit_per_order' }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
   let(:extension_point) { extension_point_repository.get_extension_point(extension_point_type) }
 
   before do
     extension_point_repository.create_extension_point(extension_point_type)
+    extension_point_repository.create_deprecated_extension_point(deprecated_extension_point_type)
     Script::Layers::Infrastructure::ExtensionPointRepository.stubs(:new).returns(extension_point_repository)
   end
 
@@ -37,6 +39,12 @@ describe Script::Layers::Application::ExtensionPoints do
   describe '.types' do
     it 'should return an array of all types' do
       assert_equal %w(discount unit_limit_per_order), Script::Layers::Application::ExtensionPoints.types
+    end
+  end
+
+  describe '.non_deprecated_types' do
+    it 'should return an array of all types' do
+      assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.non_deprecated_types
     end
   end
 end

--- a/test/project_types/script/layers/domain/extension_point_test.rb
+++ b/test/project_types/script/layers/domain/extension_point_test.rb
@@ -27,16 +27,16 @@ describe Script::Layers::Domain::ExtensionPoint do
         refute_nil sdk.sdk_version
         refute_nil sdk.toolchain_version
       end
+    end
 
-      describe "when deprecation status is specified" do
-        let(:config_with_deprecation) { config.merge({ "deprecated" => true }) }
+    describe "when deprecation status is specified" do
+      let(:config_with_deprecation) { config.merge({ "deprecated" => true }) }
 
-        subject { Script::Layers::Domain::ExtensionPoint.new(type, config_with_deprecation) }
+      subject { Script::Layers::Domain::ExtensionPoint.new(type, config_with_deprecation) }
 
-        it "should construct a deprecated extension point" do
-          extension_point = subject
-          assert extension_point.deprecated?
-        end
+      it "should construct a deprecated extension point" do
+        extension_point = subject
+        assert extension_point.deprecated?
       end
     end
   end

--- a/test/project_types/script/layers/domain/extension_point_test.rb
+++ b/test/project_types/script/layers/domain/extension_point_test.rb
@@ -15,15 +15,29 @@ describe Script::Layers::Domain::ExtensionPoint do
   end
 
   describe ".new" do
-    subject { Script::Layers::Domain::ExtensionPoint.new(type, config) }
-    it "should construct new ExtensionPoint" do
-      extension_point = subject
-      assert_equal type, extension_point.type
+    describe "when deprecation status is not specified" do
+      subject { Script::Layers::Domain::ExtensionPoint.new(type, config) }
+      it "should construct new, non-deprecated ExtensionPoint" do
+        extension_point = subject
+        assert_equal type, extension_point.type
+        refute extension_point.deprecated?
 
-      sdk = extension_point.sdks[:ts]
-      refute_nil sdk.package
-      refute_nil sdk.sdk_version
-      refute_nil sdk.toolchain_version
+        sdk = extension_point.sdks[:ts]
+        refute_nil sdk.package
+        refute_nil sdk.sdk_version
+        refute_nil sdk.toolchain_version
+      end
+
+      describe "when deprecation status is specified" do
+        let(:config_with_deprecation) { config.merge({ "deprecation" => true }) }
+
+        subject { Script::Layers::Domain::ExtensionPoint.new(type, config) }
+
+        it "should construct a deprecated extension point" do
+          extension_point = subject
+          refute extension_point.deprecated?
+        end
+      end
     end
   end
 end

--- a/test/project_types/script/layers/domain/extension_point_test.rb
+++ b/test/project_types/script/layers/domain/extension_point_test.rb
@@ -29,13 +29,13 @@ describe Script::Layers::Domain::ExtensionPoint do
       end
 
       describe "when deprecation status is specified" do
-        let(:config_with_deprecation) { config.merge({ "deprecation" => true }) }
+        let(:config_with_deprecation) { config.merge({ "deprecated" => true }) }
 
-        subject { Script::Layers::Domain::ExtensionPoint.new(type, config) }
+        subject { Script::Layers::Domain::ExtensionPoint.new(type, config_with_deprecation) }
 
         it "should construct a deprecated extension point" do
           extension_point = subject
-          refute extension_point.deprecated?
+          assert extension_point.deprecated?
         end
       end
     end

--- a/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
@@ -8,7 +8,7 @@ describe Script::Layers::Infrastructure::ExtensionPointRepository do
   describe ".get_extension_point" do
     describe "when the extension point is configured" do
       Script::Layers::Infrastructure::ExtensionPointRepository.new
-        .send(:extension_points)
+        .send(:extension_point_configs)
         .each do |extension_point_type, _config|
         it "should be able to load the #{extension_point_type} extension point" do
           extension_point = subject.get_extension_point(extension_point_type)
@@ -32,7 +32,7 @@ describe Script::Layers::Infrastructure::ExtensionPointRepository do
 
   describe ".extension_point_types" do
     it 'should return the ep keys' do
-      subject.stubs(:extension_points).returns({ "discount" => {}, "other" => {} })
+      subject.stubs(:extension_point_configs).returns({ "discount" => {}, "other" => {} })
       assert_equal ['discount', 'other'], subject.send(:extension_point_types)
     end
   end

--- a/test/project_types/script/layers/infrastructure/fake_extension_point_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_extension_point_repository.rb
@@ -14,6 +14,10 @@ module Script
           @cache[type] = Domain::ExtensionPoint.new(type, example_config(type))
         end
 
+        def create_deprecated_extension_point(type)
+          @cache[type] = Domain::ExtensionPoint.new(type, deprecated_config(type))
+        end
+
         def get_extension_point(type)
           if @cache.key?(type)
             @cache[type]
@@ -22,11 +26,19 @@ module Script
           end
         end
 
+        def extension_points
+          @cache.values
+        end
+
         def extension_point_types
-          %w(discount unit_limit_per_order)
+          @cache.keys
         end
 
         private
+
+        def deprecated_config(type)
+          example_config(type).merge({ "deprecated" => true })
+        end
 
         def example_config(type)
           {


### PR DESCRIPTION
### WHY are these changes introduced?

Issue: https://github.com/Shopify/script-service/issues/2440

We're deprecating use of the Discounts EP. We should discourage the further creation of Discount scripts on the CLI.



### WHAT is this pull request doing?

I'm using a fairly casual deprecation method since this isn't being used in production. It doesn't prevent the usage of `discounts` scripts, it just hides them from the list during the initial creation. This should help steer away script authors from creating new `discounts` scripts.

The change was larger in size then anticipated because previously the list of types was being derived directly from yaml. I've added an intermediary layer  which transforms the yaml configs into domain objects, which then allows us to filter by deprecated status.

In future PRs, I'd like to add simple deprecation warnings to the other scripts commands. For the sake of brevity I haven't attempted that here. **Any recommendations on how to go about doing that in a way that can be cleanly shared across commands would be appreciated.**

### Tophat

![Screen Shot 2021-01-13 at 2 00 53 PM](https://user-images.githubusercontent.com/8670351/104497023-c2247280-55a7-11eb-9f0a-e417845062d9.png)

### Update checklist
- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~

I haven't added a changelog entry since AFAIK nothing in the scripts component is public facing.
