### PR TITLE
Use bundle exec for dev

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -11,7 +11,7 @@ test:
   run: |
     if [ "$#" -eq 1 ] && [[ -f $1 ]];
     then
-      rake test TEST=$1
+      bundle exec rake test TEST=$1
     else
-      rake test $@
+      bundle exec rake test $@
     fi


### PR DESCRIPTION
To prevent failures such as:

```
/Users/andyw8/.gem/ruby/2.5.1/gems/bundler-1.17.3/lib/bundler/runtime.rb:319:in `check_for_activated_spec!': You have already activated rake 13.0.3, but your Gemfile requires rake 13.0.1. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ Not public-facing
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
