### PR TITLE
Resolve windows navgiation error

### DIFF
--- a/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb
@@ -334,20 +334,13 @@ module CLI
         end
 
         def read_char
-          raw_tty! do
-            getc = $stdin.getc
-            getc ? getc.chr : :timeout
+          if $stdin.tty? && !ENV['TEST']
+            $stdin.getch # raw mode for tty
+          else
+            $stdin.getc
           end
         rescue IOError
           "\e"
-        end
-
-        def raw_tty!
-          if ENV['TEST'] || !$stdin.tty?
-            yield
-          else
-            $stdin.raw { yield }
-          end
         end
 
         def presented_options(recalculate: false)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves #1012,  resolves #971   <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Only works for Ruby 2.7 and up

Windows users would face a queued up "return" character when navigating after filtering options. @paulomarg and I found that instead of using $stdin.getc, $stdin.getch resolves this issue.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
