### PR TITLE
Add Result Monad

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,7 @@ namespace :rdoc do
     'lib/shopify-cli/partners_api.rb',
     'lib/shopify-cli/process_supervision.rb',
     'lib/shopify-cli/project.rb',
+    'lib/shopify-cli/result.rb',
     'lib/shopify-cli/tunnel.rb',
   ]
 

--- a/lib/shopify-cli/result.rb
+++ b/lib/shopify-cli/result.rb
@@ -1,0 +1,424 @@
+module ShopifyCli
+  ##
+  # This module defines two containers for wrapping the result of an action. One
+  # for signifying the successful execution of an action and one for signifying
+  # a failure. Both containers implement the same API, which has been designed
+  # to simplify transforming a result through a series of steps and centralize
+  # the error handling in one place. The implementation is heavily inspired by a
+  # concept known as result monads in other languages. Consider the following
+  # example that uses lambda expressions as stand-ins for more complex method
+  # objects:
+  #
+  #   require 'open-uri'
+  #   Todo = Struct.new(:title, :completed)
+  #
+  #   fetch_data = ->(url) { open(url) }
+  #   parse_data = ->(json) { JSON.parse(json) }
+  #   build_todo = ->(attrs) do
+  #     Todo.new(attrs.fetch(:title), attrs.fetch(:completed))
+  #   end
+  #
+  #   Result.wrap(&fetch_data)
+  #     .call("https://jsonplaceholder.typicode.com/todos/1")
+  #     .then(&parse_data)
+  #     .then(&build_todo)
+  #     .map(&:title)
+  #     .unwrap(nil) # => String | nil
+  #
+  # If everything goes well, this code returns the title of the to do that is
+  # being fetched from `https://jsonplaceholder.typicode.com/todos/1`. However,
+  # there are several possible failure scenarios:
+  #
+  # * fetching the data could fail due to a network error,
+  # * the data returned from the server might not be valid JSON, or
+  # * the data is valid but does not have the right shape.
+  #
+  # If any of these scenarios arises, all subsequent `then` and `map` blocks are
+  # skipped until the result is either unwrapped or we manually recover from the
+  # failure by specifying a `rescue` clause:
+  #
+  #   Result.wrap { raise "Boom!" }
+  #     .rescue { |e| e.message.upcase }
+  #     .unwrap(nil) # => "BOOM!"
+  #
+  # In the event of a failure that hasn't been rescued from,
+  # `unwrap` returns the fallback value specified by the caller:
+  #
+  #   Result.wrap { raise "Boom!" }.unwrap(nil) # => nil
+  #   Result.wrap { raise "Boom!" }.unwrap { |e| e.message } # => "Boom!"
+  #
+  module Result
+    class Error < RuntimeError; end
+    class UnexpectedSuccess < Error; end
+    class UnexpectedFailure < Error; end
+
+    ##
+    # Implements a container for wrapping a success value. The main purpose of
+    # the container is to support further transformations of the result and
+    # centralize error handling should any of the subsequent transformations
+    # fail:
+    #
+    #   result = Result
+    #     .new("{}")
+    #     .then { |json| JSON.parse(json) }
+    #     .tap do |result|
+    #       result.success? # => true
+    #       result.value # => {}
+    #     .then { |data| data.fetch(:firstname) }
+    #     .tap do |result|
+    #       result.failure? # => true
+    #       result.error # => KeyError
+    #     end
+    #
+    # `Success` implements two transformation functions: `then` and `map`. The
+    # former makes no assumption regarding the return value of the
+    # transformation. The latter on the other hand expects the transformation to
+    # be successful. If this assumption is violated, program execution is
+    # interrupted and an error is raised. As the purpose of result objects is to
+    # guard against exactly that. This is generally a flaw and requires the code
+    # to either be hardened or to substitute the call to `map` with a call to
+    # `then`. `map` should only be used for transformations that cannot fail and
+    # when the caller wants to state exactly that fact.
+    #
+    class Success
+      attr_reader :value
+
+      ##
+      # initializes a new `Success` from an arbitrary value.
+      def initialize(value)
+        @value = value
+      end
+
+      ##
+      # always returns true to indicate that this result represents a success.
+      #
+      def success?
+        true
+      end
+
+      ##
+      # always returns false to indicate that this result represents a success.
+      #
+      def failure?
+        false
+      end
+
+      ##
+      # raises an `UnexpectedSuccess` as a `Failure` does not carry an error
+      # value.
+      #
+      def error
+        raise UnexpectedSuccess
+      end
+
+      ##
+      # returns a new `Success` wrapping the result of the given block. The
+      # block is called with the current value. If the block raises an exception
+      # or returns a `Failure`, an exception is raised. `map` assumes any
+      # transformation to succeed. Transformations that are expected to fail under
+      # certain conditions should only be transformed using `then`:
+      #
+      #   Success
+      #     .new(nil)
+      #     .map { |n| n + 1 } # => raises NoMethodError
+      #
+      # Therefore, map should only be used here if the previous success value is
+      # guaranteed to be a number or if the block handles nil cases properly:
+      #
+      #   Success
+      #     .new(nil)
+      #     .map { |n| (n || 0) + 1 }
+      #     .value # => 1
+      #
+      def map(&block)
+        self.then(&block).tap do |result|
+          return result if result.success?
+
+          result.unwrap { |error| error }.tap do |error|
+            case error
+            when Exception
+              raise error
+            else
+              raise UnexpectedFailure, error
+            end
+          end
+        end
+      end
+
+      ##
+      # returns a new result by wrapping the return value of the block. The
+      # block is invoked with the current success value. The result can either
+      # be a `Success` or a `Failure`. The former is the default. The latter
+      # occurs when executing the block either
+      #
+      # - raised an exception,
+      # - returned an instance of a subclass of `Exception`, or
+      # - returned a `Failure`.
+      #
+      # The example below illustrates this behavior:
+      #
+      #   result = Success
+      #     .new(1)
+      #     .then { |n| n + 1 }
+      #     .tap do |result|
+      #       result.success? # => true
+      #       result.value # => 2
+      #     end
+      #
+      #   result.then { |n| n / 0 }.error # => ZeroDivisionError
+      #   result.then { RuntimeError.new }.error # => RuntimeError
+      #   result.then { Failure.new("Boom!") }.error # => "Boom!"
+      #
+      def then(&block)
+        Result.wrap(&block).call(@value)
+      end
+
+      ##
+      # is a no-op and simply returns itself. Only a `Failure` can be
+      # transformed using `rescue`.
+      #
+      def rescue
+        self
+      end
+
+      ##
+      # returns the success value and ignores the fallback value that was either
+      # provided as a method argument or by passing a block. However, the caller
+      # is still required to specify a fallback value to ensure that in the
+      # event of a `Failure` program execution can continue in a controlled
+      # manner:
+      #
+      #    Success.new(1).unwrap(0) => 1
+      #
+      def unwrap(*args, &block)
+        raise ArgumentError, "expected either a fallback value or a block" unless args.one? ^ block
+        @value
+      end
+    end
+
+    ##
+    # Implements a container for wrapping an error value. In many cases, the
+    # error value is going to be an exception but other values are fully
+    # supported:
+    #
+    #   Failure
+    #     .new(RuntimeError.new("Something went wrong"))
+    #     .error # => RuntimeError.new
+    #
+    #   Failure
+    #     .new("Something went wrong")
+    #     .error # => "Something went wrong"
+    #
+    # `Failure` does not support transformations with `then` and `map`. When any
+    # of these two methods is invoked on a `Failure`, the `Failure` itself is
+    # returned unless it is rescued from or unwrapped. This enables the caller to
+    # build optimistic transformation chains and defer error handling:
+    #
+    #   Failure
+    #     .new(nil)
+    #     .then { |json| JSON.parse(json) }                      # Ignored
+    #     .then(&:with_indifferent_access)                       # Ignored
+    #     .then { |data| data.values_at(:firstname, :lastname) } # Ignored
+    #     .unwrap(Person.new("John", "Doe"))                     # => Person
+    #
+    # Alternatively, we could resucue from the error and then proceed with the
+    # remanining transformations:
+    #
+    #   Person = Struct.new(:firstname, :lastname)
+    #   Failure
+    #     .new(nil)
+    #     .then { |json| JSON.parse(json) }                      # Ignored
+    #     .then(&:with_indifferent_access)                       # Ignored
+    #     .rescue { {firstname: "John", lastname: "Doe" }}
+    #     .then { |data| data.values_at(:firstname, :lastname) } # Executed
+    #     .then { |members| Person.new(*members) }               # Executed
+    #     .unwrap(nil)                                           # => Person
+    #
+    class Failure
+      attr_reader :error
+
+      ##
+      # initializes a new `Failure` from an arbitrary value. In many cases, this
+      # value is going to be an instance of a subclass of `Exception` but any
+      # type is supported.
+      #
+      def initialize(error)
+        @error = error
+      end
+
+      ##
+      # always returns `false` to indicate that this result represents a failure.
+      #
+      def success?
+        false
+      end
+
+      ##
+      # Always returns `true` to indicate that this result represents a failure.
+      #
+      def failure?
+        true
+      end
+
+      ##
+      # raises an `ShopifyCli::Result::UnexpectedError` as a
+      # `ShopifyCli::Result::Failure` does not carry a success value.
+      #
+      def value
+        raise UnexpectedFailure
+      end
+
+      ##
+      # is a no-op and simply returns itself. This is essential to skip
+      # transformation steps in a chain once an error has occurred.
+      #
+      def map
+        self
+      end
+
+      ##
+      # is a no-op and simply returns itself. This is essential to skip
+      # transformation steps in a chain once an error has occurred.
+      #
+      def then
+        self
+      end
+
+      ##
+      # can be used to recover from a failure or produce a new failure with a
+      # different error.
+      #
+      #   Failure
+      #     .new("Something went wrong")
+      #     .rescue { |msg| [msg, "but we fixed it!"].join(" "") }
+      #     .tap do |result|
+      #        result.success? # => true
+      #        result.value # => "Something went wrong but we fixed it!"
+      #     end
+      #
+      # `rescue` is opinionated when it comes to the return value of the block.
+      # If the return value is an `Exception` – either one that was raised or an
+      # instance of a subclass of `Exception` – a `Failure` is returned. Any
+      # other value results in a `Success` unless the value has been explicitly
+      # wrapped in a `Failure`:
+      #
+      #   Failure
+      #     .new(RuntimeError.new)
+      #     .resuce { "All good! "}
+      #     .success? # => true
+      #
+      #   Failure
+      #     .new(RuntimeError.new)
+      #     .resuce { Failure.new("Still broken!") }
+      #     .success? # => false
+      #
+      def rescue(&block)
+        Result.wrap(&block).call(@error)
+      end
+
+      ##
+      # returns the fallback value specified by the caller. The fallback value
+      # can be provided as a method argument or as a block. If a block is given,
+      # it receives the error as its first and only argument:
+      #
+      #   failure = Failure.new(RuntimeError.new("Something went wrong!"))
+      #
+      #   failure.unwrap(nil) # => nil
+      #   failure.unwrap { |e| e.message } # => "Something went wrong!"
+      #
+      # #### Parameters
+      #
+      # * `*args` should be an `Array` with zero or one element
+      # * `&block`  should be a Proc that takes zero or one argument
+      #
+      # #### Raises
+      #
+      # * `ArgumentError` if both a fallback argument and a block is provided
+      #
+      def unwrap(*args, &block)
+        raise ArgumentError, "expected either a fallback value or a block" unless args.one? ^ block
+        block ? block.call(@error) : args.pop
+      end
+    end
+
+    ##
+    # wraps the given value into a `ShopifyCli::Result::Success` container
+    #
+    # #### Parameters
+    #
+    # * `value` a value of arbitrary type
+    #
+    def self.success(value)
+      Result::Success.new(value)
+    end
+
+    ##
+    # wraps the given value into a `ShopifyCli::Result::Failure` container
+    #
+    # #### Parameters
+    #
+    # * `error` a value of arbitrary type
+    #
+    def self.failure(error)
+      Result::Failure.new(error)
+    end
+
+    ##
+    # takes either a value or a block and chooses the appropriate result
+    # container based on the type of the value or the type of the block's return
+    # value. If the type is an exception, it is wrapped in a
+    # `ShopifyCli::Result::Failure` and otherwise in a
+    # `ShopifyCli::Result::Success`. If a block was provided instead of value, a
+    # `Proc` is returned and the result wrapping doesn't occur until the block
+    # is invoked.
+    #
+    # #### Parameters
+    #
+    # * `*args` should be an `Array` with zero or one element
+    # * `&block` should be a `Proc` that takes zero or one argument
+    #
+    # #### Returns
+    #
+    # Returns either a `Result::Success`, `Result::Failure` or a `Proc` that
+    # produces one of the former when invoked.
+    #
+    # #### Examples
+    #
+    #   Result.wrap(1) # => ShopifyCli::Result::Success
+    #   Result.wrap(RuntimeError.new) # => ShopifyCli::Result::Failure
+    #
+    #   Result.wrap { 1 } # => Proc
+    #   Result.wrap { 1 }.call # => ShopifyCli::Result::Success
+    #   Result.wrap { raise }.call # => ShopifyCli::Result::Failure
+    #
+    #   Result.wrap { |s| s.upcase }.call("hello").tap do |result|
+    #     result # => Result::Success
+    #     result.value # => "HELLO"
+    #   end
+    #
+    def self.wrap(*args, &block)
+      raise ArgumentError, "expected either a value or a block" unless args.one? ^ block
+
+      if args.one?
+        args.pop.yield_self do |value|
+          case value
+          when Result::Success, Result::Failure
+            value
+          when Exception
+            Result.failure(value)
+          else
+            Result.success(value)
+          end
+        end
+      else
+        ->(value = nil) do
+          begin
+            wrap(block.call(value))
+          rescue => error
+            wrap(error)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -116,6 +116,7 @@ module ShopifyCli
   autoload :Project, 'shopify-cli/project'
   autoload :ProjectType, 'shopify-cli/project_type'
   autoload :Resources, 'shopify-cli/resources'
+  autoload :Result, 'shopify-cli/result'
   autoload :Shopifolk, 'shopify-cli/shopifolk'
   autoload :SubCommand, 'shopify-cli/sub_command'
   autoload :Task, 'shopify-cli/task'

--- a/test/shopify-cli/result_test.rb
+++ b/test/shopify-cli/result_test.rb
@@ -1,0 +1,188 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Result
+    class ConvenienceConstructorTest < Minitest::Test
+      def test_success_constructor
+        assert_kind_of(Result::Success, Result.success(1))
+      end
+
+      def test_failure_constructor
+        assert_kind_of(Result::Failure, Result.failure(1))
+      end
+
+      def test_wrap_constructs_a_failure_result_when_given_an_exception
+        assert_kind_of(Result::Failure, Result.wrap(RuntimeError.new))
+      end
+
+      def test_wrap_constructs_a_success_result_by_default
+        assert_kind_of(Result::Success, Result.wrap("Success"))
+      end
+
+      def test_wrap_does_not_wrap_another_result
+        assert_equal "Success", Result.wrap(Result.wrap("Success")).value
+      end
+
+      def test_supports_deferring_result_construction
+        assert_kind_of(Result::Success, Result.wrap { "Success" }.call)
+      end
+
+      def test_forwards_caller_argument_when_deferring_result_construction
+        assert_equal "Success", Result.wrap { |value| value }.call("Success").value
+      end
+
+      def test_captures_exceptions_and_wraps_them_in_an_error_when_deferring_result_construction
+        assert_kind_of(Result::Failure, Result.wrap { raise "Failure" }.call)
+      end
+    end
+
+    class SuccessTest < Minitest::Test
+      def test_describes_its_state_correctly
+        assert Success.new(:value).success?
+        refute Success.new(:value).failure?
+      end
+
+      def test_value_retrieves_the_result_value
+        assert_equal :value, Success.new(:value).value
+      end
+
+      def test_error_raises_an_unexpected_success_exception
+        assert_raises Result::UnexpectedSuccess do
+          Success.new(:value).error
+        end
+      end
+
+      def test_unwrap_returns_the_value
+        assert_equal :value, Success.new(:value).unwrap {}
+      end
+
+      def test_additional_arguments_to_unwrap_are_ignored
+        assert_nothing_raised do
+          Success.new(:value).unwrap(:fallback_value)
+        end
+      end
+
+      def test_map_returns_a_success_result
+        Success.new(1).map { |n| n + 1 }.tap do |result|
+          assert result.success?
+          assert_equal 2, result.value
+        end
+      end
+
+      def test_map_does_not_capture_exceptions
+        assert_raises RuntimeError do
+          Success.new(1).map { raise }
+        end
+      end
+
+      def test_map_raises_if_the_block_returns_an_error
+        assert_raises RuntimeError do
+          Success.new(1).map { RuntimeError.new }
+        end
+      end
+
+      def test_map_raises_an_unexpected_failure_when_encountering_a_failure
+        assert_raises UnexpectedFailure do |error|
+          Success.new("Message").map { |message| Result.failure(message) }
+          assert_equal "Message", error.message
+        end
+      end
+
+      def test_then_returns_the_return_value_of_the_block_unchanged_if_it_is_a_result
+        assert Success.new("Success").then { Failure.new("Failure") }.failure?
+
+        Success.new(1).then { |n| Success.new(n + 1) }.tap do |result|
+          assert result.success?
+          assert_equal 2, result.value
+        end
+      end
+
+      def test_then_automatically_wraps_the_result_of_the_block
+        assert_equal 2, Success.new(1).then { |n| n + 1 }.value
+      end
+
+      def test_then_captures_exceptions_and_wraps_them_in_an_error
+        assert Success.new(1).then { raise "Failure" }.failure?
+      end
+
+      def test_rescue_simply_returns_itself
+        success = Success.new(:success)
+        called = false
+        assert_same(success, success.rescue { called = true })
+        refute called
+      end
+    end
+
+    class FailureTest < Minitest::Test
+      def test_describes_its_state_correctly
+        refute Failure.new(:value).success?
+        assert Failure.new(:value).failure?
+      end
+
+      def test_error
+        assert_equal :error, Failure.new(:error).error
+      end
+
+      def test_value_raises_an_unexpected_failure_exception
+        assert_raises Result::UnexpectedFailure do
+          Failure.new(:error).value
+        end
+      end
+
+      def test_unwrap_raises_an_error_if_no_fallback_has_been_provided
+        assert_raises ArgumentError do
+          Failure.new(:value).unwrap
+        end
+      end
+
+      def test_unwrap_returns_the_fallback_value
+        assert_equal :fallback, Failure.new(:error).unwrap(:fallback)
+      end
+
+      def test_unwrap_returns_the_return_value_of_the_block
+        error = RuntimeError.new
+        assert_equal error, Failure.new(error).unwrap { |err| err }
+      end
+
+      def test_unrwap_raises_an_argument_error_when_both_a_fallback_value_and_a_block_are_given
+        assert_raises ArgumentError do
+          Failure.new(:error).unwrap(:fallback) {}
+        end
+      end
+
+      def test_map_returns_itself
+        error = Failure.new(:error)
+        called = false
+        assert_same(error, error.map { called = true })
+        refute called
+      end
+
+      def test_then_simply_returns_itself
+        error = Failure.new(:error)
+        called = false
+        assert_same(error, error.then { called = true })
+        refute called
+      end
+
+      def test_rescue_returns_the_return_value_of_the_block_unchanged_if_it_is_a_result
+        assert Failure.new("Failure").rescue { Success.new("Success") }.success?
+
+        Failure.new(1).rescue { |n| Failure.new(n + 1) }.tap do |result|
+          assert result.failure?
+          assert_equal 2, result.error
+        end
+      end
+
+      def test_rescue_automatically_wraps_the_result_of_the_block
+        Failure.new(1).rescue { |n| n + 1 }.tap do |result|
+          assert result.success?
+          assert 2, result.value
+        end
+      end
+
+      def test_rescue_captures_exceptions_and_wraps_them_in_an_error
+        assert Failure.new(1).then { raise "Failure" }.failure?
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

This PR introduces a result monad to simplify working with method objects. Method objects while not yet formalized are in quite a few places in the Shopify CLI. Introducing a result monad will allows us to standardize return values of these objects and furthermore simplify chaining multiple method objects in a pipeline.

### WHAT is this pull request doing?

It introduces two containers for wrapping the result of an action. One for signifying the successful execution of an action and one for signifying a failure. Both containers implement the same API, which has been designed to simplify transforming a result through a series of steps and centralize the error handling in one place. The implementation is heavily inspired by a concept known as result monads in other languages. Consider the following example that uses lambda expressions as stand-ins for more complex method objects:

  ```ruby
  require 'open-uri'
  Todo = Struct.new(:title, :completed)

  fetch_data = ->(url) { open(url) }
  parse_data = ->(json) { JSON.parse(json) }
  build_todo = ->(attrs) do
    Todo.new(attrs.fetch(:title), attrs.fetch(:completed))
  end

  Result.wrap(&fetch_data)
    .call("https://jsonplaceholder.typicode.com/todos/1")
    .then(&parse_data)
    .then(&build_todo)
    .map(&:title)
    .unwrap(nil) # => String | nil
  ```

If everything goes well, this code returns the title of the to do that is being fetched from `https://jsonplaceholder.typicode.com/todos/1`. However, there are several possible failure scenarios:

* fetching the data could fail due to a network error,
* the data returned from the server might not be valid JSON, or
* the data is valid but does not have the right shape.

If any of these scenarios arises, all subsequent `then` and `map` blocks are skipped until the result is either unwrapped or we manually recover from the failure by specifying a `rescue` clause:

  ```ruby
  Result.wrap { raise "Boom!" }
    .rescue { |e| e.message.upcase }
    .unwrap(nil) # => "BOOM!"
  ```

In the event of a failure that hasn't been rescued from, `unwrap` returns the fallback value specified by the caller:

  ```ruby
  Result.wrap { raise "Boom!" }.unwrap(nil) # => nil
  Result.wrap { raise "Boom!" }.unwrap { |e| e.message } # => "Boom!"
  ```

### Further context

Please see [Branch exploration/extension-specifications](https://github.com/Shopify/shopify-app-cli/compare/exploration/extension-specifications) for more details on how we're planning to use `Result` in the `Extension` project context.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
