### PR TITLE
Remove unnecessary call to `spring stop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ------
 
+* [#1041](https://github.com/Shopify/shopify-app-cli/pull/1041): Remove unnecessary shell call to `spring stop`. We already pass `--skip-spring` when creating the app so running `spring stop` would have no effect.
 * [#1034](https://github.com/Shopify/shopify-app-cli/pull/1034): Abort if a system call fails.
 
 Version 1.5.0

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -140,9 +140,6 @@ module Rails
         end
 
         CLI::UI::Frame.open(@ctx.message('rails.create.running_generator')) do
-          # `spring stop` will fail if Spring isn't present, but it's safe to continue so we force
-          # a success exit code.
-          syscall(["spring stop || true"])
           syscall(%w(rails generate shopify_app))
         end
 

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -45,8 +45,6 @@ module Rails
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
                        chdir: File.join(@context.root, 'test-app'))
-        expect_command(["spring stop || true"],
-                       chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails db:create),
@@ -99,8 +97,6 @@ module Rails
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=postgresql test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
                        chdir: File.join(@context.root, 'test-app'))
-        expect_command(["spring stop || true"],
-                       chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails db:create),
@@ -148,8 +144,6 @@ module Rails
         Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 --edge -J test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
-                       chdir: File.join(@context.root, 'test-app'))
-        expect_command(["spring stop || true"],
                        chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
                        chdir: File.join(@context.root, 'test-app'))
@@ -231,7 +225,7 @@ module Rails
       def create_gem_path_and_binaries
         FileUtils.mkdir_p('gem/path/bin')
         gem_path = File.expand_path('gem/path')
-        ['bundle', 'rails', 'spring'].each do |f|
+        ['bundle', 'rails'].each do |f|
           FileUtils.touch("#{gem_path}/bin/#{f}")
         end
         gem_path


### PR DESCRIPTION
When the app is generated we pass `--skip-spring` so there should be no
need to ever call `spring stop`.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
