### PR TITLE
Add detailed message with context when command is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ------
 
+* [#1079](https://github.com/Shopify/shopify-app-cli/pull/1079): Add detailed message with context when command is not found
 * [#1049](https://github.com/Shopify/shopify-app-cli/pull/1049): Add schema versioning support to the script project type
 * [#1059](https://github.com/Shopify/shopify-app-cli/pull/1059): Remove the functionality of the `generate` command for node apps, since it will no longer be feasible with the new node library
 * [#1046](https://github.com/Shopify/shopify-app-cli/pull/1046): Include a vendored copy of Webrick, as it's no longer included in Ruby 3.
@@ -18,7 +19,7 @@ Version 1.4.1
 * [#917](https://github.com/Shopify/shopify-app-cli/pull/917): Ensure analytics for create action includes the same fields as other commands
 
 Version 1.4.0
-------
+-----
 * Updates to tests, dependencies and internal tooling
 * [#924](https://github.com/Shopify/shopify-app-cli/pull/924): Improve debugging messages on Partner API errors
 

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -13,6 +13,7 @@ module ShopifyCli
           },
         },
       },
+
       core: {
         connect: {
           help: <<~HELP,
@@ -379,6 +380,22 @@ module ShopifyCli
           MESSAGE
         },
       },
+
+      kit: {
+        resolver: {
+          any_possible_matches: "{{bold:Did you mean?}}",
+          command_not_found: "Command not found",
+          in_project: <<~INFO,
+              Project: {{green:%s}} (%s)
+              Run {{command:%s help}} to see available commands for %s projects.
+#{'              '}
+              INFO
+          not_in_project: "You aren't in a project folder. Run {{command:%s help}} to see available core commands.\n\n",
+          possible_matches: "{{command:%s %s}}",
+          tool_not_found: "{{command:%s %s}} was not found",
+        },
+      },
+
     }.freeze
   end
 end


### PR DESCRIPTION
**Paired with @carmelal**

### WHY are these changes introduced?
Fixes #585. The CLI should remind the user what context/project they're in (or if they're not in one) if they try to run a command that isn't found.

### WHAT is this pull request doing?
When a user tries to run a command that isn't found, the CLI reminds the user what context/project they're in, and suggests that they run `shopify help` to view available core commands. 

Messages moved from resolver.rb to messages.rb.

**Inside a project:**

![CLI reminder inside a project](https://user-images.githubusercontent.com/41079854/108267296-01ab2500-7139-11eb-9288-ae9a0741f719.jpg)

**Outside a project:**

![CLI reminder outside a project](https://user-images.githubusercontent.com/41079854/108267377-1ab3d600-7139-11eb-95e7-38e09e0c6df1.jpg)

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
