### PR TITLE
LazyDelegator & LazySpecificationHandler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,7 @@ namespace :rdoc do
     "lib/shopify-cli/project.rb",
     "lib/shopify-cli/result.rb",
     "lib/shopify-cli/tunnel.rb",
+    "lib/shopify-cli/lazy_delegator.rb",
   ]
 
   task all: [:markdown, :wiki, :cleanup]

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -70,6 +70,7 @@ module Extension
     autoload :ValidationError, Project.project_filepath("models/validation_error")
     autoload :Specification, Project.project_filepath("models/specification")
     autoload :Specifications, Project.project_filepath("models/specifications")
+    autoload :LazySpecificationHandler, Project.project_filepath("models/lazy_specification_handler")
   end
 
   autoload :ExtensionProjectKeys, Project.project_filepath("extension_project_keys")

--- a/lib/project_types/extension/commands/extension_command.rb
+++ b/lib/project_types/extension/commands/extension_command.rb
@@ -10,11 +10,14 @@ module Extension
 
       def extension_type
         @extension_type ||= begin
-          unless Extension.specifications.valid?(project.extension_type_identifier)
-            @ctx.abort(@ctx.message("errors.unknown_type", project.extension_type_identifier))
-          end
+          identifier = project.extension_type_identifier
+          Models::LazySpecificationHandler.new(identifier) do
+            unless Extension.specifications.valid?(identifier)
+              @ctx.abort(@ctx.message("errors.unknown_type", project.extension_type_identifier))
+            end
 
-          Extension.specifications[project.extension_type_identifier]
+            Extension.specifications[identifier]
+          end
         end
       end
     end

--- a/lib/project_types/extension/models/lazy_specification_handler.rb
+++ b/lib/project_types/extension/models/lazy_specification_handler.rb
@@ -1,0 +1,12 @@
+module Extension
+  module Models
+    class LazySpecificationHandler < ShopifyCli::LazyDelegator
+      attr_reader :identifier
+
+      def initialize(identifier, &specification_handler_initializer)
+        super(&specification_handler_initializer)
+        @identifier = identifier
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/lazy_delegator.rb
+++ b/lib/shopify-cli/lazy_delegator.rb
@@ -1,0 +1,53 @@
+module ShopifyCli
+  ##
+  # `LazyDelegator` defers initialization of its underlying delegatee until the
+  # latter is accessed for the first time due to a method call that the
+  # delegator cannot handle itself:
+  #
+  #   result = LazyDelegator.new do
+  #     # carry out costly operation ...
+  #   end
+  #
+  #   result      # referencing the object itself does not result in Proc evaluation
+  #   result.to_h # however, calling a method on it will result in Proc evaluation
+  #
+  # LazyDelegator lends itself to being subclassed in scenarios where some
+  # facts are known and others are costly to compute:
+  #
+  #   class LazySpecificationHandler < ShopifyCli::LazyDelegator
+  #     attr_reader :identifier
+  #
+  #     def initialize(identifier, &initializer)
+  #       super(&initializer)
+  #       @identifier = identifier
+  #     end
+  #   end
+  #
+  #   handler = LazySpecificationHandler.new(:product_subscription) do
+  #      # fetch specification from the Partners Dashboard API ...
+  #   end
+  #
+  #   # Accessing identifier will not result in Proc evaluation as it is
+  #   # available as an attribute of the delegator itself
+  #   handler.identifier # => :product_subscription
+  #
+  #   # Accessing the specification will result in evaluation of the Proc
+  #   # and in our example in a subsequent network call
+  #   handler.specification # => <Extension::Models::Specifcation:...>
+  #
+  class LazyDelegator < SimpleDelegator
+    def initialize(&delegatee_initializer)
+      super([false, delegatee_initializer])
+    end
+
+    protected
+
+    def __getobj__(*)
+      initialized, value_or_initializer = super
+      return value_or_initializer if initialized
+      value_or_initializer.call.tap do |value|
+        __setobj__([true, value])
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -109,6 +109,7 @@ module ShopifyCli
   autoload :JsDeps, "shopify-cli/js_deps"
   autoload :JsSystem, "shopify-cli/js_system"
   autoload :MethodObject, "shopify-cli/method_object"
+  autoload :LazyDelegator, "shopify-cli/lazy_delegator"
   autoload :Log, "shopify-cli/log"
   autoload :OAuth, "shopify-cli/oauth"
   autoload :Options, "shopify-cli/options"

--- a/test/project_types/extension/models/lazy_specification_handler_test.rb
+++ b/test/project_types/extension/models/lazy_specification_handler_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+module Extension
+  module Models
+    class LazySpecificationHandlerTest < MiniTest::Test
+      def setup
+        ShopifyCli::ProjectType.load_type(:extension)
+        super
+      end
+
+      def test_accessing_the_identifier_does_not_result_in_delegatee_resolution
+        delegatee_resolved = false
+        handler = LazySpecificationHandler.new("test-extension") do
+          delegatee_resolved = true
+        end
+        assert_equal "test-extension", handler.identifier
+        refute delegatee_resolved
+      end
+    end
+  end
+end

--- a/test/shopify-cli/lazy_delegator_test.rb
+++ b/test/shopify-cli/lazy_delegator_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+require 'securerandom'
+
+module ShopifyCli
+  class LazyDelegatorTest < MiniTest::Test
+    def test_defers_invocation_of_the_provided_block_until_absolutely_necessary
+      person_created = false
+
+      person = LazyDelegator.new do
+        person_created = true
+        create_person
+      end
+
+      refute person_created
+      person.firstname
+      assert person_created
+    end
+
+    def test_delegates_method_calls_to_the_return_value_of_the_provided_block
+      person = LazyDelegator.new { create_person(firstname: "Jane") }
+      assert_equal "Jane", person.firstname
+    end
+
+    def test_memoizes_the_return_value_of_the_provided_block
+      person = LazyDelegator.new { create_person(firstname: "Jane") }
+      assert_equal person.id, person.id
+    end
+
+    private
+
+    def create_person(firstname: "John", lastname: "Doe")
+      OpenStruct.new(firstname: firstname, lastname: lastname, id: SecureRandom.uuid)
+    end
+  end
+end

--- a/test/shopify-cli/lazy_delegator_test.rb
+++ b/test/shopify-cli/lazy_delegator_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'securerandom'
+require "test_helper"
+require "securerandom"
 
 module ShopifyCli
   class LazyDelegatorTest < MiniTest::Test


### PR DESCRIPTION
### WHY are these changes introduced?

In future, we will have to defer costly network calls when fetching specifications from the Partner Dashboard API until the call is absolutely necessary.

### WHAT is this pull request doing?

This PR introduces a generic mechanism for constructing delegators that defer delegates resolution until it becomes necessary.

`LazyDelegator` defers initialization of its underlying delegatee until the latter is accessed for the first time due to a method call that the delegator cannot handle itself:

```ruby
result = LazyDelegator.new do
  # carry out costly operation ...
end

result      # referencing the object itself does not result in Proc evaluation
result.to_h # however, calling a method on it will result in Proc evaluation
```

LazyDelegator lends itself to being subclassed in scenarios where some facts are known and others are costly to compute:

```ruby
class LazySpecificationHandler < ShopifyCli::LazyDelegator
  attr_reader :identifier

  def initialize(identifier, &initializer)
    super(&initializer)
    @identifier = identifier
  end
end

handler = LazySpecificationHandler.new(:product_subscription) do
   # fetch specification from the Partners Dashboard API ...
end

# Accessing identifier will not result in Proc evaluation as it is
# available as an attribute of the delegator itself
handler.identifier # => :product_subscription

# Accessing the specification will result in evaluation of the Proc
# and in our example in a subsequent network call
handler.specification # => <Extension::Models::Specifcation:...>
```

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
