### PR TITLE
[scripts] Run npm install with legacy-peer-deps flag for AssemblyScript projects

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -27,7 +27,7 @@ module Script
         def install_dependencies
           check_node_version!
 
-          output, status = ctx.capture2e("npm", "install", "--no-audit", "--no-optional", "--loglevel error")
+          output, status = ctx.capture2e("npm install --no-audit --no-optional --legacy-peer-deps --loglevel error")
           raise Errors::DependencyInstallError, output unless status.success?
         end
 

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -186,7 +186,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
           .with("node", "--version")
           .returns(["v14.5.1", mock(success?: true)])
         ctx.expects(:capture2e)
-          .with("npm", "install", "--no-audit", "--no-optional", "--loglevel error")
+          .with("npm install --no-audit --no-optional --legacy-peer-deps --loglevel error")
           .returns([nil, mock(success?: true)])
         subject
       end


### PR DESCRIPTION
Closes https://github.com/Shopify/script-service/issues/2404

### WHY are these changes introduced?

Managing script projects does not currently work with the newer versions of npm/node because they now treat unsatisfied peer dependencies as errors instead of warnings.

Dependencies in the AS projects have a peer dependency on AS which is currently 0.X.Y versioned. This makes it tough to satisfy peer deps because 3p packages like as-pect specify their own peer dependency (currently `^0.12.0`) and shopify tooling has its own (`^0.16.1`). As-pect does not release a new version for each new version of AS so we can't just update that whenever we update our version of AS.

### WHAT is this pull request doing?

Adds the `--legacy-peer-deps` flag to the `npm install` call which will treat peer dependency errors as warnings like npm v<7. When we bump an AS/tooling/as-pect package version, we should be tophatting to catch any sort of error which means that we will know if there actually is a conflict between AssemblyScript versions or not.

### Screenshot
Installing dependencies will now work for the earliest version of node we support (14.5.0) and the newest version.

![image](https://user-images.githubusercontent.com/28009669/107089373-85295580-67cc-11eb-9755-2510065e95d0.png)
