### PR TITLE
Add version constraints to 'create rails'

### DIFF
--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -29,7 +29,7 @@ module Rails
 
         ruby_version = Ruby.version(@ctx)
         @ctx.abort(@ctx.message('rails.create.error.invalid_ruby_version')) unless
-          ruby_version.satisfies?('~>2.5') || ruby_version.satisfies?('<3.1')
+          ruby_version.satisfies?('~>2.5') || ruby_version.satisfies?('~>3.0.0')
 
         check_node
         check_yarn
@@ -113,7 +113,7 @@ module Rails
       end
 
       def build(name, db)
-        @ctx.abort(@ctx.message('rails.create.error.install_failure', 'rails')) unless install_gem('rails')
+        @ctx.abort(@ctx.message('rails.create.error.install_failure', 'rails')) unless install_gem('rails', '<6.1')
         @ctx.abort(@ctx.message('rails.create.error.install_failure', 'bundler ~>2.0')) unless
           install_gem('bundler', '~>2.0')
 
@@ -136,7 +136,7 @@ module Rails
 
         @ctx.puts(@ctx.message('rails.create.adding_shopify_gem'))
         File.open(File.join(@ctx.root, 'Gemfile'), 'a') do |f|
-          f.puts "\ngem 'shopify_app', '>=11.3.0'"
+          f.puts "\ngem 'shopify_app', '>=17.0.3'"
         end
         CLI::UI::Frame.open(@ctx.message('rails.create.running_bundle_install')) do
           syscall(%w(bundle install))

--- a/lib/project_types/rails/gem.rb
+++ b/lib/project_types/rails/gem.rb
@@ -99,7 +99,7 @@ module Rails
         # there was a specific version given during new(), so
         # check version of gem found to determine match
         require 'semantic/semantic'
-        found_version, _ = path.match(%r{/#{Regexp.quote(name)}-([\d\.]+)})&.captures
+        found_version, _ = path.match(%r{/#{Regexp.quote(name)}-(\d\.\d\.\d)})&.captures
         found_version.nil? ? false : Semantic::Version.new(found_version).satisfies?(version)
       else
         # otherwise ignore the actual version number,

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -31,6 +31,11 @@ module Rails
         assert_raises ShopifyCli::Abort do
           perform_command
         end
+
+        Ruby.expects(:version).returns(Semantic::Version.new('3.1.0'))
+        assert_raises ShopifyCli::Abort do
+          perform_command
+        end
       end
 
       def test_can_create_new_app
@@ -40,7 +45,7 @@ module Rails
         Gem.stubs(:gem_home).returns(gem_path)
 
         Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
-        Gem.expects(:install).with(@context, 'rails', nil).returns(true)
+        Gem.expects(:install).with(@context, 'rails', '<6.1').returns(true)
         Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
@@ -92,7 +97,7 @@ module Rails
         Gem.stubs(:gem_home).returns(gem_path)
 
         Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
-        Gem.expects(:install).with(@context, 'rails', nil).returns(true)
+        Gem.expects(:install).with(@context, 'rails', '<6.1').returns(true)
         Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=postgresql test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
@@ -140,7 +145,7 @@ module Rails
         Gem.stubs(:gem_home).returns(gem_path)
 
         Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
-        Gem.expects(:install).with(@context, 'rails', nil).returns(true)
+        Gem.expects(:install).with(@context, 'rails', '<6.1').returns(true)
         Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 --edge -J test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
@@ -189,7 +194,7 @@ module Rails
         Gem.stubs(:gem_home).returns(gem_path)
 
         Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
-        Gem.expects(:install).with(@context, 'rails', nil).returns(true)
+        Gem.expects(:install).with(@context, 'rails', '<6.1').returns(true)
         Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
         Dir.stubs(:exist?).returns(true)
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #1057 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Limits `rails` installation to `<6.1` (due to https://github.com/Shopify/shopify_app/pull/1134)
Limits `shopify_app` installation to `>=17.0.3` (due to https://github.com/Shopify/shopify_app/pull/1097)
Correction to version checking as `rails` doesn't follow Semantic Versioning format.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).