### PR TITLE
MethodObject

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ namespace :rdoc do
     'lib/shopify-cli/git.rb',
     'lib/shopify-cli/heroku.rb',
     'lib/shopify-cli/js_deps.rb',
+    'lib/shopify-cli/method_object.rb',
     'lib/shopify-cli/partners_api.rb',
     'lib/shopify-cli/process_supervision.rb',
     'lib/shopify-cli/project.rb',

--- a/lib/shopify-cli/method_object.rb
+++ b/lib/shopify-cli/method_object.rb
@@ -1,0 +1,104 @@
+module ShopifyCli
+  ##
+  # The `MethodObject` mixin can be included in any class that implements `call`
+  # to ensure that
+  #
+  # * `call` will always return a `ShopifyCli::Result` by prepending a module
+  #   that takes care of the result wrapping and
+  # * a `to_proc` method that allows instances of this class to be passed as a
+  #   block.
+  #
+  # For convenience, this mixin also adds the corresponding class methods:
+  # `call` and `to_proc`. Method and result objects pair nicely as they greatly
+  # simplify the creation of complex processing chains:
+  #
+  #   class Serialize
+  #     include MethodObject
+  #
+  #     def call(attrs)
+  #       attrs.to_json
+  #     end
+  #   end
+  #
+  #   class Deserialize
+  #     include MethodObject
+  #
+  #     def call(json)
+  #       JSON.parse(json)
+  #     end
+  #   end
+  #
+  #   Serialize
+  #     .call(firstname: "John", lastname: "Doe")
+  #     .then(&Deserialize)
+  #     .map { |attrs| OpenStruct.new(attrs) }
+  #     .unwrap(nil)
+  #
+  # While this example is contrived, it still illustrates some key advantages of
+  # this programming paradigm:
+  #
+  # * chaining operations is as simple as repeatedly calling `then` or `map`,
+  # * method objects don't have to be manually instantiated but can be
+  #   constructed using the `&` operator,
+  # * error handling is deferred until the result is unwrapped.
+  #
+  # Please see the section for `ShopifyCli::Result`,
+  # `ShopifyCli::Result::Success`, and `ShopifyCli::Result::Failure` for more
+  # information on the API of result objects.
+  #
+  module MethodObject
+    module AutoCreateResultObject
+      ##
+      # invokes the original `call` implementation and wraps its return value
+      # into a result object.
+      #
+      def call(*args, **kwargs)
+        Result.wrap { super(*args, **kwargs) }.call
+      end
+    end
+
+    module ClassMethods
+      ##
+      # creates a new instance and invokes `call`. Any positional argument
+      # is forward to `call`. Keyword arguments are either forwarded to the
+      # inializer or to `call`. If the keyword argument matches the name of
+      # property, it is forwarded to the initializer, otherwise to call.
+      #
+      def call(*args, **kwargs)
+        properties.keys.yield_self do |properties|
+          new(**kwargs.slice(*properties))
+            .call(*args, **kwargs.slice(*(kwargs.keys - properties)))
+        end
+      end
+
+      ##
+      # returns a proc that invokes `call` with all arguments it receives when
+      # called itself.
+      #
+      def to_proc
+        method(:call).to_proc
+      end
+    end
+
+    ##
+    # is invoked when this mixin is included into a class. This results in
+    #
+    # * including `SmartProperties`,
+    # * prepending the result wrapping mechanism, and
+    # * adding the class methods `.call` and `.to_proc`.
+    #
+    def self.included(method_object_implementation)
+      method_object_implementation.prepend(AutoCreateResultObject)
+      method_object_implementation.include(SmartProperties)
+      method_object_implementation.extend(ClassMethods)
+    end
+
+    ##
+    # returns a proc that invokes `call` with all arguments it receives when
+    # called itself.
+    #
+    def to_proc
+      method(:call).to_proc
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -108,6 +108,7 @@ module ShopifyCli
   autoload :Heroku, 'shopify-cli/heroku'
   autoload :JsDeps, 'shopify-cli/js_deps'
   autoload :JsSystem, 'shopify-cli/js_system'
+  autoload :MethodObject, 'shopify-cli/method_object'
   autoload :Log, 'shopify-cli/log'
   autoload :OAuth, 'shopify-cli/oauth'
   autoload :Options, 'shopify-cli/options'

--- a/test/shopify-cli/method_object_test.rb
+++ b/test/shopify-cli/method_object_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+module ShopifyCli
+  class MethodObjectTest < Minitest::Test
+    class GenerateHelloWorld
+      include ShopifyCli::MethodObject
+
+      def call(*)
+        "Hello World"
+      end
+    end
+
+    class GenerateNumber
+      include ShopifyCli::MethodObject
+
+      property :range, accepts: Range
+
+      def call(*)
+        rand(range)
+      end
+    end
+
+    class Upcase
+      include ShopifyCli::MethodObject
+
+      def call(string)
+        string.upcase
+      end
+    end
+
+    class ToJson
+      include ShopifyCli::MethodObject
+
+      def call(**data)
+        data.to_json
+      end
+    end
+
+    def test_returns_a_result
+      GenerateHelloWorld.new.call.tap do |result|
+        assert_kind_of(ShopifyCli::Result::Success, result)
+        assert_equal "Hello World", result.value
+      end
+    end
+
+    def test_chain_of_method_object
+      GenerateHelloWorld
+        .call
+        .then(&Upcase)
+        .tap do |result|
+          assert result.success?
+          assert_equal "HELLO WORLD", result.value
+        end
+    end
+
+    def test_handles_errors_gracefully
+      GenerateNumber
+        .call
+        .then(&Upcase)
+        .tap do |result|
+          assert result.failure?
+          assert_kind_of(NoMethodError, result.unwrap { |err| err })
+        end
+    end
+
+    def test_support_configuration_options
+      assert_includes 1..10, GenerateNumber.call(range: 1..10).value
+    end
+
+    def test_forwards_all_keyword_arguments_that_are_not_configuration_options_to_call
+      ToJson
+        .call(firstname: "John", lastname: "Doe")
+        .map { |json| JSON.parse(json) }
+        .map { |hash| OpenStruct.new(hash) }
+        .tap do |result|
+          assert result.success?
+
+          result.value.tap do |person|
+            assert_equal "John", person.firstname
+            assert_equal "Doe", person.lastname
+          end
+        end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Simplify the creation of method objects.

### WHAT is this pull request doing?

It introduces the `MethodObject` mixin that can be included in any class that implements `call` to ensure that

* `call` will always yield a `ShopifyCli::Result` by prepending a module that takes care of the result wrapping and
* a `to_proc` method that allows instances of this class to be passed as a block.

For convenience, this mixin also adds the corresponding class methods: `call` and `to_proc`. Method and result objects pair nicely as they greatly simplify the creation of complex processing chains:

```ruby
class Serialize
  include MethodObject

  def call(attrs)
    attrs.to_json
  end
end

class Deserialize
  include MethodObject

  def call(json)
    JSON.parse(json)
  end
end

Serialize
  .call(firstname: "John", lastname: "Doe")
  .then(&Deserialize)
  .map { |attrs| OpenStruct.new(attrs) }
  .unwrap(nil)
```

While this example is contrived, it still illustrates some key advantages of this programming paradigm:

* chaining operations is as simple as repeatedly calling `then` or `map`,
* method objects don't have to be manually instantiated but can be constructed using the `&` operator,
* error handling is deferred until the result is unwrapped.

Please see the section for `ShopifyCli::Result`, `ShopifyCli::Result::Success`, and `ShopifyCli::Result::Failure` for more information on the API of result objects.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
