### PR TITLE
Scripts schema version push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ------
 
+* [#1049](https://github.com/Shopify/shopify-app-cli/pull/1049): Add schema versioning support to the script project type
 * [#1046](https://github.com/Shopify/shopify-app-cli/pull/1046): Include a vendored copy of Webrick, as it's no longer included in Ruby 3.
 * [#1041](https://github.com/Shopify/shopify-app-cli/pull/1041): Remove unnecessary shell call to `spring stop`. We already pass `--skip-spring` when creating the app so running `spring stop` would have no effect.
 * [#1034](https://github.com/Shopify/shopify-app-cli/pull/1034): Abort if a system call fails.

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -42,6 +42,7 @@ module Script
     module Domain
       autoload :Errors, Project.project_filepath('layers/domain/errors')
       autoload :PushPackage, Project.project_filepath('layers/domain/push_package')
+      autoload :Metadata, Project.project_filepath('layers/domain/metadata')
       autoload :ExtensionPoint, Project.project_filepath('layers/domain/extension_point')
       autoload :Script, Project.project_filepath('layers/domain/script')
     end

--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -3,7 +3,9 @@ mutation AppScriptUpdateOrCreate(
   $title: String,
   $sourceCode: String,
   $language: String,
-  $force: Boolean
+  $force: Boolean,
+  $schemaMajorVersion: String,
+  $schemaMinorVersion: String
 ) {
   appScriptUpdateOrCreate(
     extensionPointName: $extensionPointName
@@ -11,6 +13,8 @@ mutation AppScriptUpdateOrCreate(
     sourceCode: $sourceCode
     language: $language
     force: $force
+    schemaMajorVersion: $schemaMajorVersion
+    schemaMinorVersion: $schemaMinorVersion
 ) {
     userErrors {
       field

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -11,7 +11,7 @@ module Script
                 UI::StrictSpinner.spin(ctx.message('script.application.building_script')) do |spinner|
                   Infrastructure::PushPackageRepository
                     .new(ctx: ctx)
-                    .create_push_package(script, task_runner.build, task_runner.compiled_type)
+                    .create_push_package(script, task_runner.build, task_runner.compiled_type, task_runner.metadata)
                   spinner.update_title(ctx.message('script.application.built'))
                 end
               rescue StandardError => e

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -22,7 +22,7 @@ module Script
           def push_script(ctx, task_runner, script, api_key, force)
             UI::PrintingSpinner.spin(ctx, ctx.message('script.application.pushing')) do |p_ctx, spinner|
               Infrastructure::PushPackageRepository.new(ctx: p_ctx)
-                .get_push_package(script, task_runner.compiled_type)
+                .get_push_package(script, task_runner.compiled_type, task_runner.metadata)
                 .push(Infrastructure::ScriptService.new(ctx: p_ctx), api_key, force)
               spinner.update_title(p_ctx.message('script.application.pushed'))
             end

--- a/lib/project_types/script/layers/domain/errors.rb
+++ b/lib/project_types/script/layers/domain/errors.rb
@@ -24,6 +24,10 @@ module Script
         end
 
         class ServiceFailureError < ScriptProjectError; end
+
+        class MetadataNotFoundError < ScriptProjectError; end
+
+        class MetadataValidationError < ScriptProjectError; end
       end
     end
   end

--- a/lib/project_types/script/layers/domain/metadata.rb
+++ b/lib/project_types/script/layers/domain/metadata.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Domain
+      class Metadata
+        attr_reader :schema_major_version, :schema_minor_version
+
+        def initialize(schema_major_version, schema_minor_version)
+          @schema_major_version = schema_major_version
+          @schema_minor_version = schema_minor_version
+        end
+
+        class << self
+          def create_from_json(ctx, metadata_json)
+            metadata_hash = JSON.parse(metadata_json)
+            schema_versions = metadata_hash["schemaVersions"]
+            if schema_versions.nil?
+              err_msg = "script.error.metadata_schema_versions_missing"
+              raise ::Script::Layers::Domain::Errors::MetadataValidationError, ctx.message(err_msg)
+            end
+            # Scripts may be attached to more than one EP in the future but not right now
+            unless schema_versions.count == 1
+              err_msg = "script.error.metadata_schema_versions_single_key"
+              raise ::Script::Layers::Domain::Errors::MetadataValidationError, ctx.message(err_msg)
+            end
+
+            _, version = schema_versions.first
+            schema_major_version = version["major"]
+            schema_minor_version = version["minor"]
+            if schema_major_version.nil?
+              err_msg = "script.error.metadata_schema_versions_missing_major"
+              raise ::Script::Layers::Domain::Errors::MetadataValidationError, ctx.message(err_msg)
+            end
+
+            if schema_minor_version.nil?
+              err_msg = "script.error.metadata_schema_versions_missing_minor"
+              raise ::Script::Layers::Domain::Errors::MetadataValidationError, ctx.message(err_msg)
+            end
+
+            Metadata.new(schema_major_version, schema_minor_version)
+          rescue ::Script::Layers::Domain::Errors::MetadataValidationError
+            raise
+          rescue
+            err_msg = "script.error.metadata_validation_cause"
+            raise ::Script::Layers::Domain::Errors::MetadataValidationError, ctx.message(err_msg)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -4,13 +4,14 @@ module Script
   module Layers
     module Domain
       class PushPackage
-        attr_reader :id, :script, :script_content, :compiled_type
+        attr_reader :id, :script, :script_content, :compiled_type, :metadata
 
-        def initialize(id, script, script_content, compiled_type)
+        def initialize(id, script, script_content, compiled_type, metadata)
           @id = id
           @script = script
           @script_content = script_content
           @compiled_type = compiled_type
+          @metadata = metadata
         end
 
         def push(script_service, api_key, force)
@@ -20,7 +21,9 @@ module Script
             script_content: @script_content,
             compiled_type: @compiled_type,
             api_key: api_key,
-            force: force
+            force: force,
+            schema_major_version: @metadata.schema_major_version,
+            schema_minor_version: @metadata.schema_minor_version,
           )
         end
       end

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -5,6 +5,7 @@ module Script
     module Infrastructure
       class AssemblyScriptTaskRunner
         BYTECODE_FILE = "build/%{name}.wasm"
+        METADATA_FILE = "build/metadata.json"
         SCRIPT_SDK_BUILD = "npm run build"
 
         attr_reader :ctx, :script_name, :script_source_file
@@ -36,6 +37,16 @@ module Script
           return false unless ctx.dir_exist?("node_modules")
           check_if_ep_dependencies_up_to_date!
           true
+        end
+
+        def metadata
+          unless @ctx.file_exist?(METADATA_FILE)
+            msg = @ctx.message('script.error.metadata_not_found_cause', METADATA_FILE)
+            raise Domain::Errors::MetadataNotFoundError, msg
+          end
+
+          raw_contents = File.read(METADATA_FILE)
+          Domain::Metadata.create_from_json(@ctx, raw_contents)
         end
 
         private

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -7,7 +7,7 @@ module Script
         include SmartProperties
         property! :ctx, accepts: ShopifyCli::Context
 
-        def create_push_package(script, script_content, compiled_type)
+        def create_push_package(script, script_content, compiled_type, metadata)
           build_file_path = file_path(script.name, compiled_type)
           write_to_path(build_file_path, script_content)
 
@@ -16,10 +16,11 @@ module Script
             script,
             script_content,
             compiled_type,
+            metadata,
           )
         end
 
-        def get_push_package(script, compiled_type)
+        def get_push_package(script, compiled_type, metadata)
           build_file_path = file_path(script.name, compiled_type)
 
           raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
@@ -31,6 +32,7 @@ module Script
             script,
             script_content,
             compiled_type,
+            metadata,
           )
         end
 

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -16,7 +16,9 @@ module Script
           script_content:,
           compiled_type:,
           api_key: nil,
-          force: false
+          force: false,
+          schema_major_version:,
+          schema_minor_version:
         )
           query_name = "app_script_update_or_create"
           variables = {
@@ -25,6 +27,8 @@ module Script
             sourceCode: Base64.encode64(script_content),
             language: compiled_type,
             force: force,
+            schemaMajorVersion: schema_major_version.to_s, # API expects string value
+            schemaMinorVersion: schema_minor_version.to_s, # API expects string value
           }
           resp_hash = script_service_request(query_name: query_name, api_key: api_key, variables: variables)
           user_errors = resp_hash["data"]["appScriptUpdateOrCreate"]["userErrors"]

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -50,6 +50,25 @@ module Script
 
           script_not_found_cause: "Couldn't find script %s for extension point %s",
 
+          service_failure_cause: "Internal service error.",
+          service_failure_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
+
+          metadata_validation_cause: "Invalid script extension metadata.",
+          metadata_validation_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
+
+          metadata_schema_versions_missing: "Invalid script metadata:" \
+                                            " 'schemaVersions' field is missing",
+          metadata_schema_versions_single_key: "Invalid script extension metadata:" \
+                                               " 'schemaVersions' can have only one extension point name.",
+          metadata_schema_versions_missing_major: "Invalid script extension metadata:" \
+                                                  " 'schemaVersions' is missing the 'major' field",
+          metadata_schema_versions_missing_minor: "Invalid script extension metadata:" \
+                                                  " 'schemaVersions' is missing the 'minor' field",
+
+          metadata_not_found_cause: "Script version file (%s) cannot be found.",
+          metadata_not_found_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date and " \
+                                     "'package.json' contains a 'scripts/build' entry with a " \
+                                     "'--metadata build/metadata.json' argument",
           app_not_installed_cause: "App not installed on store.",
 
           app_script_not_pushed_help: "Script isn't on the app. Run {{command:shopify push}}, and then try again.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -53,6 +53,9 @@ module Script
           service_failure_cause: "Internal service error.",
           service_failure_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
 
+          user_error_cause: "Invalid script extension metadata.",
+          user_error_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
+
           metadata_validation_cause: "Invalid script extension metadata.",
           metadata_validation_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
 

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -155,6 +155,11 @@ module Script
             cause_of_error: ShopifyCli::Context.message('script.error.script_repush_cause', e.api_key),
             help_suggestion: ShopifyCli::Context.message('script.error.script_repush_help'),
           }
+        when Layers::Infrastructure::Errors::ScriptServiceUserError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.user_error_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.user_error_help'),
+          }
         when Layers::Infrastructure::Errors::ShopAuthenticationError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.shop_auth_cause'),

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -102,6 +102,21 @@ module Script
               e.extension_point_type
             ),
           }
+        when Layers::Domain::Errors::ServiceFailureError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.service_failure_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.service_failure_help'),
+          }
+        when Layers::Domain::Errors::MetadataValidationError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.metadata_validation_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.metadata_validation_help'),
+          }
+        when Layers::Domain::Errors::MetadataNotFoundError
+          {
+            cause_of_error: ShopifyCli::Context.message('script.error.metadata_not_found_cause'),
+            help_suggestion: ShopifyCli::Context.message('script.error.metadata_not_found_help'),
+          }
         when Layers::Infrastructure::Errors::AppNotInstalledError
           {
             cause_of_error: ShopifyCli::Context.message('script.error.app_not_installed_cause'),

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -13,9 +13,10 @@ describe Script::Layers::Application::BuildScript do
     let(:op_failed_msg) { 'msg' }
     let(:content) { 'content' }
     let(:compiled_type) { 'wasm' }
+    let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0') }
     let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
     let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
-    let(:task_runner) { stub(compiled_type: compiled_type) }
+    let(:task_runner) { stub(compiled_type: compiled_type, metadata: metadata) }
     let(:script_repository) { Script::Layers::Infrastructure::FakeScriptRepository.new(ctx: @context) }
     let(:script) do
       Script::Layers::Infrastructure::FakeScriptRepository.new(ctx: @context).create_script(language, ep, script_name)
@@ -36,7 +37,7 @@ describe Script::Layers::Application::BuildScript do
         Script::Layers::Infrastructure::PushPackageRepository
           .any_instance
           .expects(:create_push_package)
-          .with(script, content, 'wasm')
+          .with(script, content, 'wasm', metadata)
         capture_io { subject }
       end
     end

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -13,6 +13,8 @@ describe Script::Layers::Application::PushScript do
   let(:api_key) { 'api_key' }
   let(:force) { true }
   let(:extension_point_type) { 'discount' }
+  let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0') }
+  let(:schema_minor_version) { '0' }
   let(:script_name) { 'name' }
   let(:source_file) { 'src/script.ts' }
   let(:project) do
@@ -21,7 +23,7 @@ describe Script::Layers::Application::PushScript do
   end
   let(:push_package_repository) { Script::Layers::Infrastructure::FakePushPackageRepository.new }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
-  let(:task_runner) { stub(compiled_type: 'wasm') }
+  let(:task_runner) { stub(compiled_type: 'wasm', metadata: metadata) }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
   let(:script_repository) { Script::Layers::Infrastructure::FakeScriptRepository.new(@context) }
   let(:script) { script_repository.create_script(language, ep, script_name) }
@@ -36,7 +38,7 @@ describe Script::Layers::Application::PushScript do
       .returns(task_runner)
     Script::ScriptProject.stubs(:current).returns(project)
     extension_point_repository.create_extension_point(extension_point_type)
-    push_package_repository.create_push_package(script, 'content', compiled_type)
+    push_package_repository.create_push_package(script, 'content', compiled_type, metadata)
   end
 
   describe '.call' do

--- a/test/project_types/script/layers/domain/domain_package_test.rb
+++ b/test/project_types/script/layers/domain/domain_package_test.rb
@@ -14,8 +14,15 @@ describe Script::Layers::Domain::PushPackage do
   let(:force) { false }
   let(:script_content) { "(module)" }
   let(:compiled_type) { "wasm" }
+  let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0') }
   let(:push_package) do
-    Script::Layers::Domain::PushPackage.new(id, script, script_content, compiled_type)
+    Script::Layers::Domain::PushPackage.new(
+      id,
+      script,
+      script_content,
+      compiled_type,
+      metadata,
+    )
   end
   let(:script_service) { Minitest::Mock.new }
   let(:id) { "push_package_id" }

--- a/test/project_types/script/layers/domain/metadata_test.rb
+++ b/test/project_types/script/layers/domain/metadata_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+describe Script::Layers::Domain::Metadata do
+  let(:schema_major_version) { "1" }
+  let(:schema_minor_version) { "0" }
+  let(:ctx) { ShopifyCli::Context.new }
+  let(:raw_json) do
+    JSON.dump(
+      {
+        schemaVersions: {
+          example: {
+            major: schema_major_version, minor: schema_minor_version
+          },
+        },
+      },
+    )
+  end
+
+  describe ".new" do
+    subject { Script::Layers::Domain::Metadata.new(schema_major_version, schema_minor_version) }
+
+    it "should construct new Metadata" do
+      assert_equal schema_major_version, subject.schema_major_version
+      assert_equal schema_minor_version, subject.schema_minor_version
+    end
+  end
+
+  describe ".create_from_json" do
+    describe "with valid json" do
+      subject { Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json) }
+
+      it "should construct new Metadata" do
+        assert_equal schema_major_version, subject.schema_major_version
+        assert_equal schema_minor_version, subject.schema_minor_version
+      end
+    end
+
+    describe "with missing schemaVersions" do
+      it "should raise an appropriate error" do
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
+          Script::Layers::Domain::Metadata.create_from_json(ctx, '{}')
+        end
+      end
+    end
+
+    describe "with multiple EPs" do
+      let(:raw_json_multiple_eps) do
+        JSON.dump(
+          {
+            schemaVersions: {
+              example1: {  major: schema_major_version, minor: schema_minor_version },
+              example2: {  major: schema_major_version, minor: schema_minor_version },
+            },
+          },
+        )
+      end
+
+      it "should raise an appropriate error" do
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
+          Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json_multiple_eps)
+        end
+      end
+    end
+
+    describe "with missing major version" do
+      let(:raw_json_no_major) do
+        JSON.dump(
+          {
+            schemaVersions: {
+              example: { minor: schema_minor_version },
+            },
+          },
+        )
+      end
+
+      it "should raise an appropriate error" do
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
+          Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json_no_major)
+        end
+      end
+    end
+
+    describe "with missing minor version" do
+      let(:raw_json_no_minor) do
+        JSON.dump(
+          {
+            schemaVersions: {
+              example: { major: schema_major_version },
+            },
+          },
+        )
+      end
+
+      it "should raise an appropriate error" do
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
+          Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json_no_minor)
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -216,6 +216,42 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
     end
   end
 
+  describe ".metadata" do
+    subject { as_task_runner.metadata }
+
+    describe "when metadata file is present and valid" do
+      let(:metadata_json) do
+        JSON.dump(
+          {
+            schemaVersions: {
+              example: { major: '1', minor: '0' },
+            },
+          },
+        )
+      end
+
+      it "should return a proper metadata object" do
+        File.expects(:read).with('build/metadata.json').once.returns(metadata_json)
+
+        ctx
+          .expects(:file_exist?)
+          .with('build/metadata.json')
+          .once
+          .returns(true)
+
+        assert subject
+      end
+    end
+
+    describe "when metadata file is missing" do
+      it "should raise an exception" do
+        assert_raises(Script::Layers::Domain::Errors::MetadataNotFoundError) do
+          subject
+        end
+      end
+    end
+  end
+
   private
 
   def stub_npm_outdated(output)

--- a/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
@@ -8,12 +8,18 @@ module Script
           @cache = {}
         end
 
-        def create_push_package(script, script_content, compiled_type)
+        def create_push_package(script, script_content, compiled_type, metadata)
           id = id(script.name, compiled_type)
-          @cache[id] = Domain::PushPackage.new(script.id, script, script_content, compiled_type)
+          @cache[id] = Domain::PushPackage.new(
+            script.id,
+            script,
+            script_content,
+            compiled_type,
+            metadata,
+          )
         end
 
-        def get_push_package(script, compiled_type)
+        def get_push_package(script, compiled_type, _)
           id = id(script.name, compiled_type)
           if @cache.key?(id)
             @cache[id]

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -9,6 +9,8 @@ describe Script::Layers::Infrastructure::ScriptService do
   let(:script_service) { Script::Layers::Infrastructure::ScriptService.new(ctx: ctx) }
   let(:api_key) { "fake_key" }
   let(:extension_point_type) { "DISCOUNT" }
+  let(:schema_major_version) { "1" }
+  let(:schema_minor_version) { "0" }
   let(:script_service_proxy) do
     <<~HERE
       query ProxyRequest($api_key: String, $shop_domain: String, $query: String!, $variables: String) {
@@ -34,12 +36,16 @@ describe Script::Layers::Infrastructure::ScriptService do
           $title: String,
           $sourceCode: String,
           $language: String,
+          $schemaMajorVersion: String,
+          $schemaMinorVersion: String
         ) {
           appScriptUpdateOrCreate(
             extensionPointName: $extensionPointName
             title: $title
             sourceCode: $sourceCode
             language: $language
+            schemaMajorVersion: $schemaMajorVersion
+            schemaMinorVersion: $schemaMinorVersion
         ) {
             userErrors {
               field
@@ -69,6 +75,8 @@ describe Script::Layers::Infrastructure::ScriptService do
             sourceCode: Base64.encode64(script_content),
             language: "ts",
             force: false,
+            schemaMajorVersion: schema_major_version,
+            schemaMinorVersion: schema_minor_version,
           }.to_json,
           query: app_script_update_or_create,
         },
@@ -79,6 +87,8 @@ describe Script::Layers::Infrastructure::ScriptService do
     subject do
       script_service.push(
         extension_point_type: extension_point_type,
+        schema_major_version: schema_major_version,
+        schema_minor_version: schema_minor_version,
         script_name: script_name,
         script_content: script_content,
         compiled_type: "ts",


### PR DESCRIPTION
Supersedes https://github.com/Shopify/shopify-app-cli/pull/1040

This PR propagates the version of the extension point schema used by the script to script-service when pushing.

### WHY are these changes introduced?

Script-service needs to know what version of a schema is in use by a script to validate the version is valid and to correctly format payloads for the script.

### WHAT is this pull request doing?

This starts sending the schema version as a parameter to script-service. It also raises errors if the metadata file is missing or is invalid (though we can change to use a more tolerant approach should we choose to).

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
