### PR TITLE
Abort on failed system call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ------
 
+* [#1034](https://github.com/Shopify/shopify-app-cli/pull/1034): Abort if a system call fails.
+
 Version 1.5.0
 -----
 * [#965](https://github.com/Shopify/shopify-app-cli/pull/965): Remove --no-optional when using npm to create new project

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -140,10 +140,9 @@ module Rails
         end
 
         CLI::UI::Frame.open(@ctx.message('rails.create.running_generator')) do
-          begin
-            syscall(%w(spring stop))
-          rescue
-          end
+          # `spring stop` will fail if Spring isn't present, but it's safe to continue so we force
+          # a success exit code.
+          syscall(["spring stop || true"])
           syscall(%w(rails generate shopify_app))
         end
 

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -336,7 +336,11 @@ module ShopifyCli
     #   stat = @ctx.system('ls', 'a_folder')
     #
     def system(*args, **kwargs)
-      CLI::Kit::System.system(*args, env: @env, **kwargs)
+      process_status = CLI::Kit::System.system(*args, env: @env, **kwargs)
+      unless process_status.success?
+        abort("System call failed: #{args.join(' ')}")
+      end
+      true
     end
 
     # Execute a command in the user's environment

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -329,7 +329,7 @@ module ShopifyCli
     # - `**kwargs`: additional keyword arguments to pass to Process.spawn
     #
     # #### Returns
-    # - `status`: boolean success status of the command execution
+    # - `status`: The `Process::Status` result of the command execution.
     #
     # #### Usage
     #
@@ -340,7 +340,7 @@ module ShopifyCli
       unless process_status.success?
         abort("System call failed: #{args.join(' ')}")
       end
-      true
+      process_status
     end
 
     # Execute a command in the user's environment

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -45,7 +45,7 @@ module Rails
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
                        chdir: File.join(@context.root, 'test-app'))
-        expect_command(%W(#{gem_path}/bin/spring stop),
+        expect_command(["spring stop || true"],
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
                        chdir: File.join(@context.root, 'test-app'))
@@ -99,7 +99,7 @@ module Rails
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=postgresql test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
                        chdir: File.join(@context.root, 'test-app'))
-        expect_command(%W(#{gem_path}/bin/spring stop),
+        expect_command(["spring stop || true"],
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
                        chdir: File.join(@context.root, 'test-app'))
@@ -149,7 +149,7 @@ module Rails
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 --edge -J test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
                        chdir: File.join(@context.root, 'test-app'))
-        expect_command(%W(#{gem_path}/bin/spring stop),
+        expect_command(["spring stop || true"],
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
                        chdir: File.join(@context.root, 'test-app'))
@@ -214,7 +214,8 @@ module Rails
       private
 
       def expect_command(command, chdir: @context.root)
-        @context.expects(:system).with(*command, chdir: chdir)
+        process_status = stub('process_status', success?: true)
+        @context.expects(:system).with(*command, chdir: chdir).returns(process_status)
       end
 
       def perform_command(add_cmd = nil)


### PR DESCRIPTION
### WHY are these changes introduced?

As seen in #1026, if running a Rails generator command fails, an error is outputted but the script still continues. This can lead to the command appearing to succeed even though a broken/incomplete app was generated.

I've also opened https://github.com/Shopify/cli-kit/pull/123 to fix some some incorrect documentation.

### WHAT is this pull request doing?

Check the process status of system calls and abort if it fails.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
