### PR TITLE
[Scripts] Add 'use_msgpack' field to the script push operation

### DIFF
--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -5,7 +5,8 @@ mutation AppScriptUpdateOrCreate(
   $language: String,
   $force: Boolean,
   $schemaMajorVersion: String,
-  $schemaMinorVersion: String
+  $schemaMinorVersion: String,
+  $useMsgpack: Boolean
 ) {
   appScriptUpdateOrCreate(
     extensionPointName: $extensionPointName
@@ -15,6 +16,7 @@ mutation AppScriptUpdateOrCreate(
     force: $force
     schemaMajorVersion: $schemaMajorVersion
     schemaMinorVersion: $schemaMinorVersion
+    useMsgpack: $useMsgpack
 ) {
     userErrors {
       field

--- a/lib/project_types/script/layers/domain/metadata.rb
+++ b/lib/project_types/script/layers/domain/metadata.rb
@@ -4,11 +4,12 @@ module Script
   module Layers
     module Domain
       class Metadata
-        attr_reader :schema_major_version, :schema_minor_version
+        attr_reader :schema_major_version, :schema_minor_version, :use_msgpack
 
-        def initialize(schema_major_version, schema_minor_version)
+        def initialize(schema_major_version, schema_minor_version, use_msgpack)
           @schema_major_version = schema_major_version
           @schema_minor_version = schema_minor_version
+          @use_msgpack = use_msgpack
         end
 
         class << self
@@ -38,7 +39,13 @@ module Script
               raise ::Script::Layers::Domain::Errors::MetadataValidationError, ctx.message(err_msg)
             end
 
-            Metadata.new(schema_major_version, schema_minor_version)
+            use_msgpack = if metadata_hash["flags"]
+              metadata_hash["flags"]["use_msgpack"]
+            else
+              false
+            end
+
+            Metadata.new(schema_major_version, schema_minor_version, use_msgpack)
           rescue ::Script::Layers::Domain::Errors::MetadataValidationError
             raise
           rescue

--- a/lib/project_types/script/layers/domain/metadata.rb
+++ b/lib/project_types/script/layers/domain/metadata.rb
@@ -39,11 +39,7 @@ module Script
               raise ::Script::Layers::Domain::Errors::MetadataValidationError, ctx.message(err_msg)
             end
 
-            use_msgpack = if metadata_hash["flags"]
-              metadata_hash["flags"]["use_msgpack"]
-            else
-              false
-            end
+            use_msgpack = !!metadata_hash.dig("flags", "use_msgpack")
 
             Metadata.new(schema_major_version, schema_minor_version, use_msgpack)
           rescue ::Script::Layers::Domain::Errors::MetadataValidationError

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -22,8 +22,7 @@ module Script
             compiled_type: @compiled_type,
             api_key: api_key,
             force: force,
-            schema_major_version: @metadata.schema_major_version,
-            schema_minor_version: @metadata.schema_minor_version,
+            metadata: @metadata,
           )
         end
       end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -17,8 +17,7 @@ module Script
           compiled_type:,
           api_key: nil,
           force: false,
-          schema_major_version:,
-          schema_minor_version:
+          metadata:
         )
           query_name = "app_script_update_or_create"
           variables = {
@@ -27,8 +26,9 @@ module Script
             sourceCode: Base64.encode64(script_content),
             language: compiled_type,
             force: force,
-            schemaMajorVersion: schema_major_version.to_s, # API expects string value
-            schemaMinorVersion: schema_minor_version.to_s, # API expects string value
+            schemaMajorVersion: metadata.schema_major_version.to_s, # API expects string value
+            schemaMinorVersion: metadata.schema_minor_version.to_s, # API expects string value
+            useMsgpack: metadata.use_msgpack,
           }
           resp_hash = script_service_request(query_name: query_name, api_key: api_key, variables: variables)
           user_errors = resp_hash["data"]["appScriptUpdateOrCreate"]["userErrors"]

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -13,7 +13,7 @@ describe Script::Layers::Application::BuildScript do
     let(:op_failed_msg) { 'msg' }
     let(:content) { 'content' }
     let(:compiled_type) { 'wasm' }
-    let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0') }
+    let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0', false) }
     let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
     let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
     let(:task_runner) { stub(compiled_type: compiled_type, metadata: metadata) }

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -12,8 +12,9 @@ describe Script::Layers::Application::PushScript do
   let(:language) { 'ts' }
   let(:api_key) { 'api_key' }
   let(:force) { true }
+  let(:use_msgpack) { true }
   let(:extension_point_type) { 'discount' }
-  let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0') }
+  let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0', use_msgpack) }
   let(:schema_minor_version) { '0' }
   let(:script_name) { 'name' }
   let(:source_file) { 'src/script.ts' }

--- a/test/project_types/script/layers/domain/domain_package_test.rb
+++ b/test/project_types/script/layers/domain/domain_package_test.rb
@@ -14,7 +14,7 @@ describe Script::Layers::Domain::PushPackage do
   let(:force) { false }
   let(:script_content) { "(module)" }
   let(:compiled_type) { "wasm" }
-  let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0') }
+  let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0', true) }
   let(:push_package) do
     Script::Layers::Domain::PushPackage.new(
       id,

--- a/test/project_types/script/layers/domain/metadata_test.rb
+++ b/test/project_types/script/layers/domain/metadata_test.rb
@@ -5,6 +5,7 @@ require "project_types/script/test_helper"
 describe Script::Layers::Domain::Metadata do
   let(:schema_major_version) { "1" }
   let(:schema_minor_version) { "0" }
+  let(:use_msgpack) { true }
   let(:ctx) { ShopifyCli::Context.new }
   let(:raw_json) do
     JSON.dump(
@@ -14,12 +15,15 @@ describe Script::Layers::Domain::Metadata do
             major: schema_major_version, minor: schema_minor_version
           },
         },
+        flags: {
+          use_msgpack: true
+        },
       },
     )
   end
 
   describe ".new" do
-    subject { Script::Layers::Domain::Metadata.new(schema_major_version, schema_minor_version) }
+    subject { Script::Layers::Domain::Metadata.new(schema_major_version, schema_minor_version, use_msgpack) }
 
     it "should construct new Metadata" do
       assert_equal schema_major_version, subject.schema_major_version

--- a/test/project_types/script/layers/domain/metadata_test.rb
+++ b/test/project_types/script/layers/domain/metadata_test.rb
@@ -16,7 +16,7 @@ describe Script::Layers::Domain::Metadata do
           },
         },
         flags: {
-          use_msgpack: true
+          use_msgpack: true,
         },
       },
     )

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -11,6 +11,7 @@ describe Script::Layers::Infrastructure::ScriptService do
   let(:extension_point_type) { "DISCOUNT" }
   let(:schema_major_version) { "1" }
   let(:schema_minor_version) { "0" }
+  let(:use_msgpack) { true }
   let(:script_service_proxy) do
     <<~HERE
       query ProxyRequest($api_key: String, $shop_domain: String, $query: String!, $variables: String) {
@@ -37,7 +38,8 @@ describe Script::Layers::Infrastructure::ScriptService do
           $sourceCode: String,
           $language: String,
           $schemaMajorVersion: String,
-          $schemaMinorVersion: String
+          $schemaMinorVersion: String,
+          $useMsgpack: Boolean
         ) {
           appScriptUpdateOrCreate(
             extensionPointName: $extensionPointName
@@ -46,6 +48,7 @@ describe Script::Layers::Infrastructure::ScriptService do
             language: $language
             schemaMajorVersion: $schemaMajorVersion
             schemaMinorVersion: $schemaMinorVersion
+            useMsgpack: $useMsgpack
         ) {
             userErrors {
               field
@@ -77,6 +80,7 @@ describe Script::Layers::Infrastructure::ScriptService do
             force: false,
             schemaMajorVersion: schema_major_version,
             schemaMinorVersion: schema_minor_version,
+            useMsgpack: use_msgpack,
           }.to_json,
           query: app_script_update_or_create,
         },
@@ -87,8 +91,11 @@ describe Script::Layers::Infrastructure::ScriptService do
     subject do
       script_service.push(
         extension_point_type: extension_point_type,
-        schema_major_version: schema_major_version,
-        schema_minor_version: schema_minor_version,
+        metadata: Script::Layers::Domain::Metadata.new(
+          schema_major_version,
+          schema_minor_version,
+          use_msgpack,
+        ),
         script_name: script_name,
         script_content: script_content,
         compiled_type: "ts",


### PR DESCRIPTION
This PR adds a `use_msgpack` boolean field to the `app_script_update_or_create` call. PRs to produce this field into `build/metadata.json` at script build time, and to consume this field on the backend are already open in their respective repositories.

_Note that this field is temporary, and will be removed once the msgpack migration completes._


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
