### PR TITLE
Add flag to force rails migration to add access scopes

### DIFF
--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -143,7 +143,7 @@ module Rails
         end
 
         CLI::UI::Frame.open(@ctx.message('rails.create.running_generator')) do
-          syscall(%w(rails generate shopify_app))
+          syscall(%w(rails generate shopify_app --new-shopify-cli-app))
         end
 
         CLI::UI::Frame.open(@ctx.message('rails.create.running_migrations')) do

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -45,7 +45,7 @@ module Rails
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
           chdir: File.join(@context.root, 'test-app'))
-        expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
+        expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),
           chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails db:create),
           chdir: File.join(@context.root, 'test-app'))
@@ -97,7 +97,7 @@ module Rails
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=postgresql test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
           chdir: File.join(@context.root, 'test-app'))
-        expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
+        expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),
           chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails db:create),
           chdir: File.join(@context.root, 'test-app'))
@@ -145,7 +145,7 @@ module Rails
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 --edge -J test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
           chdir: File.join(@context.root, 'test-app'))
-        expect_command(%W(#{gem_path}/bin/rails generate shopify_app),
+        expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),
           chdir: File.join(@context.root, 'test-app'))
         expect_command(%W(#{gem_path}/bin/rails db:create),
           chdir: File.join(@context.root, 'test-app'))


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify/shopify_app#1191 has changed the shopify_app gem to prompt the user before adding a potentially breaking migration. Since the CLI captures the output of the generate:shopify_app command, the prompt never shows up when creating a new rails project and appears to hang, even though it's just waiting for user input.

### WHAT is this pull request doing?

To allow the CLI to go around the prompt, a force_access_scopes_migration flag has been added to the generator to allow the app to be created without user input. We just need to start passing in this flag when creating new rails projects

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
