### PR TITLE
Prevent commands from succeeded for deprecated EPs

### DIFF
--- a/lib/project_types/script/errors.rb
+++ b/lib/project_types/script/errors.rb
@@ -25,5 +25,13 @@ module Script
         @config_file = config_file
       end
     end
+
+    class DeprecatedEPError < ScriptProjectError
+      attr_reader :ep
+      def initialize(ep)
+        super()
+        @ep = ep
+      end
+    end
   end
 end

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -17,6 +17,12 @@ module Script
             !ep.deprecated?
           end.map(&:type)
         end
+
+        def self.deprecated_types
+          Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
+            ep.deprecated?
+          end.map(&:type)
+        end
       end
     end
   end

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -19,9 +19,10 @@ module Script
         end
 
         def self.deprecated_types
-          Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
-            ep.deprecated?
-          end.map(&:type)
+          Infrastructure::ExtensionPointRepository.new
+            .extension_points
+            .select(&:deprecated?)
+            .map(&:type)
         end
       end
     end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -5,9 +5,9 @@ module Script
     MESSAGES = {
       script: {
         error: {
-          deprecated_ep: "This project uses Extension point %s which has been deprecated. "\
+          deprecated_ep: "This project uses an extension point %s which has been deprecated. "\
                          "This Script will no longer function in production.",
-          deprecated_ep_cause: "Try using a different Extension point.",
+          deprecated_ep_cause: "Try using a different extension point.",
           generic: "{{red:{{x}} Error}}",
           eacces_cause: "You don't have permission to write to this directory.",
           eacces_help: "Change your directory permissions and try again.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -5,7 +5,8 @@ module Script
     MESSAGES = {
       script: {
         error: {
-          deprecated_ep: "This project uses Extension point %s which has been deprecated. This Script will no longer function in production.",
+          deprecated_ep: "This project uses Extension point %s which has been deprecated.
+ This Script will no longer function in production.",
           deprecated_ep_cause: "Try using a different Extension point.",
           generic: "{{red:{{x}} Error}}",
           eacces_cause: "You don't have permission to write to this directory.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -5,8 +5,8 @@ module Script
     MESSAGES = {
       script: {
         error: {
-          deprecated_ep: "This project uses Extension point %s which has been deprecated.
- This Script will no longer function in production.",
+          deprecated_ep: "This project uses Extension point %s which has been deprecated. "\
+                         "This Script will no longer function in production.",
           deprecated_ep_cause: "Try using a different Extension point.",
           generic: "{{red:{{x}} Error}}",
           eacces_cause: "You don't have permission to write to this directory.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -5,6 +5,8 @@ module Script
     MESSAGES = {
       script: {
         error: {
+          deprecated_ep: "This project uses Extension point %s which has been deprecated. This Script will no longer function in production.",
+          deprecated_ep_cause: "Try using a different Extension point.",
           generic: "{{red:{{x}} Error}}",
           eacces_cause: "You don't have permission to write to this directory.",
           eacces_help: "Change your directory permissions and try again.",

--- a/lib/project_types/script/script_project.rb
+++ b/lib/project_types/script/script_project.rb
@@ -10,6 +10,7 @@ module Script
     def initialize(*args)
       super
       @extension_point_type = lookup_config('extension_point_type')
+      raise Errors::DeprecatedEPError, @extension_point_type if deprecated?(@extension_point_type)
       @script_name = lookup_config('script_name')
       @language = 'ts'
       ShopifyCli::Core::Monorail.metadata = {
@@ -32,6 +33,10 @@ module Script
     end
 
     private
+
+    def deprecated?(ep)
+      Script::Layers::Application::ExtensionPoints.deprecated_types.include?(ep)
+    end
 
     def lookup_config(key)
       raise Errors::InvalidContextError, key unless config.key?(key)

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -84,7 +84,7 @@ module Script
         when Errors::DeprecatedEPError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.deprecated_ep', e.ep),
-            help_suggestion: ShopifyCli::Context.message('script.error.deprecated_ep_cause')
+            help_suggestion: ShopifyCli::Context.message('script.error.deprecated_ep_cause'),
           }
         when Layers::Domain::Errors::InvalidExtensionPointError
           {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -81,6 +81,11 @@ module Script
             cause_of_error: ShopifyCli::Context.message('script.error.project_exists_cause'),
             help_suggestion: ShopifyCli::Context.message('script.error.project_exists_help'),
           }
+        when Errors::DeprecatedEPError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.deprecated_ep', e.ep),
+            help_suggestion: ShopifyCli::Context.message('script.error.deprecated_ep_cause')
+          }
         when Layers::Domain::Errors::InvalidExtensionPointError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.invalid_extension_cause', e.type),

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -43,8 +43,14 @@ describe Script::Layers::Application::ExtensionPoints do
   end
 
   describe '.non_deprecated_types' do
-    it 'should return an array of all types' do
+    it 'should return an array of all non deprecated types' do
       assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.non_deprecated_types
+    end
+  end
+
+  describe '.deprecated_types' do
+    it 'should return an array of all deprecated types' do
+      assert_equal %w(unit_limit_per_order), Script::Layers::Application::ExtensionPoints.deprecated_types
     end
   end
 end

--- a/test/project_types/script/script_project_test.rb
+++ b/test/project_types/script/script_project_test.rb
@@ -30,6 +30,23 @@ module Script
       }, ShopifyCli::Core::Monorail.metadata)
     end
 
+    def test_initialize_with_deprecated_ep
+      ShopifyCli::Project
+        .any_instance
+        .expects(:load_yaml_file)
+        .with('.shopify-cli.yml')
+        .returns({
+          'extension_point_type' => @extension_point_type,
+          'script_name' => @script_name,
+        })
+
+      Script::Layers::Application::ExtensionPoints.stubs(:deprecated_types).returns([@extension_point_type])
+
+      assert_raises Errors::DeprecatedEPError do
+        ScriptProject.new(directory: 'testdir')
+      end
+    end
+
     def test_create_when_directory_does_not_exist
       @context
         .expects(:dir_exist?)


### PR DESCRIPTION
### WHY are these changes introduced?

Issue: https://github.com/Shopify/script-service/issues/2440

The C0 Discounts EP is being deprecated. In a previous PR, we prevented Discounts from being shown as an option in the EP list when creating a script. However, users with Discount scripts are still able to push their scripts to Script Service and those commands will succeed, but not work in production

### WHAT is this pull request doing?

When attempting to initialize a Script Project, an error is raised which informs you that the EP your script uses is deprecated. Since this EP isn't officially released, there's no particular need to provide recourse for the developer.

This doesn't truly prevent anyone from publishing Discount Scripts, that update will come to Script Service soon.

### Update checklist

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~
I haven't added a changelog entry since this isn't public.
