### PR TITLE
Fix rubocop violations

### DIFF
--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -5,12 +5,12 @@ module Script
     module Domain
       class PushPackage
         attr_reader :id,
-                    :extension_point_type,
-                    :script_name,
-                    :description,
-                    :script_content,
-                    :compiled_type,
-                    :metadata
+          :extension_point_type,
+          :script_name,
+          :description,
+          :script_content,
+          :compiled_type,
+          :metadata
 
         def initialize(
           id:,


### PR DESCRIPTION
### WHY are these changes introduced?

The build was passing in https://github.com/Shopify/shopify-app-cli/pull/1072 but there were some rubocop violations when I merged 🤷 

### WHAT is this pull request doing?

Fixes the rubocop violations. 

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
