### PR TITLE
Propagate script schema version to script-service

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -42,6 +42,7 @@ module Script
     module Domain
       autoload :Errors, Project.project_filepath('layers/domain/errors')
       autoload :PushPackage, Project.project_filepath('layers/domain/push_package')
+      autoload :Metadata, Project.project_filepath('layers/domain/metadata')
       autoload :ExtensionPoint, Project.project_filepath('layers/domain/extension_point')
       autoload :Script, Project.project_filepath('layers/domain/script')
     end

--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -3,7 +3,9 @@ mutation AppScriptUpdateOrCreate(
   $title: String,
   $sourceCode: String,
   $language: String,
-  $force: Boolean
+  $force: Boolean,
+  $schemaMajorVersion: String,
+  $schemaMinorVersion: String
 ) {
   appScriptUpdateOrCreate(
     extensionPointName: $extensionPointName
@@ -11,6 +13,8 @@ mutation AppScriptUpdateOrCreate(
     sourceCode: $sourceCode
     language: $language
     force: $force
+    schemaMajorVersion: $schemaMajorVersion
+    schemaMinorVersion: $schemaMinorVersion
 ) {
     userErrors {
       field

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -11,7 +11,7 @@ module Script
                 UI::StrictSpinner.spin(ctx.message('script.application.building_script')) do |spinner|
                   Infrastructure::PushPackageRepository
                     .new(ctx: ctx)
-                    .create_push_package(script, task_runner.build, task_runner.compiled_type)
+                    .create_push_package(script, task_runner.build, task_runner.compiled_type, task_runner.metadata)
                   spinner.update_title(ctx.message('script.application.built'))
                 end
               rescue StandardError => e

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -22,7 +22,7 @@ module Script
           def push_script(ctx, task_runner, script, api_key, force)
             UI::PrintingSpinner.spin(ctx, ctx.message('script.application.pushing')) do |p_ctx, spinner|
               Infrastructure::PushPackageRepository.new(ctx: p_ctx)
-                .get_push_package(script, task_runner.compiled_type)
+                .get_push_package(script, task_runner.compiled_type, task_runner.metadata)
                 .push(Infrastructure::ScriptService.new(ctx: p_ctx), api_key, force)
               spinner.update_title(p_ctx.message('script.application.pushed'))
             end

--- a/lib/project_types/script/layers/domain/errors.rb
+++ b/lib/project_types/script/layers/domain/errors.rb
@@ -24,6 +24,8 @@ module Script
         end
 
         class ServiceFailureError < ScriptProjectError; end
+
+        class MetadataNotFoundError < ScriptProjectError; end
       end
     end
   end

--- a/lib/project_types/script/layers/domain/metadata.rb
+++ b/lib/project_types/script/layers/domain/metadata.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Domain
+      class Metadata
+        attr_reader :schema_major_version, :schema_minor_version
+
+        def initialize(schema_major_version, schema_minor_version)
+          @schema_major_version = schema_major_version
+          @schema_minor_version = schema_minor_version
+        end
+
+        class << self
+          def create_from_json(metadata_json)
+            metadata_hash = JSON.load(metadata_json)
+            schema_versions = metadata_hash["schemaVersions"]
+            # FIXME use proper error types
+            raise "Metadata is missing schemaVersions" if schema_versions.nil?
+
+            # Scripts may be attached to more than one EP in the future but not right now
+            raise "Metadata schemaVersions should have one key" unless schema_versions.count == 1
+
+            _, version = schema_versions.first
+            schema_major_version = version["major"]
+            schema_minor_version = version["minor"]
+            raise "Metadata schema version is missing major key" if schema_major_version.nil?
+
+            is_prerelease = schema_major_version == "prerelease"
+            raise "Metadata schema version is missing minor key" if schema_minor_version.nil? && !is_prerelease
+
+            Metadata.new(schema_major_version, schema_minor_version)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -4,13 +4,15 @@ module Script
   module Layers
     module Domain
       class PushPackage
-        attr_reader :id, :script, :script_content, :compiled_type
+        attr_reader :id, :script, :script_content, :compiled_type, :schema_major_version, :schema_minor_version
 
-        def initialize(id, script, script_content, compiled_type)
+        def initialize(id, script, script_content, compiled_type, schema_major_version, schema_minor_version)
           @id = id
           @script = script
           @script_content = script_content
           @compiled_type = compiled_type
+          @schema_major_version = schema_major_version
+          @schema_minor_version = schema_minor_version
         end
 
         def push(script_service, api_key, force)
@@ -20,7 +22,9 @@ module Script
             script_content: @script_content,
             compiled_type: @compiled_type,
             api_key: api_key,
-            force: force
+            force: force,
+            schema_major_version: @schema_major_version,
+            schema_minor_version: @schema_minor_version,
           )
         end
       end

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -5,6 +5,7 @@ module Script
     module Infrastructure
       class AssemblyScriptTaskRunner
         BYTECODE_FILE = "build/%{name}.wasm"
+        METADATA_FILE = "build/metadata.json"
         SCRIPT_SDK_BUILD = "npm run build"
 
         attr_reader :ctx, :script_name, :script_source_file
@@ -36,6 +37,13 @@ module Script
           return false unless ctx.dir_exist?("node_modules")
           check_if_ep_dependencies_up_to_date!
           true
+        end
+
+        def metadata
+          raise Domain::Errors::MetadataNotFoundError unless @ctx.file_exist?(METADATA_FILE)
+
+          raw_contents = File.read(METADATA_FILE)
+          Domain::Metadata.create_from_json(raw_contents)
         end
 
         private

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -7,7 +7,7 @@ module Script
         include SmartProperties
         property! :ctx, accepts: ShopifyCli::Context
 
-        def create_push_package(script, script_content, compiled_type)
+        def create_push_package(script, script_content, compiled_type, metadata)
           build_file_path = file_path(script.name, compiled_type)
           write_to_path(build_file_path, script_content)
 
@@ -16,10 +16,12 @@ module Script
             script,
             script_content,
             compiled_type,
+            metadata.schema_major_version,
+            metadata.schema_minor_version,
           )
         end
 
-        def get_push_package(script, compiled_type)
+        def get_push_package(script, compiled_type, metadata)
           build_file_path = file_path(script.name, compiled_type)
 
           raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
@@ -31,6 +33,8 @@ module Script
             script,
             script_content,
             compiled_type,
+            metadata.schema_major_version,
+            metadata.schema_minor_version,
           )
         end
 

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -16,7 +16,9 @@ module Script
           script_content:,
           compiled_type:,
           api_key: nil,
-          force: false
+          force: false,
+          schema_major_version:,
+          schema_minor_version:
         )
           query_name = "app_script_update_or_create"
           variables = {
@@ -25,6 +27,8 @@ module Script
             sourceCode: Base64.encode64(script_content),
             language: compiled_type,
             force: force,
+            schemaMajorVersion: schema_major_version.to_s, # API expects string value
+            schemaMinorVersion: schema_minor_version.to_s, # API expects string value
           }
           resp_hash = script_service_request(query_name: query_name, api_key: api_key, variables: variables)
           user_errors = resp_hash["data"]["appScriptUpdateOrCreate"]["userErrors"]


### PR DESCRIPTION
Propagates the version of the extension point schema used by the script to script-service when pushing.

WIP

### WHY are these changes introduced?

Script-service needs to know what version of a schema is in use by a script to validate the version is valid and to correctly format payloads for the script.

### WHAT is this pull request doing?

This starts sending the schema version as a parameter to script-service. It also raises errors if the metadata file is missing or is invalid (though we can change to use a more tolerant approach should we choose to).

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
