### PR TITLE
[scripts] Support defining script description

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -5,6 +5,7 @@ module Script
     class Create < ShopifyCli::SubCommand
       options do |parser, flags|
         parser.on('--name=NAME') { |name| flags[:name] = name }
+        parser.on('--description=DESCRIPTION') { |description| flags[:description] = description }
         parser.on('--extension_point=EP_NAME') { |ep_name| flags[:extension_point] = ep_name }
         parser.on('--language=LANGUAGE') { |language| flags[:language] = language }
       end
@@ -23,7 +24,8 @@ module Script
           ctx: @ctx,
           language: form.language,
           script_name: form.name,
-          extension_point_type: form.extension_point
+          extension_point_type: form.extension_point,
+          description: form.description
         )
         @ctx.puts(@ctx.message('script.create.change_directory_notice', project.script_name))
       rescue Script::Errors::ScriptProjectAlreadyExistsError => e

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -3,10 +3,11 @@
 module Script
   module Forms
     class Create < ShopifyCli::Form
-      flag_arguments :extension_point, :name, :language
+      flag_arguments :extension_point, :name, :language, :description
 
       def ask
         self.name = valid_name
+        self.description ||= ask_description
         self.extension_point ||= ask_extension_point
         self.language = ask_language
       end
@@ -22,6 +23,10 @@ module Script
 
       def ask_name
         CLI::UI::Prompt.ask(@ctx.message('script.forms.create.script_name'))
+      end
+
+      def ask_description
+        CLI::UI::Prompt.ask(@ctx.message('script.forms.create.description'))
       end
 
       def valid_name

--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -1,6 +1,7 @@
 mutation AppScriptUpdateOrCreate(
   $extensionPointName: ExtensionPointName!,
   $title: String,
+  $description: String,
   $sourceCode: String,
   $language: String,
   $force: Boolean,
@@ -11,6 +12,7 @@ mutation AppScriptUpdateOrCreate(
   appScriptUpdateOrCreate(
     extensionPointName: $extensionPointName
     title: $title
+    description: $description
     sourceCode: $sourceCode
     language: $language
     force: $force
@@ -28,6 +30,7 @@ mutation AppScriptUpdateOrCreate(
       configSchema
       extensionPointName
       title
+      description
     }
   }
 }

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -5,16 +5,17 @@ module Script
     module Application
       class BuildScript
         class << self
-          def call(ctx:, task_runner:, script_name:, extension_point_type:)
+          def call(ctx:, task_runner:, script_name:, description:, extension_point_type:)
             CLI::UI::Frame.open(ctx.message('script.application.building')) do
               begin
                 UI::StrictSpinner.spin(ctx.message('script.application.building_script')) do |spinner|
                   Infrastructure::PushPackageRepository.new(ctx: ctx).create_push_package(
-                    extension_point_type,
-                    script_name,
-                    task_runner.build,
-                    task_runner.compiled_type,
-                    task_runner.metadata
+                    extension_point_type: extension_point_type,
+                    script_name: script_name,
+                    description: description,
+                    script_content: task_runner.build,
+                    compiled_type: task_runner.compiled_type,
+                    metadata: task_runner.metadata
                   )
                   spinner.update_title(ctx.message('script.application.built'))
                 end

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -7,9 +7,9 @@ module Script
     module Application
       class CreateScript
         class << self
-          def call(ctx:, language:, script_name:, extension_point_type:)
+          def call(ctx:, language:, script_name:, extension_point_type:, description:)
             extension_point = ExtensionPoints.get(type: extension_point_type)
-            project = setup_project(ctx, language, script_name, extension_point)
+            project = setup_project(ctx, language, script_name, extension_point, description)
             project_creator = Infrastructure::ProjectCreator
               .for(ctx, language, extension_point, script_name, project.directory)
             install_dependencies(ctx, language, script_name, project_creator)
@@ -19,7 +19,7 @@ module Script
 
           private
 
-          def setup_project(ctx, language, script_name, extension_point)
+          def setup_project(ctx, language, script_name, extension_point, description)
             ScriptProject.create(ctx, script_name)
             ScriptProject.write(
               ctx,
@@ -27,7 +27,8 @@ module Script
               organization_id: nil, # TODO: can you provide this at creation
               extension_point_type: extension_point.type,
               script_name: script_name,
-              language: language
+              language: language,
+              description: description
             )
             ScriptProject.current
           end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -13,15 +13,17 @@ module Script
               ctx: ctx,
               task_runner: task_runner,
               extension_point_type: script_project.extension_point_type,
-              script_name: script_project.script_name
+              script_name: script_project.script_name,
+              description: script_project.description
             )
 
             UI::PrintingSpinner.spin(ctx, ctx.message('script.application.pushing')) do |p_ctx, spinner|
               package = Infrastructure::PushPackageRepository.new(ctx: p_ctx).get_push_package(
-                script_project.extension_point_type,
-                script_project.script_name,
-                task_runner.compiled_type,
-                task_runner.metadata
+                extension_point_type: script_project.extension_point_type,
+                script_name: script_project.script_name,
+                description: script_project.description,
+                compiled_type: task_runner.compiled_type,
+                metadata: task_runner.metadata
               )
               package.push(Infrastructure::ScriptService.new(ctx: p_ctx), script_project.api_key, force)
               spinner.update_title(p_ctx.message('script.application.pushed'))

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -4,12 +4,27 @@ module Script
   module Layers
     module Domain
       class PushPackage
-        attr_reader :id, :extension_point_type, :script_project, :script_content, :compiled_type, :metadata
+        attr_reader :id,
+                    :extension_point_type,
+                    :script_name,
+                    :description,
+                    :script_content,
+                    :compiled_type,
+                    :metadata
 
-        def initialize(id:, extension_point_type:, script_name:, script_content:, compiled_type:, metadata:)
+        def initialize(
+          id:,
+          extension_point_type:,
+          script_name:,
+          description:,
+          script_content:,
+          compiled_type:,
+          metadata:
+        )
           @id = id
           @extension_point_type = extension_point_type
           @script_name = script_name
+          @description = description
           @script_content = script_content
           @compiled_type = compiled_type
           @metadata = metadata
@@ -19,6 +34,7 @@ module Script
           script_service.push(
             extension_point_type: @extension_point_type,
             script_name: @script_name,
+            description: @description,
             script_content: @script_content,
             compiled_type: @compiled_type,
             api_key: api_key,

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -7,7 +7,14 @@ module Script
         include SmartProperties
         property! :ctx, accepts: ShopifyCli::Context
 
-        def create_push_package(extension_point_type, script_name, script_content, compiled_type, metadata)
+        def create_push_package(
+          extension_point_type:,
+          script_name:,
+          description:,
+          script_content:,
+          compiled_type:,
+          metadata:
+        )
           build_file_path = file_path(script_name, compiled_type)
           write_to_path(build_file_path, script_content)
 
@@ -15,13 +22,14 @@ module Script
             id: build_file_path,
             extension_point_type: extension_point_type,
             script_name: script_name,
+            description: description,
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata,
           )
         end
 
-        def get_push_package(extension_point_type, script_name, compiled_type, metadata)
+        def get_push_package(extension_point_type:, script_name:, description:, compiled_type:, metadata:)
           build_file_path = file_path(script_name, compiled_type)
           raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
 
@@ -31,6 +39,7 @@ module Script
             id: build_file_path,
             extension_point_type: extension_point_type,
             script_name: script_name,
+            description: description,
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata,

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -15,6 +15,7 @@ module Script
           script_name:,
           script_content:,
           compiled_type:,
+          description: nil,
           api_key: nil,
           force: false,
           metadata:
@@ -23,6 +24,7 @@ module Script
           variables = {
             extensionPointName: extension_point_type.upcase,
             title: script_name,
+            description: description,
             sourceCode: Base64.encode64(script_content),
             language: compiled_type,
             force: force,

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -128,6 +128,7 @@ module Script
             Usage: {{command:%1$s create script}}
             Options:
               {{command:--name=NAME}} Script project name. Use any string.
+              {{command:--description=DESCRIPTION}} Description of the project. Use any string.
               {{command:--extension_point=TYPE}} Extension point name. Allowed values: %2$s.
           HELP
 
@@ -201,6 +202,7 @@ module Script
             select_extension_point: "Which extension point do you want to use?",
             select_language: "Which language do you want to use?",
             script_name: "Script Name",
+            description: "Description",
           },
         },
 

--- a/lib/project_types/script/script_project.rb
+++ b/lib/project_types/script/script_project.rb
@@ -2,13 +2,14 @@
 
 module Script
   class ScriptProject < ShopifyCli::Project
-    attr_reader :extension_point_type, :script_name, :language
+    attr_reader :extension_point_type, :script_name, :language, :description
 
     def initialize(*args)
       super
       @extension_point_type = lookup_config!('extension_point_type')
       raise Errors::DeprecatedEPError, @extension_point_type if deprecated?(@extension_point_type)
       @script_name = lookup_config!('script_name')
+      @description = lookup_config('description')
       @language = lookup_language
       ShopifyCli::Core::Monorail.metadata = {
         "script_name" => @script_name,

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -16,10 +16,12 @@ module Script
         @language = 'assemblyscript'
         @script_name = 'name'
         @ep_type = 'discount'
+        @description = 'description'
         @script_project = TestHelpers::FakeScriptProject.new(
           language: @language,
           extension_point_type: @ep_type,
-          script_name: @script_name
+          script_name: @script_name,
+          description: @description
         )
         Layers::Application::ExtensionPoints.stubs(:languages).returns(%w(assemblyscript))
       end
@@ -33,10 +35,13 @@ module Script
       end
 
       def test_can_create_new_script
-        Script::Layers::Application::CreateScript
-          .expects(:call)
-          .with(ctx: @context, language: @language, script_name: @script_name, extension_point_type: @ep_type)
-          .returns(@script_project)
+        Script::Layers::Application::CreateScript.expects(:call).with(
+          ctx: @context,
+          language: @language,
+          script_name: @script_name,
+          extension_point_type: @ep_type,
+          description: @description
+        ).returns(@script_project)
 
         @context
           .expects(:puts)
@@ -58,7 +63,8 @@ module Script
           ctx: @context,
           language: @language,
           script_name: @script_name,
-          extension_point_type: @ep_type
+          extension_point_type: @ep_type,
+          description: @description
         ).raises(StandardError)
 
         ScriptProject.expects(:cleanup).with(
@@ -83,7 +89,8 @@ module Script
           ctx: @context,
           language: @language,
           script_name: @script_name,
-          extension_point_type: @ep_type
+          extension_point_type: @ep_type,
+          description: @description
         ).raises(error)
 
         UI::ErrorHandler.expects(:pretty_print_and_raise).with(
@@ -101,7 +108,14 @@ module Script
       private
 
       def perform_command
-        run_cmd("create script --name=#{@script_name} --extension_point=#{@ep_type} --language=#{@language}")
+        args = {
+          name: @script_name,
+          description: @description,
+          extension_point: @ep_type,
+          language: @language,
+        }
+
+        run_cmd("create script #{args.map { |k, v| "--#{k}=#{v}" }.join(' ')}")
       end
     end
   end

--- a/test/project_types/script/forms/create_test.rb
+++ b/test/project_types/script/forms/create_test.rb
@@ -15,10 +15,12 @@ module Script
 
       def test_returns_all_defined_attributes_if_valid
         name = 'name'
+        description = 'my description'
         extension_point = 'discount'
-        form = ask(name: name, extension_point: extension_point, language: 'assemblyscript')
+        form = ask(name: name, description: description, extension_point: extension_point, language: 'assemblyscript')
         assert_equal(form.name, name)
         assert_equal(form.extension_point, extension_point)
+        assert_equal(form.description, description)
       end
 
       def test_asks_extension_point_if_no_flag
@@ -29,25 +31,37 @@ module Script
           @context.message('script.forms.create.select_extension_point'),
           options: eps
         )
-        ask(name: 'name', language: 'assemblyscript')
+        ask(name: 'name', description: 'my description', language: 'assemblyscript')
       end
 
       def test_asks_name_if_no_flag
         name = 'name'
         CLI::UI::Prompt.expects(:ask).with(@context.message('script.forms.create.script_name')).returns(name)
-        form = ask(extension_point: 'discount', language: 'assemblyscript')
+        form = ask(description: 'my description', extension_point: 'discount', language: 'assemblyscript')
         assert_equal name, form.name
+      end
+
+      def test_asks_description_if_no_flag
+        description = 'description'
+        CLI::UI::Prompt.expects(:ask).with(@context.message('script.forms.create.description')).returns(description)
+        form = ask(name: 'name', extension_point: 'discount', language: 'assemblyscript')
+        assert_equal description, form.description
       end
 
       def test_name_is_cleaned_after_prompt
         name = 'name with space'
         CLI::UI::Prompt.expects(:ask).with(@context.message('script.forms.create.script_name')).returns(name)
-        form = ask(extension_point: 'discount', language: 'assemblyscript')
+        form = ask(description: 'my description', extension_point: 'discount', language: 'assemblyscript')
         assert_equal 'name_with_space', form.name
       end
 
       def test_name_is_cleaned_when_using_flag
-        form = ask(name: 'name with space', extension_point: 'discount', language: 'assemblyscript')
+        form = ask(
+          name: 'name with space',
+          description: 'my description',
+          extension_point: 'discount',
+          language: 'assemblyscript'
+        )
         assert_equal 'name_with_space', form.name
       end
 
@@ -60,7 +74,7 @@ module Script
 
       def test_invalid_name_as_option
         assert_raises(Script::Errors::InvalidScriptNameError) do
-          ask(name: 'na/me', language: 'assemblyscript')
+          ask(name: 'na/me', description: 'my description', language: 'assemblyscript')
         end
       end
 
@@ -68,7 +82,7 @@ module Script
         language = 'assemblyscript'
         Layers::Application::ExtensionPoints.expects(:languages).returns(%w(assemblyscript))
         CLI::UI::Prompt.expects(:ask).never
-        form = ask(name: 'name', extension_point: 'discount')
+        form = ask(name: 'name', description: 'my description', extension_point: 'discount')
         assert_equal language, form.language
       end
 
@@ -80,7 +94,7 @@ module Script
           .expects(:ask)
           .with(@context.message('script.forms.create.select_language'), options: all_languages)
           .returns(language)
-        form = ask(name: 'name', extension_point: 'discount')
+        form = ask(name: 'name', description: 'my description', extension_point: 'discount')
         assert_equal language, form.language
       end
 
@@ -88,7 +102,7 @@ module Script
         language = 'AssemblyScript'
         all_languages = %w(assemblyscript rust)
         Layers::Application::ExtensionPoints.expects(:languages).returns(all_languages)
-        form = ask(name: 'name', extension_point: 'discount', language: language)
+        form = ask(name: 'name', description: 'my description', extension_point: 'discount', language: language)
         assert_equal language.downcase, form.language
       end
 
@@ -97,14 +111,21 @@ module Script
         all_languages = %w(assemblyscript rust)
         Layers::Application::ExtensionPoints.expects(:languages).returns(all_languages)
         assert_raises(Script::Errors::InvalidLanguageError) do
-          ask(name: 'name', extension_point: 'discount', language: language)
+          ask(name: 'name', description: 'my description', extension_point: 'discount', language: language)
         end
       end
 
       private
 
-      def ask(name: nil, extension_point: nil, language: nil)
-        Create.ask(@context, [], name: name, extension_point: extension_point, language: language)
+      def ask(name: nil, description: nil, extension_point: nil, language: nil)
+        Create.ask(
+          @context,
+          [],
+          name: name,
+          description: description,
+          extension_point: extension_point,
+          language: language
+        )
       end
     end
   end

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -8,6 +8,7 @@ describe Script::Layers::Application::BuildScript do
     let(:language) { 'assemblyscript' }
     let(:extension_point_type) { 'discount' }
     let(:script_name) { 'name' }
+    let(:description) { 'my description' }
     let(:op_failed_msg) { 'msg' }
     let(:content) { 'content' }
     let(:compiled_type) { 'wasm' }
@@ -19,7 +20,8 @@ describe Script::Layers::Application::BuildScript do
         ctx: @context,
         task_runner: task_runner,
         script_name: script_name,
-        extension_point_type: extension_point_type
+        extension_point_type: extension_point_type,
+        description: description
       )
     end
 
@@ -27,10 +29,14 @@ describe Script::Layers::Application::BuildScript do
       it 'should return normally' do
         CLI::UI::Frame.expects(:with_frame_color_override).never
         task_runner.expects(:build).returns(content)
-        Script::Layers::Infrastructure::PushPackageRepository
-          .any_instance
-          .expects(:create_push_package)
-          .with(extension_point_type, script_name, content, 'wasm', metadata)
+        Script::Layers::Infrastructure::PushPackageRepository.any_instance.expects(:create_push_package).with(
+          extension_point_type: extension_point_type,
+          script_name: script_name,
+          description: description,
+          script_content: content,
+          compiled_type: 'wasm',
+          metadata: metadata
+        )
         capture_io { subject }
       end
     end

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -10,6 +10,7 @@ describe Script::Layers::Application::CreateScript do
   let(:extension_point_type) { 'discount' }
   let(:script_name) { 'name' }
   let(:compiled_type) { 'wasm' }
+  let(:description) { 'description' }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
   let(:task_runner) { stub(compiled_type: compiled_type) }
@@ -35,8 +36,13 @@ describe Script::Layers::Application::CreateScript do
 
   describe '.call' do
     subject do
-      Script::Layers::Application::CreateScript
-        .call(ctx: @context, language: language, script_name: script_name, extension_point_type: extension_point_type)
+      Script::Layers::Application::CreateScript.call(
+        ctx: @context,
+        language: language,
+        script_name: script_name,
+        extension_point_type: extension_point_type,
+        description: description
+      )
     end
 
     it 'should create a new script' do
@@ -46,7 +52,7 @@ describe Script::Layers::Application::CreateScript do
         .returns(ep)
       Script::Layers::Application::CreateScript
         .expects(:setup_project)
-        .with(@context, language, script_name, ep)
+        .with(@context, language, script_name, ep, description)
         .returns(script_project)
       Script::Layers::Application::CreateScript
         .expects(:install_dependencies)
@@ -59,7 +65,8 @@ describe Script::Layers::Application::CreateScript do
 
     describe '.setup_project' do
       subject do
-        Script::Layers::Application::CreateScript.send(:setup_project, @context, language, script_name, ep)
+        Script::Layers::Application::CreateScript
+          .send(:setup_project, @context, language, script_name, ep, description)
       end
 
       it 'should succeed and update ctx root' do
@@ -72,7 +79,8 @@ describe Script::Layers::Application::CreateScript do
             organization_id: nil,
             extension_point_type: ep.type,
             script_name: script_name,
-            language: language
+            language: language,
+            description: description
           )
         capture_io do
           assert_equal script_project, subject

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -16,11 +16,13 @@ describe Script::Layers::Application::PushScript do
   let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0', use_msgpack) }
   let(:schema_minor_version) { '0' }
   let(:script_name) { 'name' }
+  let(:description) { 'my description' }
   let(:project) do
     TestHelpers::FakeScriptProject.new(
       language: language,
       extension_point_type: extension_point_type,
       script_name: script_name,
+      description: description,
       env: { api_key: api_key }
     )
   end
@@ -38,7 +40,14 @@ describe Script::Layers::Application::PushScript do
       .returns(task_runner)
     Script::ScriptProject.stubs(:current).returns(project)
     extension_point_repository.create_extension_point(extension_point_type)
-    push_package_repository.create_push_package(extension_point_type, script_name, 'content', compiled_type, metadata)
+    push_package_repository.create_push_package(
+      extension_point_type: extension_point_type,
+      script_name: script_name,
+      description: description,
+      script_content: 'content',
+      compiled_type: compiled_type,
+      metadata: metadata
+    )
   end
 
   describe '.call' do
@@ -52,7 +61,8 @@ describe Script::Layers::Application::PushScript do
         ctx: @context,
         task_runner: task_runner,
         extension_point_type: extension_point_type,
-        script_name: script_name
+        script_name: script_name,
+        description: description
       )
       Script::Layers::Infrastructure::ScriptService
         .expects(:new).returns(script_service_instance)

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -6,6 +6,7 @@ describe Script::Layers::Domain::PushPackage do
   let(:extension_point_type) { "discount" }
   let(:script_id) { 'id' }
   let(:script_name) { "foo_script" }
+  let(:description) { "my description" }
   let(:api_key) { "fake_key" }
   let(:force) { false }
   let(:script_content) { "(module)" }
@@ -16,6 +17,7 @@ describe Script::Layers::Domain::PushPackage do
       id: id,
       extension_point_type: extension_point_type,
       script_name: script_name,
+      description: description,
       script_content: script_content,
       compiled_type: compiled_type,
       metadata: metadata

--- a/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
@@ -8,19 +8,28 @@ module Script
           @cache = {}
         end
 
-        def create_push_package(extension_point_type, script_name, script_content, compiled_type, metadata)
+        def create_push_package(
+          extension_point_type:,
+          script_name:,
+          description:,
+          script_content:,
+          compiled_type:,
+          metadata:
+        )
           id = id(script_name, compiled_type)
           @cache[id] = Domain::PushPackage.new(
             id: id,
             extension_point_type: extension_point_type,
             script_name: script_name,
+            description: description,
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata
           )
         end
 
-        def get_push_package(_, script_name, compiled_type, _)
+        def get_push_package(extension_point_type:, script_name:, description:, compiled_type:, metadata:)
+          _ = extension_point_type, description, metadata
           id = id(script_name, compiled_type)
           if @cache.key?(id)
             @cache[id]

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -29,11 +29,13 @@ describe Script::Layers::Infrastructure::ScriptService do
     let(:script_name) { "foo_bar" }
     let(:script_content) { "(module)" }
     let(:api_key) { "fake_key" }
+    let(:description) { "my description" }
     let(:app_script_update_or_create) do
       <<~HERE
         mutation AppScriptUpdateOrCreate(
           $extensionPointName: ExtensionPointName!,
           $title: String,
+          $description: String,
           $sourceCode: String,
           $language: String,
           $schemaMajorVersion: String,
@@ -43,6 +45,7 @@ describe Script::Layers::Infrastructure::ScriptService do
           appScriptUpdateOrCreate(
             extensionPointName: $extensionPointName
             title: $title
+            description: $description
             sourceCode: $sourceCode
             language: $language
             schemaMajorVersion: $schemaMajorVersion
@@ -58,6 +61,7 @@ describe Script::Layers::Infrastructure::ScriptService do
               configSchema
               extensionPointName
               title
+              description
             }
           }
         }
@@ -74,6 +78,7 @@ describe Script::Layers::Infrastructure::ScriptService do
           variables: {
             extensionPointName: extension_point_type,
             title: script_name,
+            description: description,
             sourceCode: Base64.encode64(script_content),
             language: "AssemblyScript",
             force: false,
@@ -98,6 +103,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         script_name: script_name,
         script_content: script_content,
         compiled_type: "AssemblyScript",
+        description: description,
         api_key: api_key,
       )
     end

--- a/test/project_types/script/test_helpers/fake_script_project.rb
+++ b/test/project_types/script/test_helpers/fake_script_project.rb
@@ -3,6 +3,7 @@ module TestHelpers
     property :extension_point_type
     property :script_name
     property :language
+    property :description
     property :env
 
     def api_key


### PR DESCRIPTION

Fixes https://github.com/Shopify/script-service/issues/2487
Depends on https://github.com/Shopify/script-service/pull/2537

### WHY are these changes introduced?

We want a script developer to define a description of a script project.

### WHAT is this pull request doing?

This PR:
- Allows the user to specify a description during creation with `shopify create script --description=something` or through a prompt if no flag is passed
- Sends that description along with the PushPackage when creating or updating the app script

### Screenshot
![image](https://user-images.githubusercontent.com/28009669/107573525-a23e9980-6bbb-11eb-96dc-efa16b9a344e.png)

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
