### PR TITLE
[scripts] Send configuration ui definition when pushing script

### DIFF
--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -16,7 +16,7 @@ module Script
         Layers::Application::PushScript.call(ctx: @ctx, force: options.flags.key?(:force))
         @ctx.puts(@ctx.message("script.push.script_pushed", api_key: api_key))
       rescue StandardError => e
-        msg = @ctx.message("script.push.error.operation_failed", api_key: ScriptProject.current.api_key)
+        msg = @ctx.message("script.push.error.operation_failed", api_key: ShopifyCli::Project.current.env.api_key)
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: msg)
       end
 

--- a/lib/project_types/script/errors.rb
+++ b/lib/project_types/script/errors.rb
@@ -4,6 +4,23 @@ module Script
   module Errors
     class InvalidContextError < ScriptProjectError; end
     class InvalidScriptNameError < ScriptProjectError; end
+
+    class InvalidConfigUiDefinitionError < ScriptProjectError
+      attr_reader :filename
+      def initialize(filename)
+        super()
+        @filename = filename
+      end
+    end
+
+    class MissingSpecifiedConfigUiDefinitionError < ScriptProjectError
+      attr_reader :filename
+      def initialize(filename)
+        super()
+        @filename = filename
+      end
+    end
+
     class NoExistingAppsError < ScriptProjectError; end
     class NoExistingOrganizationsError < ScriptProjectError; end
 

--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -2,7 +2,7 @@ mutation AppScriptUpdateOrCreate(
   $extensionPointName: ExtensionPointName!,
   $title: String,
   $description: String,
-  $configUiYaml: String,
+  $configUi: String,
   $sourceCode: String,
   $language: String,
   $force: Boolean,
@@ -14,7 +14,7 @@ mutation AppScriptUpdateOrCreate(
     extensionPointName: $extensionPointName
     title: $title
     description: $description
-    configUiYaml: $configUiYaml
+    configUi: $configUi
     sourceCode: $sourceCode
     language: $language
     force: $force

--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -2,6 +2,7 @@ mutation AppScriptUpdateOrCreate(
   $extensionPointName: ExtensionPointName!,
   $title: String,
   $description: String,
+  $configUiYaml: String,
   $sourceCode: String,
   $language: String,
   $force: Boolean,
@@ -13,6 +14,7 @@ mutation AppScriptUpdateOrCreate(
     extensionPointName: $extensionPointName
     title: $title
     description: $description
+    configUiYaml: $configUiYaml
     sourceCode: $sourceCode
     language: $language
     force: $force

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -5,17 +5,15 @@ module Script
     module Application
       class BuildScript
         class << self
-          def call(ctx:, task_runner:, script_name:, description:, extension_point_type:)
+          def call(ctx:, task_runner:, script_project:)
             CLI::UI::Frame.open(ctx.message("script.application.building")) do
               begin
                 UI::StrictSpinner.spin(ctx.message("script.application.building_script")) do |spinner|
                   Infrastructure::PushPackageRepository.new(ctx: ctx).create_push_package(
-                    extension_point_type: extension_point_type,
-                    script_name: script_name,
-                    description: description,
+                    script_project: script_project,
                     script_content: task_runner.build,
                     compiled_type: task_runner.compiled_type,
-                    metadata: task_runner.metadata
+                    metadata: task_runner.metadata,
                   )
                   spinner.update_title(ctx.message("script.application.built"))
                 end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -9,19 +9,11 @@ module Script
             script_project = ScriptProject.current
             task_runner = Infrastructure::TaskRunner.for(ctx, script_project.language, script_project.script_name)
             ProjectDependencies.install(ctx: ctx, task_runner: task_runner)
-            BuildScript.call(
-              ctx: ctx,
-              task_runner: task_runner,
-              extension_point_type: script_project.extension_point_type,
-              script_name: script_project.script_name,
-              description: script_project.description
-            )
+            BuildScript.call(ctx: ctx, task_runner: task_runner, script_project: script_project)
 
             UI::PrintingSpinner.spin(ctx, ctx.message("script.application.pushing")) do |p_ctx, spinner|
               package = Infrastructure::PushPackageRepository.new(ctx: p_ctx).get_push_package(
-                extension_point_type: script_project.extension_point_type,
-                script_name: script_project.script_name,
-                description: script_project.description,
+                script_project: script_project,
                 compiled_type: task_runner.compiled_type,
                 metadata: task_runner.metadata
               )

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -8,6 +8,7 @@ module Script
           :extension_point_type,
           :script_name,
           :description,
+          :configuration_ui_yaml,
           :script_content,
           :compiled_type,
           :metadata
@@ -19,7 +20,8 @@ module Script
           description:,
           script_content:,
           compiled_type:,
-          metadata:
+          metadata:,
+          configuration_ui_yaml:
         )
           @id = id
           @extension_point_type = extension_point_type
@@ -28,6 +30,7 @@ module Script
           @script_content = script_content
           @compiled_type = compiled_type
           @metadata = metadata
+          @configuration_ui_yaml = configuration_ui_yaml
         end
 
         def push(script_service, api_key, force)
@@ -40,6 +43,7 @@ module Script
             api_key: api_key,
             force: force,
             metadata: @metadata,
+            configuration_ui_yaml: @configuration_ui_yaml,
           )
         end
       end

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -8,7 +8,7 @@ module Script
           :extension_point_type,
           :script_name,
           :description,
-          :configuration_ui_yaml,
+          :config_ui,
           :script_content,
           :compiled_type,
           :metadata
@@ -21,7 +21,7 @@ module Script
           script_content:,
           compiled_type:,
           metadata:,
-          configuration_ui_yaml:
+          config_ui:
         )
           @id = id
           @extension_point_type = extension_point_type
@@ -30,7 +30,7 @@ module Script
           @script_content = script_content
           @compiled_type = compiled_type
           @metadata = metadata
-          @configuration_ui_yaml = configuration_ui_yaml
+          @config_ui = config_ui
         end
 
         def push(script_service, api_key, force)
@@ -43,7 +43,7 @@ module Script
             api_key: api_key,
             force: force,
             metadata: @metadata,
-            configuration_ui_yaml: @configuration_ui_yaml,
+            config_ui: @config_ui,
           )
         end
       end

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -7,42 +7,37 @@ module Script
         include SmartProperties
         property! :ctx, accepts: ShopifyCli::Context
 
-        def create_push_package(
-          extension_point_type:,
-          script_name:,
-          description:,
-          script_content:,
-          compiled_type:,
-          metadata:
-        )
-          build_file_path = file_path(script_name, compiled_type)
+        def create_push_package(script_project:, script_content:, compiled_type:, metadata:)
+          build_file_path = file_path(script_project.script_name, compiled_type)
           write_to_path(build_file_path, script_content)
 
           Domain::PushPackage.new(
             id: build_file_path,
-            extension_point_type: extension_point_type,
-            script_name: script_name,
-            description: description,
+            extension_point_type: script_project.extension_point_type,
+            script_name: script_project.script_name,
+            description: script_project.description,
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata,
+            configuration_ui_yaml: script_project.configuration_ui_yaml,
           )
         end
 
-        def get_push_package(extension_point_type:, script_name:, description:, compiled_type:, metadata:)
-          build_file_path = file_path(script_name, compiled_type)
+        def get_push_package(script_project:, compiled_type:, metadata:)
+          build_file_path = file_path(script_project.script_name, compiled_type)
           raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
 
           script_content = File.read(build_file_path)
 
           Domain::PushPackage.new(
             id: build_file_path,
-            extension_point_type: extension_point_type,
-            script_name: script_name,
-            description: description,
+            extension_point_type: script_project.extension_point_type,
+            script_name: script_project.script_name,
+            description: script_project.description,
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata,
+            configuration_ui_yaml: script_project.configuration_ui_yaml,
           )
         end
 

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -19,7 +19,7 @@ module Script
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata,
-            configuration_ui_yaml: script_project.configuration_ui_yaml,
+            config_ui: script_project.config_ui,
           )
         end
 
@@ -37,7 +37,7 @@ module Script
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata,
-            configuration_ui_yaml: script_project.configuration_ui_yaml,
+            config_ui: script_project.config_ui,
           )
         end
 

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -18,13 +18,15 @@ module Script
           description: nil,
           api_key: nil,
           force: false,
-          metadata:
+          metadata:,
+          configuration_ui_yaml:
         )
           query_name = "app_script_update_or_create"
           variables = {
             extensionPointName: extension_point_type.upcase,
             title: script_name,
             description: description,
+            configUiYaml: configuration_ui_yaml,
             sourceCode: Base64.encode64(script_content),
             language: compiled_type,
             force: force,

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -19,14 +19,14 @@ module Script
           api_key: nil,
           force: false,
           metadata:,
-          configuration_ui_yaml:
+          config_ui:
         )
           query_name = "app_script_update_or_create"
           variables = {
             extensionPointName: extension_point_type.upcase,
             title: script_name,
             description: description,
-            configUiYaml: configuration_ui_yaml,
+            configUi: config_ui,
             sourceCode: Base64.encode64(script_content),
             language: compiled_type,
             force: force,

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -51,6 +51,12 @@ module Script
           invalid_config: "Can't change the configuration values because %1$s is missing or "\
                           "it is not formatted properly.",
 
+          invalid_config_ui_definition_cause: "The UI configuration file %s contains invalid YAML.",
+          invalid_config_ui_definition_help: "Fix the errors and try again.",
+
+          missing_config_ui_definition_cause: "You are missing the UI configuration file %s.",
+          missing_config_ui_definition_help: "Create this file and try again.",
+
           script_not_found_cause: "Couldn't find script %s for extension point %s",
 
           service_failure_cause: "Internal service error.",

--- a/lib/project_types/script/script_project.rb
+++ b/lib/project_types/script/script_project.rb
@@ -44,10 +44,10 @@ module Script
       return nil unless filename
 
       path = File.join(directory, filename)
-      raise Errors::MissingSpecifiedConfigUiDefinitionError unless File.exist?(path)
+      raise Errors::MissingSpecifiedConfigUiDefinitionError, filename unless File.exist?(path)
 
       contents = File.read(path)
-      raise Errors::InvalidConfigUiDefinitionError unless valid_configuration_ui_yaml?(contents)
+      raise Errors::InvalidConfigUiDefinitionError, filename unless valid_configuration_ui_yaml?(contents)
 
       contents
     end

--- a/lib/project_types/script/script_project.rb
+++ b/lib/project_types/script/script_project.rb
@@ -2,7 +2,7 @@
 
 module Script
   class ScriptProject < ShopifyCli::Project
-    attr_reader :extension_point_type, :script_name, :language, :description, :configuration_ui_yaml
+    attr_reader :extension_point_type, :script_name, :language, :description, :config_ui
 
     def initialize(*args)
       super
@@ -10,7 +10,7 @@ module Script
       raise Errors::DeprecatedEPError, @extension_point_type if deprecated?(@extension_point_type)
       @script_name = lookup_config!("script_name")
       @description = lookup_config("description")
-      @configuration_ui_yaml = lookup_configuration_ui_yaml
+      @config_ui = lookup_config_ui
       @language = lookup_language
       ShopifyCli::Core::Monorail.metadata = {
         "script_name" => @script_name,
@@ -39,15 +39,15 @@ module Script
       config[key]
     end
 
-    def lookup_configuration_ui_yaml
-      filename = lookup_config("configuration_ui_file")
+    def lookup_config_ui
+      filename = lookup_config("config_ui_file")
       return nil unless filename
 
       path = File.join(directory, filename)
       raise Errors::MissingSpecifiedConfigUiDefinitionError, filename unless File.exist?(path)
 
       contents = File.read(path)
-      raise Errors::InvalidConfigUiDefinitionError, filename unless valid_configuration_ui_yaml?(contents)
+      raise Errors::InvalidConfigUiDefinitionError, filename unless valid_config_ui?(contents)
 
       contents
     end
@@ -61,7 +61,7 @@ module Script
       end
     end
 
-    def valid_configuration_ui_yaml?(raw_yaml)
+    def valid_config_ui?(raw_yaml)
       require "yaml" # takes 20ms, so deferred as late as possible.
       YAML.safe_load(raw_yaml)
       true

--- a/lib/project_types/script/script_project.rb
+++ b/lib/project_types/script/script_project.rb
@@ -2,7 +2,9 @@
 
 module Script
   class ScriptProject < ShopifyCli::Project
-    attr_reader :extension_point_type, :script_name, :language, :description
+    CONFIG_UI_DEFINITION_PATH = 'configuration-ui.yml'
+
+    attr_reader :extension_point_type, :script_name, :language, :description, :configuration_ui_yaml
 
     def initialize(*args)
       super
@@ -10,6 +12,7 @@ module Script
       raise Errors::DeprecatedEPError, @extension_point_type if deprecated?(@extension_point_type)
       @script_name = lookup_config!("script_name")
       @description = lookup_config("description")
+      @configuration_ui_yaml = lookup_configuration_ui_yaml
       @language = lookup_language
       ShopifyCli::Core::Monorail.metadata = {
         "script_name" => @script_name,
@@ -36,6 +39,12 @@ module Script
     def lookup_config!(key)
       raise Errors::InvalidContextError, key unless config.key?(key)
       config[key]
+    end
+
+    def lookup_configuration_ui_yaml
+      path = File.join(directory, CONFIG_UI_DEFINITION_PATH)
+      return nil unless File.exist?(path)
+      File.read(path)
     end
 
     def lookup_language

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -61,6 +61,18 @@ module Script
               Script::Layers::Application::ExtensionPoints.languages(type: e.extension_point_type).join(", ")
             ),
           }
+        when Errors::InvalidConfigUiDefinitionError
+          {
+            cause_of_error: ShopifyCli::Context
+              .message("script.error.invalid_config_ui_definition_cause", e.filename),
+            help_suggestion: ShopifyCli::Context.message("script.error.invalid_config_ui_definition_help"),
+          }
+        when Errors::MissingSpecifiedConfigUiDefinitionError
+          {
+            cause_of_error: ShopifyCli::Context
+              .message("script.error.missing_config_ui_definition_cause", e.filename),
+            help_suggestion: ShopifyCli::Context.message("script.error.missing_config_ui_definition_help"),
+          }
         when Errors::InvalidScriptNameError
           {
             cause_of_error: ShopifyCli::Context.message("script.error.invalid_script_name_cause"),

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -14,14 +14,13 @@ describe Script::Layers::Application::BuildScript do
     let(:compiled_type) { "wasm" }
     let(:metadata) { Script::Layers::Domain::Metadata.new("1", "0", false) }
     let(:task_runner) { stub(compiled_type: compiled_type, metadata: metadata) }
+    let(:script_project) { stub }
 
     subject do
       Script::Layers::Application::BuildScript.call(
         ctx: @context,
         task_runner: task_runner,
-        script_name: script_name,
-        extension_point_type: extension_point_type,
-        description: description
+        script_project: script_project
       )
     end
 
@@ -30,9 +29,7 @@ describe Script::Layers::Application::BuildScript do
         CLI::UI::Frame.expects(:with_frame_color_override).never
         task_runner.expects(:build).returns(content)
         Script::Layers::Infrastructure::PushPackageRepository.any_instance.expects(:create_push_package).with(
-          extension_point_type: extension_point_type,
-          script_name: script_name,
-          description: description,
+          script_project: script_project,
           script_content: content,
           compiled_type: "wasm",
           metadata: metadata

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -23,7 +23,7 @@ describe Script::Layers::Application::PushScript do
       extension_point_type: extension_point_type,
       script_name: script_name,
       description: description,
-      configuration_ui_yaml: '',
+      configuration_ui_yaml: "",
       env: { api_key: api_key }
     )
   end

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -23,7 +23,7 @@ describe Script::Layers::Application::PushScript do
       extension_point_type: extension_point_type,
       script_name: script_name,
       description: description,
-      configuration_ui_yaml: "",
+      config_ui: "",
       env: { api_key: api_key }
     )
   end

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -23,6 +23,7 @@ describe Script::Layers::Application::PushScript do
       extension_point_type: extension_point_type,
       script_name: script_name,
       description: description,
+      configuration_ui_yaml: '',
       env: { api_key: api_key }
     )
   end
@@ -41,9 +42,7 @@ describe Script::Layers::Application::PushScript do
     Script::ScriptProject.stubs(:current).returns(project)
     extension_point_repository.create_extension_point(extension_point_type)
     push_package_repository.create_push_package(
-      extension_point_type: extension_point_type,
-      script_name: script_name,
-      description: description,
+      script_project: project,
       script_content: "content",
       compiled_type: compiled_type,
       metadata: metadata
@@ -60,9 +59,7 @@ describe Script::Layers::Application::PushScript do
       Script::Layers::Application::BuildScript.expects(:call).with(
         ctx: @context,
         task_runner: task_runner,
-        extension_point_type: extension_point_type,
-        script_name: script_name,
-        description: description
+        script_project: project
       )
       Script::Layers::Infrastructure::ScriptService
         .expects(:new).returns(script_service_instance)

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -7,6 +7,7 @@ describe Script::Layers::Domain::PushPackage do
   let(:script_id) { "id" }
   let(:script_name) { "foo_script" }
   let(:description) { "my description" }
+  let(:configuration_ui_yaml) { "---\nversion: 1\n" }
   let(:api_key) { "fake_key" }
   let(:force) { false }
   let(:script_content) { "(module)" }
@@ -18,6 +19,7 @@ describe Script::Layers::Domain::PushPackage do
       extension_point_type: extension_point_type,
       script_name: script_name,
       description: description,
+      configuration_ui_yaml: configuration_ui_yaml,
       script_content: script_content,
       compiled_type: compiled_type,
       metadata: metadata

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -7,7 +7,7 @@ describe Script::Layers::Domain::PushPackage do
   let(:script_id) { "id" }
   let(:script_name) { "foo_script" }
   let(:description) { "my description" }
-  let(:configuration_ui_yaml) { "---\nversion: 1\n" }
+  let(:config_ui) { "---\nversion: 1\n" }
   let(:api_key) { "fake_key" }
   let(:force) { false }
   let(:script_content) { "(module)" }
@@ -19,7 +19,7 @@ describe Script::Layers::Domain::PushPackage do
       extension_point_type: extension_point_type,
       script_name: script_name,
       description: description,
-      configuration_ui_yaml: configuration_ui_yaml,
+      config_ui: config_ui,
       script_content: script_content,
       compiled_type: compiled_type,
       metadata: metadata

--- a/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
@@ -23,7 +23,7 @@ module Script
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata,
-            configuration_ui_yaml: script_project.configuration_ui_yaml,
+            config_ui: script_project.config_ui,
           )
         end
 

--- a/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_push_package_repository.rb
@@ -9,28 +9,27 @@ module Script
         end
 
         def create_push_package(
-          extension_point_type:,
-          script_name:,
-          description:,
+          script_project:,
           script_content:,
           compiled_type:,
           metadata:
         )
-          id = id(script_name, compiled_type)
+          id = id(script_project.script_name, compiled_type)
           @cache[id] = Domain::PushPackage.new(
             id: id,
-            extension_point_type: extension_point_type,
-            script_name: script_name,
-            description: description,
+            extension_point_type: script_project.extension_point_type,
+            script_name: script_project.script_name,
+            description: script_project.description,
             script_content: script_content,
             compiled_type: compiled_type,
-            metadata: metadata
+            metadata: metadata,
+            configuration_ui_yaml: script_project.configuration_ui_yaml,
           )
         end
 
-        def get_push_package(extension_point_type:, script_name:, description:, compiled_type:, metadata:)
-          _ = extension_point_type, description, metadata
-          id = id(script_name, compiled_type)
+        def get_push_package(script_project:, compiled_type:, metadata:)
+          _ = metadata
+          id = id(script_project.script_name, compiled_type)
           if @cache.key?(id)
             @cache[id]
           else

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -12,6 +12,7 @@ describe Script::Layers::Infrastructure::ScriptService do
   let(:schema_major_version) { "1" }
   let(:schema_minor_version) { "0" }
   let(:use_msgpack) { true }
+  let(:configuration_ui_yaml) { "---\nversion:1\n" }
   let(:script_service_proxy) do
     <<~HERE
       query ProxyRequest($api_key: String, $shop_domain: String, $query: String!, $variables: String) {
@@ -36,6 +37,7 @@ describe Script::Layers::Infrastructure::ScriptService do
           $extensionPointName: ExtensionPointName!,
           $title: String,
           $description: String,
+          $configUiYaml: String,
           $sourceCode: String,
           $language: String,
           $schemaMajorVersion: String,
@@ -46,6 +48,7 @@ describe Script::Layers::Infrastructure::ScriptService do
             extensionPointName: $extensionPointName
             title: $title
             description: $description
+            configUiYaml: $configUiYaml
             sourceCode: $sourceCode
             language: $language
             schemaMajorVersion: $schemaMajorVersion
@@ -79,6 +82,7 @@ describe Script::Layers::Infrastructure::ScriptService do
             extensionPointName: extension_point_type,
             title: script_name,
             description: description,
+            configUiYaml: configuration_ui_yaml,
             sourceCode: Base64.encode64(script_content),
             language: "AssemblyScript",
             force: false,
@@ -104,6 +108,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         script_content: script_content,
         compiled_type: "AssemblyScript",
         description: description,
+        configuration_ui_yaml: configuration_ui_yaml,
         api_key: api_key,
       )
     end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -12,7 +12,7 @@ describe Script::Layers::Infrastructure::ScriptService do
   let(:schema_major_version) { "1" }
   let(:schema_minor_version) { "0" }
   let(:use_msgpack) { true }
-  let(:configuration_ui_yaml) { "---\nversion:1\n" }
+  let(:config_ui) { "---\nversion:1\n" }
   let(:script_service_proxy) do
     <<~HERE
       query ProxyRequest($api_key: String, $shop_domain: String, $query: String!, $variables: String) {
@@ -37,7 +37,7 @@ describe Script::Layers::Infrastructure::ScriptService do
           $extensionPointName: ExtensionPointName!,
           $title: String,
           $description: String,
-          $configUiYaml: String,
+          $configUi: String,
           $sourceCode: String,
           $language: String,
           $schemaMajorVersion: String,
@@ -48,7 +48,7 @@ describe Script::Layers::Infrastructure::ScriptService do
             extensionPointName: $extensionPointName
             title: $title
             description: $description
-            configUiYaml: $configUiYaml
+            configUi: $configUi
             sourceCode: $sourceCode
             language: $language
             schemaMajorVersion: $schemaMajorVersion
@@ -82,7 +82,7 @@ describe Script::Layers::Infrastructure::ScriptService do
             extensionPointName: extension_point_type,
             title: script_name,
             description: description,
-            configUiYaml: configuration_ui_yaml,
+            configUi: config_ui,
             sourceCode: Base64.encode64(script_content),
             language: "AssemblyScript",
             force: false,
@@ -108,7 +108,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         script_content: script_content,
         compiled_type: "AssemblyScript",
         description: description,
-        configuration_ui_yaml: configuration_ui_yaml,
+        config_ui: config_ui,
         api_key: api_key,
       )
     end

--- a/test/project_types/script/script_project_test.rb
+++ b/test/project_types/script/script_project_test.rb
@@ -164,8 +164,8 @@ module Script
       end
     end
 
-    describe "#configuration_ui_yaml" do
-      let(:configuration_ui_file) { "ui-config.yml" }
+    describe "#config_ui" do
+      let(:config_ui_file) { "ui-config.yml" }
       let(:language) { "assemblyscript" }
 
       before do
@@ -176,7 +176,7 @@ module Script
       end
 
       subject do
-        Script::ScriptProject.current.configuration_ui_yaml
+        Script::ScriptProject.current.config_ui
       end
 
       describe "when ui_configuration_file field exists in config" do
@@ -188,25 +188,25 @@ module Script
             extension_point_type: @extension_point_type,
             script_name: @script_name,
             language: language,
-            configuration_ui_file: configuration_ui_file
+            config_ui_file: config_ui_file
           )
         end
 
         describe "when file exists" do
           describe "when YAML is valid" do
-            let(:configuration_ui_yaml) { "---\nversion: 1" }
+            let(:config_ui) { "---\nversion: 1" }
 
             it "returns the raw contents" do
-              @context.write(configuration_ui_file, configuration_ui_yaml)
-              assert_equal configuration_ui_yaml, subject
+              @context.write(config_ui_file, config_ui)
+              assert_equal config_ui, subject
             end
           end
 
           describe "when YAML is invalid" do
-            let(:configuration_ui_yaml) { "*" }
+            let(:config_ui) { "*" }
 
             it "raises InvalidConfigUiDefinitionError" do
-              @context.write(configuration_ui_file, configuration_ui_yaml)
+              @context.write(config_ui_file, config_ui)
               assert_raises(Script::Errors::InvalidConfigUiDefinitionError) { subject }
             end
           end

--- a/test/project_types/script/test_helpers/fake_script_project.rb
+++ b/test/project_types/script/test_helpers/fake_script_project.rb
@@ -4,6 +4,7 @@ module TestHelpers
     property :script_name
     property :language
     property :description
+    property :configuration_ui_yaml
     property :env
 
     def api_key

--- a/test/project_types/script/test_helpers/fake_script_project.rb
+++ b/test/project_types/script/test_helpers/fake_script_project.rb
@@ -4,7 +4,7 @@ module TestHelpers
     property :script_name
     property :language
     property :description
-    property :configuration_ui_yaml
+    property :config_ui
     property :env
 
     def api_key

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -147,7 +147,21 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when InvalidLanguageError" do
-        let(:err) { Script::Layers::Domain::Errors::InvalidExtensionPointError.new("ruby") }
+        let(:err) { Script::Errors::InvalidLanguageError.new("ruby", "discount") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when InvalidConfigUiDefinitionError" do
+        let(:err) { Script::Errors::InvalidConfigUiDefinitionError.new("filename") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when MissingSpecifiedConfigUiDefinitionError" do
+        let(:err) { Script::Errors::MissingSpecifiedConfigUiDefinitionError.new("filename") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/2521

We want a script developer to define a ui via a yaml configuration and include that file in the script's deploy package on push.

### WHAT is this pull request doing?

- Allows a developer to specify a configuration ui definition. The flow of doing this will be improved in another PR that creates an empty file by default. But to manually test it, a dev can:
  - create a configuration file with an appropriate definition
  - set the value of the `configuration_ui_file` field in a script project's `.shopify-cli.yml` to the filename of the configuration file.

### Error cases
Currently, YAML validation errors from Script Service are not shown. This is because the base PR (https://github.com/Shopify/script-service/pull/2597) is getting big and I want to merge it before adding custom error tags. Afterwards, we can easily catch those error tags and display appropriate messages.  

#### Config file contains invalid YAML
<details>
<img src="https://user-images.githubusercontent.com/28009669/109725412-177c0980-7b7f-11eb-8289-22158ae5b0d7.png" />
</details>

#### `configuration_ui_file` is set in the `.shopify-cli.yml` but no file exists
<details>
<img src="https://user-images.githubusercontent.com/28009669/109725458-2ebaf700-7b7f-11eb-9e0c-c212ae19934a.png" />
</details>


### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
