### PR TITLE
Fix rubocop violations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,19 +5,19 @@ source "https://rubygems.org"
 # They are all for CI and tests
 # `dev` uses no gems
 group :development, :test do
-  gem 'rake'
-  gem 'pry-byebug'
-  gem 'byebug'
-  gem 'rubocop-shopify', require: false
-  gem 'rubocop-minitest', require: false
+  gem "rake"
+  gem "pry-byebug"
+  gem "byebug"
+  gem "rubocop-shopify", require: false
+  gem "rubocop-minitest", require: false
 end
 
 group :test do
-  gem 'mocha', require: false
-  gem 'minitest', '>= 5.0.0', require: false
-  gem 'minitest-reporters', require: false
-  gem 'minitest-fail-fast', require: false
-  gem 'fakefs', '>= 1.0', require: false
-  gem 'webmock', require: false
-  gem 'timecop', require: false
+  gem "mocha", require: false
+  gem "minitest", ">= 5.0.0", require: false
+  gem "minitest-reporters", require: false
+  gem "minitest-fail-fast", require: false
+  gem "fakefs", ">= 1.0", require: false
+  gem "webmock", require: false
+  gem "timecop", require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
-require_relative 'bin/load_shopify'
-require 'rake/testtask'
-require 'rubocop/rake_task'
-require 'bundler/gem_tasks'
+require_relative "bin/load_shopify"
+require "rake/testtask"
+require "rubocop/rake_task"
+require "bundler/gem_tasks"
 
 Rake::TestTask.new do |t|
   t.libs += %w(test)
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = false
   t.warning = false
 end
@@ -16,35 +16,35 @@ task(default: [:test, :rubocop])
 
 desc("Start up irb with cli loaded")
 task :console do
-  exec('irb', '-r', './bin/load_shopify.rb', '-r', 'byebug')
+  exec("irb", "-r", "./bin/load_shopify.rb", "-r", "byebug")
 end
 
 namespace :rdoc do
-  repo = 'https://github.com/Shopify/shopify-app-cli.wiki.git'
-  intermediate = 'markdown_intermediate'
+  repo = "https://github.com/Shopify/shopify-app-cli.wiki.git"
+  intermediate = "markdown_intermediate"
   file_to_doc = [
-    'lib/shopify-cli/admin_api.rb',
-    'lib/shopify-cli/context.rb',
-    'lib/shopify-cli/db.rb',
-    'lib/shopify-cli/git.rb',
-    'lib/shopify-cli/heroku.rb',
-    'lib/shopify-cli/js_deps.rb',
-    'lib/shopify-cli/method_object.rb',
-    'lib/shopify-cli/partners_api.rb',
-    'lib/shopify-cli/process_supervision.rb',
-    'lib/shopify-cli/project.rb',
-    'lib/shopify-cli/result.rb',
-    'lib/shopify-cli/tunnel.rb',
+    "lib/shopify-cli/admin_api.rb",
+    "lib/shopify-cli/context.rb",
+    "lib/shopify-cli/db.rb",
+    "lib/shopify-cli/git.rb",
+    "lib/shopify-cli/heroku.rb",
+    "lib/shopify-cli/js_deps.rb",
+    "lib/shopify-cli/method_object.rb",
+    "lib/shopify-cli/partners_api.rb",
+    "lib/shopify-cli/process_supervision.rb",
+    "lib/shopify-cli/project.rb",
+    "lib/shopify-cli/result.rb",
+    "lib/shopify-cli/tunnel.rb",
   ]
 
   task all: [:markdown, :wiki, :cleanup]
 
   desc("Generate markdown files from rdoc comments")
   task :markdown do
-    require 'rdoc/rdoc'
-    require 'docgen/markdown'
+    require "rdoc/rdoc"
+    require "docgen/markdown"
     options = RDoc::Options.new
-    options.setup_generator('markdown')
+    options.setup_generator("markdown")
     options.op_dir = intermediate
     options.files = file_to_doc
     RDoc::RDoc.new.document(options)
@@ -52,14 +52,14 @@ namespace :rdoc do
 
   desc("Copy markdown documentation to the wiki and commit them")
   task :wiki do
-    require 'tmpdir'
+    require "tmpdir"
     Dir.mktmpdir do |temp_dir|
       system("git clone --depth=1 #{repo} #{temp_dir}")
-      FileUtils.cp(Dir[File.join(intermediate, '*.md')], temp_dir)
+      FileUtils.cp(Dir[File.join(intermediate, "*.md")], temp_dir)
       Dir.chdir(temp_dir) do
-        system('git add --all')
+        system("git add --all")
         system('git commit -am "auto doc update"')
-        system('git push')
+        system("git push")
       end
     end
   end
@@ -71,10 +71,10 @@ namespace :rdoc do
 end
 
 desc("Generate markdown documentation and update the wiki")
-task(rdoc: 'rdoc:all')
+task(rdoc: "rdoc:all")
 
 namespace :package do
-  require 'shopify-cli/packager'
+  require "shopify-cli/packager"
 
   task all: [:debian, :rpm, :homebrew]
 
@@ -95,4 +95,4 @@ namespace :package do
 end
 
 desc("Builds all distribution packages of the CLI")
-task(package: 'package:all')
+task(package: "package:all")

--- a/bin/load_shopify.rb
+++ b/bin/load_shopify.rb
@@ -3,20 +3,20 @@
 lib_path = File.expand_path("../../lib", __FILE__)
 $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
 
-ENV['SHELLPID'] ||= Process.ppid.to_s
-ENV['USER_PWD'] ||= Dir.pwd
+ENV["SHELLPID"] ||= Process.ppid.to_s
+ENV["USER_PWD"] ||= Dir.pwd
 
 # Prune non-absolute paths from PATH to prevent non-deterministic behavior
 # i.e. If user has "." or "./bin" in their PATH
 # Note that this logic is duplicated in lib/shopify.rb
-ENV['PATH'] = ENV['PATH'].split(File::PATH_SEPARATOR).select do |p|
-  p.start_with?('/', '~', /[A-Z]:\\/)
+ENV["PATH"] = ENV["PATH"].split(File::PATH_SEPARATOR).select do |p|
+  p.start_with?("/", "~", /[A-Z]:\\/)
 end.join(File::PATH_SEPARATOR)
 
 $original_env = ENV.to_hash
 
-require 'shopify_cli'
+require "shopify_cli"
 
-if ENV['PRINT_LOADED_FEATURES']
+if ENV["PRINT_LOADED_FEATURES"]
   puts $LOADED_FEATURES
 end

--- a/bin/shopify
+++ b/bin/shopify
@@ -14,7 +14,7 @@ module Kernel
     raise if name == "#{RUBY_VERSION[/\d+\.\d+/]}/psych.so"
     STDERR.puts "[Note] You cannot use gems with Shopify App CLI."
     STDERR.puts "[LoadError] #{e.message}"
-    if ENV['DEBUG']
+    if ENV["DEBUG"]
       STDERR.puts e.backtrace
       STDERR.puts "\n"
     end
@@ -27,7 +27,7 @@ module Kernel
   end
 end
 
-require_relative './load_shopify'
+require_relative "./load_shopify"
 
 exit(ShopifyCli::ErrorHandler.call do
   ShopifyCli::Core::EntryPoint.call(ARGV.dup)

--- a/ext/shopify-cli/extconf.rb
+++ b/ext/shopify-cli/extconf.rb
@@ -1,8 +1,8 @@
-require 'rbconfig'
-require 'fileutils'
+require "rbconfig"
+require "fileutils"
 
-gem = File.expand_path('../../../', __FILE__)
-exe = File.join(gem, 'bin', 'shopify')
+gem = File.expand_path("../../../", __FILE__)
+exe = File.join(gem, "bin", "shopify")
 
 if RUBY_PLATFORM.match(/mingw32/)
   bat_path = File.dirname(RbConfig.ruby)
@@ -22,8 +22,8 @@ if RUBY_PLATFORM.match(/mingw32/)
     \t echo "#{script_content}">> "#{bat}"
   MAKEFILE
 else
-  script = exe + '.sh'
-  symlink = '/usr/local/bin/shopify'
+  script = exe + ".sh"
+  symlink = "/usr/local/bin/shopify"
 
   script_content = <<~SCRIPT
     #!/usr/bin/env bash
@@ -44,4 +44,4 @@ else
   MAKEFILE
 end
 
-File.write('Makefile', makefile_content)
+File.write("Makefile", makefile_content)

--- a/lib/docgen/markdown.rb
+++ b/lib/docgen/markdown.rb
@@ -1,5 +1,5 @@
-require 'rdoc/rdoc'
-require 'erb'
+require "rdoc/rdoc"
+require "erb"
 
 module RDoc
   module Generator
@@ -26,13 +26,13 @@ module RDoc
       private
 
       def render(data)
-        class_template_path = File.join(File.dirname(__FILE__), 'class_template.md.erb')
-        class_renderer = ERB.new(File.read(class_template_path), nil, '-')
+        class_template_path = File.join(File.dirname(__FILE__), "class_template.md.erb")
+        class_renderer = ERB.new(File.read(class_template_path), nil, "-")
         data.each do |cls|
           File.write("#{cls.filename}.md", class_renderer.result(cls.instance_eval { binding }))
         end
-        index_template_path = File.join(File.dirname(__FILE__), 'index_template.md.erb')
-        index_renderer = ERB.new(File.read(index_template_path), nil, '-')
+        index_template_path = File.join(File.dirname(__FILE__), "index_template.md.erb")
+        index_renderer = ERB.new(File.read(index_template_path), nil, "-")
         File.write("Core-APIs.md", index_renderer.result(OpenStruct.new(classes: data).instance_eval { binding }))
       end
 
@@ -46,8 +46,8 @@ module RDoc
             kind: kind,
             comment: @converter.convert(klass.comment.parse),
             constants: build_members(klass.constants),
-            class_methods: build_members(klass.method_list.select { |m| m.type == 'class' }),
-            instance_methods: build_members(klass.method_list.select { |m| m.type == 'instance' }),
+            class_methods: build_members(klass.method_list.select { |m| m.type == "class" }),
+            instance_methods: build_members(klass.method_list.select { |m| m.type == "instance" }),
             attributes: build_members(klass.attributes),
             extended: build_members(klass.extends),
             included: build_members(klass.includes),
@@ -68,7 +68,7 @@ module RDoc
           ClassMember.new(
             title:     m.name,
             comment:   @converter.convert(m.comment.parse),
-            signature: m.respond_to?(:arglists) ? m.arglists : '',
+            signature: m.respond_to?(:arglists) ? m.arglists : "",
             source_code: source(m),
           )
         end
@@ -77,7 +77,7 @@ module RDoc
       # Just extracts sourcecode from html formatting/highlighting into a text
       # blob so that markdown can format it with a codeblock
       def source(m)
-        return '' unless m.respond_to?(:token_stream)
+        return "" unless m.respond_to?(:token_stream)
         # each line, get the text
         src = (m.token_stream || []).map do |t|
           next unless t
@@ -93,7 +93,7 @@ module RDoc
           indent = n if n < indent
           break if n == 0
         end
-        src.gsub!(/^#{' ' * indent}/, '') if indent > 0
+        src.gsub!(/^#{' ' * indent}/, "") if indent > 0
         src
       end
     end

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -3,77 +3,77 @@
 module Extension
   class Project < ShopifyCli::ProjectType
     hidden_feature
-    title('App Extension')
-    creator('Extension::Commands::Create')
+    title("App Extension")
+    creator("Extension::Commands::Create")
 
-    register_command('Extension::Commands::Build', "build")
-    register_command('Extension::Commands::Register', "register")
-    register_command('Extension::Commands::Push', "push")
-    register_command('Extension::Commands::Serve', "serve")
-    register_command('Extension::Commands::Tunnel', "tunnel")
+    register_command("Extension::Commands::Build", "build")
+    register_command("Extension::Commands::Register", "register")
+    register_command("Extension::Commands::Push", "push")
+    register_command("Extension::Commands::Serve", "serve")
+    register_command("Extension::Commands::Tunnel", "tunnel")
 
-    require Project.project_filepath('messages/messages')
-    require Project.project_filepath('messages/message_loading')
-    require Project.project_filepath('extension_project_keys')
+    require Project.project_filepath("messages/messages")
+    require Project.project_filepath("messages/message_loading")
+    require Project.project_filepath("extension_project_keys")
     register_messages(Extension::Messages::MessageLoading.load)
   end
 
   module Commands
-    autoload :ExtensionCommand, Project.project_filepath('commands/extension_command')
-    autoload :Create, Project.project_filepath('commands/create')
-    autoload :Register, Project.project_filepath('commands/register')
-    autoload :Build, Project.project_filepath('commands/build')
-    autoload :Serve, Project.project_filepath('commands/serve')
-    autoload :Push, Project.project_filepath('commands/push')
-    autoload :Tunnel, Project.project_filepath('commands/tunnel')
+    autoload :ExtensionCommand, Project.project_filepath("commands/extension_command")
+    autoload :Create, Project.project_filepath("commands/create")
+    autoload :Register, Project.project_filepath("commands/register")
+    autoload :Build, Project.project_filepath("commands/build")
+    autoload :Serve, Project.project_filepath("commands/serve")
+    autoload :Push, Project.project_filepath("commands/push")
+    autoload :Tunnel, Project.project_filepath("commands/tunnel")
   end
 
   module Tasks
-    autoload :UserErrors, Project.project_filepath('tasks/user_errors')
-    autoload :GetApps, Project.project_filepath('tasks/get_apps')
-    autoload :GetApp, Project.project_filepath('tasks/get_app')
-    autoload :CreateExtension, Project.project_filepath('tasks/create_extension')
-    autoload :UpdateDraft, Project.project_filepath('tasks/update_draft')
-    autoload :FetchSpecifications, Project.project_filepath('tasks/fetch_specifications')
-    autoload :ConfigureFeatures, Project.project_filepath('tasks/configure_features')
+    autoload :UserErrors, Project.project_filepath("tasks/user_errors")
+    autoload :GetApps, Project.project_filepath("tasks/get_apps")
+    autoload :GetApp, Project.project_filepath("tasks/get_app")
+    autoload :CreateExtension, Project.project_filepath("tasks/create_extension")
+    autoload :UpdateDraft, Project.project_filepath("tasks/update_draft")
+    autoload :FetchSpecifications, Project.project_filepath("tasks/fetch_specifications")
+    autoload :ConfigureFeatures, Project.project_filepath("tasks/configure_features")
 
     module Converters
-      autoload :RegistrationConverter, Project.project_filepath('tasks/converters/registration_converter')
-      autoload :VersionConverter, Project.project_filepath('tasks/converters/version_converter')
-      autoload :ValidationErrorConverter, Project.project_filepath('tasks/converters/validation_error_converter')
-      autoload :AppConverter, Project.project_filepath('tasks/converters/app_converter')
+      autoload :RegistrationConverter, Project.project_filepath("tasks/converters/registration_converter")
+      autoload :VersionConverter, Project.project_filepath("tasks/converters/version_converter")
+      autoload :ValidationErrorConverter, Project.project_filepath("tasks/converters/validation_error_converter")
+      autoload :AppConverter, Project.project_filepath("tasks/converters/app_converter")
     end
   end
 
   module Forms
-    autoload :Create, Project.project_filepath('forms/create')
-    autoload :Register, Project.project_filepath('forms/register')
+    autoload :Create, Project.project_filepath("forms/create")
+    autoload :Register, Project.project_filepath("forms/register")
   end
 
   module Features
-    autoload :ArgoSetup, Project.project_filepath('features/argo_setup')
-    autoload :ArgoSetupStep, Project.project_filepath('features/argo_setup_step')
-    autoload :ArgoSetupSteps, Project.project_filepath('features/argo_setup_steps')
-    autoload :ArgoDependencies, Project.project_filepath('features/argo_dependencies')
-    autoload :ArgoConfig, Project.project_filepath('features/argo_config')
-    autoload :Argo, Project.project_filepath('features/argo')
+    autoload :ArgoSetup, Project.project_filepath("features/argo_setup")
+    autoload :ArgoSetupStep, Project.project_filepath("features/argo_setup_step")
+    autoload :ArgoSetupSteps, Project.project_filepath("features/argo_setup_steps")
+    autoload :ArgoDependencies, Project.project_filepath("features/argo_dependencies")
+    autoload :ArgoConfig, Project.project_filepath("features/argo_config")
+    autoload :Argo, Project.project_filepath("features/argo")
   end
 
   module Models
     module SpecificationHandlers
-      autoload :Default, Project.project_filepath('models/specification_handlers/default')
+      autoload :Default, Project.project_filepath("models/specification_handlers/default")
     end
 
-    autoload :App, Project.project_filepath('models/app')
-    autoload :Registration, Project.project_filepath('models/registration')
-    autoload :Version, Project.project_filepath('models/version')
-    autoload :ValidationError, Project.project_filepath('models/validation_error')
-    autoload :Specification, Project.project_filepath('models/specification')
-    autoload :Specifications, Project.project_filepath('models/specifications')
+    autoload :App, Project.project_filepath("models/app")
+    autoload :Registration, Project.project_filepath("models/registration")
+    autoload :Version, Project.project_filepath("models/version")
+    autoload :ValidationError, Project.project_filepath("models/validation_error")
+    autoload :Specification, Project.project_filepath("models/specification")
+    autoload :Specifications, Project.project_filepath("models/specifications")
   end
 
-  autoload :ExtensionProjectKeys, Project.project_filepath('extension_project_keys')
-  autoload :ExtensionProject, Project.project_filepath('extension_project')
+  autoload :ExtensionProjectKeys, Project.project_filepath("extension_project_keys")
+  autoload :ExtensionProject, Project.project_filepath("extension_project")
 
   def self.specifications
     @specifications ||= Models::Specifications.new(

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Commands
@@ -12,9 +12,9 @@ module Extension
       def call(_args, _command_name)
         system = ShopifyCli::JsSystem.new(ctx: @ctx)
 
-        CLI::UI::Frame.open(@ctx.message('build.frame_title', system.package_manager)) do
+        CLI::UI::Frame.open(@ctx.message("build.frame_title", system.package_manager)) do
           success = system.call(yarn: YARN_BUILD_COMMAND, npm: NPM_BUILD_COMMAND)
-          @ctx.abort(@ctx.message('build.build_failure_message')) unless success
+          @ctx.abort(@ctx.message("build.build_failure_message")) unless success
         end
       end
 

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -4,24 +4,24 @@ module Extension
   module Commands
     class Create < ShopifyCli::SubCommand
       options do |parser, flags|
-        parser.on('--name=NAME') { |name| flags[:name] = name }
-        parser.on('--type=TYPE') { |type| flags[:type] = type.upcase }
+        parser.on("--name=NAME") { |name| flags[:name] = name }
+        parser.on("--type=TYPE") { |type| flags[:type] = type.upcase }
       end
 
       def call(args, _)
         with_create_form(args) do |form|
           if Dir.exist?(form.directory_name)
-            @ctx.abort(@ctx.message('create.errors.directory_exists', form.directory_name))
+            @ctx.abort(@ctx.message("create.errors.directory_exists", form.directory_name))
           end
 
           if form.type.create(form.directory_name, @ctx)
             ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
             ExtensionProject.write_env_file(context: @ctx, title: form.name)
 
-            @ctx.puts(@ctx.message('create.ready_to_start', form.directory_name, form.name))
-            @ctx.puts(@ctx.message('create.learn_more', form.type.name))
+            @ctx.puts(@ctx.message("create.ready_to_start", form.directory_name, form.name))
+            @ctx.puts(@ctx.message("create.learn_more", form.type.name))
           else
-            @ctx.puts(@ctx.message('create.try_again'))
+            @ctx.puts(@ctx.message("create.try_again"))
           end
         end
       end

--- a/lib/project_types/extension/commands/extension_command.rb
+++ b/lib/project_types/extension/commands/extension_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Commands
@@ -11,7 +11,7 @@ module Extension
       def extension_type
         @extension_type ||= begin
           unless Extension.specifications.valid?(project.extension_type_identifier)
-            @ctx.abort(@ctx.message('errors.unknown_type', project.extension_type_identifier))
+            @ctx.abort(@ctx.message("errors.unknown_type", project.extension_type_identifier))
           end
 
           Extension.specifications[project.extension_type_identifier]

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Commands
@@ -10,7 +10,7 @@ module Extension
         Commands::Register.new(@ctx).call(args, name) unless project.registered?
         Commands::Build.new(@ctx).call(args, name)
 
-        CLI::UI::Frame.open(@ctx.message('push.frame_title')) do
+        CLI::UI::Frame.open(@ctx.message("push.frame_title")) do
           updated_draft_version = update_draft
           show_message(updated_draft_version)
         end
@@ -30,18 +30,18 @@ module Extension
       end
 
       def output_success_messages(draft)
-        @ctx.puts(@ctx.message('push.success_confirmation', project.title, format_time(draft.last_user_interaction_at)))
-        @ctx.puts(@ctx.message('push.success_info', draft.location))
+        @ctx.puts(@ctx.message("push.success_confirmation", project.title, format_time(draft.last_user_interaction_at)))
+        @ctx.puts(@ctx.message("push.success_info", draft.location))
       end
 
       def output_validation_errors(draft)
-        @ctx.puts(@ctx.message('push.pushed_with_errors', format_time(draft.last_user_interaction_at)))
+        @ctx.puts(@ctx.message("push.pushed_with_errors", format_time(draft.last_user_interaction_at)))
 
         draft.validation_errors.each do |error|
-          @ctx.puts(format('{{x}} %s: %s', error.field.last, error.message))
+          @ctx.puts(format("{{x}} %s: %s", error.field.last, error.message))
         end
 
-        @ctx.puts(@ctx.message('push.push_with_errors_info'))
+        @ctx.puts(@ctx.message("push.push_with_errors_info"))
       end
 
       def format_time(time)
@@ -49,7 +49,7 @@ module Extension
       end
 
       def with_waiting_text
-        @ctx.puts(@ctx.message('push.waiting_text'))
+        @ctx.puts(@ctx.message("push.waiting_text"))
         yield
       end
 

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -4,13 +4,13 @@ module Extension
   module Commands
     class Register < ExtensionCommand
       options do |parser, flags|
-        parser.on('--api_key=KEY') { |key| flags[:api_key] = key.downcase }
-        parser.on('--api-key=KEY') { |key| flags[:api_key] = key.downcase }
+        parser.on("--api_key=KEY") { |key| flags[:api_key] = key.downcase }
+        parser.on("--api-key=KEY") { |key| flags[:api_key] = key.downcase }
       end
 
       def call(args, _command_name)
-        CLI::UI::Frame.open(@ctx.message('register.frame_title')) do
-          @ctx.abort(@ctx.message('register.already_registered')) if project.registered?
+        CLI::UI::Frame.open(@ctx.message("register.frame_title")) do
+          @ctx.abort(@ctx.message("register.already_registered")) if project.registered?
 
           with_register_form(args) do |form|
             should_continue = confirm_registration(form.app)
@@ -18,8 +18,8 @@ module Extension
 
             update_project_files(form.app, registration)
 
-            @ctx.puts(@ctx.message('register.success', project.title, form.app.title))
-            @ctx.puts(@ctx.message('register.success_info'))
+            @ctx.puts(@ctx.message("register.success", project.title, form.app.title))
+            @ctx.puts(@ctx.message("register.success_info"))
           end
         end
       end
@@ -43,12 +43,12 @@ module Extension
       end
 
       def confirm_registration(app)
-        @ctx.puts(@ctx.message('register.confirm_info', extension_type.name))
-        CLI::UI::Prompt.confirm(@ctx.message('register.confirm_question', app.title))
+        @ctx.puts(@ctx.message("register.confirm_info", extension_type.name))
+        CLI::UI::Prompt.confirm(@ctx.message("register.confirm_question", app.title))
       end
 
       def register_extension(app)
-        @ctx.puts(@ctx.message('register.waiting_text'))
+        @ctx.puts(@ctx.message("register.waiting_text"))
 
         Tasks::CreateExtension.call(
           context: @ctx,
@@ -71,7 +71,7 @@ module Extension
       end
 
       def abort_not_registered
-        @ctx.puts(@ctx.message('register.confirm_abort'))
+        @ctx.puts(@ctx.message("register.confirm_abort"))
         raise ShopifyCli::AbortSilent
       end
     end

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -7,9 +7,9 @@ module Extension
       NPM_SERVE_COMMAND = %w(run-script server)
 
       def call(_args, _command_name)
-        CLI::UI::Frame.open(@ctx.message('serve.frame_title')) do
+        CLI::UI::Frame.open(@ctx.message("serve.frame_title")) do
           success = ShopifyCli::JsSystem.call(@ctx, yarn: YARN_SERVE_COMMAND, npm: NPM_SERVE_COMMAND)
-          @ctx.abort(@ctx.message('serve.serve_failure_message')) unless success
+          @ctx.abort(@ctx.message("serve.serve_failure_message")) unless success
         end
       end
 

--- a/lib/project_types/extension/commands/tunnel.rb
+++ b/lib/project_types/extension/commands/tunnel.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Commands
     class Tunnel < ExtensionCommand
       options do |parser, flags|
-        parser.on('--port=PORT') { |port| flags[:port] = port }
+        parser.on("--port=PORT") { |port| flags[:port] = port }
       end
 
-      AUTH_SUBCOMMAND = 'auth'
-      START_SUBCOMMAND = 'start'
-      STOP_SUBCOMMAND = 'stop'
-      STATUS_SUBCOMMAND = 'status'
+      AUTH_SUBCOMMAND = "auth"
+      START_SUBCOMMAND = "start"
+      STOP_SUBCOMMAND = "stop"
+      STATUS_SUBCOMMAND = "status"
       DEFAULT_PORT = 39351
 
       def call(args, _name)
@@ -27,11 +27,11 @@ module Extension
       end
 
       def self.help
-        ShopifyCli::Context.message('tunnel.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("tunnel.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('tunnel.extended_help', ShopifyCli::TOOL_NAME, DEFAULT_PORT)
+        ShopifyCli::Context.message("tunnel.extended_help", ShopifyCli::TOOL_NAME, DEFAULT_PORT)
       end
 
       private
@@ -40,9 +40,9 @@ module Extension
         tunnel_url = ShopifyCli::Tunnel.urls.first
 
         if tunnel_url.nil?
-          @ctx.puts(@ctx.message('tunnel.no_tunnel_running'))
+          @ctx.puts(@ctx.message("tunnel.no_tunnel_running"))
         else
-          @ctx.puts(@ctx.message('tunnel.tunnel_running_at', tunnel_url))
+          @ctx.puts(@ctx.message("tunnel.tunnel_running_at", tunnel_url))
         end
       end
 
@@ -50,7 +50,7 @@ module Extension
         return DEFAULT_PORT unless options.flags.key?(:port)
 
         port = options.flags[:port].to_i
-        @ctx.abort(@ctx.message('tunnel.invalid_port', options.flags[:port])) unless port > 0
+        @ctx.abort(@ctx.message("tunnel.invalid_port", options.flags[:port])) unless port > 0
         port
       end
 
@@ -58,7 +58,7 @@ module Extension
         token = args.shift
 
         if token.nil?
-          @ctx.puts(@ctx.message('tunnel.missing_token'))
+          @ctx.puts(@ctx.message("tunnel.missing_token"))
           @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
         else
           ShopifyCli::Tunnel.auth(@ctx, token)

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   class ExtensionProject < ShopifyCli::Project
@@ -13,7 +13,7 @@ module Extension
         )
       end
 
-      def write_env_file(context:, title:, api_key: '', api_secret: '', registration_id: nil)
+      def write_env_file(context:, title:, api_key: "", api_secret: "", registration_id: nil)
         ShopifyCli::Resources::EnvFile.new(
           api_key: api_key,
           secret: api_secret,
@@ -34,11 +34,11 @@ module Extension
     end
 
     def app
-      Models::App.new(api_key: env['api_key'], secret: env['secret'])
+      Models::App.new(api_key: env["api_key"], secret: env["secret"])
     end
 
     def registered?
-      property_present?('api_key') && property_present?('secret') && registration_id?
+      property_present?("api_key") && property_present?("secret") && registration_id?
     end
 
     def title

--- a/lib/project_types/extension/extension_project_keys.rb
+++ b/lib/project_types/extension/extension_project_keys.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module ExtensionProjectKeys
-    REGISTRATION_ID_KEY = 'EXTENSION_ID'
-    EXTENSION_TYPE_KEY = 'EXTENSION_TYPE'
-    TITLE_KEY = 'EXTENSION_TITLE'
+    REGISTRATION_ID_KEY = "EXTENSION_ID"
+    EXTENSION_TYPE_KEY = "EXTENSION_TYPE"
+    TITLE_KEY = "EXTENSION_TITLE"
   end
 end

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'base64'
-require 'shopify_cli'
-require 'semantic/semantic'
+require "base64"
+require "shopify_cli"
+require "semantic/semantic"
 
 module Extension
   module Features
@@ -31,19 +31,19 @@ module Extension
 
       def config(context)
         js_system = ShopifyCli::JsSystem.new(ctx: context)
-        if js_system.package_manager == 'yarn'
+        if js_system.package_manager == "yarn"
           run_yarn_install(context, js_system)
           run_yarn_run_script(context, js_system)
         end
         filepath = File.join(context.root, SCRIPT_PATH)
-        context.abort(context.message('features.argo.missing_file_error')) unless File.exist?(filepath)
+        context.abort(context.message("features.argo.missing_file_error")) unless File.exist?(filepath)
         begin
           {
             renderer_version: extract_argo_renderer_version(context),
             serialized_script: Base64.strict_encode64(File.read(filepath).chomp),
           }
         rescue StandardError
-          context.abort(context.message('features.argo.script_prepare_error'))
+          context.abort(context.message("features.argo.script_prepare_error"))
         end
       end
 
@@ -53,12 +53,12 @@ module Extension
         result = run_list_command(context)
         found_version = find_version_number(context, result)
         context.abort(
-          context.message('features.argo.dependencies.argo_renderer_package_invalid_version_error')
+          context.message("features.argo.dependencies.argo_renderer_package_invalid_version_error")
         ) if found_version.nil?
         ::Semantic::Version.new(found_version).to_s
       rescue ArgumentError
         context.abort(
-          context.message('features.argo.dependencies.argo_renderer_package_invalid_version_error')
+          context.message("features.argo.dependencies.argo_renderer_package_invalid_version_error")
         )
       end
 
@@ -70,10 +70,10 @@ module Extension
         if found_package.nil?
           error = "'#{renderer_package_name}' not found."
           context.abort(
-            context.message('features.argo.dependencies.argo_missing_renderer_package_error', error)
+            context.message("features.argo.dependencies.argo_missing_renderer_package_error", error)
           )
         end
-        found_package.split('@')[2]&.strip
+        found_package.split("@")[2]&.strip
       end
 
       def run_list_command(context)
@@ -84,7 +84,7 @@ module Extension
           capture_response: true
         )
         context.abort(
-          context.message('features.argo.dependencies.argo_missing_renderer_package_error', error)
+          context.message("features.argo.dependencies.argo_missing_renderer_package_error", error)
         ) unless status.success?
         result
       end
@@ -97,7 +97,7 @@ module Extension
         )
 
         context.abort(
-          context.message('features.argo.dependencies.yarn_install_error', error)
+          context.message("features.argo.dependencies.yarn_install_error", error)
         ) unless status.success?
       end
 
@@ -109,7 +109,7 @@ module Extension
         )
 
         context.abort(
-          context.message('features.argo.dependencies.yarn_run_script_error', error)
+          context.message("features.argo.dependencies.yarn_run_script_error", error)
         ) unless status.success?
       end
     end

--- a/lib/project_types/extension/features/argo_config.rb
+++ b/lib/project_types/extension/features/argo_config.rb
@@ -3,7 +3,7 @@
 module Extension
   module Features
     class ArgoConfig
-      CONFIG_FILE_NAME = 'extension.config.yml'
+      CONFIG_FILE_NAME = "extension.config.yml"
 
       class << self
         def parse_yaml(context, permitted_keys = [])
@@ -11,7 +11,7 @@ module Extension
 
           return {} unless File.size?(file_name)
 
-          require 'yaml' # takes 20ms, so deferred as late as possible.
+          require "yaml" # takes 20ms, so deferred as late as possible.
           begin
             config = YAML.load_file(file_name)
 
@@ -21,7 +21,7 @@ module Extension
             return {} if config.nil?
 
             unless config.is_a?(Hash)
-              raise ShopifyCli::Abort, ShopifyCli::Context.message('core.yaml.error.not_hash', CONFIG_FILE_NAME)
+              raise ShopifyCli::Abort, ShopifyCli::Context.message("core.yaml.error.not_hash", CONFIG_FILE_NAME)
             end
 
             config.transform_keys!(&:to_sym)
@@ -31,7 +31,7 @@ module Extension
           rescue Psych::SyntaxError => e
             raise(
               ShopifyCli::Abort,
-              ShopifyCli::Context.message('core.yaml.error.invalid', CONFIG_FILE_NAME, e.message)
+              ShopifyCli::Context.message("core.yaml.error.invalid", CONFIG_FILE_NAME, e.message)
             )
           end
         end
@@ -47,7 +47,7 @@ module Extension
             raise(
               ShopifyCli::Abort,
               ShopifyCli::Context.message(
-                'features.argo.config.unpermitted_keys',
+                "features.argo.config.unpermitted_keys",
                 CONFIG_FILE_NAME,
                 unpermitted_keys.map { |k| "\n- #{k}" }.join
               )

--- a/lib/project_types/extension/features/argo_dependencies.rb
+++ b/lib/project_types/extension/features/argo_dependencies.rb
@@ -5,21 +5,21 @@ module Extension
     class ArgoDependencies
       def self.node_installed(min_major:, min_minor: nil)
         -> (context) do
-          out, status = CLI::Kit::System.capture2('node', '-v')
-          context.abort(context.message('features.argo.dependencies.node.node_not_installed')) unless status.success?
+          out, status = CLI::Kit::System.capture2("node", "-v")
+          context.abort(context.message("features.argo.dependencies.node.node_not_installed")) unless status.success?
 
-          min_version = 'v' + min_major .to_s + '.' + (min_minor.nil? ? 'x' : min_minor.to_s) + '.x'
+          min_version = "v" + min_major .to_s + "." + (min_minor.nil? ? "x" : min_minor.to_s) + ".x"
           version = out.strip
           parsed_version = version.match(/v(?<major>\d+).(?<minor>\d+).(?<patch>\d+)/)
 
           unless min_major.nil? || parsed_version[:major].to_i >= min_major
-            context.abort(context.message('features.argo.dependencies.node.version_too_low', version, min_version))
+            context.abort(context.message("features.argo.dependencies.node.version_too_low", version, min_version))
           end
 
           return if parsed_version[:major].to_i > min_major
 
           unless min_minor.nil? || parsed_version[:minor].to_i >= min_minor
-            context.abort(context.message('features.argo.dependencies.node.version_too_low', version, min_version))
+            context.abort(context.message("features.argo.dependencies.node.version_too_low", version, min_version))
           end
         end
       end

--- a/lib/project_types/extension/features/argo_setup.rb
+++ b/lib/project_types/extension/features/argo_setup.rb
@@ -5,8 +5,8 @@ module Extension
     class ArgoSetup
       include SmartProperties
 
-      GIT_DIRECTORY = '.git'
-      SCRIPTS_DIRECTORY = 'scripts'
+      GIT_DIRECTORY = ".git"
+      SCRIPTS_DIRECTORY = "scripts"
 
       property! :git_template, accepts: String
       property! :dependency_checks, default: []

--- a/lib/project_types/extension/features/argo_setup_steps.rb
+++ b/lib/project_types/extension/features/argo_setup_steps.rb
@@ -5,7 +5,7 @@ module Extension
     module ArgoSetupSteps
       YARN_INITIALIZE_COMMAND = %w(generate).freeze
       NPM_INITIALIZE_COMMAND = %w(run generate --).freeze
-      INITIALIZE_TYPE_PARAMETER = '--type=%s'
+      INITIALIZE_TYPE_PARAMETER = "--type=%s"
 
       def self.check_dependencies(dependency_checks)
         ArgoSetupStep.always_successful do |context, _identifier, _directory_name, _js_system|
@@ -21,7 +21,7 @@ module Extension
             ShopifyCli::Git.clone(git_template, directory_name, ctx: context)
             context.root = File.join(context.root, directory_name)
           rescue StandardError
-            context.puts('{{x}} Unable to clone the repository.')
+            context.puts("{{x}} Unable to clone the repository.")
           end
         end
       end
@@ -34,8 +34,8 @@ module Extension
 
       def self.initialize_project
         ArgoSetupStep.default do |context, identifier, _directory_name, js_system|
-          frame_title = context.message('create.setup_project_frame_title')
-          failure_message = context.message('features.argo.initialization_error')
+          frame_title = context.message("create.setup_project_frame_title")
+          failure_message = context.message("features.argo.initialization_error")
 
           result = true
           CLI::UI::Frame.open(frame_title, failure_text: failure_message) do

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -11,7 +11,7 @@ module Extension
       end
 
       def directory_name
-        @directory_name ||= name.strip.gsub(/( )/, '_').downcase
+        @directory_name ||= name.strip.gsub(/( )/, "_").downcase
       end
 
       private
@@ -20,16 +20,16 @@ module Extension
         ask_with_reprompt(
           initial_value: name,
           break_condition: -> (current_name) { Models::Registration.valid_title?(current_name) },
-          prompt_message: ctx.message('create.ask_name'),
-          reprompt_message: ctx.message('create.invalid_name', Models::Registration::MAX_TITLE_LENGTH)
+          prompt_message: ctx.message("create.ask_name"),
+          reprompt_message: ctx.message("create.invalid_name", Models::Registration::MAX_TITLE_LENGTH)
         )
       end
 
       def ask_type
         return Extension.specifications[type] if Extension.specifications.valid?(type)
-        ctx.puts(ctx.message('create.invalid_type')) unless type.nil?
+        ctx.puts(ctx.message("create.invalid_type")) unless type.nil?
 
-        CLI::UI::Prompt.ask(ctx.message('create.ask_type')) do |handler|
+        CLI::UI::Prompt.ask(ctx.message("create.ask_type")) do |handler|
           Extension.specifications.each do |type|
             handler.option("#{type.name} #{type.tagline}") { type }
           end

--- a/lib/project_types/extension/forms/register.rb
+++ b/lib/project_types/extension/forms/register.rb
@@ -18,11 +18,11 @@ module Extension
       def ask_app
         if !api_key.nil?
           found_app = Tasks::GetApp.call(context: ctx, api_key: api_key)
-          ctx.abort(ctx.message('register.invalid_api_key', api_key)) if found_app.nil?
+          ctx.abort(ctx.message("register.invalid_api_key", api_key)) if found_app.nil?
           found_app
         else
           apps = load_apps
-          CLI::UI::Prompt.ask(ctx.message('register.ask_app')) do |handler|
+          CLI::UI::Prompt.ask(ctx.message("register.ask_app")) do |handler|
             apps.each do |app|
               handler.option("#{app.title} by #{app.business_name}") { app }
             end
@@ -31,15 +31,15 @@ module Extension
       end
 
       def load_apps
-        ctx.puts(@ctx.message('register.loading_apps'))
+        ctx.puts(@ctx.message("register.loading_apps"))
         apps = Tasks::GetApps.call(context: ctx)
 
         apps.empty? ? abort_no_apps : apps
       end
 
       def abort_no_apps
-        ctx.puts(@ctx.message('register.no_apps'))
-        ctx.puts(@ctx.message('register.learn_about_apps'))
+        ctx.puts(@ctx.message("register.no_apps"))
+        ctx.puts(@ctx.message("register.learn_about_apps"))
         raise ShopifyCli::AbortSilent
       end
     end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Messages
     MESSAGES = {
       create: {
-        ask_name: 'Extension name',
-        invalid_name: 'Extension name must be under %s characters',
-        ask_type: 'What type of extension are you creating?',
-        invalid_type: 'Extension type is invalid.',
-        setup_project_frame_title: 'Initializing project',
+        ask_name: "Extension name",
+        invalid_name: "Extension name must be under %s characters",
+        ask_type: "What type of extension are you creating?",
+        invalid_type: "Extension type is invalid.",
+        setup_project_frame_title: "Initializing project",
         ready_to_start: <<~MESSAGE,
           {{v}} A new folder was generated at {{green:./%s}}.
           {{*}} You’re ready to start building {{green:%s}}!
@@ -19,49 +19,49 @@ module Extension
           {{*}} Once you're ready to version and publish your extension,
           run {{command:shopify register}} to register this extension with one of your apps.
         MESSAGE
-        try_again: '{{*}} Fix the errors and run {{command:shopify create extension}} again.',
+        try_again: "{{*}} Fix the errors and run {{command:shopify create extension}} again.",
         errors: {
-          directory_exists: 'Directory ‘%s’ already exists. Please remove it or choose a new name for your project.',
+          directory_exists: "Directory ‘%s’ already exists. Please remove it or choose a new name for your project.",
         },
       },
       build: {
-        frame_title: 'Building extension with: %s...',
-        build_failure_message: 'Failed to build extension code.',
+        frame_title: "Building extension with: %s...",
+        build_failure_message: "Failed to build extension code.",
       },
       register: {
-        frame_title: 'Registering Extension',
-        waiting_text: 'Registering with Shopify...',
-        already_registered: 'Extension is already registered.',
-        loading_apps: 'Loading your apps...',
-        ask_app: 'Which app would you like to register this extension with?',
-        no_apps: '{{x}} You don’t have any apps.',
-        learn_about_apps: '{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, ' \
-          'or try creating a new app using {{command:shopify create}}.',
-        invalid_api_key: 'The API key %s does not match any of your apps.',
-        confirm_info: 'This will create a new extension registration for %s, which can’t be undone.',
-        confirm_question: 'Would you like to register this extension with {{green:%s}}? (y/n)',
-        confirm_abort: 'Extension was not registered.',
-        success: '{{v}} Registered {{green:%s}} with {{green:%s}}.',
-        success_info: '{{*}} Run {{command:shopify push}} to push your extension to Shopify.',
+        frame_title: "Registering Extension",
+        waiting_text: "Registering with Shopify...",
+        already_registered: "Extension is already registered.",
+        loading_apps: "Loading your apps...",
+        ask_app: "Which app would you like to register this extension with?",
+        no_apps: "{{x}} You don’t have any apps.",
+        learn_about_apps: "{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, " \
+          "or try creating a new app using {{command:shopify create}}.",
+        invalid_api_key: "The API key %s does not match any of your apps.",
+        confirm_info: "This will create a new extension registration for %s, which can’t be undone.",
+        confirm_question: "Would you like to register this extension with {{green:%s}}? (y/n)",
+        confirm_abort: "Extension was not registered.",
+        success: "{{v}} Registered {{green:%s}} with {{green:%s}}.",
+        success_info: "{{*}} Run {{command:shopify push}} to push your extension to Shopify.",
       },
       push: {
-        frame_title: 'Pushing your extension to Shopify',
-        waiting_text: 'Pushing code to Shopify...',
-        pushed_with_errors: '{{x}} Code pushed to Shopify with errors on %s.',
-        push_with_errors_info: '{{*}} Fix these errors and run {{command:shopify push}} to revalidate your extension.',
-        success_confirmation: '{{v}} Pushed {{green:%s}} to a draft on %s.',
-        success_info: '{{*}} Visit %s to version and publish your extension.',
+        frame_title: "Pushing your extension to Shopify",
+        waiting_text: "Pushing code to Shopify...",
+        pushed_with_errors: "{{x}} Code pushed to Shopify with errors on %s.",
+        push_with_errors_info: "{{*}} Fix these errors and run {{command:shopify push}} to revalidate your extension.",
+        success_confirmation: "{{v}} Pushed {{green:%s}} to a draft on %s.",
+        success_info: "{{*}} Visit %s to version and publish your extension.",
       },
       serve: {
-        frame_title: 'Serving extension...',
-        serve_failure_message: 'Failed to run extension code.',
+        frame_title: "Serving extension...",
+        serve_failure_message: "Failed to run extension code.",
       },
       tunnel: {
-        missing_token: '{{x}} {{red:auth requires a token argument}}. '\
-          'Find it on your ngrok dashboard: {{underline:https://dashboard.ngrok.com/auth/your-authtoken}}.',
-        invalid_port: '%s is not a valid port.',
-        no_tunnel_running: 'No tunnel running.',
-        tunnel_running_at: 'Tunnel running at: {{underline:%s}}',
+        missing_token: "{{x}} {{red:auth requires a token argument}}. "\
+          "Find it on your ngrok dashboard: {{underline:https://dashboard.ngrok.com/auth/your-authtoken}}.",
+        invalid_port: "%s is not a valid port.",
+        no_tunnel_running: "No tunnel running.",
+        tunnel_running_at: "Tunnel running at: {{underline:%s}}",
         help: <<~HELP,
           Start or stop an http tunnel to your local development extension using ngrok.
             Usage: {{command:%s tunnel [ auth | start | stop | status ]}}
@@ -87,48 +87,48 @@ module Extension
       },
       features: {
         argo: {
-          missing_file_error: 'Could not find built extension file.',
-          script_prepare_error: 'An error occurred while attempting to prepare your script.',
-          initialization_error: '{{x}} There was an error while initializing the project.',
+          missing_file_error: "Could not find built extension file.",
+          script_prepare_error: "An error occurred while attempting to prepare your script.",
+          initialization_error: "{{x}} There was an error while initializing the project.",
           dependencies: {
             node: {
-              node_not_installed: 'Node must be installed to create this extension.',
-              version_too_low: 'Your node version %s does not meet the minimum required version %s',
+              node_not_installed: "Node must be installed to create this extension.",
+              version_too_low: "Your node version %s does not meet the minimum required version %s",
             },
-            argo_missing_renderer_package_error: '%s Install the missing package and try again.',
+            argo_missing_renderer_package_error: "%s Install the missing package and try again.",
             argo_renderer_package_invalid_version_error: <<~MESSAGE,
               The renderer package version is not a valid SemVer Version (http://semver.org)
             MESSAGE
             yarn_install_error: "Something went wrong while running 'yarn install'. %s.",
-            yarn_run_script_error: 'Something went wrong while running script. %s.',
+            yarn_run_script_error: "Something went wrong while running script. %s.",
           },
           config: {
-            unpermitted_keys: '`%s` contains the following unpermitted keys: %s',
+            unpermitted_keys: "`%s` contains the following unpermitted keys: %s",
           },
         },
       },
       tasks: {
         errors: {
-          parse_error: 'Unable to parse response from Partners Dashboard.',
+          parse_error: "Unable to parse response from Partners Dashboard.",
         },
       },
       errors: {
-        unknown_type: 'Unknown extension type %s',
+        unknown_type: "Unknown extension type %s",
       },
     }
 
     TYPES = {
       product_subscription: {
-        name: 'Product Subscription',
-        tagline: '(limit 1 per app)',
+        name: "Product Subscription",
+        tagline: "(limit 1 per app)",
         overrides: {
           register: {
-            confirm_info: 'You can only create one %s extension per app, which can’t be undone.',
+            confirm_info: "You can only create one %s extension per app, which can’t be undone.",
           },
         },
       },
       checkout_post_purchase: {
-        name: 'Checkout Post Purchase',
+        name: "Checkout Post Purchase",
       },
     }
   end

--- a/lib/project_types/extension/models/specification_handlers/checkout_post_purchase.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_post_purchase.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'base64'
+require "base64"
 
 module Extension
   module Models

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -19,11 +19,11 @@ module Extension
         end
 
         def name
-          message('name')
+          message("name")
         end
 
         def tagline
-          message('tagline') || ""
+          message("tagline") || ""
         end
 
         def config(context)

--- a/lib/project_types/extension/models/specifications.rb
+++ b/lib/project_types/extension/models/specifications.rb
@@ -5,7 +5,7 @@ module Extension
 
       property! :custom_handler_root,
         accepts: ->(d) { File.directory?(d) },
-        default: -> { File.expand_path('lib/project_types/extension/models/specification_handlers', ShopifyCli::ROOT) }
+        default: -> { File.expand_path("lib/project_types/extension/models/specification_handlers", ShopifyCli::ROOT) }
 
       property! :custom_handler_namespace,
         accepts: ->(m) { m.respond_to?(:const_get) },
@@ -64,8 +64,8 @@ module Extension
 
       def ensure_legacy_compatibility(specification_attribute_sets)
         specification_attribute_sets.each do |attributes|
-          next unless attributes.fetch(:identifier) == 'product_subscription'
-          attributes[:graphql_identifier] = 'SUBSCRIPTION_MANAGEMENT'
+          next unless attributes.fetch(:identifier) == "product_subscription"
+          attributes[:graphql_identifier] = "SUBSCRIPTION_MANAGEMENT"
         end
       end
 

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -38,12 +38,12 @@ module Extension
       def surface_area_configurations
         {
           admin: {
-            git_template: 'https://github.com/Shopify/argo-admin-template.git',
-            renderer_package_name: '@shopify/argo-admin',
+            git_template: "https://github.com/Shopify/argo-admin-template.git",
+            renderer_package_name: "@shopify/argo-admin",
           },
           checkout: {
-            git_template: 'https://github.com/Shopify/argo-checkout-template.git',
-            renderer_package_name: '@shopify/argo-checkout',
+            git_template: "https://github.com/Shopify/argo-checkout-template.git",
+            renderer_package_name: "@shopify/argo-checkout",
           },
         }
       end

--- a/lib/project_types/extension/tasks/converters/app_converter.rb
+++ b/lib/project_types/extension/tasks/converters/app_converter.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
     module Converters
       module AppConverter
-        API_KEY_FIELD = 'apiKey'
-        API_SECRET_KEYS_FIELD = 'apiSecretKeys'
-        API_SECRET_FIELD = 'secret'
-        TITLE_FIELD = 'title'
-        ORGANIZATION_NAME_FIELD = 'businessName'
+        API_KEY_FIELD = "apiKey"
+        API_SECRET_KEYS_FIELD = "apiSecretKeys"
+        API_SECRET_FIELD = "secret"
+        TITLE_FIELD = "title"
+        ORGANIZATION_NAME_FIELD = "businessName"
 
         def self.from_hash(hash, organization = {})
           return nil if hash.nil?

--- a/lib/project_types/extension/tasks/converters/registration_converter.rb
+++ b/lib/project_types/extension/tasks/converters/registration_converter.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
     module Converters
       module RegistrationConverter
-        ID_FIELD = 'id'
-        TYPE_FIELD = 'type'
-        TITLE_FIELD = 'title'
-        DRAFT_VERSION_FIELD = 'draftVersion'
+        ID_FIELD = "id"
+        TYPE_FIELD = "type"
+        TITLE_FIELD = "title"
+        DRAFT_VERSION_FIELD = "draftVersion"
 
         def self.from_hash(context, hash)
-          context.abort(context.message('tasks.errors.parse_error')) if hash.nil?
+          context.abort(context.message("tasks.errors.parse_error")) if hash.nil?
 
           Models::Registration.new(
             id: hash[ID_FIELD].to_i,

--- a/lib/project_types/extension/tasks/converters/validation_error_converter.rb
+++ b/lib/project_types/extension/tasks/converters/validation_error_converter.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
     module Converters
       module ValidationErrorConverter
-        FIELD_FIELD = 'field'
-        MESSAGE_FIELD = 'message'
+        FIELD_FIELD = "field"
+        MESSAGE_FIELD = "message"
 
         def self.from_array(context, errors)
           return [] if errors.nil?
-          context.abort(context.message('tasks.errors.parse_error')) unless errors.is_a?(Array)
+          context.abort(context.message("tasks.errors.parse_error")) unless errors.is_a?(Array)
 
           errors.map do |error|
             Models::ValidationError.new(

--- a/lib/project_types/extension/tasks/converters/version_converter.rb
+++ b/lib/project_types/extension/tasks/converters/version_converter.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
     module Converters
       module VersionConverter
-        REGISTRATION_ID_FIELD = 'registrationId'
-        CONTEXT_FIELD = 'context'
-        LAST_USER_INTERACTION_AT_FIELD = 'lastUserInteractionAt'
-        LOCATION_FIELD = 'location'
-        VALIDATION_ERRORS_FIELD = 'validationErrors'
+        REGISTRATION_ID_FIELD = "registrationId"
+        CONTEXT_FIELD = "context"
+        LAST_USER_INTERACTION_AT_FIELD = "lastUserInteractionAt"
+        LOCATION_FIELD = "location"
+        VALIDATION_ERRORS_FIELD = "validationErrors"
 
         def self.from_hash(context, hash)
-          context.abort(context.message('tasks.errors.parse_error')) if hash.nil?
+          context.abort(context.message("tasks.errors.parse_error")) if hash.nil?
 
           Models::Version.new(
             registration_id: hash[REGISTRATION_ID_FIELD].to_i,

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
     class CreateExtension < ShopifyCli::Task
       include UserErrors
 
-      GRAPHQL_FILE = 'extension_create'
+      GRAPHQL_FILE = "extension_create"
 
       RESPONSE_FIELD = %w(data extensionCreate)
-      REGISTRATION_FIELD = 'extensionRegistration'
+      REGISTRATION_FIELD = "extensionRegistration"
 
       def call(context:, api_key:, type:, title:, config:, extension_context: nil)
         input = {
@@ -21,7 +21,7 @@ module Extension
         }
 
         response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
-        context.abort(context.message('tasks.errors.parse_error')) if response.nil?
+        context.abort(context.message("tasks.errors.parse_error")) if response.nil?
 
         abort_if_user_errors(context, response)
         Converters::RegistrationConverter.from_hash(context, response.dig(REGISTRATION_FIELD))

--- a/lib/project_types/extension/tasks/fetch_specifications.rb
+++ b/lib/project_types/extension/tasks/fetch_specifications.rb
@@ -14,10 +14,10 @@ module Extension
 
       def product_subscription_specification
         {
-          identifier: 'product_subscription',
+          identifier: "product_subscription",
           features: {
             argo: {
-              surface_area: 'admin',
+              surface_area: "admin",
             },
           },
         }
@@ -25,10 +25,10 @@ module Extension
 
       def checkout_post_purchase_specification
         {
-          identifier: 'checkout_post_purchase',
+          identifier: "checkout_post_purchase",
           features: {
             argo: {
-              surface_area: 'checkout',
+              surface_area: "checkout",
             },
           },
         }

--- a/lib/project_types/extension/tasks/get_app.rb
+++ b/lib/project_types/extension/tasks/get_app.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
     class GetApp < ShopifyCli::Task
-      GRAPHQL_FILE = 'get_app_by_api_key'
+      GRAPHQL_FILE = "get_app_by_api_key"
 
       RESPONSE_FIELD = %w(data)
-      APP_FIELD = 'app'
+      APP_FIELD = "app"
 
       def call(context:, api_key:)
         input = { api_key: api_key }
 
         response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
-        context.abort(context.message('tasks.errors.parse_error')) if response.nil?
+        context.abort(context.message("tasks.errors.parse_error")) if response.nil?
 
         Converters::AppConverter.from_hash(response.dig(APP_FIELD))
       end

--- a/lib/project_types/extension/tasks/get_apps.rb
+++ b/lib/project_types/extension/tasks/get_apps.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
@@ -18,9 +18,9 @@ module Extension
       end
 
       def apps_owned_by_organization(organization)
-        return [] unless organization.key?('apps') && organization['apps'].any?
+        return [] unless organization.key?("apps") && organization["apps"].any?
 
-        organization['apps'].map do |app|
+        organization["apps"].map do |app|
           Converters::AppConverter.from_hash(app, organization)
         end
       end

--- a/lib/project_types/extension/tasks/update_draft.rb
+++ b/lib/project_types/extension/tasks/update_draft.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
     class UpdateDraft < ShopifyCli::Task
       include UserErrors
 
-      GRAPHQL_FILE = 'extension_update_draft'
+      GRAPHQL_FILE = "extension_update_draft"
 
       RESPONSE_FIELD = %w(data extensionUpdateDraft)
-      VERSION_FIELD = 'extensionVersion'
+      VERSION_FIELD = "extensionVersion"
 
       def call(context:, api_key:, registration_id:, config:, extension_context:)
         input = {
@@ -19,7 +19,7 @@ module Extension
           extension_context: extension_context,
         }
         response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
-        context.abort(context.message('tasks.errors.parse_error')) if response.nil?
+        context.abort(context.message("tasks.errors.parse_error")) if response.nil?
 
         abort_if_user_errors(context, response)
         Converters::VersionConverter.from_hash(context, response.dig(VERSION_FIELD))

--- a/lib/project_types/extension/tasks/user_errors.rb
+++ b/lib/project_types/extension/tasks/user_errors.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Extension
   module Tasks
     module UserErrors
-      USER_ERRORS_FIELD = 'userErrors'
-      MESSAGE_FIELD = 'message'
-      USER_ERRORS_PARSE_ERROR = 'Unable to parse errors from server.'
+      USER_ERRORS_FIELD = "userErrors"
+      MESSAGE_FIELD = "message"
+      USER_ERRORS_PARSE_ERROR = "Unable to parse errors from server."
 
       def abort_if_user_errors(context, response)
         return if response.nil?

--- a/lib/project_types/node/cli.rb
+++ b/lib/project_types/node/cli.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 module Node
   class Project < ShopifyCli::ProjectType
-    title('Node.js App')
-    creator('Node::Commands::Create')
-    connector('Node::Commands::Connect')
+    title("Node.js App")
+    creator("Node::Commands::Create")
+    connector("Node::Commands::Connect")
 
-    register_command('Node::Commands::Deploy', "deploy")
-    register_command('Node::Commands::Generate', "generate")
-    register_command('Node::Commands::Open', "open")
-    register_command('Node::Commands::Populate', "populate")
-    register_command('Node::Commands::Serve', "serve")
-    register_command('Node::Commands::Tunnel', "tunnel")
+    register_command("Node::Commands::Deploy", "deploy")
+    register_command("Node::Commands::Generate", "generate")
+    register_command("Node::Commands::Open", "open")
+    register_command("Node::Commands::Populate", "populate")
+    register_command("Node::Commands::Serve", "serve")
+    register_command("Node::Commands::Tunnel", "tunnel")
     # register_task('Node::Tasks::NodeTask', 'node_task')
 
-    require Project.project_filepath('messages/messages')
+    require Project.project_filepath("messages/messages")
     register_messages(Node::Messages::MESSAGES)
   end
 
   # define/autoload project specific Commands
   module Commands
-    autoload :Connect, Project.project_filepath('commands/connect')
-    autoload :Create, Project.project_filepath('commands/create')
-    autoload :Deploy, Project.project_filepath('commands/deploy')
-    autoload :Generate, Project.project_filepath('commands/generate')
-    autoload :Open, Project.project_filepath('commands/open')
-    autoload :Populate, Project.project_filepath('commands/populate')
-    autoload :Serve, Project.project_filepath('commands/serve')
-    autoload :Tunnel, Project.project_filepath('commands/tunnel')
+    autoload :Connect, Project.project_filepath("commands/connect")
+    autoload :Create, Project.project_filepath("commands/create")
+    autoload :Deploy, Project.project_filepath("commands/deploy")
+    autoload :Generate, Project.project_filepath("commands/generate")
+    autoload :Open, Project.project_filepath("commands/open")
+    autoload :Populate, Project.project_filepath("commands/populate")
+    autoload :Serve, Project.project_filepath("commands/serve")
+    autoload :Tunnel, Project.project_filepath("commands/tunnel")
   end
 
   # define/autoload project specific Tasks
@@ -35,6 +35,6 @@ module Node
 
   # define/autoload project specific Forms
   module Forms
-    autoload :Create, Project.project_filepath('forms/create')
+    autoload :Create, Project.project_filepath("forms/create")
   end
 end

--- a/lib/project_types/node/commands/connect.rb
+++ b/lib/project_types/node/commands/connect.rb
@@ -4,11 +4,11 @@ module Node
     class Connect < ShopifyCli::SubCommand
       def call(*)
         if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
-          @ctx.puts(@ctx.message('node.connect.production_warning'))
+          @ctx.puts(@ctx.message("node.connect.production_warning"))
         end
 
-        app = ShopifyCli::Commands::Connect.new.default_connect('node')
-        @ctx.done(@ctx.message('node.connect.connected', app))
+        app = ShopifyCli::Commands::Connect.new.default_connect("node")
+        @ctx.done(@ctx.message("node.connect.connected", app))
       end
     end
   end

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -4,14 +4,14 @@ module Node
     class Create < ShopifyCli::SubCommand
       options do |parser, flags|
         # backwards compatibility allow 'title' for now
-        parser.on('--title=TITLE') { |t| flags[:title] = t }
-        parser.on('--name=NAME') { |t| flags[:title] = t }
-        parser.on('--organization_id=ID') { |url| flags[:organization_id] = url }
-        parser.on('--organization-id=ID') { |url| flags[:organization_id] = url }
-        parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
-        parser.on('--shop-domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
-        parser.on('--type=APPTYPE') { |url| flags[:type] = url }
-        parser.on('--verbose') { flags[:verbose] = true }
+        parser.on("--title=TITLE") { |t| flags[:title] = t }
+        parser.on("--name=NAME") { |t| flags[:title] = t }
+        parser.on("--organization_id=ID") { |url| flags[:organization_id] = url }
+        parser.on("--organization-id=ID") { |url| flags[:organization_id] = url }
+        parser.on("--shop_domain=MYSHOPIFYDOMAIN") { |url| flags[:shop_domain] = url }
+        parser.on("--shop-domain=MYSHOPIFYDOMAIN") { |url| flags[:shop_domain] = url }
+        parser.on("--type=APPTYPE") { |url| flags[:type] = url }
+        parser.on("--verbose") { flags[:verbose] = true }
       end
 
       def call(args, _name)
@@ -24,7 +24,7 @@ module Node
 
         ShopifyCli::Project.write(
           @ctx,
-          project_type: 'node',
+          project_type: "node",
           organization_id: form.organization_id,
         )
 
@@ -39,65 +39,65 @@ module Node
           api_key: api_client["apiKey"],
           secret: api_client["apiSecretKeys"].first["secret"],
           shop: form.shop_domain,
-          scopes: 'write_products,write_customers,write_draft_orders',
+          scopes: "write_products,write_customers,write_draft_orders",
         ).write(@ctx)
 
-        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client['id'], local_debug?)
+        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client["id"], local_debug?)
 
-        @ctx.puts(@ctx.message('apps.create.info.created', form.title, partners_url))
-        @ctx.puts(@ctx.message('apps.create.info.serve', form.name, ShopifyCli::TOOL_NAME))
+        @ctx.puts(@ctx.message("apps.create.info.created", form.title, partners_url))
+        @ctx.puts(@ctx.message("apps.create.info.serve", form.name, ShopifyCli::TOOL_NAME))
         unless ShopifyCli::Shopifolk.acting_as_shopify_organization?
-          @ctx.puts(@ctx.message('apps.create.info.install', partners_url, form.title))
+          @ctx.puts(@ctx.message("apps.create.info.install", partners_url, form.title))
         end
       end
 
       def self.help
-        ShopifyCli::Context.message('node.create.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.create.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
       end
 
       private
 
       def check_node
-        cmd_path = @ctx.which('node')
-        @ctx.abort(@ctx.message('node.create.error.node_required')) if cmd_path.nil?
+        cmd_path = @ctx.which("node")
+        @ctx.abort(@ctx.message("node.create.error.node_required")) if cmd_path.nil?
 
-        version, stat = @ctx.capture2e('node', '-v')
-        @ctx.abort(@ctx.message('node.create.error.node_version_failure')) unless stat.success?
+        version, stat = @ctx.capture2e("node", "-v")
+        @ctx.abort(@ctx.message("node.create.error.node_version_failure")) unless stat.success?
 
-        @ctx.done(@ctx.message('node.create.node_version', version))
+        @ctx.done(@ctx.message("node.create.node_version", version))
       end
 
       def check_npm
-        cmd_path = @ctx.which('npm')
-        @ctx.abort(@ctx.message('node.create.error.npm_required')) if cmd_path.nil?
+        cmd_path = @ctx.which("npm")
+        @ctx.abort(@ctx.message("node.create.error.npm_required")) if cmd_path.nil?
 
-        version, stat = @ctx.capture2e('npm', '-v')
-        @ctx.abort(@ctx.message('node.create.error.npm_version_failure')) unless stat.success?
+        version, stat = @ctx.capture2e("npm", "-v")
+        @ctx.abort(@ctx.message("node.create.error.npm_version_failure")) unless stat.success?
 
-        @ctx.done(@ctx.message('node.create.npm_version', version))
+        @ctx.done(@ctx.message("node.create.npm_version", version))
       end
 
       def set_npm_config
         # check available npmrc (either user or system) for production registry
-        registry, _ = @ctx.capture2('npm config get @shopify:registry')
-        return if registry.include?('https://registry.yarnpkg.com')
+        registry, _ = @ctx.capture2("npm config get @shopify:registry")
+        return if registry.include?("https://registry.yarnpkg.com")
 
         # available npmrc doesn't have production registry =>
         # set a project-based .npmrc
         @ctx.system(
-          'npm',
-          '--userconfig',
-          './.npmrc',
-          'config',
-          'set',
-          '@shopify:registry',
-          'https://registry.yarnpkg.com',
+          "npm",
+          "--userconfig",
+          "./.npmrc",
+          "config",
+          "set",
+          "@shopify:registry",
+          "https://registry.yarnpkg.com",
           chdir: @ctx.root
         )
       end
 
       def build(name)
-        ShopifyCli::Git.clone('https://github.com/Shopify/shopify-app-node.git', name)
+        ShopifyCli::Git.clone("https://github.com/Shopify/shopify-app-node.git", name)
 
         @ctx.root = File.join(@ctx.root, name)
 
@@ -105,12 +105,12 @@ module Node
         ShopifyCli::JsDeps.install(@ctx, !options.flags[:verbose].nil?)
 
         begin
-          @ctx.rm_r('.git')
-          @ctx.rm_r('.github')
-          @ctx.rm(File.join('server', 'handlers', 'client.js'))
+          @ctx.rm_r(".git")
+          @ctx.rm_r(".github")
+          @ctx.rm(File.join("server", "handlers", "client.js"))
           @ctx.rename(
-            File.join('server', 'handlers', 'client.cli.js'),
-            File.join('server', 'handlers', 'client.js')
+            File.join("server", "handlers", "client.cli.js"),
+            File.join("server", "handlers", "client.js")
           )
         rescue Errno::ENOENT => e
           @ctx.debug(e)

--- a/lib/project_types/node/commands/deploy.rb
+++ b/lib/project_types/node/commands/deploy.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
     class Deploy < ShopifyCli::Command
-      subcommand :Heroku, 'heroku', Project.project_filepath('commands/deploy/heroku')
+      subcommand :Heroku, "heroku", Project.project_filepath("commands/deploy/heroku")
 
       def call(*)
         @ctx.puts(self.class.help)
       end
 
       def self.help
-        ShopifyCli::Context.message('node.deploy.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.deploy.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('node.deploy.extended_help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.deploy.extended_help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/deploy/heroku.rb
+++ b/lib/project_types/node/commands/deploy/heroku.rb
@@ -1,70 +1,70 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
     class Deploy
       class Heroku < ShopifyCli::SubCommand
         def self.help
-          ShopifyCli::Context.message('node.deploy.heroku.help', ShopifyCli::TOOL_NAME)
+          ShopifyCli::Context.message("node.deploy.heroku.help", ShopifyCli::TOOL_NAME)
         end
 
         def call(*)
           spin_group = CLI::UI::SpinGroup.new
           heroku_service = ShopifyCli::Heroku.new(@ctx)
 
-          spin_group.add(@ctx.message('node.deploy.heroku.downloading')) do |spinner|
+          spin_group.add(@ctx.message("node.deploy.heroku.downloading")) do |spinner|
             heroku_service.download
-            spinner.update_title(@ctx.message('node.deploy.heroku.downloaded'))
+            spinner.update_title(@ctx.message("node.deploy.heroku.downloaded"))
           end
           spin_group.wait
 
           install_message = @ctx.message(
-            @ctx.windows? ? 'node.deploy.heroku.installing_windows' : 'node.deploy.heroku.installing'
+            @ctx.windows? ? "node.deploy.heroku.installing_windows" : "node.deploy.heroku.installing"
           )
           spin_group.add(install_message) do |spinner|
             heroku_service.install
-            spinner.update_title(@ctx.message('node.deploy.heroku.installed'))
+            spinner.update_title(@ctx.message("node.deploy.heroku.installed"))
           end
           spin_group.wait
 
-          spin_group.add(@ctx.message('node.deploy.heroku.git.checking')) do |spinner|
+          spin_group.add(@ctx.message("node.deploy.heroku.git.checking")) do |spinner|
             ShopifyCli::Git.init(@ctx)
-            spinner.update_title(@ctx.message('node.deploy.heroku.git.initialized'))
+            spinner.update_title(@ctx.message("node.deploy.heroku.git.initialized"))
           end
           spin_group.wait
 
           if (account = heroku_service.whoami)
-            @ctx.puts(@ctx.message('node.deploy.heroku.authenticated_with_account', account))
+            @ctx.puts(@ctx.message("node.deploy.heroku.authenticated_with_account", account))
           else
             CLI::UI::Frame.open(
-              @ctx.message('node.deploy.heroku.authenticating'),
-              success_text: @ctx.message('node.deploy.heroku.authenticated')
+              @ctx.message("node.deploy.heroku.authenticating"),
+              success_text: @ctx.message("node.deploy.heroku.authenticated")
             ) do
               heroku_service.authenticate
             end
           end
 
           if (app_name = heroku_service.app)
-            @ctx.puts(@ctx.message('node.deploy.heroku.app.selected', app_name))
+            @ctx.puts(@ctx.message("node.deploy.heroku.app.selected", app_name))
           else
-            app_type = CLI::UI::Prompt.ask(@ctx.message('node.deploy.heroku.app.no_apps_found')) do |handler|
-              handler.option(@ctx.message('node.deploy.heroku.app.create')) { :new }
-              handler.option(@ctx.message('node.deploy.heroku.app.select')) { :existing }
+            app_type = CLI::UI::Prompt.ask(@ctx.message("node.deploy.heroku.app.no_apps_found")) do |handler|
+              handler.option(@ctx.message("node.deploy.heroku.app.create")) { :new }
+              handler.option(@ctx.message("node.deploy.heroku.app.select")) { :existing }
             end
 
             if app_type == :existing
-              app_name = CLI::UI::Prompt.ask(@ctx.message('node.deploy.heroku.app.name'))
+              app_name = CLI::UI::Prompt.ask(@ctx.message("node.deploy.heroku.app.name"))
               CLI::UI::Frame.open(
-                @ctx.message('node.deploy.heroku.app.selecting', app_name),
-                success_text: @ctx.message('node.deploy.heroku.app.selected', app_name)
+                @ctx.message("node.deploy.heroku.app.selecting", app_name),
+                success_text: @ctx.message("node.deploy.heroku.app.selected", app_name)
               ) do
                 heroku_service.select_existing_app(app_name)
               end
             elsif app_type == :new
               CLI::UI::Frame.open(
-                @ctx.message('node.deploy.heroku.app.creating'),
-                success_text: @ctx.message('node.deploy.heroku.app.created')
+                @ctx.message("node.deploy.heroku.app.creating"),
+                success_text: @ctx.message("node.deploy.heroku.app.created")
               ) do
                 heroku_service.create_new_app
               end
@@ -74,9 +74,9 @@ module Node
           branches = ShopifyCli::Git.branches(@ctx)
           if branches.length == 1
             branch_to_deploy = branches[0]
-            @ctx.puts(@ctx.message('node.deploy.heroku.git.branch_selected', branch_to_deploy))
+            @ctx.puts(@ctx.message("node.deploy.heroku.git.branch_selected", branch_to_deploy))
           else
-            branch_to_deploy = CLI::UI::Prompt.ask(@ctx.message('node.deploy.heroku.git.what_branch')) do |handler|
+            branch_to_deploy = CLI::UI::Prompt.ask(@ctx.message("node.deploy.heroku.git.what_branch")) do |handler|
               branches.each do |branch|
                 handler.option(branch) { branch }
               end
@@ -84,8 +84,8 @@ module Node
           end
 
           CLI::UI::Frame.open(
-            @ctx.message('node.deploy.heroku.deploying'),
-            success_text: @ctx.message('node.deploy.heroku.deployed')
+            @ctx.message("node.deploy.heroku.deploying"),
+            success_text: @ctx.message("node.deploy.heroku.deployed")
           ) do
             heroku_service.deploy(branch_to_deploy)
           end

--- a/lib/project_types/node/commands/generate.rb
+++ b/lib/project_types/node/commands/generate.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
     class Generate < ShopifyCli::Command
-      subcommand :Page, 'page', Project.project_filepath('commands/generate/page')
-      subcommand :Billing, 'billing', Project.project_filepath('commands/generate/billing')
-      subcommand :Webhook, 'webhook', Project.project_filepath('commands/generate/webhook')
+      subcommand :Page, "page", Project.project_filepath("commands/generate/page")
+      subcommand :Billing, "billing", Project.project_filepath("commands/generate/billing")
+      subcommand :Webhook, "webhook", Project.project_filepath("commands/generate/webhook")
 
       def call(*)
         @ctx.puts(self.class.help)
       end
 
       def self.help
-        ShopifyCli::Context.message('node.generate.help')
+        ShopifyCli::Context.message("node.generate.help")
       end
 
       def self.extended_help
@@ -30,11 +30,11 @@ module Node
       def self.response(code, name, ctx)
         case code
         when 1
-          ctx.message('node.generate.error.generic', name)
+          ctx.message("node.generate.error.generic", name)
         when 2
-          ctx.message('node.generate.error.name_exists', name)
+          ctx.message("node.generate.error.name_exists", name)
         else
-          ctx.message('node.error.generic')
+          ctx.message("node.error.generic")
         end
       end
     end

--- a/lib/project_types/node/commands/open.rb
+++ b/lib/project_types/node/commands/open.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
@@ -9,7 +9,7 @@ module Node
       end
 
       def self.help
-        ShopifyCli::Context.message('node.open.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.open.help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/populate.rb
+++ b/lib/project_types/node/commands/populate.rb
@@ -1,22 +1,22 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
     class Populate < ShopifyCli::Command
-      subcommand :Customer, 'customers', Project.project_filepath('commands/populate/customer')
-      subcommand :DraftOrder, 'draftorders', Project.project_filepath('commands/populate/draft_order')
-      subcommand :Product, 'products', Project.project_filepath('commands/populate/product')
+      subcommand :Customer, "customers", Project.project_filepath("commands/populate/customer")
+      subcommand :DraftOrder, "draftorders", Project.project_filepath("commands/populate/draft_order")
+      subcommand :Product, "products", Project.project_filepath("commands/populate/product")
 
       def call(_args, _name)
         @ctx.puts(self.class.help)
       end
 
       def self.help
-        ShopifyCli::Context.message('node.populate.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.populate.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('node.populate.extended_help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.populate.extended_help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/populate/customer.rb
+++ b/lib/project_types/node/commands/populate/customer.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
@@ -15,11 +15,11 @@ module Node
         end
 
         def message(data)
-          ret = data['customerCreate']['customer']
-          id = ShopifyCli::API.gid_to_id(ret['id'])
+          ret = data["customerCreate"]["customer"]
+          id = ShopifyCli::API.gid_to_id(ret["id"])
           @ctx.message(
-            'node.populate.customer.added',
-            ret['displayName'],
+            "node.populate.customer.added",
+            ret["displayName"],
             ShopifyCli::Project.current.env.shop,
             admin_url,
             id

--- a/lib/project_types/node/commands/populate/draft_order.rb
+++ b/lib/project_types/node/commands/populate/draft_order.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
@@ -11,16 +11,16 @@ module Node
             lineItems: [{
               originalUnitPrice: price,
               quantity: 1,
-              weight: { value: 10, unit: 'GRAMS' },
+              weight: { value: 10, unit: "GRAMS" },
               title: ShopifyCli::Helpers::Haikunator.title,
             }],
           }
         end
 
         def message(data)
-          ret = data['draftOrderCreate']['draftOrder']
-          id = ShopifyCli::API.gid_to_id(ret['id'])
-          @ctx.message('node.populate.draft_order.added', ShopifyCli::Project.current.env.shop, admin_url, id)
+          ret = data["draftOrderCreate"]["draftOrder"]
+          id = ShopifyCli::API.gid_to_id(ret["id"])
+          @ctx.message("node.populate.draft_order.added", ShopifyCli::Project.current.env.shop, admin_url, id)
         end
       end
     end

--- a/lib/project_types/node/commands/populate/product.rb
+++ b/lib/project_types/node/commands/populate/product.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
@@ -14,11 +14,11 @@ module Node
         end
 
         def message(data)
-          ret = data['productCreate']['product']
-          id = ShopifyCli::API.gid_to_id(ret['id'])
+          ret = data["productCreate"]["product"]
+          id = ShopifyCli::API.gid_to_id(ret["id"])
           @ctx.message(
-            'node.populate.product.added',
-            ret['title'],
+            "node.populate.product.added",
+            ret["title"],
             ShopifyCli::Project.current.env.shop,
             admin_url,
             id

--- a/lib/project_types/node/commands/serve.rb
+++ b/lib/project_types/node/commands/serve.rb
@@ -5,15 +5,15 @@ module Node
       prerequisite_task :ensure_env, :ensure_dev_store
 
       options do |parser, flags|
-        parser.on('--host=HOST') do |h|
-          flags[:host] = h.gsub('"', '')
+        parser.on("--host=HOST") do |h|
+          flags[:host] = h.gsub('"', "")
         end
       end
 
       def call(*)
         project = ShopifyCli::Project.current
         url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx)
-        @ctx.abort(@ctx.message('node.serve.error.host_must_be_https')) if url.match(/^https/i).nil?
+        @ctx.abort(@ctx.message("node.serve.error.host_must_be_https")) if url.match(/^https/i).nil?
         project.env.update(@ctx, :host, url)
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @ctx,
@@ -23,22 +23,22 @@ module Node
 
         if project.env.shop
           project_url = "#{project.env.host}/auth?shop=#{project.env.shop}"
-          @ctx.puts("\n" + @ctx.message('node.serve.open_info', project_url) + "\n")
+          @ctx.puts("\n" + @ctx.message("node.serve.open_info", project_url) + "\n")
         end
 
-        CLI::UI::Frame.open(@ctx.message('node.serve.running_server')) do
+        CLI::UI::Frame.open(@ctx.message("node.serve.running_server")) do
           env = project.env.to_h
-          env['PORT'] = ShopifyCli::Tunnel::PORT.to_s
-          @ctx.system('npm run dev', env: env)
+          env["PORT"] = ShopifyCli::Tunnel::PORT.to_s
+          @ctx.system("npm run dev", env: env)
         end
       end
 
       def self.help
-        ShopifyCli::Context.message('node.serve.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.serve.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('node.serve.extended_help')
+        ShopifyCli::Context.message("node.serve.extended_help")
       end
     end
   end

--- a/lib/project_types/node/commands/tunnel.rb
+++ b/lib/project_types/node/commands/tunnel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'shopify_cli'
+require "shopify_cli"
 
 module Node
   module Commands
@@ -10,17 +10,17 @@ module Node
       def call(args, _name)
         subcommand = args.shift
         case subcommand
-        when 'auth'
+        when "auth"
           token = args.shift
           if token.nil?
-            @ctx.puts(@ctx.message('node.tunnel.error.token_argument_missing'))
+            @ctx.puts(@ctx.message("node.tunnel.error.token_argument_missing"))
             @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
           else
             ShopifyCli::Tunnel.auth(@ctx, token)
           end
-        when 'start'
+        when "start"
           ShopifyCli::Tunnel.start(@ctx)
-        when 'stop'
+        when "stop"
           ShopifyCli::Tunnel.stop(@ctx)
         else
           @ctx.puts(self.class.help)
@@ -28,11 +28,11 @@ module Node
       end
 
       def self.help
-        ShopifyCli::Context.message('node.tunnel.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.tunnel.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('node.tunnel.extended_help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("node.tunnel.extended_help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/forms/create.rb
+++ b/lib/project_types/node/forms/create.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require "uri"
 
 module Node
   module Forms
@@ -7,7 +7,7 @@ module Node
       flag_arguments :title, :organization_id, :shop_domain, :type
 
       def ask
-        self.title ||= CLI::UI::Prompt.ask(ctx.message('node.forms.create.app_name'))
+        self.title ||= CLI::UI::Prompt.ask(ctx.message("node.forms.create.app_name"))
         self.type = ask_type
         self.name = self.title.downcase.split(" ").join("_")
         res = ShopifyCli::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
@@ -19,16 +19,16 @@ module Node
 
       def ask_type
         if type.nil?
-          return CLI::UI::Prompt.ask(ctx.message('node.forms.create.app_type.select')) do |handler|
-            handler.option(ctx.message('node.forms.create.app_type.select_public')) { 'public' }
-            handler.option(ctx.message('node.forms.create.app_type.select_custom')) { 'custom' }
+          return CLI::UI::Prompt.ask(ctx.message("node.forms.create.app_type.select")) do |handler|
+            handler.option(ctx.message("node.forms.create.app_type.select_public")) { "public" }
+            handler.option(ctx.message("node.forms.create.app_type.select_custom")) { "custom" }
           end
         end
 
         unless ShopifyCli::Tasks::CreateApiClient::VALID_APP_TYPES.include?(type)
-          ctx.abort(ctx.message('node.forms.create.error.invalid_app_type', type))
+          ctx.abort(ctx.message("node.forms.create.error.invalid_app_type", type))
         end
-        ctx.puts(ctx.message('node.forms.create.app_type.selected', type))
+        ctx.puts(ctx.message("node.forms.create.app_type.selected", type))
         type
       end
     end

--- a/lib/project_types/rails/cli.rb
+++ b/lib/project_types/rails/cli.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 module Rails
   class Project < ShopifyCli::ProjectType
-    title('Ruby on Rails App')
-    creator('Rails::Commands::Create')
-    connector('Rails::Commands::Connect')
+    title("Ruby on Rails App")
+    creator("Rails::Commands::Create")
+    connector("Rails::Commands::Connect")
 
-    register_command('Rails::Commands::Deploy', "deploy")
-    register_command('Rails::Commands::Generate', "generate")
-    register_command('Rails::Commands::Open', "open")
-    register_command('Rails::Commands::Populate', "populate")
-    register_command('Rails::Commands::Serve', "serve")
-    register_command('Rails::Commands::Tunnel', "tunnel")
+    register_command("Rails::Commands::Deploy", "deploy")
+    register_command("Rails::Commands::Generate", "generate")
+    register_command("Rails::Commands::Open", "open")
+    register_command("Rails::Commands::Populate", "populate")
+    register_command("Rails::Commands::Serve", "serve")
+    register_command("Rails::Commands::Tunnel", "tunnel")
     # register_task('Rails::Tasks::RailsTask', 'rails_task')
 
-    require Project.project_filepath('messages/messages')
+    require Project.project_filepath("messages/messages")
     register_messages(Rails::Messages::MESSAGES)
   end
 
   # define/autoload project specific Commands
   module Commands
-    autoload :Connect, Project.project_filepath('commands/connect')
-    autoload :Create, Project.project_filepath('commands/create')
-    autoload :Deploy, Project.project_filepath('commands/deploy')
-    autoload :Generate, Project.project_filepath('commands/generate')
-    autoload :Open, Project.project_filepath('commands/open')
-    autoload :Populate, Project.project_filepath('commands/populate')
-    autoload :Serve, Project.project_filepath('commands/serve')
-    autoload :Tunnel, Project.project_filepath('commands/tunnel')
+    autoload :Connect, Project.project_filepath("commands/connect")
+    autoload :Create, Project.project_filepath("commands/create")
+    autoload :Deploy, Project.project_filepath("commands/deploy")
+    autoload :Generate, Project.project_filepath("commands/generate")
+    autoload :Open, Project.project_filepath("commands/open")
+    autoload :Populate, Project.project_filepath("commands/populate")
+    autoload :Serve, Project.project_filepath("commands/serve")
+    autoload :Tunnel, Project.project_filepath("commands/tunnel")
   end
 
   # define/autoload project specific Tasks
@@ -35,9 +35,9 @@ module Rails
 
   # define/autoload project specific Forms
   module Forms
-    autoload :Create, Project.project_filepath('forms/create')
+    autoload :Create, Project.project_filepath("forms/create")
   end
 
-  autoload :Ruby, Project.project_filepath('ruby')
-  autoload :Gem, Project.project_filepath('gem')
+  autoload :Ruby, Project.project_filepath("ruby")
+  autoload :Gem, Project.project_filepath("gem")
 end

--- a/lib/project_types/rails/commands/connect.rb
+++ b/lib/project_types/rails/commands/connect.rb
@@ -4,11 +4,11 @@ module Rails
     class Connect < ShopifyCli::SubCommand
       def call(*)
         if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
-          @ctx.puts(@ctx.message('rails.connect.production_warning'))
+          @ctx.puts(@ctx.message("rails.connect.production_warning"))
         end
 
-        app = ShopifyCli::Commands::Connect.new.default_connect('rails')
-        @ctx.done(@ctx.message('rails.connect.connected', app))
+        app = ShopifyCli::Commands::Connect.new.default_connect("rails")
+        @ctx.done(@ctx.message("rails.connect.connected", app))
       end
     end
   end

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -14,16 +14,16 @@ module Rails
 
       options do |parser, flags|
         # backwards compatibility allow 'title' for now
-        parser.on('--title=TITLE') { |t| flags[:title] = t }
-        parser.on('--name=NAME') { |t| flags[:title] = t }
-        parser.on('--organization_id=ID') { |url| flags[:organization_id] = url }
-        parser.on('--organization-id=ID') { |url| flags[:organization_id] = url }
-        parser.on('--shop_domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
-        parser.on('--shop-domain=MYSHOPIFYDOMAIN') { |url| flags[:shop_domain] = url }
-        parser.on('--type=APPTYPE') { |url| flags[:type] = url }
-        parser.on('--db=DB') { |db| flags[:db] = db }
-        parser.on('--rails_opts=RAILSOPTS') { |opts| flags[:rails_opts] = opts }
-        parser.on('--rails-opts=RAILSOPTS') { |opts| flags[:rails_opts] = opts }
+        parser.on("--title=TITLE") { |t| flags[:title] = t }
+        parser.on("--name=NAME") { |t| flags[:title] = t }
+        parser.on("--organization_id=ID") { |url| flags[:organization_id] = url }
+        parser.on("--organization-id=ID") { |url| flags[:organization_id] = url }
+        parser.on("--shop_domain=MYSHOPIFYDOMAIN") { |url| flags[:shop_domain] = url }
+        parser.on("--shop-domain=MYSHOPIFYDOMAIN") { |url| flags[:shop_domain] = url }
+        parser.on("--type=APPTYPE") { |url| flags[:type] = url }
+        parser.on("--db=DB") { |db| flags[:db] = db }
+        parser.on("--rails_opts=RAILSOPTS") { |opts| flags[:rails_opts] = opts }
+        parser.on("--rails-opts=RAILSOPTS") { |opts| flags[:rails_opts] = opts }
       end
 
       def call(args, _name)
@@ -31,8 +31,8 @@ module Rails
         return @ctx.puts(self.class.help) if form.nil?
 
         ruby_version = Ruby.version(@ctx)
-        @ctx.abort(@ctx.message('rails.create.error.invalid_ruby_version')) unless
-          ruby_version.satisfies?('~>2.5') || ruby_version.satisfies?('~>3.0.0')
+        @ctx.abort(@ctx.message("rails.create.error.invalid_ruby_version")) unless
+          ruby_version.satisfies?("~>2.5") || ruby_version.satisfies?("~>3.0.0")
 
         check_node
         check_yarn
@@ -41,7 +41,7 @@ module Rails
         set_custom_ua
         ShopifyCli::Project.write(
           @ctx,
-          project_type: 'rails',
+          project_type: "rails",
           organization_id: form.organization_id,
         )
 
@@ -56,74 +56,74 @@ module Rails
           api_key: api_client["apiKey"],
           secret: api_client["apiSecretKeys"].first["secret"],
           shop: form.shop_domain,
-          scopes: 'write_products,write_customers,write_draft_orders',
+          scopes: "write_products,write_customers,write_draft_orders",
         ).write(@ctx)
 
-        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client['id'], local_debug?)
+        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client["id"], local_debug?)
 
-        @ctx.puts(@ctx.message('apps.create.info.created', form.title, partners_url))
-        @ctx.puts(@ctx.message('apps.create.info.serve', form.name, ShopifyCli::TOOL_NAME))
+        @ctx.puts(@ctx.message("apps.create.info.created", form.title, partners_url))
+        @ctx.puts(@ctx.message("apps.create.info.serve", form.name, ShopifyCli::TOOL_NAME))
         unless ShopifyCli::Shopifolk.acting_as_shopify_organization?
-          @ctx.puts(@ctx.message('apps.create.info.install', partners_url, form.title))
+          @ctx.puts(@ctx.message("apps.create.info.install", partners_url, form.title))
         end
       end
 
       def self.help
-        ShopifyCli::Context.message('rails.create.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.create.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
       end
 
       private
 
       def check_node
-        cmd_path = @ctx.which('node')
+        cmd_path = @ctx.which("node")
         if cmd_path.nil?
-          @ctx.abort(@ctx.message('rails.create.error.node_required')) unless @ctx.windows?
-          @ctx.puts("{{x}} {{red:" + @ctx.message('rails.create.error.node_required') + "}}")
-          @ctx.puts(@ctx.message('rails.create.info.open_new_shell', 'node'))
+          @ctx.abort(@ctx.message("rails.create.error.node_required")) unless @ctx.windows?
+          @ctx.puts("{{x}} {{red:" + @ctx.message("rails.create.error.node_required") + "}}")
+          @ctx.puts(@ctx.message("rails.create.info.open_new_shell", "node"))
           raise ShopifyCli::AbortSilent
         end
 
-        version, stat = @ctx.capture2e('node', '-v')
+        version, stat = @ctx.capture2e("node", "-v")
         unless stat.success?
-          @ctx.abort(@ctx.message('rails.create.error.node_version_failure')) unless @ctx.windows?
+          @ctx.abort(@ctx.message("rails.create.error.node_version_failure")) unless @ctx.windows?
           # execution stops above if not Windows
-          @ctx.puts("{{x}} {{red:" + @ctx.message('rails.create.error.node_version_failure') + "}}")
-          @ctx.puts(@ctx.message('rails.create.info.open_new_shell', 'node'))
+          @ctx.puts("{{x}} {{red:" + @ctx.message("rails.create.error.node_version_failure") + "}}")
+          @ctx.puts(@ctx.message("rails.create.info.open_new_shell", "node"))
           raise ShopifyCli::AbortSilent
         end
 
-        @ctx.done(@ctx.message('rails.create.node_version', version))
+        @ctx.done(@ctx.message("rails.create.node_version", version))
       end
 
       def check_yarn
-        cmd_path = @ctx.which('yarn')
+        cmd_path = @ctx.which("yarn")
         if cmd_path.nil?
-          @ctx.abort(@ctx.message('rails.create.error.yarn_required')) unless @ctx.windows?
-          @ctx.puts("{{x}} {{red:" + @ctx.message('rails.create.error.yarn_required') + "}}")
-          @ctx.puts(@ctx.message('rails.create.info.open_new_shell', 'yarn'))
+          @ctx.abort(@ctx.message("rails.create.error.yarn_required")) unless @ctx.windows?
+          @ctx.puts("{{x}} {{red:" + @ctx.message("rails.create.error.yarn_required") + "}}")
+          @ctx.puts(@ctx.message("rails.create.info.open_new_shell", "yarn"))
           raise ShopifyCli::AbortSilent
         end
 
-        version, stat = @ctx.capture2e('yarn', '-v')
+        version, stat = @ctx.capture2e("yarn", "-v")
         unless stat.success?
-          @ctx.abort(@ctx.message('rails.create.error.yarn_version_failure')) unless @ctx.windows?
-          @ctx.puts("{{x}} {{red:" + @ctx.message('rails.create.error.yarn_version_failure') + "}}")
-          @ctx.puts(@ctx.message('rails.create.info.open_new_shell', 'yarn'))
+          @ctx.abort(@ctx.message("rails.create.error.yarn_version_failure")) unless @ctx.windows?
+          @ctx.puts("{{x}} {{red:" + @ctx.message("rails.create.error.yarn_version_failure") + "}}")
+          @ctx.puts(@ctx.message("rails.create.info.open_new_shell", "yarn"))
           raise ShopifyCli::AbortSilent
         end
 
-        @ctx.done(@ctx.message('rails.create.yarn_version', version))
+        @ctx.done(@ctx.message("rails.create.yarn_version", version))
       end
 
       def build(name, db)
-        @ctx.abort(@ctx.message('rails.create.error.install_failure', 'rails')) unless install_gem('rails', '<6.1')
-        @ctx.abort(@ctx.message('rails.create.error.install_failure', 'bundler ~>2.0')) unless
-          install_gem('bundler', '~>2.0')
+        @ctx.abort(@ctx.message("rails.create.error.install_failure", "rails")) unless install_gem("rails", "<6.1")
+        @ctx.abort(@ctx.message("rails.create.error.install_failure", "bundler ~>2.0")) unless
+          install_gem("bundler", "~>2.0")
 
         full_path = File.join(@ctx.root, name)
-        @ctx.abort(@ctx.message('rails.create.error.dir_exists', name)) if Dir.exist?(full_path)
+        @ctx.abort(@ctx.message("rails.create.error.dir_exists", name)) if Dir.exist?(full_path)
 
-        CLI::UI::Frame.open(@ctx.message('rails.create.generating_app', name)) do
+        CLI::UI::Frame.open(@ctx.message("rails.create.generating_app", name)) do
           new_command = %w(rails new)
           new_command += DEFAULT_RAILS_FLAGS
           new_command << "--database=#{db}"
@@ -135,34 +135,34 @@ module Rails
 
         @ctx.root = full_path
 
-        File.open(File.join(@ctx.root, '.gitignore'), 'a') { |f| f.write('.env') }
+        File.open(File.join(@ctx.root, ".gitignore"), "a") { |f| f.write(".env") }
 
-        @ctx.puts(@ctx.message('rails.create.adding_shopify_gem'))
-        File.open(File.join(@ctx.root, 'Gemfile'), 'a') do |f|
+        @ctx.puts(@ctx.message("rails.create.adding_shopify_gem"))
+        File.open(File.join(@ctx.root, "Gemfile"), "a") do |f|
           f.puts "\ngem 'shopify_app', '>=17.0.3'"
         end
-        CLI::UI::Frame.open(@ctx.message('rails.create.running_bundle_install')) do
+        CLI::UI::Frame.open(@ctx.message("rails.create.running_bundle_install")) do
           syscall(%w(bundle install))
         end
 
-        CLI::UI::Frame.open(@ctx.message('rails.create.running_generator')) do
+        CLI::UI::Frame.open(@ctx.message("rails.create.running_generator")) do
           syscall(%w(rails generate shopify_app --new-shopify-cli-app))
         end
 
-        CLI::UI::Frame.open(@ctx.message('rails.create.running_migrations')) do
+        CLI::UI::Frame.open(@ctx.message("rails.create.running_migrations")) do
           syscall(%w(rails db:create))
           syscall(%w(rails db:migrate RAILS_ENV=development))
         end
 
-        unless File.exist?(File.join(@ctx.root, 'config/webpacker.yml'))
-          CLI::UI::Frame.open(@ctx.message('rails.create.running_webpacker_install')) do
+        unless File.exist?(File.join(@ctx.root, "config/webpacker.yml"))
+          CLI::UI::Frame.open(@ctx.message("rails.create.running_webpacker_install")) do
             syscall(%w(rails webpacker:install))
           end
         end
       end
 
       def set_custom_ua
-        ua_path = File.join('config', 'initializers', 'user_agent.rb')
+        ua_path = File.join("config", "initializers", "user_agent.rb")
         @ctx.write(ua_path, USER_AGENT_CODE)
       end
 

--- a/lib/project_types/rails/commands/deploy.rb
+++ b/lib/project_types/rails/commands/deploy.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
     class Deploy < ShopifyCli::Command
-      subcommand :Heroku, 'heroku', Project.project_filepath('commands/deploy/heroku')
+      subcommand :Heroku, "heroku", Project.project_filepath("commands/deploy/heroku")
 
       def call(*)
         @ctx.puts(self.class.help)
       end
 
       def self.help
-        ShopifyCli::Context.message('rails.deploy.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.deploy.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('rails.deploy.extended_help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.deploy.extended_help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/deploy/heroku.rb
+++ b/lib/project_types/rails/commands/deploy/heroku.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
@@ -8,15 +8,15 @@ module Rails
         DB_CHECK_CMD = 'bundle exec rails runner "puts ActiveRecord::Base.connection.adapter_name.downcase"'
 
         def self.help
-          ShopifyCli::Context.message('rails.deploy.heroku.help', ShopifyCli::TOOL_NAME)
+          ShopifyCli::Context.message("rails.deploy.heroku.help", ShopifyCli::TOOL_NAME)
         end
 
         def call(*)
-          CLI::UI::Frame.open(@ctx.message('rails.deploy.heroku.db_check.validating')) do
-            CLI::UI::Spinner.spin(@ctx.message('rails.deploy.heroku.db_check.checking')) do |spinner|
+          CLI::UI::Frame.open(@ctx.message("rails.deploy.heroku.db_check.validating")) do
+            CLI::UI::Spinner.spin(@ctx.message("rails.deploy.heroku.db_check.checking")) do |spinner|
               db_type, err = check_db(@ctx)
               @ctx.abort(@ctx.message(err)) unless err.nil?
-              spinner.update_title(@ctx.message('rails.deploy.heroku.db_check.validated', db_type))
+              spinner.update_title(@ctx.message("rails.deploy.heroku.db_check.validated", db_type))
             end
             true
           end
@@ -24,53 +24,53 @@ module Rails
           spin_group = CLI::UI::SpinGroup.new
           heroku_service = ShopifyCli::Heroku.new(@ctx)
 
-          spin_group.add(@ctx.message('rails.deploy.heroku.downloading')) do |spinner|
+          spin_group.add(@ctx.message("rails.deploy.heroku.downloading")) do |spinner|
             heroku_service.download
-            spinner.update_title(@ctx.message('rails.deploy.heroku.downloaded'))
+            spinner.update_title(@ctx.message("rails.deploy.heroku.downloaded"))
           end
           spin_group.wait
 
-          spin_group.add(@ctx.message('rails.deploy.heroku.installing')) do |spinner|
+          spin_group.add(@ctx.message("rails.deploy.heroku.installing")) do |spinner|
             heroku_service.install
-            spinner.update_title(@ctx.message('rails.deploy.heroku.installed'))
+            spinner.update_title(@ctx.message("rails.deploy.heroku.installed"))
           end
-          spin_group.add(@ctx.message('rails.deploy.heroku.git.checking')) do |spinner|
+          spin_group.add(@ctx.message("rails.deploy.heroku.git.checking")) do |spinner|
             ShopifyCli::Git.init(@ctx)
-            spinner.update_title(@ctx.message('rails.deploy.heroku.git.initialized'))
+            spinner.update_title(@ctx.message("rails.deploy.heroku.git.initialized"))
           end
           spin_group.wait
 
           if (account = heroku_service.whoami)
-            @ctx.puts(@ctx.message('rails.deploy.heroku.authenticated_with_account', account))
+            @ctx.puts(@ctx.message("rails.deploy.heroku.authenticated_with_account", account))
           else
             CLI::UI::Frame.open(
-              @ctx.message('rails.deploy.heroku.authenticating'),
-              success_text: @ctx.message('rails.deploy.heroku.authenticated')
+              @ctx.message("rails.deploy.heroku.authenticating"),
+              success_text: @ctx.message("rails.deploy.heroku.authenticated")
             ) do
               heroku_service.authenticate
             end
           end
 
           if (app_name = heroku_service.app)
-            @ctx.puts(@ctx.message('rails.deploy.heroku.app.selected', app_name))
+            @ctx.puts(@ctx.message("rails.deploy.heroku.app.selected", app_name))
           else
-            app_type = CLI::UI::Prompt.ask(@ctx.message('rails.deploy.heroku.app.no_apps_found')) do |handler|
-              handler.option(@ctx.message('rails.deploy.heroku.app.create')) { :new }
-              handler.option(@ctx.message('rails.deploy.heroku.app.select')) { :existing }
+            app_type = CLI::UI::Prompt.ask(@ctx.message("rails.deploy.heroku.app.no_apps_found")) do |handler|
+              handler.option(@ctx.message("rails.deploy.heroku.app.create")) { :new }
+              handler.option(@ctx.message("rails.deploy.heroku.app.select")) { :existing }
             end
 
             if app_type == :existing
-              app_name = CLI::UI::Prompt.ask(@ctx.message('rails.deploy.heroku.app.name'))
+              app_name = CLI::UI::Prompt.ask(@ctx.message("rails.deploy.heroku.app.name"))
               CLI::UI::Frame.open(
-                @ctx.message('rails.deploy.heroku.app.selecting', app_name),
-                success_text: @ctx.message('rails.deploy.heroku.app.selected', app_name)
+                @ctx.message("rails.deploy.heroku.app.selecting", app_name),
+                success_text: @ctx.message("rails.deploy.heroku.app.selected", app_name)
               ) do
                 heroku_service.select_existing_app(app_name)
               end
             elsif app_type == :new
               CLI::UI::Frame.open(
-                @ctx.message('rails.deploy.heroku.app.creating'),
-                success_text: @ctx.message('rails.deploy.heroku.app.created')
+                @ctx.message("rails.deploy.heroku.app.creating"),
+                success_text: @ctx.message("rails.deploy.heroku.app.created")
               ) do
                 heroku_service.create_new_app
               end
@@ -80,9 +80,9 @@ module Rails
           branches = ShopifyCli::Git.branches(@ctx)
           if branches.length == 1
             branch_to_deploy = branches[0]
-            @ctx.puts(@ctx.message('rails.deploy.heroku.git.branch_selected', branch_to_deploy))
+            @ctx.puts(@ctx.message("rails.deploy.heroku.git.branch_selected", branch_to_deploy))
           else
-            branch_to_deploy = CLI::UI::Prompt.ask(@ctx.message('rails.deploy.heroku.git.what_branch')) do |handler|
+            branch_to_deploy = CLI::UI::Prompt.ask(@ctx.message("rails.deploy.heroku.git.what_branch")) do |handler|
               branches.each do |branch|
                 handler.option(branch) { branch }
               end
@@ -90,8 +90,8 @@ module Rails
           end
 
           CLI::UI::Frame.open(
-            @ctx.message('rails.deploy.heroku.deploying'),
-            success_text: @ctx.message('rails.deploy.heroku.deployed')
+            @ctx.message("rails.deploy.heroku.deploying"),
+            success_text: @ctx.message("rails.deploy.heroku.deployed")
           ) do
             heroku_service.deploy(branch_to_deploy)
           end
@@ -99,10 +99,10 @@ module Rails
 
         def check_db(ctx)
           out, stat = ctx.capture2e(DB_CHECK_CMD)
-          if stat.success? && out.strip == 'sqlite'
-            ['sqlite', 'rails.deploy.heroku.db_check.sqlite']
+          if stat.success? && out.strip == "sqlite"
+            ["sqlite", "rails.deploy.heroku.db_check.sqlite"]
           elsif !stat.success?
-            [nil, 'rails.deploy.heroku.db_check.problem']
+            [nil, "rails.deploy.heroku.db_check.problem"]
           else
             [out.strip, nil]
           end

--- a/lib/project_types/rails/commands/generate.rb
+++ b/lib/project_types/rails/commands/generate.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
     class Generate < ShopifyCli::Command
-      subcommand :Webhook, 'webhook', Project.project_filepath('commands/generate/webhook')
+      subcommand :Webhook, "webhook", Project.project_filepath("commands/generate/webhook")
 
       def call(*)
         @ctx.puts(self.class.help)
       end
 
       def self.help
-        ShopifyCli::Context.message('rails.generate.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.generate.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
@@ -24,7 +24,7 @@ module Rails
           end
           extended_help += "\n"
         end
-        extended_help += ShopifyCli::Context.message('rails.generate.extended_help', ShopifyCli::TOOL_NAME)
+        extended_help += ShopifyCli::Context.message("rails.generate.extended_help", ShopifyCli::TOOL_NAME)
       end
 
       def self.run_generate(script, name, ctx)
@@ -38,11 +38,11 @@ module Rails
       def self.response(code, name, ctx)
         case code
         when 1
-          ctx.message('rails.generate.error.generic', name)
+          ctx.message("rails.generate.error.generic", name)
         when 2
-          ctx.message('rails.generate.error.name_exists', name)
+          ctx.message("rails.generate.error.name_exists", name)
         else
-          ctx.message('rails.error.generic')
+          ctx.message("rails.error.generic")
         end
       end
     end

--- a/lib/project_types/rails/commands/generate/webhook.rb
+++ b/lib/project_types/rails/commands/generate/webhook.rb
@@ -1,5 +1,5 @@
-require 'shopify_cli'
-require 'json'
+require "shopify_cli"
+require "json"
 module Rails
   module Commands
     class Generate
@@ -7,16 +7,16 @@ module Rails
         def call(args, _name)
           selected_type = args.first
           schema = ShopifyCli::AdminAPI::Schema.get(@ctx)
-          webhooks = schema.get_names_from_type('WebhookSubscriptionTopic')
+          webhooks = schema.get_names_from_type("WebhookSubscriptionTopic")
           unless selected_type && webhooks.include?(selected_type)
-            selected_type = CLI::UI::Prompt.ask(@ctx.message('rails.generate.webhook.select')) do |handler|
+            selected_type = CLI::UI::Prompt.ask(@ctx.message("rails.generate.webhook.select")) do |handler|
               webhooks.each do |type|
                 handler.option(type) { type }
               end
             end
           end
           spin_group = CLI::UI::SpinGroup.new
-          spin_group.add(@ctx.message('rails.generate.webhook.selected', selected_type)) do |spinner|
+          spin_group.add(@ctx.message("rails.generate.webhook.selected", selected_type)) do |spinner|
             Rails::Commands::Generate.run_generate(generate_command(selected_type), selected_type, @ctx)
             spinner.update_title("{{green:#{selected_type}}} config/initializers/shopify_app.rb")
           end
@@ -24,7 +24,7 @@ module Rails
         end
 
         def self.help
-          ShopifyCli::Context.message('rails.generate.webhook.help', ShopifyCli::TOOL_NAME)
+          ShopifyCli::Context.message("rails.generate.webhook.help", ShopifyCli::TOOL_NAME)
         end
 
         def generate_command(selected_type)

--- a/lib/project_types/rails/commands/open.rb
+++ b/lib/project_types/rails/commands/open.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
@@ -9,7 +9,7 @@ module Rails
       end
 
       def self.help
-        ShopifyCli::Context.message('rails.open.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.open.help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/populate.rb
+++ b/lib/project_types/rails/commands/populate.rb
@@ -1,22 +1,22 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
     class Populate < ShopifyCli::Command
-      subcommand :Product, 'products', Project.project_filepath('commands/populate/product')
-      subcommand :Customer, 'customers', Project.project_filepath('commands/populate/customer')
-      subcommand :DraftOrder, 'draftorders', Project.project_filepath('commands/populate/draft_order')
+      subcommand :Product, "products", Project.project_filepath("commands/populate/product")
+      subcommand :Customer, "customers", Project.project_filepath("commands/populate/customer")
+      subcommand :DraftOrder, "draftorders", Project.project_filepath("commands/populate/draft_order")
 
       def call(_args, _name)
         @ctx.puts(self.class.help)
       end
 
       def self.help
-        ShopifyCli::Context.message('rails.populate.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.populate.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('rails.populate.extended_help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.populate.extended_help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/populate/customer.rb
+++ b/lib/project_types/rails/commands/populate/customer.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
@@ -15,11 +15,11 @@ module Rails
         end
 
         def message(data)
-          ret = data['customerCreate']['customer']
-          id = ShopifyCli::API.gid_to_id(ret['id'])
+          ret = data["customerCreate"]["customer"]
+          id = ShopifyCli::API.gid_to_id(ret["id"])
           @ctx.message(
-            'rails.populate.customer.added',
-            ret['displayName'],
+            "rails.populate.customer.added",
+            ret["displayName"],
             ShopifyCli::Project.current.env.shop,
             admin_url,
             id

--- a/lib/project_types/rails/commands/populate/draft_order.rb
+++ b/lib/project_types/rails/commands/populate/draft_order.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
@@ -11,16 +11,16 @@ module Rails
             lineItems: [{
               originalUnitPrice: price,
               quantity: 1,
-              weight: { value: 10, unit: 'GRAMS' },
+              weight: { value: 10, unit: "GRAMS" },
               title: ShopifyCli::Helpers::Haikunator.title,
             }],
           }
         end
 
         def message(data)
-          ret = data['draftOrderCreate']['draftOrder']
-          id = ShopifyCli::API.gid_to_id(ret['id'])
-          @ctx.message('rails.populate.draft_order.added', ShopifyCli::Project.current.env.shop, admin_url, id)
+          ret = data["draftOrderCreate"]["draftOrder"]
+          id = ShopifyCli::API.gid_to_id(ret["id"])
+          @ctx.message("rails.populate.draft_order.added", ShopifyCli::Project.current.env.shop, admin_url, id)
         end
       end
     end

--- a/lib/project_types/rails/commands/populate/product.rb
+++ b/lib/project_types/rails/commands/populate/product.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
@@ -14,11 +14,11 @@ module Rails
         end
 
         def message(data)
-          ret = data['productCreate']['product']
-          id = ShopifyCli::API.gid_to_id(ret['id'])
+          ret = data["productCreate"]["product"]
+          id = ShopifyCli::API.gid_to_id(ret["id"])
           @ctx.message(
-            'rails.populate.product.added',
-            ret['title'],
+            "rails.populate.product.added",
+            ret["title"],
             ShopifyCli::Project.current.env.shop,
             admin_url,
             id

--- a/lib/project_types/rails/commands/serve.rb
+++ b/lib/project_types/rails/commands/serve.rb
@@ -5,15 +5,15 @@ module Rails
       prerequisite_task :ensure_env, :ensure_dev_store
 
       options do |parser, flags|
-        parser.on('--host=HOST') do |h|
-          flags[:host] = h.gsub('"', '')
+        parser.on("--host=HOST") do |h|
+          flags[:host] = h.gsub('"', "")
         end
       end
 
       def call(*)
         project = ShopifyCli::Project.current
         url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx)
-        @ctx.abort(@ctx.message('rails.serve.error.host_must_be_https')) if url.match(/^https/i).nil?
+        @ctx.abort(@ctx.message("rails.serve.error.host_must_be_https")) if url.match(/^https/i).nil?
         project.env.update(@ctx, :host, url)
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @ctx,
@@ -23,28 +23,28 @@ module Rails
 
         if project.env.shop
           project_url = "#{project.env.host}/login?shop=#{project.env.shop}"
-          @ctx.puts("\n" + @ctx.message('rails.serve.open_info', project_url) + "\n")
+          @ctx.puts("\n" + @ctx.message("rails.serve.open_info", project_url) + "\n")
         end
 
-        CLI::UI::Frame.open(@ctx.message('rails.serve.running_server')) do
+        CLI::UI::Frame.open(@ctx.message("rails.serve.running_server")) do
           env = ShopifyCli::Project.current.env.to_h
-          env.delete('HOST')
-          env['PORT'] = ShopifyCli::Tunnel::PORT.to_s
-          env['GEM_PATH'] = Gem.gem_path(@ctx)
+          env.delete("HOST")
+          env["PORT"] = ShopifyCli::Tunnel::PORT.to_s
+          env["GEM_PATH"] = Gem.gem_path(@ctx)
           if @ctx.windows?
             @ctx.system("ruby bin\\rails server", env: env)
           else
-            @ctx.system('bin/rails server', env: env)
+            @ctx.system("bin/rails server", env: env)
           end
         end
       end
 
       def self.help
-        ShopifyCli::Context.message('rails.serve.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.serve.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('rails.serve.extended_help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.serve.extended_help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/tunnel.rb
+++ b/lib/project_types/rails/commands/tunnel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   module Commands
@@ -10,17 +10,17 @@ module Rails
       def call(args, _name)
         subcommand = args.shift
         case subcommand
-        when 'auth'
+        when "auth"
           token = args.shift
           if token.nil?
-            @ctx.puts(@ctx.message('rails.tunnel.error.token_argument_missing'))
+            @ctx.puts(@ctx.message("rails.tunnel.error.token_argument_missing"))
             @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
           else
             ShopifyCli::Tunnel.auth(@ctx, token)
           end
-        when 'start'
+        when "start"
           ShopifyCli::Tunnel.start(@ctx)
-        when 'stop'
+        when "stop"
           ShopifyCli::Tunnel.stop(@ctx)
         else
           @ctx.puts(self.class.help)
@@ -28,11 +28,11 @@ module Rails
       end
 
       def self.help
-        ShopifyCli::Context.message('rails.tunnel.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.tunnel.help", ShopifyCli::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message('rails.tunnel.extended_help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("rails.tunnel.extended_help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/forms/create.rb
+++ b/lib/project_types/rails/forms/create.rb
@@ -1,25 +1,25 @@
-require 'uri'
+require "uri"
 
 module Rails
   module Forms
     class Create < ShopifyCli::Form
       attr_accessor :name
       flag_arguments :title, :organization_id, :shop_domain, :type, :db
-      VALID_DB_TYPES = ['sqlite3',
-                        'mysql',
-                        'postgresql',
-                        'sqlite3',
-                        'oracle',
-                        'frontbase',
-                        'ibm_db',
-                        'sqlserver',
-                        'jdbcmysql',
-                        'jdbcsqlite3',
-                        'jdbcpostgresql',
-                        'jdbc']
+      VALID_DB_TYPES = ["sqlite3",
+                        "mysql",
+                        "postgresql",
+                        "sqlite3",
+                        "oracle",
+                        "frontbase",
+                        "ibm_db",
+                        "sqlserver",
+                        "jdbcmysql",
+                        "jdbcsqlite3",
+                        "jdbcpostgresql",
+                        "jdbc"]
 
       def ask
-        self.title ||= CLI::UI::Prompt.ask(ctx.message('rails.forms.create.app_name'))
+        self.title ||= CLI::UI::Prompt.ask(ctx.message("rails.forms.create.app_name"))
         self.type = ask_type
         self.name = self.title.downcase.split(" ").join("_")
         res = ShopifyCli::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
@@ -32,24 +32,24 @@ module Rails
 
       def ask_type
         if type.nil?
-          return CLI::UI::Prompt.ask(ctx.message('rails.forms.create.app_type.select')) do |handler|
-            handler.option(ctx.message('rails.forms.create.app_type.select_public')) { 'public' }
-            handler.option(ctx.message('rails.forms.create.app_type.select_custom')) { 'custom' }
+          return CLI::UI::Prompt.ask(ctx.message("rails.forms.create.app_type.select")) do |handler|
+            handler.option(ctx.message("rails.forms.create.app_type.select_public")) { "public" }
+            handler.option(ctx.message("rails.forms.create.app_type.select_custom")) { "custom" }
           end
         end
 
         unless ShopifyCli::Tasks::CreateApiClient::VALID_APP_TYPES.include?(type)
-          ctx.abort(ctx.message('rails.forms.create.error.invalid_app_type', type))
+          ctx.abort(ctx.message("rails.forms.create.error.invalid_app_type", type))
         end
-        ctx.puts(ctx.message('rails.forms.create.app_type.selected', type))
+        ctx.puts(ctx.message("rails.forms.create.app_type.selected", type))
         type
       end
 
       def ask_db
         if db.nil?
-          return 'sqlite3' unless CLI::UI::Prompt.confirm(ctx.message('rails.forms.create.db.want_select'),
+          return "sqlite3" unless CLI::UI::Prompt.confirm(ctx.message("rails.forms.create.db.want_select"),
             default: false)
-          @db = CLI::UI::Prompt.ask(ctx.message('rails.forms.create.db.select')) do |handler|
+          @db = CLI::UI::Prompt.ask(ctx.message("rails.forms.create.db.select")) do |handler|
             VALID_DB_TYPES.each do |db_type|
               handler.option(ctx.message("rails.forms.create.db.select_#{db_type}")) { db_type }
             end
@@ -57,9 +57,9 @@ module Rails
         end
 
         unless VALID_DB_TYPES.include?(db)
-          ctx.abort(ctx.message('rails.forms.create.error.invalid_db_type', db))
+          ctx.abort(ctx.message("rails.forms.create.error.invalid_db_type", db))
         end
-        ctx.puts(ctx.message('rails.forms.create.db.selected', db))
+        ctx.puts(ctx.message("rails.forms.create.db.selected", db))
         db
       end
     end

--- a/lib/project_types/rails/gem.rb
+++ b/lib/project_types/rails/gem.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Rails
   class Gem
@@ -14,52 +14,52 @@ module Rails
         name = args.shift
         version = args.shift
         gem = new(ctx: ctx, name: name, version: version)
-        ctx.debug(ctx.message('rails.gem.installed_debug', name, gem.installed?))
+        ctx.debug(ctx.message("rails.gem.installed_debug", name, gem.installed?))
         gem.installed? ? true : gem.install!
       end
 
       def binary_path_for(ctx, binary)
-        path_to_binary = File.join(gem_home(ctx), 'bin', binary)
+        path_to_binary = File.join(gem_home(ctx), "bin", binary)
         File.exist?(path_to_binary) ? path_to_binary : binary
       end
 
       def gem_home(ctx)
-        ctx.getenv('GEM_HOME') || apply_gem_home(ctx)
+        ctx.getenv("GEM_HOME") || apply_gem_home(ctx)
       end
 
       def gem_path(ctx)
-        ctx.getenv('GEM_PATH') || apply_gem_path(ctx)
+        ctx.getenv("GEM_PATH") || apply_gem_path(ctx)
       end
 
       private
 
       def apply_gem_home(ctx)
-        path = ''
+        path = ""
         # extract GEM_HOME from `gem environment home` command
-        out, stat = ctx.capture2e('gem', 'environment', 'home')
-        path = out&.empty? ? '' : out.strip if stat.success?
+        out, stat = ctx.capture2e("gem", "environment", "home")
+        path = out&.empty? ? "" : out.strip if stat.success?
         # fallback if return from `gem environment home` is empty (somewhat unlikely)
         path = fallback_gem_home_path(ctx) if path.empty?
         # fallback if path isn't writable (if using a system installed ruby)
         path = fallback_gem_home_path(ctx) unless File.writable?(path)
         ctx.mkdir_p(path) unless Dir.exist?(path)
-        ctx.debug(ctx.message('rails.gem.setting_gem_home', path))
-        ctx.setenv('GEM_HOME', path)
+        ctx.debug(ctx.message("rails.gem.setting_gem_home", path))
+        ctx.setenv("GEM_HOME", path)
       end
 
       def apply_gem_path(ctx)
-        path = ''
-        out, stat = ctx.capture2e('gem', 'environment', 'path')
-        path = out&.empty? ? '' : out.strip if stat.success?
+        path = ""
+        out, stat = ctx.capture2e("gem", "environment", "path")
+        path = out&.empty? ? "" : out.strip if stat.success?
         # usually GEM_PATH already contains GEM_HOME
         # if gem_home() falls back to our fallback path, we need to add it
         path = gem_home(ctx) + File::PATH_SEPARATOR + path unless path.include?(gem_home(ctx))
-        ctx.debug(ctx.message('rails.gem.setting_gem_path', path))
-        ctx.setenv('GEM_PATH', path)
+        ctx.debug(ctx.message("rails.gem.setting_gem_path", path))
+        ctx.setenv("GEM_PATH", path)
       end
 
       def fallback_gem_home_path(ctx)
-        File.join(ctx.getenv('HOME'), '.gem', 'ruby', RUBY_VERSION)
+        File.join(ctx.getenv("HOME"), ".gem", "ruby", RUBY_VERSION)
       end
     end
 
@@ -67,7 +67,7 @@ module Rails
       found = false
       paths = self.class.gem_path(ctx).split(File::PATH_SEPARATOR)
       paths.each do |path|
-        ctx.debug(ctx.message('rails.gem.checking_installation_path', "#{path}/gems/", name))
+        ctx.debug(ctx.message("rails.gem.checking_installation_path", "#{path}/gems/", name))
         found = !!Dir.glob("#{path}/gems/#{name}-*").detect do |f|
           gem_satisfies_version?(f)
         end
@@ -78,18 +78,18 @@ module Rails
 
     def install!
       spin = CLI::UI::SpinGroup.new
-      spin.add(ctx.message('rails.gem.installing', name)) do |spinner|
+      spin.add(ctx.message("rails.gem.installing", name)) do |spinner|
         args = %w(gem install)
         args.push(name)
         unless version.nil?
-          if ctx.windows? && version.include?('~')
-            args.push('-v', "\"#{version}\"")
+          if ctx.windows? && version.include?("~")
+            args.push("-v", "\"#{version}\"")
           else
-            args.push('-v', version)
+            args.push("-v", version)
           end
         end
         ctx.system(*args)
-        spinner.update_title(ctx.message('rails.gem.installed', name))
+        spinner.update_title(ctx.message("rails.gem.installed", name))
       end
       spin.wait
     end
@@ -98,7 +98,7 @@ module Rails
       if version
         # there was a specific version given during new(), so
         # check version of gem found to determine match
-        require 'semantic/semantic'
+        require "semantic/semantic"
         found_version, _ = path.match(%r{/#{Regexp.quote(name)}-(\d\.\d\.\d)})&.captures
         found_version.nil? ? false : Semantic::Version.new(found_version).satisfies?(version)
       else

--- a/lib/project_types/rails/ruby.rb
+++ b/lib/project_types/rails/ruby.rb
@@ -8,8 +8,8 @@ module Rails
 
     class << self
       def version(ctx)
-        require 'semantic/semantic'
-        out, _ = ctx.capture2('ruby', '-v')
+        require "semantic/semantic"
+        out, _ = ctx.capture2("ruby", "-v")
         Semantic::Version.new(VERSION_STRING.match(out)[1])
       end
     end

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -3,77 +3,77 @@
 module Script
   class Project < ShopifyCli::ProjectType
     hidden_feature(feature_set: :script_project)
-    title('Script')
-    creator('Script::Commands::Create')
+    title("Script")
+    creator("Script::Commands::Create")
 
-    register_command('Script::Commands::Push', 'push')
-    register_command('Script::Commands::Disable', 'disable')
-    register_command('Script::Commands::Enable', 'enable')
+    register_command("Script::Commands::Push", "push")
+    register_command("Script::Commands::Disable", "disable")
+    register_command("Script::Commands::Enable", "enable")
 
-    require Project.project_filepath('messages/messages')
+    require Project.project_filepath("messages/messages")
     register_messages(Script::Messages::MESSAGES)
   end
 
   # define/autoload project specific Commands
   module Commands
-    autoload :Create, Project.project_filepath('commands/create')
-    autoload :Push, Project.project_filepath('commands/push')
-    autoload :Disable, Project.project_filepath('commands/disable')
-    autoload :Enable, Project.project_filepath('commands/enable')
+    autoload :Create, Project.project_filepath("commands/create")
+    autoload :Push, Project.project_filepath("commands/push")
+    autoload :Disable, Project.project_filepath("commands/disable")
+    autoload :Enable, Project.project_filepath("commands/enable")
   end
 
   # define/autoload project specific Forms
   module Forms
-    autoload :Create, Project.project_filepath('forms/create')
-    autoload :ScriptForm, Project.project_filepath('forms/script_form')
+    autoload :Create, Project.project_filepath("forms/create")
+    autoload :ScriptForm, Project.project_filepath("forms/script_form")
   end
 
   module Layers
     module Application
-      autoload :BuildScript, Project.project_filepath('layers/application/build_script')
-      autoload :CreateScript, Project.project_filepath('layers/application/create_script')
-      autoload :PushScript, Project.project_filepath('layers/application/push_script')
-      autoload :DisableScript, Project.project_filepath('layers/application/disable_script')
-      autoload :EnableScript, Project.project_filepath('layers/application/enable_script')
-      autoload :ExtensionPoints, Project.project_filepath('layers/application/extension_points')
-      autoload :ProjectDependencies, Project.project_filepath('layers/application/project_dependencies')
+      autoload :BuildScript, Project.project_filepath("layers/application/build_script")
+      autoload :CreateScript, Project.project_filepath("layers/application/create_script")
+      autoload :PushScript, Project.project_filepath("layers/application/push_script")
+      autoload :DisableScript, Project.project_filepath("layers/application/disable_script")
+      autoload :EnableScript, Project.project_filepath("layers/application/enable_script")
+      autoload :ExtensionPoints, Project.project_filepath("layers/application/extension_points")
+      autoload :ProjectDependencies, Project.project_filepath("layers/application/project_dependencies")
     end
 
     module Domain
-      autoload :Errors, Project.project_filepath('layers/domain/errors')
-      autoload :PushPackage, Project.project_filepath('layers/domain/push_package')
-      autoload :Metadata, Project.project_filepath('layers/domain/metadata')
-      autoload :ExtensionPoint, Project.project_filepath('layers/domain/extension_point')
+      autoload :Errors, Project.project_filepath("layers/domain/errors")
+      autoload :PushPackage, Project.project_filepath("layers/domain/push_package")
+      autoload :Metadata, Project.project_filepath("layers/domain/metadata")
+      autoload :ExtensionPoint, Project.project_filepath("layers/domain/extension_point")
     end
 
     module Infrastructure
-      autoload :Errors, Project.project_filepath('layers/infrastructure/errors')
+      autoload :Errors, Project.project_filepath("layers/infrastructure/errors")
       autoload :AssemblyScriptDependencyManager,
-        Project.project_filepath('layers/infrastructure/assemblyscript_dependency_manager')
+        Project.project_filepath("layers/infrastructure/assemblyscript_dependency_manager")
       autoload :AssemblyScriptProjectCreator,
-        Project.project_filepath('layers/infrastructure/assemblyscript_project_creator')
-      autoload :AssemblyScriptTaskRunner, Project.project_filepath('layers/infrastructure/assemblyscript_task_runner')
-      autoload :AssemblyScriptTsConfig, Project.project_filepath('layers/infrastructure/assemblyscript_tsconfig')
+        Project.project_filepath("layers/infrastructure/assemblyscript_project_creator")
+      autoload :AssemblyScriptTaskRunner, Project.project_filepath("layers/infrastructure/assemblyscript_task_runner")
+      autoload :AssemblyScriptTsConfig, Project.project_filepath("layers/infrastructure/assemblyscript_tsconfig")
       autoload :RustProjectCreator,
-        Project.project_filepath('layers/infrastructure/rust_project_creator.rb')
-      autoload :RustTaskRunner, Project.project_filepath('layers/infrastructure/rust_task_runner')
+        Project.project_filepath("layers/infrastructure/rust_project_creator.rb")
+      autoload :RustTaskRunner, Project.project_filepath("layers/infrastructure/rust_task_runner")
 
-      autoload :PushPackageRepository, Project.project_filepath('layers/infrastructure/push_package_repository')
-      autoload :ExtensionPointRepository, Project.project_filepath('layers/infrastructure/extension_point_repository')
-      autoload :ProjectCreator, Project.project_filepath('layers/infrastructure/project_creator')
-      autoload :ScriptService, Project.project_filepath('layers/infrastructure/script_service')
-      autoload :TaskRunner, Project.project_filepath('layers/infrastructure/task_runner')
+      autoload :PushPackageRepository, Project.project_filepath("layers/infrastructure/push_package_repository")
+      autoload :ExtensionPointRepository, Project.project_filepath("layers/infrastructure/extension_point_repository")
+      autoload :ProjectCreator, Project.project_filepath("layers/infrastructure/project_creator")
+      autoload :ScriptService, Project.project_filepath("layers/infrastructure/script_service")
+      autoload :TaskRunner, Project.project_filepath("layers/infrastructure/task_runner")
     end
   end
 
   module UI
-    autoload :ErrorHandler, Project.project_filepath('ui/error_handler')
-    autoload :PrintingSpinner, Project.project_filepath('ui/printing_spinner')
-    autoload :StrictSpinner, Project.project_filepath('ui/strict_spinner')
+    autoload :ErrorHandler, Project.project_filepath("ui/error_handler")
+    autoload :PrintingSpinner, Project.project_filepath("ui/printing_spinner")
+    autoload :StrictSpinner, Project.project_filepath("ui/strict_spinner")
   end
 
-  autoload :ScriptProject, Project.project_filepath('script_project')
-  autoload :Errors, Project.project_filepath('errors')
+  autoload :ScriptProject, Project.project_filepath("script_project")
+  autoload :Errors, Project.project_filepath("errors")
 
   class ScriptProjectError < StandardError; end
 end

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -4,11 +4,11 @@ module Script
   module Commands
     class Create < ShopifyCli::SubCommand
       options do |parser, flags|
-        parser.on('--name=NAME') { |name| flags[:name] = name }
-        parser.on('--description=DESCRIPTION') { |description| flags[:description] = description }
-        parser.on('--extension_point=EP_NAME') { |ep_name| flags[:extension_point] = ep_name }
-        parser.on('--extension-point=EP_NAME') { |ep_name| flags[:extension_point] = ep_name }
-        parser.on('--language=LANGUAGE') { |language| flags[:language] = language }
+        parser.on("--name=NAME") { |name| flags[:name] = name }
+        parser.on("--description=DESCRIPTION") { |description| flags[:description] = description }
+        parser.on("--extension_point=EP_NAME") { |ep_name| flags[:extension_point] = ep_name }
+        parser.on("--extension-point=EP_NAME") { |ep_name| flags[:extension_point] = ep_name }
+        parser.on("--language=LANGUAGE") { |language| flags[:language] = language }
       end
 
       def call(args, _name)
@@ -28,17 +28,17 @@ module Script
           extension_point_type: form.extension_point,
           description: form.description
         )
-        @ctx.puts(@ctx.message('script.create.change_directory_notice', project.script_name))
+        @ctx.puts(@ctx.message("script.create.change_directory_notice", project.script_name))
       rescue Script::Errors::ScriptProjectAlreadyExistsError => e
-        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.create.error.operation_failed'))
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message("script.create.error.operation_failed"))
       rescue StandardError => e
         ScriptProject.cleanup(ctx: @ctx, script_name: form.name, root_dir: cur_dir) if form
-        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.create.error.operation_failed'))
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message("script.create.error.operation_failed"))
       end
 
       def self.help
         allowed_values = Script::Layers::Application::ExtensionPoints.types.map { |type| "{{cyan:#{type}}}" }
-        ShopifyCli::Context.message('script.create.help', ShopifyCli::TOOL_NAME, allowed_values.join(', '))
+        ShopifyCli::Context.message("script.create.help", ShopifyCli::TOOL_NAME, allowed_values.join(", "))
       end
     end
   end

--- a/lib/project_types/script/commands/disable.rb
+++ b/lib/project_types/script/commands/disable.rb
@@ -12,13 +12,13 @@ module Script
           shop_domain: project.env[:shop],
           extension_point_type: project.extension_point_type
         )
-        @ctx.puts(@ctx.message('script.disable.script_disabled'))
+        @ctx.puts(@ctx.message("script.disable.script_disabled"))
       rescue StandardError => e
-        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.disable.error.operation_failed'))
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message("script.disable.error.operation_failed"))
       end
 
       def self.help
-        ShopifyCli::Context.message('script.disable.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("script.disable.help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/commands/enable.rb
+++ b/lib/project_types/script/commands/enable.rb
@@ -4,10 +4,10 @@ module Script
   module Commands
     class Enable < ShopifyCli::Command
       options do |parser, flags|
-        parser.on('--config_props=KEYVALUEPAIRS', Array) { |t| flags[:config_props] = t }
-        parser.on('--config-props=KEYVALUEPAIRS', Array) { |t| flags[:config_props] = t }
-        parser.on('--config_file=CONFIGFILEPATH') { |t| flags[:config_file] = t }
-        parser.on('--config-file=CONFIGFILEPATH') { |t| flags[:config_file] = t }
+        parser.on("--config_props=KEYVALUEPAIRS", Array) { |t| flags[:config_props] = t }
+        parser.on("--config-props=KEYVALUEPAIRS", Array) { |t| flags[:config_props] = t }
+        parser.on("--config_file=CONFIGFILEPATH") { |t| flags[:config_file] = t }
+        parser.on("--config-file=CONFIGFILEPATH") { |t| flags[:config_file] = t }
       end
 
       def call(_args, _name)
@@ -25,21 +25,21 @@ module Script
           title: project.script_name
         )
         @ctx.puts(@ctx.message(
-          'script.enable.script_enabled',
+          "script.enable.script_enabled",
           api_key: api_key,
           shop_domain: shop_domain,
           type: project.extension_point_type.capitalize,
           title: project.script_name
         ))
-        @ctx.puts(@ctx.message('script.enable.info'))
+        @ctx.puts(@ctx.message("script.enable.info"))
       rescue Errors::InvalidConfigYAMLError => e
         UI::ErrorHandler.pretty_print_and_raise(e)
       rescue StandardError => e
-        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message('script.enable.error.operation_failed'))
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message("script.enable.error.operation_failed"))
       end
 
       def self.help
-        ShopifyCli::Context.message('script.enable.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("script.enable.help", ShopifyCli::TOOL_NAME)
       end
 
       private
@@ -64,7 +64,7 @@ module Script
       def parse_config_props(config_props)
         Hash[
           config_props.map do |s|
-            args = s.split(':').map(&:strip)
+            args = s.split(":").map(&:strip)
             raise Errors::InvalidConfigProps unless args.size == 2
             args
           end

--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -4,7 +4,7 @@ module Script
   module Commands
     class Push < ShopifyCli::Command
       options do |parser, flags|
-        parser.on('--force') { |t| flags[:force] = t }
+        parser.on("--force") { |t| flags[:force] = t }
       end
 
       def call(_args, _name)
@@ -14,14 +14,14 @@ module Script
         return @ctx.puts(self.class.help) unless api_key
 
         Layers::Application::PushScript.call(ctx: @ctx, force: options.flags.key?(:force))
-        @ctx.puts(@ctx.message('script.push.script_pushed', api_key: api_key))
+        @ctx.puts(@ctx.message("script.push.script_pushed", api_key: api_key))
       rescue StandardError => e
-        msg = @ctx.message('script.push.error.operation_failed', api_key: ScriptProject.current.api_key)
+        msg = @ctx.message("script.push.error.operation_failed", api_key: ScriptProject.current.api_key)
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: msg)
       end
 
       def self.help
-        ShopifyCli::Context.message('script.push.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("script.push.help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -16,21 +16,21 @@ module Script
 
       def ask_extension_point
         CLI::UI::Prompt.ask(
-          @ctx.message('script.forms.create.select_extension_point'),
+          @ctx.message("script.forms.create.select_extension_point"),
           options: Layers::Application::ExtensionPoints.non_deprecated_types
         )
       end
 
       def ask_name
-        CLI::UI::Prompt.ask(@ctx.message('script.forms.create.script_name'))
+        CLI::UI::Prompt.ask(@ctx.message("script.forms.create.script_name"))
       end
 
       def ask_description
-        CLI::UI::Prompt.ask(@ctx.message('script.forms.create.description'))
+        CLI::UI::Prompt.ask(@ctx.message("script.forms.create.description"))
       end
 
       def valid_name
-        n = (name || ask_name).downcase.gsub(' ', '_')
+        n = (name || ask_name).downcase.gsub(" ", "_")
         return n if n.match?(/^[0-9A-Za-z_-]*$/)
         raise Errors::InvalidScriptNameError
       end
@@ -48,7 +48,7 @@ module Script
         return all_languages.first if all_languages.count == 1
 
         CLI::UI::Prompt.ask(
-          ctx.message('script.forms.create.select_language'),
+          ctx.message("script.forms.create.select_language"),
           options: all_languages
         )
       end

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -6,9 +6,9 @@ module Script
       class BuildScript
         class << self
           def call(ctx:, task_runner:, script_name:, description:, extension_point_type:)
-            CLI::UI::Frame.open(ctx.message('script.application.building')) do
+            CLI::UI::Frame.open(ctx.message("script.application.building")) do
               begin
-                UI::StrictSpinner.spin(ctx.message('script.application.building_script')) do |spinner|
+                UI::StrictSpinner.spin(ctx.message("script.application.building_script")) do |spinner|
                   Infrastructure::PushPackageRepository.new(ctx: ctx).create_push_package(
                     extension_point_type: extension_point_type,
                     script_name: script_name,
@@ -17,7 +17,7 @@ module Script
                     compiled_type: task_runner.compiled_type,
                     metadata: task_runner.metadata
                   )
-                  spinner.update_title(ctx.message('script.application.built'))
+                  spinner.update_title(ctx.message("script.application.built"))
                 end
               rescue StandardError => e
                 CLI::UI::Frame.with_frame_color_override(:red) do

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -40,9 +40,9 @@ module Script
           end
 
           def bootstrap(ctx, project_creator)
-            UI::StrictSpinner.spin(ctx.message('script.create.creating')) do |spinner|
+            UI::StrictSpinner.spin(ctx.message("script.create.creating")) do |spinner|
               project_creator.bootstrap
-              spinner.update_title(ctx.message('script.create.created'))
+              spinner.update_title(ctx.message("script.create.created"))
             end
           end
         end

--- a/lib/project_types/script/layers/application/disable_script.rb
+++ b/lib/project_types/script/layers/application/disable_script.rb
@@ -5,14 +5,14 @@ module Script
     module Application
       class DisableScript
         def self.call(ctx:, api_key:, shop_domain:, extension_point_type:)
-          UI::PrintingSpinner.spin(ctx, ctx.message('script.application.disabling')) do |p_ctx, spinner|
+          UI::PrintingSpinner.spin(ctx, ctx.message("script.application.disabling")) do |p_ctx, spinner|
             script_service = Infrastructure::ScriptService.new(ctx: p_ctx)
             script_service.disable(
               api_key: api_key,
               shop_domain: shop_domain,
               extension_point_type: extension_point_type,
             )
-            spinner.update_title(p_ctx.message('script.application.disabled'))
+            spinner.update_title(p_ctx.message("script.application.disabled"))
           end
         end
       end

--- a/lib/project_types/script/layers/application/enable_script.rb
+++ b/lib/project_types/script/layers/application/enable_script.rb
@@ -5,7 +5,7 @@ module Script
     module Application
       class EnableScript
         def self.call(ctx:, api_key:, shop_domain:, configuration:, extension_point_type:, title:)
-          UI::PrintingSpinner.spin(ctx, ctx.message('script.application.enabling')) do |p_ctx, spinner|
+          UI::PrintingSpinner.spin(ctx, ctx.message("script.application.enabling")) do |p_ctx, spinner|
             script_service = Infrastructure::ScriptService.new(ctx: p_ctx)
             script_service.enable(
               api_key: api_key,
@@ -14,7 +14,7 @@ module Script
               extension_point_type: extension_point_type,
               title: title
             )
-            spinner.update_title(p_ctx.message('script.application.enabled'))
+            spinner.update_title(p_ctx.message("script.application.enabled"))
           end
         end
       end

--- a/lib/project_types/script/layers/application/project_dependencies.rb
+++ b/lib/project_types/script/layers/application/project_dependencies.rb
@@ -3,14 +3,14 @@ module Script
     module Application
       class ProjectDependencies
         def self.install(ctx:, task_runner:)
-          CLI::UI::Frame.open(ctx.message('script.project_deps.checking_with_npm')) do
+          CLI::UI::Frame.open(ctx.message("script.project_deps.checking_with_npm")) do
             begin
               if task_runner.dependencies_installed?
-                ctx.puts(ctx.message('script.project_deps.none_required'))
+                ctx.puts(ctx.message("script.project_deps.none_required"))
               else
-                UI::StrictSpinner.spin(ctx.message('script.project_deps.installing')) do |spinner|
+                UI::StrictSpinner.spin(ctx.message("script.project_deps.installing")) do |spinner|
                   task_runner.install_dependencies
-                  spinner.update_title(ctx.message('script.project_deps.installed'))
+                  spinner.update_title(ctx.message("script.project_deps.installed"))
                 end
               end
               true

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -17,7 +17,7 @@ module Script
               description: script_project.description
             )
 
-            UI::PrintingSpinner.spin(ctx, ctx.message('script.application.pushing')) do |p_ctx, spinner|
+            UI::PrintingSpinner.spin(ctx, ctx.message("script.application.pushing")) do |p_ctx, spinner|
               package = Infrastructure::PushPackageRepository.new(ctx: p_ctx).get_push_package(
                 extension_point_type: script_project.extension_point_type,
                 script_name: script_project.script_name,
@@ -26,7 +26,7 @@ module Script
                 metadata: task_runner.metadata
               )
               package.push(Infrastructure::ScriptService.new(ctx: p_ctx), script_project.api_key, force)
-              spinner.update_title(p_ctx.message('script.application.pushed'))
+              spinner.update_title(p_ctx.message("script.application.pushed"))
             end
           end
         end

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -19,7 +19,7 @@ module Script
         end
 
         def bootstrap
-          type = extension_point.type.gsub('_', '-')
+          type = extension_point.type.gsub("_", "-")
           out, status = ctx.capture2e(format(BOOTSTRAP, extension_point: type, base: path_to_project))
           raise Domain::Errors::ServiceFailureError, out unless status.success?
         end
@@ -28,10 +28,10 @@ module Script
 
         def write_npmrc
           ctx.system(
-            'npm', '--userconfig', './.npmrc', 'config', 'set', '@shopify:registry', 'https://registry.npmjs.com'
+            "npm", "--userconfig", "./.npmrc", "config", "set", "@shopify:registry", "https://registry.npmjs.com"
           )
           ctx.system(
-            'npm', '--userconfig', './.npmrc', 'config', 'set', 'engine-strict', 'true'
+            "npm", "--userconfig", "./.npmrc", "config", "set", "engine-strict", "true"
           )
         end
 

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -40,7 +40,7 @@ module Script
 
         def metadata
           unless @ctx.file_exist?(METADATA_FILE)
-            msg = @ctx.message('script.error.metadata_not_found_cause', METADATA_FILE)
+            msg = @ctx.message("script.error.metadata_not_found_cause", METADATA_FILE)
             raise Domain::Errors::MetadataNotFoundError, msg
           end
 
@@ -54,7 +54,7 @@ module Script
           output, status = @ctx.capture2e("node", "--version")
           raise Errors::DependencyInstallError, output unless status.success?
 
-          require 'semantic/semantic'
+          require "semantic/semantic"
           version = ::Semantic::Version.new(output[1..-1])
           unless version >= ::Semantic::Version.new(AssemblyScriptProjectCreator::MIN_NODE_VERSION)
             raise Errors::DependencyInstallError,
@@ -71,8 +71,8 @@ module Script
         end
 
         def check_compilation_dependencies!
-          pkg = JSON.parse(File.read('package.json'))
-          build_script = pkg.dig('scripts', 'build')
+          pkg = JSON.parse(File.read("package.json"))
+          build_script = pkg.dig("scripts", "build")
 
           raise Errors::BuildScriptNotFoundError,
             "Build script not found" if build_script.nil?
@@ -93,23 +93,23 @@ module Script
         end
 
         def check_if_ep_dependencies_up_to_date!
-          return true if ENV['SHOPIFY_CLI_SCRIPTS_IGNORE_OUTDATED']
+          return true if ENV["SHOPIFY_CLI_SCRIPTS_IGNORE_OUTDATED"]
 
           # ignore exit code since it will not be 0 unless every package is up to date which they probably won't be
           out, _ = ctx.capture2e("npm", "outdated", "--json", "--depth", "0")
           parsed_outdated_check = JSON.parse(out)
           outdated_ep_packages = parsed_outdated_check
-            .select { |package_name, _| package_name.start_with?('@shopify/extension-point-as-') }
+            .select { |package_name, _| package_name.start_with?("@shopify/extension-point-as-") }
             .select { |_, version_info| !package_is_up_to_date?(version_info) }
             .keys
           raise Errors::PackagesOutdatedError.new(outdated_ep_packages),
-            "NPM packages out of date: #{outdated_ep_packages.join(', ')}" unless outdated_ep_packages.empty?
+            "NPM packages out of date: #{outdated_ep_packages.join(", ")}" unless outdated_ep_packages.empty?
         end
 
         def package_is_up_to_date?(version_info)
-          require 'semantic/semantic'
-          current_version = version_info['current']
-          latest_version = version_info['latest']
+          require "semantic/semantic"
+          current_version = version_info["current"]
+          latest_version = version_info["latest"]
 
           # making an assumption that the script developer knows what they're doing if they're not referencing a
           # semver version

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -44,7 +44,7 @@ module Script
         class PackagesOutdatedError < ScriptProjectError
           attr_reader :outdated_packages
           def initialize(outdated_packages)
-            super("EP packages are outdated and need to be updated: #{outdated_packages.join(', ')}")
+            super("EP packages are outdated and need to be updated: #{outdated_packages.join(", ")}")
             @outdated_packages = outdated_packages
           end
         end

--- a/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
@@ -27,8 +27,8 @@ module Script
 
         def extension_point_configs
           @extension_points ||= begin
-            require 'yaml'
-            YAML.load_file(Project.project_filepath('config/extension_points.yml'))
+            require "yaml"
+            YAML.load_file(Project.project_filepath("config/extension_points.yml"))
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/rust_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/rust_project_creator.rb
@@ -10,8 +10,8 @@ module Script
         property! :script_name, accepts: String
         property! :path_to_project, accepts: String
 
-        ORIGIN_BRANCH = 'main'
-        SAMPLE_PATH = 'default'
+        ORIGIN_BRANCH = "main"
+        SAMPLE_PATH = "default"
 
         def setup_dependencies
           git_init
@@ -60,8 +60,8 @@ module Script
         end
 
         def set_script_name
-          config_file = 'Cargo.toml'
-          upstream_name = "#{extension_point.type.gsub('_', '-')}-default"
+          config_file = "Cargo.toml"
+          upstream_name = "#{extension_point.type.gsub("_", "-")}-default"
           contents = File.read(config_file)
           new_contents = contents.sub(upstream_name, script_name)
           File.write(config_file, new_contents)

--- a/lib/project_types/script/layers/infrastructure/rust_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/rust_task_runner.rb
@@ -31,7 +31,7 @@ module Script
 
         def metadata
           unless @ctx.file_exist?(METADATA_FILE)
-            msg = @ctx.message('script.error.metadata_not_found_cause', METADATA_FILE)
+            msg = @ctx.message("script.error.metadata_not_found_cause", METADATA_FILE)
             raise Domain::Errors::MetadataNotFoundError, msg
           end
 

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -37,7 +37,7 @@ module Script
 
           return resp_hash if user_errors.empty?
 
-          if user_errors.any? { |e| e['tag'] == 'already_exists_error' }
+          if user_errors.any? { |e| e["tag"] == "already_exists_error" }
             raise Errors::ScriptRepushError, api_key
           else
             raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
@@ -62,11 +62,11 @@ module Script
 
           return resp_hash if user_errors.empty?
 
-          if user_errors.any? { |e| e['tag'] == 'app_script_not_found' }
+          if user_errors.any? { |e| e["tag"] == "app_script_not_found" }
             raise Errors::AppScriptUndefinedError, api_key
-          elsif user_errors.any? { |e| e['tag'] == 'shop_script_conflict' }
+          elsif user_errors.any? { |e| e["tag"] == "shop_script_conflict" }
             raise Errors::ShopScriptConflictError
-          elsif user_errors.any? { |e| e['tag'] == 'app_script_not_pushed' }
+          elsif user_errors.any? { |e| e["tag"] == "app_script_not_pushed" }
             raise Errors::AppScriptNotPushedError
           else
             raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
@@ -88,7 +88,7 @@ module Script
           user_errors = resp_hash["data"]["shopScriptDelete"]["userErrors"]
           return resp_hash if user_errors.empty?
 
-          if user_errors.any? { |e| e['tag'] == 'shop_script_not_found' }
+          if user_errors.any? { |e| e["tag"] == "shop_script_not_found" }
             raise Errors::ShopScriptUndefinedError, api_key
           else
             raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
@@ -112,8 +112,8 @@ module Script
           def self.api_client(ctx, api_key, shop_domain)
             new(
               ctx: ctx,
-              url: 'https://script-service.myshopify.io/graphql',
-              token: '',
+              url: "https://script-service.myshopify.io/graphql",
+              token: "",
               api_key: api_key,
               shop_id: shop_domain&.to_i
             )
@@ -148,28 +148,28 @@ module Script
           options[:variables] = variables.to_json if variables
           resp = PartnersProxyAPI.query(ctx, query_name, **options)
           raise_if_graphql_failed(resp)
-          JSON.parse(resp['data']['scriptServiceProxy'])
+          JSON.parse(resp["data"]["scriptServiceProxy"])
         end
 
         def raise_if_graphql_failed(response)
           raise Errors::EmptyResponseError if response.nil?
 
-          return unless response.key?('errors')
-          case error_code(response['errors'])
-          when 'forbidden'
+          return unless response.key?("errors")
+          case error_code(response["errors"])
+          when "forbidden"
             raise Errors::ForbiddenError
-          when 'forbidden_on_shop'
+          when "forbidden_on_shop"
             raise Errors::ShopAuthenticationError
-          when 'app_not_installed_on_shop'
+          when "app_not_installed_on_shop"
             raise Errors::AppNotInstalledError
           else
-            raise Errors::GraphqlError, response['errors'].map { |e| e['message'] }
+            raise Errors::GraphqlError, response["errors"].map { |e| e["message"] }
           end
         end
 
         def error_code(errors)
           errors.map do |e|
-            code = e.dig('extensions', 'code')
+            code = e.dig("extensions", "code")
             return code if code
           end
         end

--- a/lib/project_types/script/script_project.rb
+++ b/lib/project_types/script/script_project.rb
@@ -6,10 +6,10 @@ module Script
 
     def initialize(*args)
       super
-      @extension_point_type = lookup_config!('extension_point_type')
+      @extension_point_type = lookup_config!("extension_point_type")
       raise Errors::DeprecatedEPError, @extension_point_type if deprecated?(@extension_point_type)
-      @script_name = lookup_config!('script_name')
-      @description = lookup_config('description')
+      @script_name = lookup_config!("script_name")
+      @description = lookup_config("description")
       @language = lookup_language
       ShopifyCli::Core::Monorail.metadata = {
         "script_name" => @script_name,
@@ -39,7 +39,7 @@ module Script
     end
 
     def lookup_language
-      lang = lookup_config('language')&.downcase || Layers::Domain::ExtensionPointAssemblyScriptSDK.language
+      lang = lookup_config("language")&.downcase || Layers::Domain::ExtensionPointAssemblyScriptSDK.language
       if Layers::Application::ExtensionPoints.supported_language?(type: extension_point_type, language: lang)
         lang
       else

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -1,10 +1,10 @@
-require 'cli/ui'
+require "cli/ui"
 
 module Script
   module UI
     module ErrorHandler
       def self.display(failed_op:, cause_of_error:, help_suggestion:)
-        $stderr.puts(CLI::UI.fmt(ShopifyCli::Context.message('script.error.generic')))
+        $stderr.puts(CLI::UI.fmt(ShopifyCli::Context.message("script.error.generic")))
         full_msg = failed_op ? failed_op.dup : ""
         full_msg << " #{cause_of_error}" if cause_of_error
         full_msg << " #{help_suggestion}" if help_suggestion
@@ -26,187 +26,187 @@ module Script
         case e
         when Errno::EACCES
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.eacces_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.eacces_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.eacces_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.eacces_help"),
           }
         when Errno::ENOSPC
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.enospc_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.enospc_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.enospc_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.enospc_help"),
           }
         when ShopifyCli::OAuth::Error
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.oauth_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.oauth_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.oauth_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.oauth_help"),
           }
         when Errors::InvalidContextError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.invalid_context_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.invalid_context_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.invalid_context_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.invalid_context_help"),
           }
         when Errors::InvalidConfigProps
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.invalid_config_props_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.invalid_config_props_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.invalid_config_props_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.invalid_config_props_help"),
           }
         when Errors::InvalidConfigYAMLError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.invalid_config', e.config_file),
+            cause_of_error: ShopifyCli::Context.message("script.error.invalid_config", e.config_file),
           }
         when Errors::InvalidLanguageError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.invalid_language_cause', e.language),
+            cause_of_error: ShopifyCli::Context.message("script.error.invalid_language_cause", e.language),
             help_suggestion: ShopifyCli::Context.message(
-              'script.error.invalid_language_help',
-              Script::Layers::Application::ExtensionPoints.languages(type: e.extension_point_type).join(', ')
+              "script.error.invalid_language_help",
+              Script::Layers::Application::ExtensionPoints.languages(type: e.extension_point_type).join(", ")
             ),
           }
         when Errors::InvalidScriptNameError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.invalid_script_name_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.invalid_script_name_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.invalid_script_name_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.invalid_script_name_help"),
           }
         when Errors::NoExistingAppsError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.no_existing_apps_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.no_existing_apps_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.no_existing_apps_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.no_existing_apps_help"),
           }
         when Errors::NoExistingOrganizationsError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.no_existing_orgs_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.no_existing_orgs_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.no_existing_orgs_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.no_existing_orgs_help"),
           }
         when Errors::NoExistingStoresError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.no_existing_stores_cause'),
+            cause_of_error: ShopifyCli::Context.message("script.error.no_existing_stores_cause"),
             help_suggestion: ShopifyCli::Context.message(
-              'script.error.no_existing_stores_help',
+              "script.error.no_existing_stores_help",
               organization_id: e.organization_id
             ),
           }
         when Errors::ScriptProjectAlreadyExistsError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.project_exists_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.project_exists_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.project_exists_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.project_exists_help"),
           }
         when Errors::DeprecatedEPError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.deprecated_ep', e.ep),
-            help_suggestion: ShopifyCli::Context.message('script.error.deprecated_ep_cause'),
+            cause_of_error: ShopifyCli::Context.message("script.error.deprecated_ep", e.ep),
+            help_suggestion: ShopifyCli::Context.message("script.error.deprecated_ep_cause"),
           }
         when Layers::Domain::Errors::InvalidExtensionPointError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.invalid_extension_cause', e.type),
+            cause_of_error: ShopifyCli::Context.message("script.error.invalid_extension_cause", e.type),
             help_suggestion: ShopifyCli::Context.message(
-              'script.error.invalid_extension_help',
-              Script::Layers::Application::ExtensionPoints.types.join(', ')
+              "script.error.invalid_extension_help",
+              Script::Layers::Application::ExtensionPoints.types.join(", ")
             ),
           }
         when Layers::Domain::Errors::ScriptNotFoundError
           {
             cause_of_error: ShopifyCli::Context.message(
-              'script.error.script_not_found_cause',
+              "script.error.script_not_found_cause",
               e.script_name,
               e.extension_point_type
             ),
           }
         when Layers::Domain::Errors::ServiceFailureError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.service_failure_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.service_failure_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.service_failure_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.service_failure_help"),
           }
         when Layers::Domain::Errors::MetadataValidationError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.metadata_validation_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.metadata_validation_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.metadata_validation_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.metadata_validation_help"),
           }
         when Layers::Domain::Errors::MetadataNotFoundError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.metadata_not_found_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.metadata_not_found_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.metadata_not_found_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.metadata_not_found_help"),
           }
         when Layers::Infrastructure::Errors::AppNotInstalledError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.app_not_installed_cause'),
+            cause_of_error: ShopifyCli::Context.message("script.error.app_not_installed_cause"),
           }
         when Layers::Infrastructure::Errors::AppScriptNotPushedError,
           Layers::Infrastructure::Errors::AppScriptUndefinedError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.app_script_not_pushed_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.app_script_not_pushed_help"),
           }
         when Layers::Infrastructure::Errors::BuildError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.build_error_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.build_error_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.build_error_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.build_error_help"),
           }
         when Layers::Infrastructure::Errors::DependencyInstallError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.dependency_install_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.dependency_install_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.dependency_install_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.dependency_install_help"),
           }
         when Layers::Infrastructure::Errors::EmptyResponseError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.failed_api_request_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.failed_api_request_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.failed_api_request_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.failed_api_request_help"),
           }
         when Layers::Infrastructure::Errors::ForbiddenError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.forbidden_error_cause'),
+            cause_of_error: ShopifyCli::Context.message("script.error.forbidden_error_cause"),
           }
         when Layers::Infrastructure::Errors::GraphqlError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.graphql_error_cause', e.errors.join(', ')),
-            help_suggestion: ShopifyCli::Context.message('script.error.graphql_error_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.graphql_error_cause", e.errors.join(", ")),
+            help_suggestion: ShopifyCli::Context.message("script.error.graphql_error_help"),
           }
         when Layers::Infrastructure::Errors::ScriptRepushError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.script_repush_cause', e.api_key),
-            help_suggestion: ShopifyCli::Context.message('script.error.script_repush_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.script_repush_cause", e.api_key),
+            help_suggestion: ShopifyCli::Context.message("script.error.script_repush_help"),
           }
         when Layers::Infrastructure::Errors::ScriptServiceUserError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.user_error_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.user_error_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.user_error_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.user_error_help"),
           }
         when Layers::Infrastructure::Errors::ShopAuthenticationError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.shop_auth_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.shop_auth_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.shop_auth_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.shop_auth_help"),
           }
         when Layers::Infrastructure::Errors::ShopScriptConflictError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.shop_script_conflict_cause'),
-            help_suggestion: ShopifyCli::Context.message('script.error.shop_script_conflict_help'),
+            cause_of_error: ShopifyCli::Context.message("script.error.shop_script_conflict_cause"),
+            help_suggestion: ShopifyCli::Context.message("script.error.shop_script_conflict_help"),
           }
         when Layers::Infrastructure::Errors::ShopScriptUndefinedError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.shop_script_undefined_cause'),
+            cause_of_error: ShopifyCli::Context.message("script.error.shop_script_undefined_cause"),
           }
         when Layers::Infrastructure::Errors::PackagesOutdatedError
           {
             cause_of_error: ShopifyCli::Context.message(
-              'script.error.packages_outdated_cause',
-              e.outdated_packages.join(', ')
+              "script.error.packages_outdated_cause",
+              e.outdated_packages.join(", ")
             ),
             help_suggestion: ShopifyCli::Context.message(
-              'script.error.packages_outdated_help',
-              e.outdated_packages.collect { |package| "#{package}@latest" }.join(' ')
+              "script.error.packages_outdated_help",
+              e.outdated_packages.collect { |package| "#{package}@latest" }.join(" ")
             ),
           }
         when Layers::Infrastructure::Errors::BuildScriptNotFoundError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.build_script_not_found'),
-            help_suggestion: ShopifyCli::Context.message('script.error.build_script_suggestion'),
+            cause_of_error: ShopifyCli::Context.message("script.error.build_script_not_found"),
+            help_suggestion: ShopifyCli::Context.message("script.error.build_script_suggestion"),
           }
         when Layers::Infrastructure::Errors::InvalidBuildScriptError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.invalid_build_script'),
-            help_suggestion: ShopifyCli::Context.message('script.error.build_script_suggestion'),
+            cause_of_error: ShopifyCli::Context.message("script.error.invalid_build_script"),
+            help_suggestion: ShopifyCli::Context.message("script.error.build_script_suggestion"),
           }
         when Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError
           {
-            cause_of_error: ShopifyCli::Context.message('script.error.web_assembly_binary_not_found'),
-            help_suggestion: ShopifyCli::Context.message('script.error.web_assembly_binary_not_found_suggestion'),
+            cause_of_error: ShopifyCli::Context.message("script.error.web_assembly_binary_not_found"),
+            help_suggestion: ShopifyCli::Context.message("script.error.web_assembly_binary_not_found_suggestion"),
           }
         end
       end

--- a/lib/project_types/script/ui/printing_spinner.rb
+++ b/lib/project_types/script/ui/printing_spinner.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Script
   module UI

--- a/lib/project_types/script/ui/strict_spinner.rb
+++ b/lib/project_types/script/ui/strict_spinner.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'shopify_cli'
+require "shopify_cli"
 
 module Script
   module UI

--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -3,38 +3,38 @@ module Theme
   class Project < ShopifyCli::ProjectType
     hidden_feature
 
-    title('Theme')
-    creator('Theme::Commands::Create')
-    connector('Theme::Commands::Connect')
+    title("Theme")
+    creator("Theme::Commands::Create")
+    connector("Theme::Commands::Connect")
 
-    register_command('Theme::Commands::Deploy', 'deploy')
-    register_command('Theme::Commands::Generate', 'generate')
-    register_command('Theme::Commands::Push', 'push')
-    register_command('Theme::Commands::Serve', 'serve')
+    register_command("Theme::Commands::Deploy", "deploy")
+    register_command("Theme::Commands::Generate", "generate")
+    register_command("Theme::Commands::Push", "push")
+    register_command("Theme::Commands::Serve", "serve")
 
-    register_task('Theme::Tasks::EnsureThemekitInstalled', :ensure_themekit_installed)
+    register_task("Theme::Tasks::EnsureThemekitInstalled", :ensure_themekit_installed)
 
-    require Project.project_filepath('messages/messages')
+    require Project.project_filepath("messages/messages")
     register_messages(Theme::Messages::MESSAGES)
   end
 
   module Commands
-    autoload :Connect, Project.project_filepath('commands/connect')
-    autoload :Create, Project.project_filepath('commands/create')
-    autoload :Deploy, Project.project_filepath('commands/deploy')
-    autoload :Generate, Project.project_filepath('commands/generate')
-    autoload :Push, Project.project_filepath('commands/push')
-    autoload :Serve, Project.project_filepath('commands/serve')
+    autoload :Connect, Project.project_filepath("commands/connect")
+    autoload :Create, Project.project_filepath("commands/create")
+    autoload :Deploy, Project.project_filepath("commands/deploy")
+    autoload :Generate, Project.project_filepath("commands/generate")
+    autoload :Push, Project.project_filepath("commands/push")
+    autoload :Serve, Project.project_filepath("commands/serve")
   end
 
   module Tasks
-    autoload :EnsureThemekitInstalled, Project.project_filepath('tasks/ensure_themekit_installed')
+    autoload :EnsureThemekitInstalled, Project.project_filepath("tasks/ensure_themekit_installed")
   end
 
   module Forms
-    autoload :Create, Project.project_filepath('forms/create')
-    autoload :Connect, Project.project_filepath('forms/connect')
+    autoload :Create, Project.project_filepath("forms/create")
+    autoload :Connect, Project.project_filepath("forms/connect")
   end
 
-  autoload :Themekit, Project.project_filepath('themekit')
+  autoload :Themekit, Project.project_filepath("themekit")
 end

--- a/lib/project_types/theme/commands/connect.rb
+++ b/lib/project_types/theme/commands/connect.rb
@@ -5,15 +5,15 @@ module Theme
       prerequisite_task :ensure_themekit_installed
 
       options do |parser, flags|
-        parser.on('--store=STORE') { |url| flags[:store] = url }
-        parser.on('--password=PASSWORD') { |p| flags[:password] = p }
-        parser.on('--themeid=THEME_ID') { |id| flags[:themeid] = id }
-        parser.on('--env=ENV') { |env| flags[:env] = env }
+        parser.on("--store=STORE") { |url| flags[:store] = url }
+        parser.on("--password=PASSWORD") { |p| flags[:password] = p }
+        parser.on("--themeid=THEME_ID") { |id| flags[:themeid] = id }
+        parser.on("--env=ENV") { |env| flags[:env] = env }
       end
 
       def call(args, _name)
         if ShopifyCli::Project.has_current?
-          @ctx.abort(@ctx.message('theme.connect.inside_project'))
+          @ctx.abort(@ctx.message("theme.connect.inside_project"))
         end
 
         form = Forms::Connect.ask(@ctx, args, options.flags)
@@ -21,31 +21,31 @@ module Theme
 
         build(form.store, form.password, form.themeid, form.name, form.env)
         ShopifyCli::Project.write(@ctx,
-          project_type: 'theme',
+          project_type: "theme",
           organization_id: nil)
 
-        @ctx.done(@ctx.message('theme.connect.connected', form.name, form.store, @ctx.root))
+        @ctx.done(@ctx.message("theme.connect.connected", form.name, form.store, @ctx.root))
       end
 
       def self.help
-        ShopifyCli::Context.message('theme.connect.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("theme.connect.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
       end
 
       private
 
       def build(store, password, themeid, name, env)
         if @ctx.dir_exist?(name)
-          @ctx.abort(@ctx.message('theme.connect.duplicate'))
+          @ctx.abort(@ctx.message("theme.connect.duplicate"))
         end
 
         @ctx.mkdir_p(name)
         @ctx.chdir(name)
 
-        CLI::UI::Frame.open(@ctx.message('theme.connect.connect')) do
+        CLI::UI::Frame.open(@ctx.message("theme.connect.connect")) do
           unless Themekit.connect(@ctx, store: store, password: password, themeid: themeid, env: env)
-            @ctx.chdir('..')
+            @ctx.chdir("..")
             @ctx.rm_rf(name)
-            @ctx.abort(@ctx.message('theme.connect.failed'))
+            @ctx.abort(@ctx.message("theme.connect.failed"))
           end
         end
       end

--- a/lib/project_types/theme/commands/create.rb
+++ b/lib/project_types/theme/commands/create.rb
@@ -5,10 +5,10 @@ module Theme
       prerequisite_task :ensure_themekit_installed
 
       options do |parser, flags|
-        parser.on('--name=NAME') { |t| flags[:title] = t }
-        parser.on('--password=PASSWORD') { |p| flags[:password] = p }
-        parser.on('--store=STORE') { |url| flags[:store] = url }
-        parser.on('--env=ENV') { |env| flags[:env] = env }
+        parser.on("--name=NAME") { |t| flags[:title] = t }
+        parser.on("--password=PASSWORD") { |p| flags[:password] = p }
+        parser.on("--store=STORE") { |url| flags[:store] = url }
+        parser.on("--env=ENV") { |env| flags[:env] = env }
       end
 
       def call(args, _name)
@@ -17,29 +17,29 @@ module Theme
 
         build(form.name, form.password, form.store, form.env)
         ShopifyCli::Project.write(@ctx,
-          project_type: 'theme',
+          project_type: "theme",
           organization_id: nil) # private apps are different
 
-        @ctx.done(@ctx.message('theme.create.info.created', form.name, form.store, @ctx.root))
+        @ctx.done(@ctx.message("theme.create.info.created", form.name, form.store, @ctx.root))
       end
 
       def self.help
-        ShopifyCli::Context.message('theme.create.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("theme.create.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
       end
 
       private
 
       def build(name, password, store, env)
-        @ctx.abort(@ctx.message('theme.create.duplicate_theme')) if @ctx.dir_exist?(name)
+        @ctx.abort(@ctx.message("theme.create.duplicate_theme")) if @ctx.dir_exist?(name)
 
         @ctx.mkdir_p(name)
         @ctx.chdir(name)
 
-        CLI::UI::Frame.open(@ctx.message('theme.create.creating_theme', name)) do
+        CLI::UI::Frame.open(@ctx.message("theme.create.creating_theme", name)) do
           unless Themekit.create(@ctx, name: name, password: password, store: store, env: env)
-            @ctx.chdir('..')
+            @ctx.chdir("..")
             @ctx.rm_rf(name)
-            @ctx.abort(@ctx.message('theme.create.failed'))
+            @ctx.abort(@ctx.message("theme.create.failed"))
           end
         end
       end

--- a/lib/project_types/theme/commands/deploy.rb
+++ b/lib/project_types/theme/commands/deploy.rb
@@ -5,14 +5,14 @@ module Theme
       prerequisite_task :ensure_themekit_installed
 
       options do |parser, flags|
-        parser.on('--env=ENV') { |env| flags[:env] = env }
-        parser.on('--allow-live') { flags['allow_live'] = true }
+        parser.on("--env=ENV") { |env| flags[:env] = env }
+        parser.on("--allow-live") { flags["allow_live"] = true }
       end
 
       def call(*)
-        CLI::UI::Frame.open(@ctx.message('theme.deploy.deploying')) do
-          unless CLI::UI::Prompt.confirm(@ctx.message('theme.deploy.confirmation'))
-            @ctx.abort(@ctx.message('theme.deploy.abort'))
+        CLI::UI::Frame.open(@ctx.message("theme.deploy.deploying")) do
+          unless CLI::UI::Prompt.confirm(@ctx.message("theme.deploy.confirmation"))
+            @ctx.abort(@ctx.message("theme.deploy.abort"))
           end
 
           if options.flags[:env]
@@ -23,15 +23,15 @@ module Theme
           flags = Themekit.add_flags(options.flags)
 
           unless Themekit.deploy(@ctx, flags: flags, env: env)
-            @ctx.abort(@ctx.message('theme.deploy.error'))
+            @ctx.abort(@ctx.message("theme.deploy.error"))
           end
         end
 
-        @ctx.done(@ctx.message('theme.deploy.info.deployed'))
+        @ctx.done(@ctx.message("theme.deploy.info.deployed"))
       end
 
       def self.help
-        ShopifyCli::Context.message('theme.deploy.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("theme.deploy.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/commands/generate.rb
+++ b/lib/project_types/theme/commands/generate.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module Theme
   module Commands
     class Generate < ShopifyCli::Command
       prerequisite_task :ensure_themekit_installed
 
-      subcommand :Env, 'env', Project.project_filepath('commands/generate/env')
+      subcommand :Env, "env", Project.project_filepath("commands/generate/env")
 
       def call(*)
         @ctx.puts(self.class.help)
       end
 
       def self.help
-        ShopifyCli::Context.message('theme.generate.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("theme.generate.help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/commands/generate/env.rb
+++ b/lib/project_types/theme/commands/generate/env.rb
@@ -3,10 +3,10 @@ module Theme
     class Generate
       class Env < ShopifyCli::SubCommand
         options do |parser, flags|
-          parser.on('--store=STORE') { |url| flags[:store] = url }
-          parser.on('--password=PASSWORD') { |p| flags[:password] = p }
-          parser.on('--themeid=THEME_ID') { |id| flags[:themeid] = id }
-          parser.on('--env=ENV') { |env| flags[:env] = env }
+          parser.on("--store=STORE") { |url| flags[:store] = url }
+          parser.on("--password=PASSWORD") { |p| flags[:password] = p }
+          parser.on("--themeid=THEME_ID") { |id| flags[:themeid] = id }
+          parser.on("--env=ENV") { |env| flags[:env] = env }
         end
 
         def call(*)
@@ -20,19 +20,19 @@ module Theme
         end
 
         def self.help
-          ShopifyCli::Context.message('theme.generate.env.help', ShopifyCli::TOOL_NAME)
+          ShopifyCli::Context.message("theme.generate.env.help", ShopifyCli::TOOL_NAME)
         end
 
         private
 
         def fetch_credentials
-          unless File.exist?('config.yml')
+          unless File.exist?("config.yml")
             return nil
           end
 
-          config = YAML.load_file('config.yml')
-          store = config['development']['store']
-          password = config['development']['password']
+          config = YAML.load_file("config.yml")
+          store = config["development"]["store"]
+          password = config["development"]["password"]
 
           [store, password]
         end
@@ -40,9 +40,9 @@ module Theme
         def ask_store(default)
           store = options.flags[:store] ||
             if default
-              CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_store_default', default))
+              CLI::UI::Prompt.ask(@ctx.message("theme.generate.env.ask_store_default", default))
             else
-              CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_store'), allow_empty: false)
+              CLI::UI::Prompt.ask(@ctx.message("theme.generate.env.ask_store"), allow_empty: false)
             end
           return nil if store.empty?
           store
@@ -51,9 +51,9 @@ module Theme
         def ask_password(default)
           password = options.flags[:password] ||
             if default
-              CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_password_default', default))
+              CLI::UI::Prompt.ask(@ctx.message("theme.generate.env.ask_password_default", default))
             else
-              CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_password'), allow_empty: false)
+              CLI::UI::Prompt.ask(@ctx.message("theme.generate.env.ask_password"), allow_empty: false)
             end
           return nil if password.empty?
           password
@@ -65,9 +65,9 @@ module Theme
 
           themes = Themekit.query_themes(@ctx, store: store, password: password)
 
-          @ctx.abort(@ctx.message('theme.generate.env.no_themes', ShopifyCli::TOOL_NAME)) if themes.empty?
+          @ctx.abort(@ctx.message("theme.generate.env.no_themes", ShopifyCli::TOOL_NAME)) if themes.empty?
 
-          CLI::UI::Prompt.ask(@ctx.message('theme.generate.env.ask_theme')) do |handler|
+          CLI::UI::Prompt.ask(@ctx.message("theme.generate.env.ask_theme")) do |handler|
             themes.each do |name, id|
               handler.option(name) { id }
             end

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -5,16 +5,16 @@ module Theme
       prerequisite_task :ensure_themekit_installed
 
       options do |parser, flags|
-        parser.on('--remove') { flags['remove'] = true }
-        parser.on('--nodelete') { flags['nodelete'] = true }
-        parser.on('--allow-live') { flags['allow-live'] = true }
-        parser.on('--env=ENV') { |env| flags[:env] = env }
+        parser.on("--remove") { flags["remove"] = true }
+        parser.on("--nodelete") { flags["nodelete"] = true }
+        parser.on("--allow-live") { flags["allow-live"] = true }
+        parser.on("--env=ENV") { |env| flags[:env] = env }
       end
 
       def call(args, _name)
-        if options.flags['remove']
+        if options.flags["remove"]
           remove = true
-          options.flags.delete('remove')
+          options.flags.delete("remove")
         end
 
         if options.flags[:env]
@@ -25,30 +25,30 @@ module Theme
         flags = Themekit.add_flags(options.flags)
 
         if remove
-          CLI::UI::Frame.open(@ctx.message('theme.push.remove')) do
-            unless CLI::UI::Prompt.confirm(@ctx.message('theme.push.remove_confirm'))
-              @ctx.abort(@ctx.message('theme.push.remove_abort'))
+          CLI::UI::Frame.open(@ctx.message("theme.push.remove")) do
+            unless CLI::UI::Prompt.confirm(@ctx.message("theme.push.remove_confirm"))
+              @ctx.abort(@ctx.message("theme.push.remove_abort"))
             end
 
             unless Themekit.push(@ctx, files: args, flags: flags, remove: remove, env: env)
-              @ctx.abort(@ctx.message('theme.push.error.remove_error'))
+              @ctx.abort(@ctx.message("theme.push.error.remove_error"))
             end
           end
 
-          @ctx.done(@ctx.message('theme.push.info.remove', @ctx.root))
+          @ctx.done(@ctx.message("theme.push.info.remove", @ctx.root))
         else
-          CLI::UI::Frame.open(@ctx.message('theme.push.push')) do
+          CLI::UI::Frame.open(@ctx.message("theme.push.push")) do
             unless Themekit.push(@ctx, files: args, flags: flags, remove: remove, env: env)
-              @ctx.abort(@ctx.message('theme.push.error.push_error'))
+              @ctx.abort(@ctx.message("theme.push.error.push_error"))
             end
           end
 
-          @ctx.done(@ctx.message('theme.push.info.push', @ctx.root))
+          @ctx.done(@ctx.message("theme.push.info.push", @ctx.root))
         end
       end
 
       def self.help
-        ShopifyCli::Context.message('theme.push.help', ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("theme.push.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -5,9 +5,9 @@ module Theme
       prerequisite_task :ensure_themekit_installed
 
       options do |parser, flags|
-        parser.on('--env=ENV') { |env| flags[:env] = env }
-        parser.on('--allow-live') { flags['allow-live'] = true }
-        parser.on('--notify=FILES') { |files| flags['notify'] = files }
+        parser.on("--env=ENV") { |env| flags[:env] = env }
+        parser.on("--allow-live") { flags["allow-live"] = true }
+        parser.on("--notify=FILES") { |files| flags["notify"] = files }
       end
 
       def call(*)
@@ -18,13 +18,13 @@ module Theme
 
         flags = Themekit.add_flags(options.flags)
 
-        CLI::UI::Frame.open(@ctx.message('theme.serve.serve')) do
+        CLI::UI::Frame.open(@ctx.message("theme.serve.serve")) do
           Themekit.serve(@ctx, flags: flags, env: env)
         end
       end
 
       def self.help
-        ShopifyCli::Context.message('theme.serve.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("theme.serve.help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/forms/connect.rb
+++ b/lib/project_types/theme/forms/connect.rb
@@ -5,14 +5,14 @@ module Theme
       flag_arguments :themeid, :password, :store, :env
 
       def ask
-        self.store ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_store'), allow_empty: false)
-        ctx.puts(ctx.message('theme.forms.connect.private_app', store))
-        self.password ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_password'), allow_empty: false)
+        self.store ||= CLI::UI::Prompt.ask(ctx.message("theme.forms.ask_store"), allow_empty: false)
+        ctx.puts(ctx.message("theme.forms.connect.private_app", store))
+        self.password ||= CLI::UI::Prompt.ask(ctx.message("theme.forms.ask_password"), allow_empty: false)
 
         errors = []
         errors << "store" if store.strip.empty?
         errors << "password" if password.strip.empty?
-        ctx.abort(ctx.message('theme.forms.errors', errors.join(", ").capitalize)) unless errors.empty?
+        ctx.abort(ctx.message("theme.forms.errors", errors.join(", ").capitalize)) unless errors.empty?
 
         self.themeid, self.name = ask_theme(store: store, password: password, themeid: themeid)
       end

--- a/lib/project_types/theme/forms/create.rb
+++ b/lib/project_types/theme/forms/create.rb
@@ -5,17 +5,17 @@ module Theme
       flag_arguments :title, :password, :store, :env
 
       def ask
-        self.store ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_store'), allow_empty: false)
-        ctx.puts(ctx.message('theme.forms.create.private_app', store))
-        self.password ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.ask_password'), allow_empty: false)
-        self.title ||= CLI::UI::Prompt.ask(ctx.message('theme.forms.create.ask_title'), allow_empty: false)
+        self.store ||= CLI::UI::Prompt.ask(ctx.message("theme.forms.ask_store"), allow_empty: false)
+        ctx.puts(ctx.message("theme.forms.create.private_app", store))
+        self.password ||= CLI::UI::Prompt.ask(ctx.message("theme.forms.ask_password"), allow_empty: false)
+        self.title ||= CLI::UI::Prompt.ask(ctx.message("theme.forms.create.ask_title"), allow_empty: false)
         self.name = self.title.downcase.split(" ").join("_")
 
         errors = []
         errors << "store" if store.strip.empty?
         errors << "password" if password.strip.empty?
         errors << "title" if title.strip.empty?
-        ctx.abort(ctx.message('theme.forms.errors', errors.join(", ").capitalize)) unless errors.empty?
+        ctx.abort(ctx.message("theme.forms.errors", errors.join(", ").capitalize)) unless errors.empty?
       end
     end
   end

--- a/lib/project_types/theme/tasks/ensure_themekit_installed.rb
+++ b/lib/project_types/theme/tasks/ensure_themekit_installed.rb
@@ -1,29 +1,29 @@
 module Theme
   module Tasks
     class EnsureThemekitInstalled < ShopifyCli::Task
-      URL = 'https://shopify-themekit.s3.amazonaws.com/releases/latest.json'
+      URL = "https://shopify-themekit.s3.amazonaws.com/releases/latest.json"
       OSMAP = {
-        mac: 'darwin-amd64',
-        linux: 'linux-amd64',
-        windows: 'windows-amd64',
+        mac: "darwin-amd64",
+        linux: "linux-amd64",
+        windows: "windows-amd64",
       }
       VERSION_CHECK_INTERVAL = 604800
-      VERSION_CHECK_SECTION = 'themekit_version_check'
-      LAST_CHECKED_AT_FIELD = 'last_checked_at'
+      VERSION_CHECK_SECTION = "themekit_version_check"
+      LAST_CHECKED_AT_FIELD = "last_checked_at"
 
       def call(ctx)
         _out, stat = ctx.capture2e(Themekit::THEMEKIT)
         unless stat.success?
-          CLI::UI::Frame.open(ctx.message('theme.tasks.ensure_themekit_installed.installing_themekit')) do
+          CLI::UI::Frame.open(ctx.message("theme.tasks.ensure_themekit_installed.installing_themekit")) do
             install_themekit(ctx)
           end
         end
 
         now = Time.now.to_i
         if ShopifyCli::Feature.enabled?(:themekit_auto_update) && (time_of_last_check + VERSION_CHECK_INTERVAL) < now
-          CLI::UI::Frame.open(ctx.message('theme.tasks.ensure_themekit_installed.updating_themekit')) do
+          CLI::UI::Frame.open(ctx.message("theme.tasks.ensure_themekit_installed.updating_themekit")) do
             unless Themekit.update(ctx)
-              ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.update_fail'))
+              ctx.abort(ctx.message("theme.tasks.ensure_themekit_installed.errors.update_fail"))
             end
             update_time_of_last_check(now)
           end
@@ -33,32 +33,32 @@ module Theme
       private
 
       def install_themekit(ctx)
-        require 'json'
-        require 'fileutils'
-        require 'digest'
-        require 'open-uri'
+        require "json"
+        require "fileutils"
+        require "digest"
+        require "open-uri"
 
         begin
           begin
             releases = JSON.parse(Net::HTTP.get(URI(URL)))
             release = releases["platforms"].find { |r| r["name"] == OSMAP[ctx.os] }
           rescue
-            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.releases_fail'))
+            ctx.abort(ctx.message("theme.tasks.ensure_themekit_installed.errors.releases_fail"))
           end
 
-          ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.downloading', releases['version']))
-          _out, stat = ctx.capture2e('curl', '-o', Themekit::THEMEKIT, release["url"])
-          ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) unless stat.success?
+          ctx.puts(ctx.message("theme.tasks.ensure_themekit_installed.downloading", releases["version"]))
+          _out, stat = ctx.capture2e("curl", "-o", Themekit::THEMEKIT, release["url"])
+          ctx.abort(ctx.message("theme.tasks.ensure_themekit_installed.errors.write_fail")) unless stat.success?
 
-          ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.verifying'))
-          if Digest::MD5.file(Themekit::THEMEKIT) == release['digest']
+          ctx.puts(ctx.message("theme.tasks.ensure_themekit_installed.verifying"))
+          if Digest::MD5.file(Themekit::THEMEKIT) == release["digest"]
             FileUtils.chmod("+x", Themekit::THEMEKIT)
-            ctx.puts(ctx.message('theme.tasks.ensure_themekit_installed.successful'))
+            ctx.puts(ctx.message("theme.tasks.ensure_themekit_installed.successful"))
 
-            auto = CLI::UI.confirm(ctx.message('theme.tasks.ensure_themekit_installed.auto_update'))
+            auto = CLI::UI.confirm(ctx.message("theme.tasks.ensure_themekit_installed.auto_update"))
             ShopifyCli::Feature.set(:themekit_auto_update, auto)
           else
-            ctx.abort(ctx.message('theme.tasks.ensure_themekit_installed.errors.digest_fail'))
+            ctx.abort(ctx.message("theme.tasks.ensure_themekit_installed.errors.digest_fail"))
           end
         rescue StandardError, ShopifyCli::Abort => e
           FileUtils.rm(Themekit::THEMEKIT) if File.exist?(Themekit::THEMEKIT)

--- a/lib/project_types/theme/themekit.rb
+++ b/lib/project_types/theme/themekit.rb
@@ -12,7 +12,7 @@ module Theme
       end
 
       def connect(ctx, store:, password:, themeid:, env:)
-        command = build_command('get', env)
+        command = build_command("get", env)
         command << "--password=#{password}"
         command << "--store=#{store}"
         command << "--themeid=#{themeid}"
@@ -22,7 +22,7 @@ module Theme
       end
 
       def create(ctx, password:, store:, name:, env:)
-        command = build_command('new', env)
+        command = build_command("new", env)
         command << "--password=#{password}"
         command << "--store=#{store}"
         command << "--name=#{name}"
@@ -33,11 +33,11 @@ module Theme
 
       def deploy(ctx, flags: nil, env:)
         unless push(ctx, flags: flags, env: env)
-          ctx.abort(ctx.message('theme.deploy.push_fail'))
+          ctx.abort(ctx.message("theme.deploy.push_fail"))
         end
-        ctx.done(ctx.message('theme.deploy.info.pushed'))
+        ctx.done(ctx.message("theme.deploy.info.pushed"))
 
-        command = build_command('publish', env)
+        command = build_command("publish", env)
         (command << flags).compact!
         command.flatten!
 
@@ -46,7 +46,7 @@ module Theme
       end
 
       def generate_env(ctx, store:, password:, themeid:, env:)
-        command = build_command('configure', env)
+        command = build_command("configure", env)
         command << "--password=#{password}"
         command << "--store=#{store}"
         command << "--themeid=#{themeid}"
@@ -56,7 +56,7 @@ module Theme
       end
 
       def push(ctx, files: nil, flags: nil, remove: false, env:)
-        action = remove ? 'remove' : 'deploy'
+        action = remove ? "remove" : "deploy"
         command = build_command(action, env)
 
         (command << files << flags).compact!
@@ -75,28 +75,28 @@ module Theme
             path: "themes.json",
           )
         rescue ShopifyCli::API::APIRequestUnauthorizedError
-          ctx.abort(ctx.message('theme.themekit.query_themes.bad_password'))
+          ctx.abort(ctx.message("theme.themekit.query_themes.bad_password"))
         rescue StandardError
-          ctx.abort(ctx.message('theme.themekit.query_themes.not_connect'))
+          ctx.abort(ctx.message("theme.themekit.query_themes.not_connect"))
         end
 
-        resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+        resp[1]["themes"].map { |theme| [theme["name"], theme["id"]] }.to_h
       end
 
       def serve(ctx, flags: nil, env:)
-        command = build_command('open', env)
+        command = build_command("open", env)
         out, stat = ctx.capture2e(*command)
         ctx.puts(out)
-        ctx.abort(ctx.message('theme.serve.open_fail')) unless stat.success?
+        ctx.abort(ctx.message("theme.serve.open_fail")) unless stat.success?
 
-        command = build_command('watch', env)
+        command = build_command("watch", env)
         (command << flags).compact!
         command.flatten!
         ctx.system(*command)
       end
 
       def update(ctx)
-        command = build_command('update')
+        command = build_command("update")
         ctx.system(*command)
       end
 
@@ -104,7 +104,7 @@ module Theme
 
       def build_command(action, env = nil)
         command = [THEMEKIT, action]
-        command << '--no-update-notifier'
+        command << "--no-update-notifier"
         command << "--env=#{env}" if env
         command
       end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,5 +1,5 @@
 Gem.post_uninstall do |uninstaller|
-  if uninstaller.spec.name == 'shopify-cli'
+  if uninstaller.spec.name == "shopify-cli"
     if RUBY_PLATFORM.match(/mingw32/)
       bat_path = File.dirname(RbConfig.ruby)
       bat = "#{bat_path}\\shopify.bat"
@@ -7,9 +7,9 @@ Gem.post_uninstall do |uninstaller|
       # delete the auto-generated batch script
       File.unlink(bat)
     else
-      require 'fileutils'
+      require "fileutils"
 
-      symlink = '/usr/local/bin/shopify'
+      symlink = "/usr/local/bin/shopify"
 
       # delete the symbolic link IFF it exists AND it does not point to a file
       # (i.e., it's been left hanging as a result of the uninstall, as expected)

--- a/lib/shopify-cli/admin_api.rb
+++ b/lib/shopify-cli/admin_api.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   ##
@@ -6,8 +6,8 @@ module ShopifyCli
   # these concerns are taken care of.
   #
   class AdminAPI < API
-    autoload :PopulateResourceCommand, 'shopify-cli/admin_api/populate_resource_command'
-    autoload :Schema, 'shopify-cli/admin_api/schema'
+    autoload :PopulateResourceCommand, "shopify-cli/admin_api/populate_resource_command"
+    autoload :Schema, "shopify-cli/admin_api/schema"
 
     class << self
       ##
@@ -96,19 +96,19 @@ module ShopifyCli
         env = Project.current.env
         ShopifyCli::OAuth.new(
           ctx: ctx,
-          service: 'admin',
+          service: "admin",
           client_id: env.api_key,
           secret: env.secret,
           scopes: env.scopes,
           token_path: "/access_token",
-          options: { 'grant_options[]' => 'per user' },
+          options: { "grant_options[]" => "per user" },
         ).authenticate("https://#{shop}/admin/oauth")
       end
 
-      def api_client(ctx, api_version, shop, path: 'graphql.json')
+      def api_client(ctx, api_version, shop, path: "graphql.json")
         new(
           ctx: ctx,
-          auth_header: 'X-Shopify-Access-Token',
+          auth_header: "X-Shopify-Access-Token",
           token: admin_access_token(ctx, shop),
           url: "https://#{shop}/admin/api/#{fetch_api_version(ctx, api_version, shop)}/#{path}",
         )
@@ -125,13 +125,13 @@ module ShopifyCli
         return api_version unless api_version.nil?
         client = new(
           ctx: ctx,
-          auth_header: 'X-Shopify-Access-Token',
+          auth_header: "X-Shopify-Access-Token",
           token: admin_access_token(ctx, shop),
           url: "https://#{shop}/admin/api/unstable/graphql.json",
         )
-        versions = client.query('api_versions')['data']['publicApiVersions']
-        latest = versions.find { |version| version['displayName'].include?('Latest') }
-        latest['handle']
+        versions = client.query("api_versions")["data"]["publicApiVersions"]
+        latest = versions.find { |version| version["displayName"].include?("Latest") }
+        latest["handle"]
       end
     end
   end

--- a/lib/shopify-cli/admin_api/populate_resource_command.rb
+++ b/lib/shopify-cli/admin_api/populate_resource_command.rb
@@ -1,5 +1,5 @@
-require 'shopify_cli'
-require 'optparse'
+require "shopify_cli"
+require "optparse"
 
 module ShopifyCli
   class AdminAPI
@@ -36,7 +36,7 @@ module ShopifyCli
 
         if @help
           output = display_parent_extended_help
-          output += "\n#{@ctx.message('core.populate.options.header', camel_case_resource_type)}\n"
+          output += "\n#{@ctx.message("core.populate.options.header", camel_case_resource_type)}\n"
           output += resource_options.help
           return @ctx.puts(output)
         end
@@ -45,7 +45,7 @@ module ShopifyCli
 
         if @silent
           spin_group = CLI::UI::SpinGroup.new
-          spin_group.add(@ctx.message('core.populate.populating', @count, camel_case_resource_type)) do |spinner|
+          spin_group.add(@ctx.message("core.populate.populating", @count, camel_case_resource_type)) do |spinner|
             populate
             spinner.update_title(completion_message)
           end
@@ -78,18 +78,18 @@ module ShopifyCli
           opts.on(
             "-c #{DEFAULT_COUNT}",
             "--count=#{DEFAULT_COUNT}",
-            @ctx.message('core.populate.options.count_help')
+            @ctx.message("core.populate.options.count_help")
           ) do |value|
             @count = value.to_i
           end
 
-          opts.on('-h', '--help', 'print help') do |value|
+          opts.on("-h", "--help", "print help") do |value|
             @help = value
           end
 
           opts.on("--silent") { |v| @silent = v }
 
-          opts.on('--shop=', '-s') { |value| @shop = value }
+          opts.on("--shop=", "-s") { |value| @shop = value }
         end
       end
 
@@ -100,12 +100,12 @@ module ShopifyCli
       end
 
       def input_options
-        schema.type(self.class.input_type)['inputFields'].each do |field|
+        schema.type(self.class.input_type)["inputFields"].each do |field|
           resource_options.on(
-            "--#{field['name']}=#{field['defaultValue']}",
-            field['description']
+            "--#{field["name"]}=#{field["defaultValue"]}",
+            field["description"]
           ) do |value|
-            @input[field['name']] = value
+            @input[field["name"]] = value
           end
         end
       end
@@ -120,14 +120,14 @@ module ShopifyCli
         resp = AdminAPI.query(
           @ctx, "create_#{snake_case_resource_type}", **kwargs
         )
-        @ctx.abort(resp['errors']) if resp['errors']
-        @ctx.done(message(resp['data'])) unless @silent
+        @ctx.abort(resp["errors"]) if resp["errors"]
+        @ctx.done(message(resp["data"])) unless @silent
       end
 
       def completion_message
         plural = @count > 1 ? "s" : ""
         @ctx.message(
-          'core.populate.completion_message',
+          "core.populate.completion_message",
           @count,
           "#{camel_case_resource_type}#{plural}",
           Project.current.env.shop,
@@ -142,7 +142,7 @@ module ShopifyCli
       end
 
       def price
-        format('%.2f', rand(1..10))
+        format("%.2f", rand(1..10))
       end
 
       private
@@ -155,7 +155,7 @@ module ShopifyCli
       end
 
       def camel_case_resource_type
-        @camel_case_resource_type ||= self.class.to_s.split('::').last
+        @camel_case_resource_type ||= self.class.to_s.split("::").last
       end
 
       def snake_case_resource_type
@@ -167,7 +167,7 @@ module ShopifyCli
       end
 
       def parent_command_klass
-        @parent_command_klass ||= Module.const_get(self.class.to_s.split('::')[0..-2].join('::'))
+        @parent_command_klass ||= Module.const_get(self.class.to_s.split("::")[0..-2].join("::"))
       end
     end
   end

--- a/lib/shopify-cli/admin_api/schema.rb
+++ b/lib/shopify-cli/admin_api/schema.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   class AdminAPI
@@ -7,7 +7,7 @@ module ShopifyCli
         def get(ctx)
           unless ShopifyCli::DB.exists?(:shopify_admin_schema)
             shop = Project.current.env.shop || get_shop(ctx)
-            schema = AdminAPI.query(ctx, 'admin_introspection', shop: shop)
+            schema = AdminAPI.query(ctx, "admin_introspection", shop: shop)
             ShopifyCli::DB.set(shopify_admin_schema: JSON.dump(schema))
           end
           # This is ruby magic for making a new hash with another hash.
@@ -30,7 +30,7 @@ module ShopifyCli
         data = self["data"]
         schema = data["__schema"]
         schema["types"].find do |object|
-          object['name'] == name.to_s
+          object["name"] == name.to_s
         end
       end
 

--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   class API
@@ -19,7 +19,7 @@ module ShopifyCli
     class APIRequestThrottledError < APIRequestRetriableError; end
 
     def self.gid_to_id(gid)
-      gid.split('/').last
+      gid.split("/").last
     end
 
     def query(query_name, variables: {})
@@ -30,19 +30,19 @@ module ShopifyCli
       ctx.debug(resp)
       resp
     rescue API::APIRequestServerError, API::APIRequestUnexpectedError => e
-      ctx.puts(ctx.message('core.api.error.internal_server_error'))
-      ctx.debug(ctx.message('core.api.error.internal_server_error_debug', e.message))
+      ctx.puts(ctx.message("core.api.error.internal_server_error"))
+      ctx.debug(ctx.message("core.api.error.internal_server_error_debug", e.message))
     end
 
     def request(url:, body: nil, headers: {}, method: "POST")
       CLI::Kit::Util.begin do
         uri = URI.parse(url)
         unless uri.is_a?(URI::HTTP)
-          ctx.abort(ctx.message('core.api.error.invalid_url', url))
+          ctx.abort(ctx.message("core.api.error.invalid_url", url))
         end
 
         # we delay this require so as to avoid a performance hit on starting the CLI
-        require 'shopify-cli/http_request'
+        require "shopify-cli/http_request"
         headers = default_headers.merge(headers)
         response = if method == "POST"
           HttpRequest.post(uri, body, headers)
@@ -76,12 +76,12 @@ module ShopifyCli
     def load_query(name)
       project_type = ShopifyCli::Project.current_project_type
       project_file_path = File.join(
-        ShopifyCli::ROOT, 'lib', 'project_types', project_type.to_s, 'graphql', "#{name}.graphql"
+        ShopifyCli::ROOT, "lib", "project_types", project_type.to_s, "graphql", "#{name}.graphql"
       )
       if !project_type.nil? && File.exist?(project_file_path)
         File.read(project_file_path)
       else
-        File.read(File.join(ShopifyCli::ROOT, 'lib', 'graphql', "#{name}.graphql"))
+        File.read(File.join(ShopifyCli::ROOT, "lib", "graphql", "#{name}.graphql"))
       end
     end
 
@@ -93,9 +93,9 @@ module ShopifyCli
 
     def default_headers
       {
-        'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} #{current_sha} | #{ctx.uname}",
+        "User-Agent" => "Shopify App CLI #{ShopifyCli::VERSION} #{current_sha} | #{ctx.uname}",
       }.tap do |headers|
-        headers['X-Shopify-Cli-Employee'] = '1' if Shopifolk.acting_as_shopify_organization?
+        headers["X-Shopify-Cli-Employee"] = "1" if Shopifolk.acting_as_shopify_organization?
       end.merge(auth_headers(token))
     end
 

--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   class Command < CLI::Kit::BaseCommand

--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -1,9 +1,9 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Commands
     Registry = CLI::Kit::CommandRegistry.new(
-      default: 'help',
+      default: "help",
       contextual_resolver: nil,
     )
     @core_commands = []
@@ -18,12 +18,12 @@ module ShopifyCli
       @core_commands.include?(cmd)
     end
 
-    register :Config, 'config', 'shopify-cli/commands/config', true
-    register :Connect, 'connect', 'shopify-cli/commands/connect', true
-    register :Create, 'create', 'shopify-cli/commands/create', true
-    register :Help, 'help', 'shopify-cli/commands/help', true
-    register :Logout, 'logout', 'shopify-cli/commands/logout', true
-    register :System, 'system', 'shopify-cli/commands/system', true
-    register :Version, 'version', 'shopify-cli/commands/version', true
+    register :Config, "config", "shopify-cli/commands/config", true
+    register :Connect, "connect", "shopify-cli/commands/connect", true
+    register :Create, "create", "shopify-cli/commands/create", true
+    register :Help, "help", "shopify-cli/commands/help", true
+    register :Logout, "logout", "shopify-cli/commands/logout", true
+    register :System, "system", "shopify-cli/commands/system", true
+    register :Version, "version", "shopify-cli/commands/version", true
   end
 end

--- a/lib/shopify-cli/commands/config.rb
+++ b/lib/shopify-cli/commands/config.rb
@@ -1,97 +1,97 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Commands
     class Config < ShopifyCli::Command
       hidden_feature(feature_set: :debug)
 
-      subcommand :Feature, 'feature'
-      subcommand :Analytics, 'analytics'
-      subcommand :ShopifolkBeta, 'shopifolk-beta'
+      subcommand :Feature, "feature"
+      subcommand :Analytics, "analytics"
+      subcommand :ShopifolkBeta, "shopifolk-beta"
 
       def call(*)
         @ctx.puts(self.class.help)
       end
 
       def self.help
-        ShopifyCli::Context.message('core.config.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("core.config.help", ShopifyCli::TOOL_NAME)
       end
 
       class Feature < ShopifyCli::SubCommand
         def self.help
-          ShopifyCli::Context.message('core.config.feature.help', ShopifyCli::TOOL_NAME)
+          ShopifyCli::Context.message("core.config.feature.help", ShopifyCli::TOOL_NAME)
         end
 
         options do |parser, flags|
-          parser.on('--enable') { flags[:action] = 'enable' }
-          parser.on('--disable') { flags[:action] = 'disable' }
-          parser.on('--status') { flags[:action] = 'status' }
+          parser.on("--enable") { flags[:action] = "enable" }
+          parser.on("--disable") { flags[:action] = "disable" }
+          parser.on("--status") { flags[:action] = "status" }
         end
 
         def call(args, _name)
           feature_name = args.shift
-          return @ctx.puts(@ctx.message('core.config.help', ShopifyCli::TOOL_NAME)) if feature_name.nil?
+          return @ctx.puts(@ctx.message("core.config.help", ShopifyCli::TOOL_NAME)) if feature_name.nil?
           is_enabled = ShopifyCli::Feature.enabled?(feature_name)
-          if options.flags[:action] == 'disable' && is_enabled
+          if options.flags[:action] == "disable" && is_enabled
             ShopifyCli::Feature.disable(feature_name)
-            @ctx.puts(@ctx.message('core.config.feature.disabled', feature_name))
-          elsif options.flags[:action] == 'enable' && !is_enabled
+            @ctx.puts(@ctx.message("core.config.feature.disabled", feature_name))
+          elsif options.flags[:action] == "enable" && !is_enabled
             ShopifyCli::Feature.enable(feature_name)
-            @ctx.puts(@ctx.message('core.config.feature.enabled', feature_name))
+            @ctx.puts(@ctx.message("core.config.feature.enabled", feature_name))
           elsif is_enabled
-            @ctx.puts(@ctx.message('core.config.feature.is_enabled', feature_name))
+            @ctx.puts(@ctx.message("core.config.feature.is_enabled", feature_name))
           else
-            @ctx.puts(@ctx.message('core.config.feature.is_disabled', feature_name))
+            @ctx.puts(@ctx.message("core.config.feature.is_disabled", feature_name))
           end
         end
       end
 
       class Analytics < ShopifyCli::SubCommand
         def self.help
-          ShopifyCli::Context.message('core.config.analytics.help', ShopifyCli::TOOL_NAME)
+          ShopifyCli::Context.message("core.config.analytics.help", ShopifyCli::TOOL_NAME)
         end
 
         options do |parser, flags|
-          parser.on('--enable') { flags[:action] = 'enable' }
-          parser.on('--disable') { flags[:action] = 'disable' }
-          parser.on('--status') { flags[:action] = 'status' }
+          parser.on("--enable") { flags[:action] = "enable" }
+          parser.on("--disable") { flags[:action] = "disable" }
+          parser.on("--status") { flags[:action] = "status" }
         end
 
         def call(_args, _name)
-          is_enabled = ShopifyCli::Config.get_bool('analytics', 'enabled')
-          if options.flags[:action] == 'disable' && is_enabled
-            ShopifyCli::Config.set('analytics', 'enabled', false)
-            @ctx.puts(@ctx.message('core.config.analytics.disabled'))
-          elsif options.flags[:action] == 'enable' && !is_enabled
-            ShopifyCli::Config.set('analytics', 'enabled', true)
-            @ctx.puts(@ctx.message('core.config.analytics.enabled'))
+          is_enabled = ShopifyCli::Config.get_bool("analytics", "enabled")
+          if options.flags[:action] == "disable" && is_enabled
+            ShopifyCli::Config.set("analytics", "enabled", false)
+            @ctx.puts(@ctx.message("core.config.analytics.disabled"))
+          elsif options.flags[:action] == "enable" && !is_enabled
+            ShopifyCli::Config.set("analytics", "enabled", true)
+            @ctx.puts(@ctx.message("core.config.analytics.enabled"))
           elsif is_enabled
-            @ctx.puts(@ctx.message('core.config.analytics.is_enabled'))
+            @ctx.puts(@ctx.message("core.config.analytics.is_enabled"))
           else
-            @ctx.puts(@ctx.message('core.config.analytics.is_disabled'))
+            @ctx.puts(@ctx.message("core.config.analytics.is_disabled"))
           end
         end
       end
 
       class ShopifolkBeta < ShopifyCli::SubCommand
         options do |parser, flags|
-          parser.on('--enable') { flags[:action] = 'enable' }
-          parser.on('--disable') { flags[:action] = 'disable' }
-          parser.on('--status') { flags[:action] = 'status' }
+          parser.on("--enable") { flags[:action] = "enable" }
+          parser.on("--disable") { flags[:action] = "disable" }
+          parser.on("--status") { flags[:action] = "status" }
         end
 
         def call(_args, _name)
-          is_enabled = ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
-          if options.flags[:action] == 'disable' && is_enabled
-            ShopifyCli::Config.set('shopifolk-beta', 'enabled', false)
-            @ctx.puts(@ctx.message('core.config.shopifolk_beta.disabled'))
-          elsif options.flags[:action] == 'enable' && !is_enabled
-            ShopifyCli::Config.set('shopifolk-beta', 'enabled', true)
-            @ctx.puts(@ctx.message('core.config.shopifolk_beta.enabled'))
+          is_enabled = ShopifyCli::Config.get_bool("shopifolk-beta", "enabled")
+          if options.flags[:action] == "disable" && is_enabled
+            ShopifyCli::Config.set("shopifolk-beta", "enabled", false)
+            @ctx.puts(@ctx.message("core.config.shopifolk_beta.disabled"))
+          elsif options.flags[:action] == "enable" && !is_enabled
+            ShopifyCli::Config.set("shopifolk-beta", "enabled", true)
+            @ctx.puts(@ctx.message("core.config.shopifolk_beta.enabled"))
           elsif is_enabled
-            @ctx.puts(@ctx.message('core.config.shopifolk_beta.is_enabled'))
+            @ctx.puts(@ctx.message("core.config.shopifolk_beta.is_enabled"))
           else
-            @ctx.puts(@ctx.message('core.config.shopifolk_beta.is_disabled'))
+            @ctx.puts(@ctx.message("core.config.shopifolk_beta.is_disabled"))
           end
         end
       end

--- a/lib/shopify-cli/commands/connect.rb
+++ b/lib/shopify-cli/commands/connect.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Commands
@@ -10,13 +10,13 @@ module ShopifyCli
         end
 
         def help
-          ShopifyCli::Context.message('core.connect.help', ShopifyCli::TOOL_NAME)
+          ShopifyCli::Context.message("core.connect.help", ShopifyCli::TOOL_NAME)
         end
       end
 
       def call(args, command_name)
         if Project.current&.env
-          @ctx.puts(@ctx.message('core.connect.already_connected_warning'))
+          @ctx.puts(@ctx.message("core.connect.already_connected_warning"))
         end
 
         project_type = ask_project_type
@@ -25,15 +25,15 @@ module ShopifyCli
 
         if klass
           klass.ctx = @ctx
-          klass.call(args, command_name, 'connect')
+          klass.call(args, command_name, "connect")
         else
           app = default_connect(project_type)
-          @ctx.done(@ctx.message('core.connect.connected', app))
+          @ctx.done(@ctx.message("core.connect.connected", app))
         end
       end
 
       def ask_project_type
-        CLI::UI::Prompt.ask(@ctx.message('core.connect.project_type_select')) do |handler|
+        CLI::UI::Prompt.ask(@ctx.message("core.connect.project_type_select")) do |handler|
           ShopifyCli::Commands::Create.all_visible_type.each do |type|
             handler.option(type.project_name) { type.project_type }
           end
@@ -42,9 +42,9 @@ module ShopifyCli
 
       def default_connect(project_type)
         org = ShopifyCli::Tasks::EnsureEnv.call(@ctx, regenerate: true)
-        write_cli_yml(project_type, org['id']) unless Project.has_current?
-        api_key = Project.current(force_reload: true).env['api_key']
-        get_app(org['apps'], api_key).first['title']
+        write_cli_yml(project_type, org["id"]) unless Project.has_current?
+        api_key = Project.current(force_reload: true).env["api_key"]
+        get_app(org["apps"], api_key).first["title"]
       end
 
       def write_cli_yml(project_type, org_id)
@@ -53,7 +53,7 @@ module ShopifyCli
           project_type: project_type,
           organization_id: org_id,
         )
-        @ctx.done(@ctx.message('core.connect.cli_yml_saved'))
+        @ctx.done(@ctx.message("core.connect.cli_yml_saved"))
       end
 
       def get_app(apps, api_key)

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Commands
@@ -10,11 +10,11 @@ module ShopifyCli
 
       def call(args, command_name)
         unless args.empty?
-          @ctx.puts(@ctx.message('core.create.error.invalid_app_type', args[0]))
+          @ctx.puts(@ctx.message("core.create.error.invalid_app_type", args[0]))
           return @ctx.puts(self.class.help)
         end
 
-        type_name = CLI::UI::Prompt.ask(@ctx.message('core.create.project_type_select')) do |handler|
+        type_name = CLI::UI::Prompt.ask(@ctx.message("core.create.project_type_select")) do |handler|
           self.class.all_visible_type.each do |type|
             handler.option(type.project_name) { type.project_type }
           end
@@ -22,7 +22,7 @@ module ShopifyCli
 
         klass = ProjectType.load_type(type_name).create_command
         klass.ctx = @ctx
-        klass.call(args, command_name, 'create')
+        klass.call(args, command_name, "create")
       end
 
       def self.all_visible_type
@@ -33,7 +33,7 @@ module ShopifyCli
 
       def self.help
         project_types = all_visible_type.map(&:project_type).sort.join(" | ")
-        ShopifyCli::Context.message('core.create.help', ShopifyCli::TOOL_NAME, project_types)
+        ShopifyCli::Context.message("core.create.help", ShopifyCli::TOOL_NAME, project_types)
       end
 
       def self.extended_help

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -1,11 +1,11 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Commands
     class Help < ShopifyCli::Command
       def call(args, _name)
         command = args.shift
-        if command && command != 'help'
+        if command && command != "help"
           if Registry.exist?(command)
             cmd, _ = Registry.lookup_command(command)
             subcmd, _ = cmd.subcommand_registry.lookup_command(args.first)
@@ -16,15 +16,15 @@ module ShopifyCli
             end
             return
           else
-            @ctx.puts(@ctx.message('core.help.error.command_not_found', command))
+            @ctx.puts(@ctx.message("core.help.error.command_not_found", command))
           end
         end
 
-        preamble = @ctx.message('core.help.preamble', ShopifyCli::TOOL_NAME)
+        preamble = @ctx.message("core.help.preamble", ShopifyCli::TOOL_NAME)
         @ctx.puts(preamble)
 
         core_commands.each do |name, klass|
-          next if name == 'help'
+          next if name == "help"
           @ctx.puts("{{command:#{name}}}: #{klass.help}\n")
         end
 
@@ -34,7 +34,7 @@ module ShopifyCli
         @ctx.puts("{{bold:Available commands for #{project_type_name} projects:}}\n\n")
 
         local_commands.each do |name, klass|
-          next if name == 'help'
+          next if name == "help"
           @ctx.puts("{{command:#{name}}}: #{klass.help}\n")
         end
       end

--- a/lib/shopify-cli/commands/logout.rb
+++ b/lib/shopify-cli/commands/logout.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Commands
@@ -12,11 +12,11 @@ module ShopifyCli
         LOGIN_TOKENS.each do |token|
           ShopifyCli::DB.del(token) if ShopifyCli::DB.exists?(token)
         end
-        @ctx.puts(@ctx.message('core.logout.success'))
+        @ctx.puts(@ctx.message("core.logout.success"))
       end
 
       def self.help
-        ShopifyCli::Context.message('core.logout.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("core.logout.help", ShopifyCli::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify-cli/commands/system.rb
+++ b/lib/shopify-cli/commands/system.rb
@@ -1,5 +1,5 @@
-require 'shopify_cli'
-require 'rbconfig'
+require "shopify_cli"
+require "rbconfig"
 
 module ShopifyCli
   module Commands
@@ -9,13 +9,13 @@ module ShopifyCli
       def call(args, _name)
         show_all_details = false
         flag = args.shift
-        if flag && flag != 'all'
-          @ctx.puts(@ctx.message('core.system.error.unknown_option', flag))
+        if flag && flag != "all"
+          @ctx.puts(@ctx.message("core.system.error.unknown_option", flag))
           @ctx.puts("\n" + self.class.help)
           return
         end
 
-        show_all_details = true if flag == 'all'
+        show_all_details = true if flag == "all"
 
         display_environment if show_all_details
 
@@ -27,7 +27,7 @@ module ShopifyCli
       end
 
       def self.help
-        ShopifyCli::Context.message('core.system.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("core.system.help", ShopifyCli::TOOL_NAME)
       end
 
       private
@@ -47,14 +47,14 @@ module ShopifyCli
 
         cli_constants += cli_constants_extra if show_all_details
 
-        @ctx.puts(@ctx.message('core.system.header'))
+        @ctx.puts(@ctx.message("core.system.header"))
         cli_constants.each do |s|
-          @ctx.puts("  " + @ctx.message('core.system.const', s, ShopifyCli.const_get(s.to_sym)) + "\n")
+          @ctx.puts("  " + @ctx.message("core.system.const", s, ShopifyCli.const_get(s.to_sym)) + "\n")
         end
 
         if show_all_details
           cli_path_methods.each do |m|
-            @ctx.puts("  " + @ctx.message('core.system.const', m.upcase, ShopifyCli.send(m)) + "\n")
+            @ctx.puts("  " + @ctx.message("core.system.const", m.upcase, ShopifyCli.send(m)) + "\n")
           end
         end
       end
@@ -62,23 +62,23 @@ module ShopifyCli
       def display_cli_ruby(_show_all_details)
         rbconfig_constants = %w(host RUBY_VERSION_NAME)
 
-        @ctx.puts("\n" + @ctx.message('core.system.ruby_header', RbConfig.ruby))
+        @ctx.puts("\n" + @ctx.message("core.system.ruby_header", RbConfig.ruby))
         rbconfig_constants.each do |s|
-          @ctx.puts("  " + @ctx.message('core.system.rb_config', RbConfig::CONFIG[s], s))
+          @ctx.puts("  " + @ctx.message("core.system.rb_config", RbConfig::CONFIG[s], s))
         end
       end
 
       def display_utility_commands(_show_all_details)
         commands = %w(git curl tar)
 
-        @ctx.puts("\n" + @ctx.message('core.system.command_header'))
+        @ctx.puts("\n" + @ctx.message("core.system.command_header"))
         commands.each do |s|
           cmd_path = @ctx.which(s)
 
           if !cmd_path.nil?
-            @ctx.puts("  " + @ctx.message('core.system.command_with_path', s, cmd_path))
+            @ctx.puts("  " + @ctx.message("core.system.command_with_path", s, cmd_path))
           else
-            @ctx.puts("  " + @ctx.message('core.system.command_not_found', s))
+            @ctx.puts("  " + @ctx.message("core.system.command_not_found", s))
           end
         end
       end
@@ -86,31 +86,31 @@ module ShopifyCli
       def display_ngrok
         ngrok_location = File.join(ShopifyCli.cache_dir, "ngrok#{@ctx.executable_file_extension}")
         if File.exist?(ngrok_location)
-          @ctx.puts("  " + @ctx.message('core.system.ngrok_available', ngrok_location))
+          @ctx.puts("  " + @ctx.message("core.system.ngrok_available", ngrok_location))
         else
-          @ctx.puts("  " + @ctx.message('core.system.ngrok_not_available'))
+          @ctx.puts("  " + @ctx.message("core.system.ngrok_not_available"))
         end
       end
 
       def display_project_commands(_show_all_details)
         case Project.current_project_type
         when :node
-          display_project('Node.js', %w(npm node yarn))
+          display_project("Node.js", %w(npm node yarn))
         when :rails
-          display_project('Rails', %w(gem rails rake ruby))
+          display_project("Rails", %w(gem rails rake ruby))
         end
       end
 
       def display_project(project_type, commands)
-        @ctx.puts("\n" + @ctx.message('core.system.project.header', project_type))
+        @ctx.puts("\n" + @ctx.message("core.system.project.header", project_type))
         commands.each do |s|
           cmd_path = @ctx.which(s)
           if !cmd_path.nil?
-            version_output, _ = @ctx.capture2e(s, '--version')
+            version_output, _ = @ctx.capture2e(s, "--version")
             version = version_output.match(/(\d+\.[^\s]+)/)[0]
-            @ctx.puts("  " + @ctx.message('core.system.project.command_with_path', s, cmd_path.strip, version.strip))
+            @ctx.puts("  " + @ctx.message("core.system.project.command_with_path", s, cmd_path.strip, version.strip))
           else
-            @ctx.puts("  " + @ctx.message('core.system.project.command_not_found', s))
+            @ctx.puts("  " + @ctx.message("core.system.project.command_not_found", s))
           end
         end
         display_ngrok
@@ -118,25 +118,25 @@ module ShopifyCli
       end
 
       def display_project_environment
-        @ctx.puts("\n  " + @ctx.message('core.system.project.env_header'))
-        if File.exist?('./.env')
+        @ctx.puts("\n  " + @ctx.message("core.system.project.env_header"))
+        if File.exist?("./.env")
           Project.current.env.to_h.each do |k, v|
-            display_value = if v.nil? || v.strip == ''
-              @ctx.message('core.system.project.env_not_set')
+            display_value = if v.nil? || v.strip == ""
+              @ctx.message("core.system.project.env_not_set")
             else
               k.match(/^SHOPIFY_API/) ? "********" : v
             end
-            @ctx.puts("  " + @ctx.message('core.system.project.env', k, display_value))
+            @ctx.puts("  " + @ctx.message("core.system.project.env", k, display_value))
           end
         else
-          @ctx.puts("  " + @ctx.message('core.system.project.no_env'))
+          @ctx.puts("  " + @ctx.message("core.system.project.no_env"))
         end
       end
 
       def display_environment
-        @ctx.puts(@ctx.message('core.system.environment_header'))
+        @ctx.puts(@ctx.message("core.system.environment_header"))
         %w(TERM SHELL PATH USING_SHOPIFY_CLI LANG).each do |k|
-          @ctx.puts("  " + @ctx.message('core.system.env', k, ENV[k])) unless ENV[k].nil?
+          @ctx.puts("  " + @ctx.message("core.system.env", k, ENV[k])) unless ENV[k].nil?
         end
         @ctx.puts("")
       end
@@ -144,8 +144,8 @@ module ShopifyCli
       def display_shopify_staff_identity
         is_shopifolk = ShopifyCli::Shopifolk.check
         if is_shopifolk
-          @ctx.puts("\n" + @ctx.message('core.system.identity_header'))
-          @ctx.puts("  " + @ctx.message('core.system.identity_is_shopifolk'))
+          @ctx.puts("\n" + @ctx.message("core.system.identity_header"))
+          @ctx.puts("  " + @ctx.message("core.system.identity_is_shopifolk"))
         end
       end
     end

--- a/lib/shopify-cli/commands/version.rb
+++ b/lib/shopify-cli/commands/version.rb
@@ -1,10 +1,10 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Commands
     class Version < ShopifyCli::Command
       def self.help
-        ShopifyCli::Context.message('core.version.help', ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("core.version.help", ShopifyCli::TOOL_NAME)
       end
 
       def call(_args, _name)

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'shopify_cli'
-require 'fileutils'
-require 'rbconfig'
-require 'net/http'
-require 'json'
+require "shopify_cli"
+require "fileutils"
+require "rbconfig"
+require "net/http"
+require "json"
 
 module ShopifyCli
   ##
@@ -13,9 +13,9 @@ module ShopifyCli
   # resoures.
   #
   class Context
-    GEM_LATEST_URI = URI.parse('https://rubygems.org/api/v1/versions/shopify-cli/latest.json')
-    VERSION_CHECK_SECTION = 'versioncheck'
-    LAST_CHECKED_AT_FIELD = 'last_checked_at'
+    GEM_LATEST_URI = URI.parse("https://rubygems.org/api/v1/versions/shopify-cli/latest.json")
+    VERSION_CHECK_SECTION = "versioncheck"
+    LAST_CHECKED_AT_FIELD = "last_checked_at"
     VERSION_CHECK_INTERVAL = 86400
 
     class << self
@@ -40,7 +40,7 @@ module ShopifyCli
       # * `key` - a symbol representing the message
       # * `params` - the parameters to format the string with
       def message(key, *params)
-        key_parts = key.split('.').map(&:to_sym)
+        key_parts = key.split(".").map(&:to_sym)
         str = Context.messages.dig(*key_parts)
         str ? str % params : key
       end
@@ -86,7 +86,7 @@ module ShopifyCli
     # See `#development?` for checking for development environment.
     #
     def system?
-      !Dir.exist?(File.join(ShopifyCli::ROOT, 'test'))
+      !Dir.exist?(File.join(ShopifyCli::ROOT, "test"))
     end
 
     # will return true if the cli is running on your development instance.
@@ -97,13 +97,13 @@ module ShopifyCli
 
     # will return true while tests are running, either locally or on CI
     def testing?
-      ci? || ENV['TEST']
+      ci? || ENV["TEST"]
     end
 
     ##
     # will return true if the cli is being tested on CI
     def ci?
-      ENV['CI']
+      ENV["CI"]
     end
 
     # get a environment variable value by name.
@@ -116,7 +116,7 @@ module ShopifyCli
     #
     def getenv(name)
       v = @env[name]
-      v == '' ? nil : v
+      v == "" ? nil : v
     end
 
     # set a environment variable value by name.
@@ -254,7 +254,7 @@ module ShopifyCli
     # * `uri` - a http URI to open in a browser
     #
     def open_url!(uri)
-      help = message('core.context.open_url', uri)
+      help = message("core.context.open_url", uri)
       puts(help)
     end
 
@@ -303,7 +303,7 @@ module ShopifyCli
     # * `text` - a string message to output
     #
     def debug(text)
-      puts("{{red:DEBUG}} #{text}") if getenv('DEBUG')
+      puts("{{red:DEBUG}} #{text}") if getenv("DEBUG")
     end
 
     # proxy call to Context.message.
@@ -338,7 +338,7 @@ module ShopifyCli
     def system(*args, **kwargs)
       process_status = CLI::Kit::System.system(*args, env: @env, **kwargs)
       unless process_status.success?
-        abort("System call failed: #{args.join(' ')}")
+        abort("System call failed: #{args.join(" ")}")
       end
       process_status
     end
@@ -414,13 +414,13 @@ module ShopifyCli
     #
     def on_siginfo
       # Reset any previous SIGINFO handling we had so the only action we take is the given block
-      trap('INFO', 'DEFAULT')
+      trap("INFO", "DEFAULT")
 
       fork do
         begin
           r, w = IO.pipe
           @signal = false
-          trap('SIGINFO') do
+          trap("SIGINFO") do
             @signal = true
             w.write(0)
           end
@@ -446,8 +446,8 @@ module ShopifyCli
     # @todo This is currently a duplicate of CLI::Kit::System.which() - we should make that method public when we make
     #       Kit changes and make this a wrapper instead.
     def which(cmd)
-      exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
-      ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+      exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
+      ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
         exts.each do |ext|
           exe = File.join(File.expand_path(path), "#{cmd}#{ext}")
           return exe if File.executable?(exe) && !File.directory?(exe)
@@ -483,18 +483,18 @@ module ShopifyCli
     # #### Returns
     # - ext: string for file extension on windows
     #      : empty string otherwise
-    def executable_file_extension(ext = '.exe')
+    def executable_file_extension(ext = ".exe")
       if windows?
         ext
       else
-        ''
+        ""
       end
     end
 
     private
 
     def ctx_path(fname)
-      require 'pathname'
+      require "pathname"
       if Pathname.new(fname).absolute?
         fname
       else

--- a/lib/shopify-cli/core.rb
+++ b/lib/shopify-cli/core.rb
@@ -1,8 +1,8 @@
 module ShopifyCli
   module Core
-    autoload :EntryPoint, 'shopify-cli/core/entry_point'
-    autoload :Executor, 'shopify-cli/core/executor'
-    autoload :HelpResolver, 'shopify-cli/core/help_resolver'
-    autoload :Monorail, 'shopify-cli/core/monorail'
+    autoload :EntryPoint, "shopify-cli/core/entry_point"
+    autoload :Executor, "shopify-cli/core/executor"
+    autoload :HelpResolver, "shopify-cli/core/help_resolver"
+    autoload :Monorail, "shopify-cli/core/monorail"
   end
 end

--- a/lib/shopify-cli/core/entry_point.rb
+++ b/lib/shopify-cli/core/entry_point.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Core
@@ -14,23 +14,23 @@ module ShopifyCli
           rescue ArgumentError => e
             # This can happen on RVM, because it can use fd 9 itself and block access to it. That only happens if the fd
             # did not exist beforehand, so that means there was no fd 9 before Ruby started.
-            unless e.message == 'The given fd is not accessible because RubyVM reserves it'
+            unless e.message == "The given fd is not accessible because RubyVM reserves it"
               raise e
             end
           end
 
           if !ctx.testing? && is_shell_shim
-            ctx.puts(ctx.message('core.warning.shell_shim'))
+            ctx.puts(ctx.message("core.warning.shell_shim"))
             return
           end
 
           if ctx.development?
             ctx.puts(
-              ctx.message('core.warning.development_version', File.join(ShopifyCli::ROOT, 'bin', ShopifyCli::TOOL_NAME))
+              ctx.message("core.warning.development_version", File.join(ShopifyCli::ROOT, "bin", ShopifyCli::TOOL_NAME))
             )
           elsif !ctx.testing?
             new_version = ctx.new_version
-            ctx.puts(ctx.message('core.warning.new_version', ShopifyCli::VERSION, new_version)) unless new_version.nil?
+            ctx.puts(ctx.message("core.warning.new_version", ShopifyCli::VERSION, new_version)) unless new_version.nil?
           end
 
           ProjectType.load_type(Project.current_project_type)

--- a/lib/shopify-cli/core/executor.rb
+++ b/lib/shopify-cli/core/executor.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Core

--- a/lib/shopify-cli/core/help_resolver.rb
+++ b/lib/shopify-cli/core/help_resolver.rb
@@ -1,4 +1,4 @@
-require 'cli/kit'
+require "cli/kit"
 
 module ShopifyCli
   module Core
@@ -6,7 +6,7 @@ module ShopifyCli
       def call(args)
         args = args.dup
         return super(args) unless args.first
-        if args.first.include?('-h') || args.first.include?('--help')
+        if args.first.include?("-h") || args.first.include?("--help")
           help = Commands::Help
           help.ctx = Context.new
           help.call([], nil)

--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -1,13 +1,13 @@
-require 'json'
-require 'net/http'
-require 'time'
-require 'rbconfig'
+require "json"
+require "net/http"
+require "time"
+require "rbconfig"
 
 module ShopifyCli
   module Core
     module Monorail
-      ENDPOINT_URI = URI.parse('https://monorail-edge.shopifycloud.com/v1/produce')
-      INVOCATIONS_SCHEMA = 'app_cli_command/5.0'
+      ENDPOINT_URI = URI.parse("https://monorail-edge.shopifycloud.com/v1/produce")
+      INVOCATIONS_SCHEMA = "app_cli_command/5.0"
 
       # Extra hash of data that will be sent in the payload
       @metadata = {}
@@ -46,25 +46,25 @@ module ShopifyCli
 
         # we only want to send Monorail events in production or when explicitly developing
         def enabled?
-          Context.new.system? || ENV['MONORAIL_REAL_EVENTS'] == '1'
+          Context.new.system? || ENV["MONORAIL_REAL_EVENTS"] == "1"
         end
 
         def consented?
-          ShopifyCli::Config.get_bool('analytics', 'enabled')
+          ShopifyCli::Config.get_bool("analytics", "enabled")
         end
 
         def prompt_for_consent
           return unless enabled?
-          return if ShopifyCli::Config.get_section('analytics').key?('enabled')
-          msg = Context.message('core.monorail.consent_prompt')
+          return if ShopifyCli::Config.get_section("analytics").key?("enabled")
+          msg = Context.message("core.monorail.consent_prompt")
           opt = CLI::UI::Prompt.confirm(msg)
-          ShopifyCli::Config.set('analytics', 'enabled', opt)
+          ShopifyCli::Config.set("analytics", "enabled", opt)
         end
 
         def send_event(start_time, commands, args, err = nil)
           end_time = now_in_milliseconds
           headers = {
-            'Content-Type': 'application/json; charset=utf-8',
+            'Content-Type': "application/json; charset=utf-8",
             'X-Monorail-Edge-Event-Created-At-Ms': start_time.to_s,
             'X-Monorail-Edge-Event-Sent-At-Ms': end_time.to_s,
           }
@@ -74,7 +74,7 @@ module ShopifyCli
               ENDPOINT_URI.port,
               # timeouts for opening a connection, reading, writing (in seconds)
               open_timeout: 0.2, read_timeout: 0.2, write_timeout: 0.2,
-              use_ssl: ENDPOINT_URI.scheme == 'https'
+              use_ssl: ENDPOINT_URI.scheme == "https"
             ) do |http|
               payload = build_payload(start_time, end_time, commands, args, err)
               post = Net::HTTP::Post.new(ENDPOINT_URI.request_uri, headers)
@@ -91,8 +91,8 @@ module ShopifyCli
             schema_id: INVOCATIONS_SCHEMA,
             payload: {
               project_type: Project.current_project_type.to_s,
-              command: commands.join(' '),
-              args: args.join(' '),
+              command: commands.join(" "),
+              args: args.join(" "),
               time_start: start_time,
               time_end: end_time,
               total_time: end_time - start_time,
@@ -108,7 +108,7 @@ module ShopifyCli
               if Project.has_current?
                 project = Project.current(force_reload: true)
                 payload[:api_key] = project.env&.api_key
-                payload[:partner_id] = project.config['organization_id']
+                payload[:partner_id] = project.config["organization_id"]
               end
               payload[:metadata] = JSON.dump(metadata) unless metadata.empty?
             end,

--- a/lib/shopify-cli/db.rb
+++ b/lib/shopify-cli/db.rb
@@ -1,5 +1,5 @@
-require 'pstore'
-require 'forwardable'
+require "pstore"
+require "forwardable"
 
 module ShopifyCli
   # Persists transient data like access tokens that may be cleared

--- a/lib/shopify-cli/feature.rb
+++ b/lib/shopify-cli/feature.rb
@@ -6,7 +6,7 @@ module ShopifyCli
   # Feature flags will persist between runs so if the flag is enabled or disabled,
   # it will still be in that same state on the next cli invocation.
   class Feature
-    SECTION = 'features'
+    SECTION = "features"
 
     ##
     # ShopifyCli::Feature::Set is included on commands and projects to allow you to hide

--- a/lib/shopify-cli/form.rb
+++ b/lib/shopify-cli/form.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   class Form

--- a/lib/shopify-cli/git.rb
+++ b/lib/shopify-cli/git.rb
@@ -21,7 +21,7 @@ module ShopifyCli
       #   ShopifyCli::Git.sha
       #
       def sha(dir: Dir.pwd, ctx: Context.new)
-        rev_parse('HEAD', dir: dir, ctx: ctx)
+        rev_parse("HEAD", dir: dir, ctx: ctx)
       end
 
       ##
@@ -44,11 +44,11 @@ module ShopifyCli
       #
       def clone(repository, dest, ctx: Context.new)
         if Dir.exist?(dest)
-          ctx.abort(ctx.message('core.git.error.directory_exists'))
+          ctx.abort(ctx.message("core.git.error.directory_exists"))
         else
-          success_message = ctx.message('core.git.cloned', dest)
-          CLI::UI::Frame.open(ctx.message('core.git.cloning', repository, dest), success_text: success_message) do
-            clone_progress('clone', '--single-branch', repository, dest, ctx: ctx)
+          success_message = ctx.message("core.git.cloned", dest)
+          CLI::UI::Frame.open(ctx.message("core.git.cloning", repository, dest), success_text: success_message) do
+            clone_progress("clone", "--single-branch", repository, dest, ctx: ctx)
           end
         end
       end
@@ -69,11 +69,11 @@ module ShopifyCli
       #   branches = ShopifyCli::Git.branches(@ctx)
       #
       def branches(ctx)
-        output, status = ctx.capture2e('git', 'branch', '--list', '--format=%(refname:short)')
-        ctx.abort(ctx.message('core.git.error.no_branches_found')) unless status.success?
+        output, status = ctx.capture2e("git", "branch", "--list", "--format=%(refname:short)")
+        ctx.abort(ctx.message("core.git.error.no_branches_found")) unless status.success?
 
-        branches = if output == ''
-          ['master']
+        branches = if output == ""
+          ["master"]
         else
           output.split("\n")
         end
@@ -94,14 +94,14 @@ module ShopifyCli
       #   ShopifyCli::Git.init(@ctx)
       #
       def init(ctx)
-        output, status = ctx.capture2e('git', 'status')
+        output, status = ctx.capture2e("git", "status")
 
         unless status.success?
-          ctx.abort(ctx.message('core.git.error.repo_not_initiated'))
+          ctx.abort(ctx.message("core.git.error.repo_not_initiated"))
         end
 
-        if output.include?('No commits yet')
-          ctx.abort(ctx.message('core.git.error.no_commits_made'))
+        if output.include?("No commits yet")
+          ctx.abort(ctx.message("core.git.error.no_commits_made"))
         end
       end
 
@@ -115,18 +115,18 @@ module ShopifyCli
       end
 
       def rev_parse(*args, dir: nil, ctx: Context.new)
-        exec('rev-parse', *args, dir: dir, ctx: ctx)
+        exec("rev-parse", *args, dir: dir, ctx: ctx)
       end
 
       def clone_progress(*git_command, ctx:)
         CLI::UI::Progress.progress do |bar|
           msg = []
-          require 'open3'
+          require "open3"
 
-          success = Open3.popen3('git', *git_command, '--progress') do |_stdin, _stdout, stderr, thread|
+          success = Open3.popen3("git", *git_command, "--progress") do |_stdin, _stdout, stderr, thread|
             while (line = stderr.gets)
               msg << line.chomp
-              next unless line.strip.start_with?('Receiving objects:')
+              next unless line.strip.start_with?("Receiving objects:")
               percent = (line.match(/Receiving objects:\s+(\d+)/)[1].to_f / 100).round(2)
               bar.tick(set_percent: percent)
               next

--- a/lib/shopify-cli/helpers.rb
+++ b/lib/shopify-cli/helpers.rb
@@ -1,5 +1,5 @@
 module ShopifyCli
   module Helpers
-    autoload :Haikunator, 'shopify-cli/helpers/haikunator'
+    autoload :Haikunator, "shopify-cli/helpers/haikunator"
   end
 end

--- a/lib/shopify-cli/helpers/haikunator.rb
+++ b/lib/shopify-cli/helpers/haikunator.rb
@@ -28,7 +28,7 @@ module ShopifyCli
     module Haikunator
       class << self
         def title
-          build(0, ' ')
+          build(0, " ")
         end
 
         def haikunate(token_range = 9999, delimiter = "-")

--- a/lib/shopify-cli/heroku.rb
+++ b/lib/shopify-cli/heroku.rb
@@ -1,9 +1,9 @@
 module ShopifyCli
   class Heroku
     DOWNLOAD_URLS = {
-      linux: 'https://cli-assets.heroku.com/heroku-linux-x64.tar.gz',
-      mac: 'https://cli-assets.heroku.com/heroku-darwin-x64.tar.gz',
-      windows: 'https://cli-assets.heroku.com/heroku-x64.exe',
+      linux: "https://cli-assets.heroku.com/heroku-linux-x64.tar.gz",
+      mac: "https://cli-assets.heroku.com/heroku-darwin-x64.tar.gz",
+      windows: "https://cli-assets.heroku.com/heroku-x64.exe",
     }
 
     def initialize(ctx)
@@ -12,33 +12,33 @@ module ShopifyCli
 
     def app
       return nil unless (app = git_remote)
-      app = app.split('/').last
-      app = app.split('.').first
+      app = app.split("/").last
+      app = app.split(".").first
       app
     end
 
     def authenticate
-      result = @ctx.system(heroku_command, 'login')
-      @ctx.abort(@ctx.message('core.heroku.error.authentication')) unless result.success?
+      result = @ctx.system(heroku_command, "login")
+      @ctx.abort(@ctx.message("core.heroku.error.authentication")) unless result.success?
     end
 
     def create_new_app
-      output, status = @ctx.capture2e(heroku_command, 'create')
-      @ctx.abort(@ctx.message('core.heroku.error.creation')) unless status.success?
+      output, status = @ctx.capture2e(heroku_command, "create")
+      @ctx.abort(@ctx.message("core.heroku.error.creation")) unless status.success?
       @ctx.puts(output)
     end
 
     def deploy(branch_to_deploy)
-      result = @ctx.system('git', 'push', '-u', 'heroku', "#{branch_to_deploy}:master")
-      @ctx.abort(@ctx.message('core.heroku.error.deploy')) unless result.success?
+      result = @ctx.system("git", "push", "-u", "heroku", "#{branch_to_deploy}:master")
+      @ctx.abort(@ctx.message("core.heroku.error.deploy")) unless result.success?
     end
 
     def download
       return if installed?
 
-      result = @ctx.system('curl', '-o', download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCli.cache_dir)
-      @ctx.abort(@ctx.message('core.heroku.error.download')) unless result.success?
-      @ctx.abort(@ctx.message('core.heroku.error.download')) unless File.exist?(download_path)
+      result = @ctx.system("curl", "-o", download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCli.cache_dir)
+      @ctx.abort(@ctx.message("core.heroku.error.download")) unless result.success?
+      @ctx.abort(@ctx.message("core.heroku.error.download")) unless File.exist?(download_path)
     end
 
     def install
@@ -47,22 +47,22 @@ module ShopifyCli
       result = if @ctx.windows?
         @ctx.system("\"#{download_path}\"")
       else
-        @ctx.system('tar', '-xf', download_path, chdir: ShopifyCli.cache_dir)
+        @ctx.system("tar", "-xf", download_path, chdir: ShopifyCli.cache_dir)
       end
-      @ctx.abort(@ctx.message('core.heroku.error.install')) unless result.success?
+      @ctx.abort(@ctx.message("core.heroku.error.install")) unless result.success?
 
       @ctx.rm(download_path)
     end
 
     def select_existing_app(app_name)
-      result = @ctx.system(heroku_command, 'git:remote', '-a', app_name)
+      result = @ctx.system(heroku_command, "git:remote", "-a", app_name)
 
-      msg = @ctx.message('core.heroku.error.could_not_select_app', app_name)
+      msg = @ctx.message("core.heroku.error.could_not_select_app", app_name)
       @ctx.abort(msg) unless result.success?
     end
 
     def whoami
-      output, status = @ctx.capture2e(heroku_command, 'whoami')
+      output, status = @ctx.capture2e(heroku_command, "whoami")
       return output.strip if status.success?
       nil
     end
@@ -70,7 +70,7 @@ module ShopifyCli
     private
 
     def download_filename
-      URI.parse(DOWNLOAD_URLS[@ctx.os]).path.split('/').last
+      URI.parse(DOWNLOAD_URLS[@ctx.os]).path.split("/").last
     end
 
     def download_path
@@ -78,33 +78,33 @@ module ShopifyCli
     end
 
     def git_remote
-      output, status = @ctx.capture2e('git', 'remote', 'get-url', 'heroku')
+      output, status = @ctx.capture2e("git", "remote", "get-url", "heroku")
       status.success? ? output : nil
     end
 
     def heroku_command
-      local_path = File.join(ShopifyCli.cache_dir, 'heroku', 'bin', 'heroku').to_s
+      local_path = File.join(ShopifyCli.cache_dir, "heroku", "bin", "heroku").to_s
       if File.exist?(local_path)
         local_path
       elsif @ctx.windows?
         # Check if Heroku exists in the Windows registry and run it from there
-        require 'win32/registry'
+        require "win32/registry"
         begin
           windows_path = Win32::Registry::HKEY_CURRENT_USER.open('SOFTWARE\heroku') do |reg|
-            reg[''] # This reads the 'Default' registry key
+            reg[""] # This reads the 'Default' registry key
           end
 
-          File.join(windows_path, 'bin', 'heroku').to_s
+          File.join(windows_path, "bin", "heroku").to_s
         rescue
-          'heroku'
+          "heroku"
         end
       else
-        'heroku'
+        "heroku"
       end
     end
 
     def installed?
-      _output, status = @ctx.capture2e(heroku_command, '--version')
+      _output, status = @ctx.capture2e(heroku_command, "--version")
       status.success?
     rescue
       false

--- a/lib/shopify-cli/http_request.rb
+++ b/lib/shopify-cli/http_request.rb
@@ -1,4 +1,4 @@
-require 'net/http'
+require "net/http"
 
 module ShopifyCli
   class HttpRequest
@@ -18,7 +18,7 @@ module ShopifyCli
         http.use_ssl = true
 
         req.body = body unless body.nil?
-        req['Content-Type'] = 'application/json'
+        req["Content-Type"] = "application/json"
         headers.each { |header, value| req[header] = value }
         http.request(req)
       end

--- a/lib/shopify-cli/js_deps.rb
+++ b/lib/shopify-cli/js_deps.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   ##
@@ -37,9 +37,9 @@ module ShopifyCli
     #   ShopifyCli::JsDeps.new(context).install(true)
     #
     def install(verbose = false)
-      title = ctx.message('core.js_deps.installing', @system.package_manager)
-      success = ctx.message('core.js_deps.installed')
-      failure = ctx.message('core.js_deps.error.install_error', @system.package_manager)
+      title = ctx.message("core.js_deps.installing", @system.package_manager)
+      success = ctx.message("core.js_deps.installed")
+      failure = ctx.message("core.js_deps.error.install_error", @system.package_manager)
 
       CLI::UI::Frame.open(title, success_text: success, failure_text: failure) do
         @system.call(
@@ -53,14 +53,14 @@ module ShopifyCli
 
     def yarn(verbose = false)
       cmd = %w(yarn install)
-      cmd << '--silent' unless verbose
+      cmd << "--silent" unless verbose
 
       run_install_command(cmd)
     end
 
     def npm(verbose = false)
       cmd = %w(npm install --no-audit)
-      cmd << '--quiet' unless verbose
+      cmd << "--quiet" unless verbose
 
       run_install_command(cmd)
     end
@@ -69,7 +69,7 @@ module ShopifyCli
       deps = parse_dependencies
       errors = nil
 
-      spinner_title = ctx.message('core.js_deps.installing', @system.package_manager)
+      spinner_title = ctx.message("core.js_deps.installing", @system.package_manager)
       success = CLI::UI::Spinner.spin(spinner_title, auto_debrief: false) do |spinner|
         _, errors, status = CLI::Kit::System.capture3(*cmd, env: @ctx.env, chdir: ctx.root)
         update_spinner_title_and_status(spinner, status, deps)
@@ -81,19 +81,19 @@ module ShopifyCli
 
     def update_spinner_title_and_status(spinner, status, deps)
       if status.success?
-        spinner.update_title(ctx.message('core.js_deps.installed', deps.size))
+        spinner.update_title(ctx.message("core.js_deps.installed", deps.size))
       else
-        spinner.update_title(ctx.message('core.js_deps.error.install_spinner_error', deps.size))
+        spinner.update_title(ctx.message("core.js_deps.error.install_spinner_error", deps.size))
         CLI::UI::Spinner::TASK_FAILED
       end
     end
 
     def parse_dependencies
-      package_json = File.join(ctx.root, 'package.json')
+      package_json = File.join(ctx.root, "package.json")
       pkg = begin
               JSON.parse(File.read(package_json))
             rescue Errno::ENOENT, Errno::ENOTDIR
-              ctx.abort(ctx.message('core.js_deps.error.missing_package', package_json))
+              ctx.abort(ctx.message("core.js_deps.error.missing_package", package_json))
             end
 
       %w(dependencies devDependencies).map do |key|
@@ -101,7 +101,7 @@ module ShopifyCli
       end.flatten
     rescue JSON::ParserError
       ctx.puts(
-        ctx.message('core.js_deps.error.invalid_package', File.read(File.join(path, 'package.json'))),
+        ctx.message("core.js_deps.error.invalid_package", File.read(File.join(path, "package.json"))),
         error: true
       )
       raise ShopifyCli::AbortSilent

--- a/lib/shopify-cli/js_system.rb
+++ b/lib/shopify-cli/js_system.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   ##
@@ -7,8 +7,8 @@ module ShopifyCli
   class JsSystem
     include SmartProperties
 
-    YARN_CORE_COMMAND = 'yarn'
-    NPM_CORE_COMMAND = 'npm'
+    YARN_CORE_COMMAND = "yarn"
+    NPM_CORE_COMMAND = "npm"
 
     class << self
       ##
@@ -64,8 +64,8 @@ module ShopifyCli
     #
     def yarn?
       @has_yarn ||= begin
-        cmd_path = @ctx.which('yarn')
-        File.exist?(File.join(ctx.root, 'yarn.lock')) && !cmd_path.nil?
+        cmd_path = @ctx.which("yarn")
+        File.exist?(File.join(ctx.root, "yarn.lock")) && !cmd_path.nil?
       end
     end
 

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -129,7 +129,7 @@ module ShopifyCli
             missing_package: "expected to have a file at: %s",
             invalid_package: "{{info:%s}} was not valid JSON. Fix this then try again",
             install_spinner_error: "Unable to install all %d dependencies",
-            install_error: 'An error occurred while installing dependencies',
+            install_error: "An error occurred while installing dependencies",
           },
 
           installing: "Installing dependencies with %s...",
@@ -192,9 +192,9 @@ module ShopifyCli
 
         api: {
           error: {
-            internal_server_error: '{{red:{{x}} An unexpected error occurred on Shopify.}}',
+            internal_server_error: "{{red:{{x}} An unexpected error occurred on Shopify.}}",
             internal_server_error_debug: "\n{{red:Response details:}}\n%s\n\n",
-            invalid_url: 'Invalid URL: %s',
+            invalid_url: "Invalid URL: %s",
           },
         },
 
@@ -282,7 +282,7 @@ module ShopifyCli
             MESSAGE
             development_store_select: "Which development store would you like to use?",
             app_select: "To which app does this project belong?",
-            no_apps: 'You have no apps to connect to, creating a new app.',
+            no_apps: "You have no apps to connect to, creating a new app.",
             app_name: "App name",
             app_type: {
               select: "What type of app are you building?",

--- a/lib/shopify-cli/oauth.rb
+++ b/lib/shopify-cli/oauth.rb
@@ -1,18 +1,18 @@
-require 'base64'
-require 'digest'
-require 'json'
-require 'net/http'
-require 'securerandom'
-require 'openssl'
-require 'shopify_cli'
-require 'uri'
-require 'webrick'
+require "base64"
+require "digest"
+require "json"
+require "net/http"
+require "securerandom"
+require "openssl"
+require "shopify_cli"
+require "uri"
+require "webrick"
 
 module ShopifyCli
   class OAuth
     include SmartProperties
 
-    autoload :Servlet, 'shopify-cli/oauth/servlet'
+    autoload :Servlet, "shopify-cli/oauth/servlet"
 
     class Error < StandardError; end
     LocalRequest = Struct.new(:method, :path, :query, :protocol)
@@ -54,10 +54,10 @@ module ShopifyCli
       @server ||= begin
         server = WEBrick::HTTPServer.new(
           Port: DEFAULT_PORT,
-          Logger: WEBrick::Log.new(File.open(File::NULL, 'w')),
+          Logger: WEBrick::Log.new(File.open(File::NULL, "w")),
           AccessLog: [],
         )
-        server.mount('/', Servlet, self, state_token)
+        server.mount("/", Servlet, self, state_token)
         server
       end
     end
@@ -80,17 +80,17 @@ module ShopifyCli
     end
 
     def output_authentication_info(uri)
-      login_location = ctx.message(service == 'admin' ? 'core.oauth.location.admin' : 'core.oauth.location.partner')
-      ctx.puts(ctx.message('core.oauth.authentication_required', login_location))
+      login_location = ctx.message(service == "admin" ? "core.oauth.location.admin" : "core.oauth.location.partner")
+      ctx.puts(ctx.message("core.oauth.authentication_required", login_location))
       ctx.open_url!(uri)
     end
 
     def receive_access_code
       @access_code ||= begin
         @server_thread.join(240)
-        raise Error, ctx.message('core.oauth.error.timeout') if response_query.nil?
-        raise Error, response_query['error_description'] unless response_query['error'].nil?
-        response_query['code']
+        raise Error, ctx.message("core.oauth.error.timeout") if response_query.nil?
+        raise Error, response_query["error_description"] unless response_query["error"].nil?
+        response_query["code"]
       end
     end
 
@@ -105,8 +105,8 @@ module ShopifyCli
         }.merge(confirmation_param)
       )
       store.set(
-        "#{service}_access_token".to_sym => resp['access_token'],
-        "#{service}_refresh_token".to_sym => resp['refresh_token'],
+        "#{service}_access_token".to_sym => resp["access_token"],
+        "#{service}_refresh_token".to_sym => resp["refresh_token"],
       )
     end
 
@@ -130,8 +130,8 @@ module ShopifyCli
         client_id: client_id,
       )
       store.set(
-        "#{service}_access_token".to_sym => resp['access_token'],
-        "#{service}_refresh_token".to_sym => resp['refresh_token'],
+        "#{service}_access_token".to_sym => resp["access_token"],
+        "#{service}_refresh_token".to_sym => resp["refresh_token"],
       )
     end
 
@@ -155,7 +155,7 @@ module ShopifyCli
         scope: scopes,
         subject_token: store.get("#{service}_access_token".to_sym),
       )
-      store.set("#{service}_exchange_token".to_sym => resp['access_token'])
+      store.set("#{service}_exchange_token".to_sym => resp["access_token"])
     end
 
     def post_token_request(url, params)
@@ -163,17 +163,17 @@ module ShopifyCli
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
       request = Net::HTTP::Post.new(uri.path)
-      request['User-Agent'] = "Shopify App CLI #{::ShopifyCli::VERSION}"
+      request["User-Agent"] = "Shopify App CLI #{::ShopifyCli::VERSION}"
       request.body = URI.encode_www_form(params)
       res = https.request(request)
-      raise Error, JSON.parse(res.body)['error_description'] unless res.is_a?(Net::HTTPSuccess)
+      raise Error, JSON.parse(res.body)["error_description"] unless res.is_a?(Net::HTTPSuccess)
       JSON.parse(res.body)
     end
 
     def challange_params
       {
         code_challenge: code_challenge,
-        code_challenge_method: 'S256',
+        code_challenge_method: "S256",
       }
     end
 

--- a/lib/shopify-cli/oauth/servlet.rb
+++ b/lib/shopify-cli/oauth/servlet.rb
@@ -26,18 +26,18 @@ module ShopifyCli
       end
 
       def do_GET(req, res) # rubocop:disable Naming/MethodName
-        if !req.query['error'].nil?
+        if !req.query["error"].nil?
           respond_with(
             res,
             400,
-            Context.message('core.oauth.servlet.invalid_request_response', req.query['error_description'])
+            Context.message("core.oauth.servlet.invalid_request_response", req.query["error_description"])
           )
-        elsif req.query['state'] != @state_token
-          response_message = Context.message('core.oauth.servlet.invalid_state_response')
-          req.query.merge!('error' => 'invalid_state', 'error_description' => response_message)
+        elsif req.query["state"] != @state_token
+          response_message = Context.message("core.oauth.servlet.invalid_state_response")
+          req.query.merge!("error" => "invalid_state", "error_description" => response_message)
           respond_with(res, 403, response_message)
         else
-          respond_with(res, 200, Context.message('core.oauth.servlet.success_response'))
+          respond_with(res, 200, Context.message("core.oauth.servlet.success_response"))
         end
         @oauth.response_query = req.query
         @server.shutdown
@@ -48,10 +48,10 @@ module ShopifyCli
         locals = {
           status: status,
           message: message,
-          color: successful ? 'black' : 'red',
+          color: successful ? "black" : "red",
           title:
-            Context.message(successful ? 'core.oauth.servlet.authenticated' : 'core.oauth.servlet.not_authenticated'),
-          autoclose: successful ? AUTOCLOSE_TEMPLATE : '',
+            Context.message(successful ? "core.oauth.servlet.authenticated" : "core.oauth.servlet.not_authenticated"),
+          autoclose: successful ? AUTOCLOSE_TEMPLATE : "",
         }
         response.status = status
         response.body = format(TEMPLATE, locals)

--- a/lib/shopify-cli/options.rb
+++ b/lib/shopify-cli/options.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'shopify_cli'
-require 'optparse'
+require "shopify_cli"
+require "optparse"
 
 module ShopifyCli
   class Options
@@ -31,7 +31,7 @@ module ShopifyCli
     def parser
       @parser ||= begin
         opt = OptionParser.new
-        opt.on('--help', '-h', Context.message('core.options.help_text')) do |v|
+        opt.on("--help", "-h", Context.message("core.options.help_text")) do |v|
           @help = v
         end
       end

--- a/lib/shopify-cli/packager.rb
+++ b/lib/shopify-cli/packager.rb
@@ -1,17 +1,17 @@
 module ShopifyCli
   class Packager
-    PACKAGING_DIR = File.join(ShopifyCli::ROOT, 'packaging')
-    BUILDS_DIR = File.join(PACKAGING_DIR, 'builds', ShopifyCli::VERSION)
+    PACKAGING_DIR = File.join(ShopifyCli::ROOT, "packaging")
+    BUILDS_DIR = File.join(PACKAGING_DIR, "builds", ShopifyCli::VERSION)
 
     def initialize
       FileUtils.mkdir_p(BUILDS_DIR)
     end
 
     def build_debian
-      ensure_program_installed('dpkg-deb', 'brew install dpkg')
+      ensure_program_installed("dpkg-deb", "brew install dpkg")
 
-      root_dir = File.join(PACKAGING_DIR, 'debian')
-      debian_dir = File.join(root_dir, 'shopify-cli', 'DEBIAN')
+      root_dir = File.join(PACKAGING_DIR, "debian")
+      debian_dir = File.join(root_dir, "shopify-cli", "DEBIAN")
       FileUtils.mkdir_p(debian_dir)
 
       puts "\nBuilding Debian package"
@@ -24,15 +24,15 @@ module ShopifyCli
         file_path = File.join(debian_dir, file)
 
         file_contents = File.read(File.join(root_dir, "#{file}.base"))
-        file_contents = file_contents.gsub('SHOPIFY_CLI_VERSION', ShopifyCli::VERSION)
-        File.open(file_path, 'w', 0775) { |f| f.write(file_contents) }
+        file_contents = file_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCli::VERSION)
+        File.open(file_path, "w", 0775) { |f| f.write(file_contents) }
       end
 
       puts "Building package..."
       Dir.chdir(root_dir)
-      raise "Failed to build package" unless system('dpkg-deb', '-b', 'shopify-cli')
+      raise "Failed to build package" unless system("dpkg-deb", "-b", "shopify-cli")
 
-      output_path = File.join(root_dir, 'shopify-cli.deb')
+      output_path = File.join(root_dir, "shopify-cli.deb")
       final_path = File.join(BUILDS_DIR, "shopify-cli-#{ShopifyCli::VERSION}.deb")
 
       puts "Moving generated package: \n  From: #{output_path}\n  To: #{final_path}\n\n"
@@ -40,34 +40,34 @@ module ShopifyCli
     end
 
     def build_rpm
-      ensure_program_installed('rpmbuild', 'brew install rpm')
+      ensure_program_installed("rpmbuild", "brew install rpm")
 
-      root_dir = File.join(PACKAGING_DIR, 'rpm')
-      rpm_build_dir = File.join(root_dir, 'build')
+      root_dir = File.join(PACKAGING_DIR, "rpm")
+      rpm_build_dir = File.join(root_dir, "build")
       FileUtils.mkdir_p(rpm_build_dir)
 
-      spec_path = File.join(root_dir, 'shopify-cli.spec')
+      spec_path = File.join(root_dir, "shopify-cli.spec")
       puts "\nBuilding RPM package"
 
       puts "Generating spec file..."
       File.delete(spec_path) if File.exist?(spec_path)
 
-      spec_contents = File.read(File.join(root_dir, 'shopify-cli.spec.base'))
-      spec_contents = spec_contents.gsub('SHOPIFY_CLI_VERSION', ShopifyCli::VERSION)
+      spec_contents = File.read(File.join(root_dir, "shopify-cli.spec.base"))
+      spec_contents = spec_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCli::VERSION)
       File.write(spec_path, spec_contents)
 
       puts "Building package..."
       Dir.chdir(root_dir)
-      system('rpmbuild', '-bb', File.basename(spec_path))
+      system("rpmbuild", "-bb", File.basename(spec_path))
 
-      output_dir = File.join(root_dir, 'build', 'noarch')
+      output_dir = File.join(root_dir, "build", "noarch")
 
       puts "Moving generated packages: \n  From: #{output_dir}\n  To: #{BUILDS_DIR}\n\n"
       FileUtils.mv(Dir.glob("#{output_dir}/*.rpm"), BUILDS_DIR)
     end
 
     def build_homebrew
-      root_dir = File.join(PACKAGING_DIR, 'homebrew')
+      root_dir = File.join(PACKAGING_DIR, "homebrew")
 
       build_path = File.join(BUILDS_DIR, "shopify-cli.rb")
       puts "\nBuilding Homebrew package"
@@ -75,18 +75,18 @@ module ShopifyCli
       puts "Generating formula..."
       File.delete(build_path) if File.exist?(build_path)
 
-      spec_contents = File.read(File.join(root_dir, 'shopify-cli.base.rb'))
-      spec_contents = spec_contents.gsub('SHOPIFY_CLI_VERSION', ShopifyCli::VERSION)
+      spec_contents = File.read(File.join(root_dir, "shopify-cli.base.rb"))
+      spec_contents = spec_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCli::VERSION)
 
       puts "Grabbing sha256 checksum from Rubygems.org"
-      require 'digest/sha2'
-      require 'open-uri'
+      require "digest/sha2"
+      require "open-uri"
       gem_checksum = open("https://rubygems.org/downloads/shopify-cli-#{ShopifyCli::VERSION}.gem") do |io|
         Digest::SHA256.new.hexdigest(io.read)
       end
 
       puts "Got sha256 checksum for gem: #{gem_checksum}"
-      spec_contents = spec_contents.gsub('SHOPIFY_CLI_GEM_CHECKSUM', gem_checksum)
+      spec_contents = spec_contents.gsub("SHOPIFY_CLI_GEM_CHECKSUM", gem_checksum)
 
       puts "Writing generated formula\n  To: #{build_path}\n\n"
       File.write(build_path, spec_contents)
@@ -95,7 +95,7 @@ module ShopifyCli
     private
 
     def ensure_program_installed(program, installation_cmd)
-      unless system(program, '--version', out: File::NULL, err: File::NULL)
+      unless system(program, "--version", out: File::NULL, err: File::NULL)
         raise <<~MESSAGE
 
           Could not find program #{program} which is required to build the package.

--- a/lib/shopify-cli/partners_api.rb
+++ b/lib/shopify-cli/partners_api.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   ##
@@ -6,7 +6,7 @@ module ShopifyCli
   # schema.
   #
   class PartnersAPI < API
-    autoload :Organizations, 'shopify-cli/partners_api/organizations'
+    autoload :Organizations, "shopify-cli/partners_api/organizations"
 
     # Defines the environment variable that this API looks for to operate on local
     # services. If you set this environment variable in your shell then the partners
@@ -16,7 +16,7 @@ module ShopifyCli
     #
     #  SHOPIFY_APP_CLI_LOCAL_PARTNERS=1 shopify create
     #
-    LOCAL_DEBUG = 'SHOPIFY_APP_CLI_LOCAL_PARTNERS'
+    LOCAL_DEBUG = "SHOPIFY_APP_CLI_LOCAL_PARTNERS"
 
     class << self
       ##
@@ -52,7 +52,7 @@ module ShopifyCli
 
       def partners_url_for(organization_id, api_client_id, local_debug)
         if ShopifyCli::Shopifolk.acting_as_shopify_organization?
-          organization_id = 'internal'
+          organization_id = "internal"
         end
         "#{partners_endpoint(local_debug)}/#{organization_id}/apps/#{api_client_id}"
       end
@@ -65,7 +65,7 @@ module ShopifyCli
         authenticate(ctx)
         retry
       rescue API::APIRequestNotFoundError
-        ctx.puts(ctx.message('core.partners_api.error.account_not_found', ShopifyCli::TOOL_NAME))
+        ctx.puts(ctx.message("core.partners_api.error.account_not_found", ShopifyCli::TOOL_NAME))
       end
 
       def api_client(ctx)
@@ -86,7 +86,7 @@ module ShopifyCli
       def authenticate(ctx)
         OAuth.new(
           ctx: ctx,
-          service: 'identity',
+          service: "identity",
           client_id: cli_id,
           scopes: scopes.join(" "),
           request_exchange: partners_id,
@@ -94,30 +94,30 @@ module ShopifyCli
       end
 
       def partners_id
-        return '271e16d403dfa18082ffb3d197bd2b5f4479c3fc32736d69296829cbb28d41a6' if ENV[LOCAL_DEBUG].nil?
-        'df89d73339ac3c6c5f0a98d9ca93260763e384d51d6038da129889c308973978'
+        return "271e16d403dfa18082ffb3d197bd2b5f4479c3fc32736d69296829cbb28d41a6" if ENV[LOCAL_DEBUG].nil?
+        "df89d73339ac3c6c5f0a98d9ca93260763e384d51d6038da129889c308973978"
       end
 
       def cli_id
-        return 'fbdb2649-e327-4907-8f67-908d24cfd7e3' if ENV[LOCAL_DEBUG].nil?
-        'e5380e02-312a-7408-5718-e07017e9cf52'
+        return "fbdb2649-e327-4907-8f67-908d24cfd7e3" if ENV[LOCAL_DEBUG].nil?
+        "e5380e02-312a-7408-5718-e07017e9cf52"
       end
 
       def auth_endpoint
-        return 'https://accounts.shopify.com' if ENV[LOCAL_DEBUG].nil?
-        'https://identity.myshopify.io'
+        return "https://accounts.shopify.com" if ENV[LOCAL_DEBUG].nil?
+        "https://identity.myshopify.io"
       end
 
       def endpoint
-        return 'https://partners.shopify.com' if ENV[LOCAL_DEBUG].nil?
-        'https://partners.myshopify.io/'
+        return "https://partners.shopify.com" if ENV[LOCAL_DEBUG].nil?
+        "https://partners.myshopify.io/"
       end
 
       def partners_endpoint(local_debug)
         domain = if local_debug
-          'partners.myshopify.io'
+          "partners.myshopify.io"
         else
-          'partners.shopify.com'
+          "partners.shopify.com"
         end
         "https://#{domain}"
       end

--- a/lib/shopify-cli/partners_api/organizations.rb
+++ b/lib/shopify-cli/partners_api/organizations.rb
@@ -3,26 +3,26 @@ module ShopifyCli
     class Organizations
       class << self
         def fetch_all(ctx)
-          resp = PartnersAPI.query(ctx, 'all_organizations')
-          (resp.dig('data', 'organizations', 'nodes') || []).map do |org|
-            org['stores'] = (org.dig('stores', 'nodes') || [])
+          resp = PartnersAPI.query(ctx, "all_organizations")
+          (resp.dig("data", "organizations", "nodes") || []).map do |org|
+            org["stores"] = (org.dig("stores", "nodes") || [])
             org
           end
         end
 
         def fetch(ctx, id:)
-          resp = PartnersAPI.query(ctx, 'find_organization', id: id)
-          org = resp.dig('data', 'organizations', 'nodes').first
+          resp = PartnersAPI.query(ctx, "find_organization", id: id)
+          org = resp.dig("data", "organizations", "nodes").first
           return nil if org.nil?
-          org['stores'] = (org.dig('stores', 'nodes') || [])
+          org["stores"] = (org.dig("stores", "nodes") || [])
           org
         end
 
         def fetch_with_app(ctx)
-          resp = PartnersAPI.query(ctx, 'all_orgs_with_apps')
-          (resp.dig('data', 'organizations', 'nodes') || []).map do |org|
-            org['stores'] = (org.dig('stores', 'nodes') || [])
-            org['apps'] = (org.dig('apps', 'nodes') || [])
+          resp = PartnersAPI.query(ctx, "all_orgs_with_apps")
+          (resp.dig("data", "organizations", "nodes") || []).map do |org|
+            org["stores"] = (org.dig("stores", "nodes") || [])
+            org["apps"] = (org.dig("apps", "nodes") || [])
             org
           end
         end

--- a/lib/shopify-cli/process_supervision.rb
+++ b/lib/shopify-cli/process_supervision.rb
@@ -1,4 +1,4 @@
-require 'fileutils'
+require "fileutils"
 
 module ShopifyCli
   ##
@@ -19,7 +19,7 @@ module ShopifyCli
     class << self
       def run_dir
         # is the directory where the pid and logfile are kept
-        File.join(ShopifyCli.cache_dir, 'sv')
+        File.join(ShopifyCli.cache_dir, "sv")
       end
 
       ##
@@ -36,7 +36,7 @@ module ShopifyCli
       #   will be nil if the process is not running.
       #
       def for_ident(identifier)
-        pid, time = File.read(File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.pid")).split(':')
+        pid, time = File.read(File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.pid")).split(":")
         new(identifier, pid: Integer(pid), time: time)
       rescue Errno::ENOENT
         nil
@@ -66,7 +66,7 @@ module ShopifyCli
           pid_file = new(identifier)
 
           # Make sure the file exists and is empty, otherwise Windows fails
-          File.open(pid_file.log_path, 'w') {}
+          File.open(pid_file.log_path, "w") {}
           pid = Process.spawn(
             *args,
             out: pid_file.log_path,
@@ -128,7 +128,7 @@ module ShopifyCli
       end
     end
 
-    def initialize(identifier, pid: nil, time: Time.now.strftime('%s')) # :nodoc:
+    def initialize(identifier, pid: nil, time: Time.now.strftime("%s")) # :nodoc:
       @identifier = identifier
       @pid = pid
       @time = time
@@ -204,13 +204,13 @@ module ShopifyCli
 
       # Windows does not handle SIGTERM, go straight to SIGKILL
       unless ctx.windows?
-        Process.kill('TERM', id)
+        Process.kill("TERM", id)
         50.times do
           sleep(0.1)
           break unless stat(id)
         end
       end
-      Process.kill('KILL', id) if stat(id)
+      Process.kill("KILL", id) if stat(id)
       sleep(0.1) if ctx.windows? # Give Windows a second to actually close the process
     end
 

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   ##
@@ -64,7 +64,7 @@ module ShopifyCli
       #
       def current_project_type
         return unless has_current?
-        current.config['project_type'].to_sym
+        current.config["project_type"].to_sym
       end
 
       ##
@@ -84,13 +84,13 @@ module ShopifyCli
       #   type = ShopifyCli::Project.current_project_type
       #
       def write(ctx, project_type:, organization_id:, **identifiers)
-        require 'yaml' # takes 20ms, so deferred as late as possible.
+        require "yaml" # takes 20ms, so deferred as late as possible.
         content = Hash[{ project_type: project_type, organization_id: organization_id.to_i }
           .merge(identifiers)
           .collect { |k, v| [k.to_s, v] }]
-        content['shopify_organization'] = true if Shopifolk.acting_as_shopify_organization?
+        content["shopify_organization"] = true if Shopifolk.acting_as_shopify_organization?
 
-        ctx.write('.shopify-cli.yml', YAML.dump(content))
+        ctx.write(".shopify-cli.yml", YAML.dump(content))
         clear
       end
 
@@ -113,7 +113,7 @@ module ShopifyCli
       def at(dir)
         proj_dir = directory(dir)
         unless proj_dir
-          raise(ShopifyCli::Abort, Context.message('core.project.error.not_in_project'))
+          raise(ShopifyCli::Abort, Context.message("core.project.error.not_in_project"))
         end
         @at ||= Hash.new { |h, k| h[k] = new(directory: k) }
         @at[proj_dir]
@@ -121,8 +121,8 @@ module ShopifyCli
 
       def __directory(curr)
         loop do
-          return nil if curr == '/' || /^[A-Z]:\/$/.match?(curr)
-          file = File.join(curr, '.shopify-cli.yml')
+          return nil if curr == "/" || /^[A-Z]:\/$/.match?(curr)
+          file = File.join(curr, ".shopify-cli.yml")
           return curr if File.exist?(file)
           curr = File.dirname(curr)
         end
@@ -168,15 +168,15 @@ module ShopifyCli
     #
     def config
       @config ||= begin
-        config = load_yaml_file('.shopify-cli.yml')
+        config = load_yaml_file(".shopify-cli.yml")
         unless config.is_a?(Hash)
-          raise ShopifyCli::Abort, Context.message('core.yaml.error.not_hash', '.shopify-cli.yml')
+          raise ShopifyCli::Abort, Context.message("core.yaml.error.not_hash", ".shopify-cli.yml")
         end
 
         # The app_type key was deprecated in favour of project_type, so replace it
-        if config.key?('app_type')
-          config['project_type'] = config['app_type']
-          config.delete('app_type')
+        if config.key?("app_type")
+          config["project_type"] = config["app_type"]
+          config.delete("app_type")
         end
 
         config
@@ -187,16 +187,16 @@ module ShopifyCli
 
     def load_yaml_file(relative_path)
       f = File.join(directory, relative_path)
-      require 'yaml' # takes 20ms, so deferred as late as possible.
+      require "yaml" # takes 20ms, so deferred as late as possible.
       begin
         YAML.load_file(f)
       rescue Psych::SyntaxError => e
-        raise(ShopifyCli::Abort, Context.message('core.yaml.error.invalid', relative_path, e.message))
+        raise(ShopifyCli::Abort, Context.message("core.yaml.error.invalid", relative_path, e.message))
       # rescue Errno::EACCES => e
       # TODO
       #   Dev::Helpers::EaccesHandler.diagnose_and_raise(f, e, mode: :read)
       rescue Errno::ENOENT
-        raise ShopifyCli::Abort, Context.message('core.yaml.error.not_found', f)
+        raise ShopifyCli::Abort, Context.message("core.yaml.error.not_found", f)
       end
     end
   end

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -21,7 +21,7 @@ module ShopifyCli
       end
 
       def load_type(current_type, shallow = false)
-        filepath = File.join(ShopifyCli::ROOT, 'lib', 'project_types', current_type.to_s, 'cli.rb')
+        filepath = File.join(ShopifyCli::ROOT, "lib", "project_types", current_type.to_s, "cli.rb")
         return unless File.exist?(filepath)
         @shallow_load = shallow
         @current_type = current_type
@@ -32,7 +32,7 @@ module ShopifyCli
       end
 
       def load_all
-        Dir.glob(File.join(ShopifyCli::ROOT, 'lib', 'project_types', '*', 'cli.rb')).map do |filepath|
+        Dir.glob(File.join(ShopifyCli::ROOT, "lib", "project_types", "*", "cli.rb")).map do |filepath|
           load_type(filepath.split(File::Separator)[-2].to_sym, true)
         end
       end
@@ -74,7 +74,7 @@ module ShopifyCli
       def register_command(const, cmd)
         return if project_load_shallow
         Context.new.abort(
-          Context.message('core.project_type.error.cannot_override_core', cmd, const)
+          Context.message("core.project_type.error.cannot_override_core", cmd, const)
         ) if Commands.core_command?(cmd)
         Commands.register(const, cmd)
       end

--- a/lib/shopify-cli/resources.rb
+++ b/lib/shopify-cli/resources.rb
@@ -1,5 +1,5 @@
 module ShopifyCli
   module Resources
-    autoload :EnvFile, 'shopify-cli/resources/env_file'
+    autoload :EnvFile, "shopify-cli/resources/env_file"
   end
 end

--- a/lib/shopify-cli/resources/env_file.rb
+++ b/lib/shopify-cli/resources/env_file.rb
@@ -4,13 +4,13 @@ module ShopifyCli
   module Resources
     class EnvFile
       include SmartProperties
-      FILENAME = '.env'
+      FILENAME = ".env"
       KEY_MAP = {
-        'SHOPIFY_API_KEY' => :api_key,
-        'SHOPIFY_API_SECRET' => :secret,
-        'SHOP' => :shop,
-        'SCOPES' => :scopes,
-        'HOST' => :host,
+        "SHOPIFY_API_KEY" => :api_key,
+        "SHOPIFY_API_SECRET" => :secret,
+        "SHOP" => :shop,
+        "SCOPES" => :scopes,
+        "HOST" => :host,
       }
 
       class << self
@@ -72,7 +72,7 @@ module ShopifyCli
 
       def write(ctx)
         spin_group = CLI::UI::SpinGroup.new
-        spin_group.add(ctx.message('core.env_file.saving_header', FILENAME)) do |spinner|
+        spin_group.add(ctx.message("core.env_file.saving_header", FILENAME)) do |spinner|
           output = []
           KEY_MAP.each do |key, value|
             output << "#{key}=#{send(value)}" if send(value)
@@ -80,9 +80,9 @@ module ShopifyCli
           extra.each do |key, value|
             output << "#{key}=#{value}"
           end
-          ctx.print_task(ctx.message('core.env_file.saving', FILENAME))
+          ctx.print_task(ctx.message("core.env_file.saving", FILENAME))
           ctx.write(FILENAME, output.join("\n") + "\n")
-          spinner.update_title(ctx.message('core.env_file.saved', FILENAME))
+          spinner.update_title(ctx.message("core.env_file.saved", FILENAME))
         end
         spin_group.wait
       end

--- a/lib/shopify-cli/shopifolk.rb
+++ b/lib/shopify-cli/shopifolk.rb
@@ -5,10 +5,10 @@ module ShopifyCli
   # The Shopifolk Feature flag will persist between runs so if the flag is enabled or disabled,
   # it will still be in that same state until the next class invocation.
   class Shopifolk
-    GCLOUD_CONFIG_FILE = File.expand_path('~/.config/gcloud/configurations/config_default')
-    DEV_PATH = '/opt/dev'
-    SECTION = 'core'
-    FEATURE_NAME = 'shopifolk'
+    GCLOUD_CONFIG_FILE = File.expand_path("~/.config/gcloud/configurations/config_default")
+    DEV_PATH = "/opt/dev"
+    SECTION = "core"
+    FEATURE_NAME = "shopifolk"
 
     class << self
       attr_writer :acting_as_shopify_organization
@@ -25,7 +25,7 @@ module ShopifyCli
       #     ShopifyCli::Shopifolk.check
       #
       def check
-        return false unless ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
+        return false unless ShopifyCli::Config.get_bool("shopifolk-beta", "enabled")
 
         ShopifyCli::Shopifolk.new.shopifolk?
       end
@@ -35,7 +35,7 @@ module ShopifyCli
       end
 
       def acting_as_shopify_organization?
-        !!@acting_as_shopify_organization || (Project.has_current? && Project.current.config['shopify_organization'])
+        !!@acting_as_shopify_organization || (Project.has_current? && Project.current.config["shopify_organization"])
       end
 
       def reset
@@ -52,7 +52,7 @@ module ShopifyCli
     # a valid google cloud config file with email ending in "@shopify.com"
     #
     def shopifolk?
-      return false unless ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
+      return false unless ShopifyCli::Config.get_bool("shopifolk-beta", "enabled")
       return true if Feature.enabled?(FEATURE_NAME)
 
       if shopifolk_by_gcloud? && shopifolk_by_dev?
@@ -67,7 +67,7 @@ module ShopifyCli
     private
 
     def shopifolk_by_gcloud?
-      ini&.dig("[#{SECTION}]", 'account')&.match?(/@shopify.com\z/)
+      ini&.dig("[#{SECTION}]", "account")&.match?(/@shopify.com\z/)
     end
 
     def shopifolk_by_dev?

--- a/lib/shopify-cli/sub_command.rb
+++ b/lib/shopify-cli/sub_command.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   class SubCommand < Command

--- a/lib/shopify-cli/task.rb
+++ b/lib/shopify-cli/task.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   class Task
@@ -10,8 +10,8 @@ module ShopifyCli
     private
 
     def wants_to_run_against_shopify_org?
-      @ctx.puts(@ctx.message('core.tasks.select_org_and_shop.identified_as_shopify'))
-      message = @ctx.message('core.tasks.select_org_and_shop.first_party')
+      @ctx.puts(@ctx.message("core.tasks.select_org_and_shop.identified_as_shopify"))
+      message = @ctx.message("core.tasks.select_org_and_shop.first_party")
       CLI::UI::Prompt.confirm(message, default: false)
     end
   end

--- a/lib/shopify-cli/tasks.rb
+++ b/lib/shopify-cli/tasks.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Tasks
@@ -30,11 +30,11 @@ module ShopifyCli
       Registry.add(-> () { const_get(task) }, name)
     end
 
-    register :CreateApiClient, :create_api_client, 'shopify-cli/tasks/create_api_client'
-    register :EnsureEnv, :ensure_env, 'shopify-cli/tasks/ensure_env'
-    register :EnsureLoopbackURL, :ensure_loopback_url, 'shopify-cli/tasks/ensure_loopback_url'
-    register :EnsureDevStore, :ensure_dev_store, 'shopify-cli/tasks/ensure_dev_store'
-    register :SelectOrgAndShop, :select_org_and_shop, 'shopify-cli/tasks/select_org_and_shop'
-    register :UpdateDashboardURLS, :update_dashboard_urls, 'shopify-cli/tasks/update_dashboard_urls'
+    register :CreateApiClient, :create_api_client, "shopify-cli/tasks/create_api_client"
+    register :EnsureEnv, :ensure_env, "shopify-cli/tasks/ensure_env"
+    register :EnsureLoopbackURL, :ensure_loopback_url, "shopify-cli/tasks/ensure_loopback_url"
+    register :EnsureDevStore, :ensure_dev_store, "shopify-cli/tasks/ensure_dev_store"
+    register :SelectOrgAndShop, :select_org_and_shop, "shopify-cli/tasks/select_org_and_shop"
+    register :UpdateDashboardURLS, :update_dashboard_urls, "shopify-cli/tasks/update_dashboard_urls"
   end
 end

--- a/lib/shopify-cli/tasks/create_api_client.rb
+++ b/lib/shopify-cli/tasks/create_api_client.rb
@@ -1,15 +1,15 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Tasks
     class CreateApiClient < ShopifyCli::Task
       VALID_APP_TYPES = %w(public custom)
-      DEFAULT_APP_URL = 'https://shopify.github.io/shopify-app-cli/help/start-app/'
+      DEFAULT_APP_URL = "https://shopify.github.io/shopify-app-cli/help/start-app/"
 
       def call(ctx, org_id:, title:, type:)
         resp = ShopifyCli::PartnersAPI.query(
           ctx,
-          'create_app',
+          "create_app",
           org: org_id.to_i,
           title: title,
           type: type,
@@ -23,12 +23,12 @@ module ShopifyCli
 
         errors = resp.dig("errors")
         if !errors.nil? && errors.any?
-          ctx.abort(errors.map { |err| "#{err['field']} #{err['message']}" }.join(", "))
+          ctx.abort(errors.map { |err| "#{err["field"]} #{err["message"]}" }.join(", "))
         end
 
         user_errors = resp.dig("data", "appCreate", "userErrors")
         if !user_errors.nil? && user_errors.any?
-          ctx.abort(user_errors.map { |err| "#{err['field']} #{err['message']}" }.join(", "))
+          ctx.abort(user_errors.map { |err| "#{err["field"]} #{err["message"]}" }.join(", "))
         end
 
         ShopifyCli::Core::Monorail.metadata[:api_key] = resp.dig("data", "appCreate", "app", "apiKey")

--- a/lib/shopify-cli/tasks/ensure_dev_store.rb
+++ b/lib/shopify-cli/tasks/ensure_dev_store.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Tasks
@@ -6,17 +6,17 @@ module ShopifyCli
       def call(ctx)
         @ctx = ctx
         return ctx.puts(ctx.message(
-          'core.tasks.ensure_dev_store.could_not_verify_store', project.env.shop
+          "core.tasks.ensure_dev_store.could_not_verify_store", project.env.shop
         )) if shop.nil?
-        return if shop['transferDisabled'] == true
+        return if shop["transferDisabled"] == true
         return unless CLI::UI::Prompt.confirm(
-          ctx.message('core.tasks.ensure_dev_store.convert_to_dev_store', project.env.shop)
+          ctx.message("core.tasks.ensure_dev_store.convert_to_dev_store", project.env.shop)
         )
-        ShopifyCli::PartnersAPI.query(ctx, 'convert_dev_to_test_store', input: {
-          organizationID: shop['orgID'].to_i,
-          shopId: shop['shopId'],
+        ShopifyCli::PartnersAPI.query(ctx, "convert_dev_to_test_store", input: {
+          organizationID: shop["orgID"].to_i,
+          shopId: shop["shopId"],
         })
-        ctx.puts(ctx.message('core.tasks.ensure_dev_store.transfer_disabled', project.env.shop))
+        ctx.puts(ctx.message("core.tasks.ensure_dev_store.transfer_disabled", project.env.shop))
       end
 
       private
@@ -29,9 +29,9 @@ module ShopifyCli
         @shop ||= begin
           current_domain = project.env.shop
           ShopifyCli::PartnersAPI::Organizations.fetch_all(@ctx).map do |org|
-            org['stores'].find do |store|
-              store['orgID'] = org['id']
-              store['shopDomain'] == current_domain
+            org["stores"].find do |store|
+              store["orgID"] = org["id"]
+              store["shopDomain"] == current_domain
             end
           end.compact.first
         end

--- a/lib/shopify-cli/tasks/ensure_env.rb
+++ b/lib/shopify-cli/tasks/ensure_env.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Tasks
@@ -29,10 +29,10 @@ module ShopifyCli
         org_id = if orgs.count == 1
           orgs.first["id"]
         else
-          CLI::UI::Prompt.ask(@ctx.message('core.tasks.ensure_env.organization_select')) do |handler|
+          CLI::UI::Prompt.ask(@ctx.message("core.tasks.ensure_env.organization_select")) do |handler|
             orgs.each do |org|
               handler.option(
-                @ctx.message('core.partners_api.org_name_and_id', org['businessName'], org['id'])
+                @ctx.message("core.partners_api.org_name_and_id", org["businessName"], org["id"])
               ) { org["id"] }
             end
           end
@@ -44,15 +44,15 @@ module ShopifyCli
         if apps.count == 1
           apps.first
         elsif apps.count == 0
-          @ctx.puts(@ctx.message('core.tasks.ensure_env.no_apps'))
-          title = CLI::UI::Prompt.ask(@ctx.message('core.tasks.ensure_env.app_name'))
-          type = CLI::UI::Prompt.ask(@ctx.message('core.tasks.ensure_env.app_type.select')) do |handler|
-            handler.option(@ctx.message('core.tasks.ensure_env.app_type.select_public')) { 'public' }
-            handler.option(@ctx.message('core.tasks.ensure_env.app_type.select_custom')) { 'custom' }
+          @ctx.puts(@ctx.message("core.tasks.ensure_env.no_apps"))
+          title = CLI::UI::Prompt.ask(@ctx.message("core.tasks.ensure_env.app_name"))
+          type = CLI::UI::Prompt.ask(@ctx.message("core.tasks.ensure_env.app_type.select")) do |handler|
+            handler.option(@ctx.message("core.tasks.ensure_env.app_type.select_public")) { "public" }
+            handler.option(@ctx.message("core.tasks.ensure_env.app_type.select_custom")) { "custom" }
           end
           ShopifyCli::Tasks::CreateApiClient.call(@ctx, org_id: org_id, title: title, type: type)
         else
-          CLI::UI::Prompt.ask(@ctx.message('core.tasks.ensure_env.app_select')) do |handler|
+          CLI::UI::Prompt.ask(@ctx.message("core.tasks.ensure_env.app_select")) do |handler|
             apps.each { |app| handler.option(app["title"]) { app } }
           end
         end
@@ -62,9 +62,9 @@ module ShopifyCli
         if shops.count == 1
           shop = shops.first["shopDomain"]
         elsif shops.count == 0
-          @ctx.puts(@ctx.message('core.tasks.ensure_env.no_development_stores', id))
+          @ctx.puts(@ctx.message("core.tasks.ensure_env.no_development_stores", id))
         else
-          shop = CLI::UI::Prompt.ask(@ctx.message('core.tasks.ensure_env.development_store_select')) do |handler|
+          shop = CLI::UI::Prompt.ask(@ctx.message("core.tasks.ensure_env.development_store_select")) do |handler|
             shops.each { |s| handler.option(s["shopName"]) { s["shopDomain"] } }
           end
         end
@@ -72,13 +72,13 @@ module ShopifyCli
       end
 
       def write_env(env_data, org)
-        id = org['id']
-        app = get_app(id, org['apps'])
+        id = org["id"]
+        app = get_app(id, org["apps"])
 
-        env_data[:shop] = get_shop(org['stores'], id)
+        env_data[:shop] = get_shop(org["stores"], id)
         env_data[:api_key] = app["apiKey"]
         env_data[:secret] = app["apiSecretKeys"].first["secret"]
-        env_data[:scopes] = 'write_products,write_customers,write_draft_orders' if env_data[:scopes].nil?
+        env_data[:scopes] = "write_products,write_customers,write_draft_orders" if env_data[:scopes].nil?
         env_data[:extra] = {} if env_data[:extra].nil?
 
         Resources::EnvFile.new(

--- a/lib/shopify-cli/tasks/ensure_loopback_url.rb
+++ b/lib/shopify-cli/tasks/ensure_loopback_url.rb
@@ -4,13 +4,13 @@ module ShopifyCli
       def call(ctx)
         @ctx = ctx
         api_key = Project.current.env.api_key
-        result = ShopifyCli::PartnersAPI.query(ctx, 'get_app_urls', apiKey: api_key)
+        result = ShopifyCli::PartnersAPI.query(ctx, "get_app_urls", apiKey: api_key)
         loopback = OAuth::REDIRECT_HOST
-        app = result['data']['app']
-        urls = app['redirectUrlWhitelist']
+        app = result["data"]["app"]
+        urls = app["redirectUrlWhitelist"]
         if urls.grep(/#{loopback}/).empty?
           with_loopback = urls.push(loopback)
-          ShopifyCli::PartnersAPI.query(@ctx, 'update_dashboard_urls', input: {
+          ShopifyCli::PartnersAPI.query(@ctx, "update_dashboard_urls", input: {
             redirectUrlWhitelist: with_loopback, apiKey: api_key
           })
         end

--- a/lib/shopify-cli/tasks/select_org_and_shop.rb
+++ b/lib/shopify-cli/tasks/select_org_and_shop.rb
@@ -1,4 +1,4 @@
-require 'shopify_cli'
+require "shopify_cli"
 
 module ShopifyCli
   module Tasks
@@ -35,45 +35,45 @@ module ShopifyCli
         @organization ||= if !organization_id.nil?
           org = ShopifyCli::PartnersAPI::Organizations.fetch(ctx, id: organization_id)
           if org.nil?
-            ctx.puts(ctx.message('core.tasks.select_org_and_shop.error.authentication_issue', ShopifyCli::TOOL_NAME))
-            ctx.abort(ctx.message('core.tasks.select_org_and_shop.error.organization_not_found'))
+            ctx.puts(ctx.message("core.tasks.select_org_and_shop.error.authentication_issue", ShopifyCli::TOOL_NAME))
+            ctx.abort(ctx.message("core.tasks.select_org_and_shop.error.organization_not_found"))
           end
           org
         elsif organizations.count == 0
-          ctx.puts(ctx.message('core.tasks.select_org_and_shop.error.partners_notice'))
-          ctx.puts(ctx.message('core.tasks.select_org_and_shop.authentication_issue', ShopifyCli::TOOL_NAME))
-          ctx.abort(ctx.message('core.tasks.select_org_and_shop.error.no_organizations'))
+          ctx.puts(ctx.message("core.tasks.select_org_and_shop.error.partners_notice"))
+          ctx.puts(ctx.message("core.tasks.select_org_and_shop.authentication_issue", ShopifyCli::TOOL_NAME))
+          ctx.abort(ctx.message("core.tasks.select_org_and_shop.error.no_organizations"))
         elsif organizations.count == 1
           org = organizations.first
-          ctx.puts(ctx.message('core.tasks.select_org_and_shop.organization', org['businessName'], org['id']))
+          ctx.puts(ctx.message("core.tasks.select_org_and_shop.organization", org["businessName"], org["id"]))
           org
         else
-          org_id = CLI::UI::Prompt.ask(ctx.message('core.tasks.select_org_and_shop.organization_select')) do |handler|
+          org_id = CLI::UI::Prompt.ask(ctx.message("core.tasks.select_org_and_shop.organization_select")) do |handler|
             organizations.each do |o|
-              handler.option(ctx.message('core.partners_api.org_name_and_id', o['businessName'], o['id'])) { o['id'] }
+              handler.option(ctx.message("core.partners_api.org_name_and_id", o["businessName"], o["id"])) { o["id"] }
             end
           end
-          organizations.find { |o| o['id'] == org_id }
+          organizations.find { |o| o["id"] == org_id }
         end
       end
 
       def get_shop_domain(organization)
-        valid_stores = organization['stores'].select do |store|
-          store['transferDisabled'] == true || store['convertableToPartnerTest'] == true
+        valid_stores = organization["stores"].select do |store|
+          store["transferDisabled"] == true || store["convertableToPartnerTest"] == true
         end
 
         if valid_stores.count == 0
-          ctx.puts(ctx.message('core.tasks.select_org_and_shop.error.no_development_stores'))
-          ctx.puts(ctx.message('core.tasks.select_org_and_shop.create_store', organization['id']))
-          ctx.puts(ctx.message('core.tasks.select_org_and_shop.authentication_issue', ShopifyCli::TOOL_NAME))
+          ctx.puts(ctx.message("core.tasks.select_org_and_shop.error.no_development_stores"))
+          ctx.puts(ctx.message("core.tasks.select_org_and_shop.create_store", organization["id"]))
+          ctx.puts(ctx.message("core.tasks.select_org_and_shop.authentication_issue", ShopifyCli::TOOL_NAME))
         elsif valid_stores.count == 1
-          domain = valid_stores.first['shopDomain']
-          ctx.puts(ctx.message('core.tasks.select_org_and_shop.development_store', domain))
+          domain = valid_stores.first["shopDomain"]
+          ctx.puts(ctx.message("core.tasks.select_org_and_shop.development_store", domain))
           domain
         else
           CLI::UI::Prompt.ask(
-            ctx.message('core.tasks.select_org_and_shop.development_store_select'),
-            options: valid_stores.map { |s| s['shopDomain'] }
+            ctx.message("core.tasks.select_org_and_shop.development_store_select"),
+            options: valid_stores.map { |s| s["shopDomain"] }
           )
         end
       end

--- a/lib/shopify-cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify-cli/tasks/update_dashboard_urls.rb
@@ -7,24 +7,24 @@ module ShopifyCli
         @ctx = ctx
         project = ShopifyCli::Project.current
         api_key = project.env.api_key
-        result = ShopifyCli::PartnersAPI.query(ctx, 'get_app_urls', apiKey: api_key)
-        app = result['data']['app']
-        consent = check_application_url(app['applicationUrl'], url)
-        constructed_urls = construct_redirect_urls(app['redirectUrlWhitelist'], url, callback_url)
-        return if url == app['applicationUrl']
-        ShopifyCli::PartnersAPI.query(@ctx, 'update_dashboard_urls', input: {
-          applicationUrl: consent ? url : app['applicationUrl'],
+        result = ShopifyCli::PartnersAPI.query(ctx, "get_app_urls", apiKey: api_key)
+        app = result["data"]["app"]
+        consent = check_application_url(app["applicationUrl"], url)
+        constructed_urls = construct_redirect_urls(app["redirectUrlWhitelist"], url, callback_url)
+        return if url == app["applicationUrl"]
+        ShopifyCli::PartnersAPI.query(@ctx, "update_dashboard_urls", input: {
+          applicationUrl: consent ? url : app["applicationUrl"],
           redirectUrlWhitelist: constructed_urls, apiKey: api_key
         })
-        @ctx.puts(@ctx.message('core.tasks.update_dashboard_urls.updated'))
+        @ctx.puts(@ctx.message("core.tasks.update_dashboard_urls.updated"))
       rescue
-        @ctx.puts(@ctx.message('core.tasks.update_dashboard_urls.update_error', ShopifyCli::TOOL_NAME))
+        @ctx.puts(@ctx.message("core.tasks.update_dashboard_urls.update_error", ShopifyCli::TOOL_NAME))
         raise
       end
 
       def check_application_url(application_url, new_url)
         return false if application_url.match(new_url)
-        CLI::UI::Prompt.confirm(@ctx.message('core.tasks.update_dashboard_urls.update_prompt'))
+        CLI::UI::Prompt.confirm(@ctx.message("core.tasks.update_dashboard_urls.update_prompt"))
       end
 
       def construct_redirect_urls(urls, new_url, callback_url)

--- a/lib/shopify-cli/tunnel.rb
+++ b/lib/shopify-cli/tunnel.rb
@@ -1,7 +1,7 @@
-require 'json'
-require 'fileutils'
-require 'shopify_cli'
-require 'forwardable'
+require "json"
+require "fileutils"
+require "shopify_cli"
+require "forwardable"
 
 module ShopifyCli
   ##
@@ -19,14 +19,14 @@ module ShopifyCli
     PORT = 8081 # port that ngrok will bind to
     # mapping for supported operating systems for where to download ngrok from.
     DOWNLOAD_URLS = {
-      mac: 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip',
-      linux: 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip',
-      windows: 'https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip',
+      mac: "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip",
+      linux: "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip",
+      windows: "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip",
     }
 
-    NGROK_TUNNELS_URI = URI.parse('http://localhost:4040/api/tunnels')
-    TUNNELS_FIELD = 'tunnels'
-    PUBLIC_URL_FIELD = 'public_url'
+    NGROK_TUNNELS_URI = URI.parse("http://localhost:4040/api/tunnels")
+    TUNNELS_FIELD = "tunnels"
+    PUBLIC_URL_FIELD = "public_url"
 
     ##
     # will find and stop a running tunnel process. It will also output if the
@@ -39,12 +39,12 @@ module ShopifyCli
     def stop(ctx)
       if ShopifyCli::ProcessSupervision.running?(:ngrok)
         if ShopifyCli::ProcessSupervision.stop(:ngrok)
-          ctx.puts(ctx.message('core.tunnel.stopped'))
+          ctx.puts(ctx.message("core.tunnel.stopped"))
         else
-          ctx.abort(ctx.message('core.tunnel.error.stop'))
+          ctx.abort(ctx.message("core.tunnel.error.stop"))
         end
       else
-        ctx.puts(ctx.message('core.tunnel.not_running'))
+        ctx.puts(ctx.message("core.tunnel.not_running"))
       end
     end
 
@@ -65,15 +65,15 @@ module ShopifyCli
       install(ctx)
       url, account, seconds_remaining = start_ngrok(ctx, port)
       if account
-        ctx.puts(ctx.message('core.tunnel.start_with_account', url, account))
+        ctx.puts(ctx.message("core.tunnel.start_with_account", url, account))
       else
         if seconds_remaining <= 0
-          ctx.puts(ctx.message('core.tunnel.timed_out'))
+          ctx.puts(ctx.message("core.tunnel.timed_out"))
           url, _account, seconds_remaining = restart_ngrok(ctx, port)
         end
-        ctx.puts(ctx.message('core.tunnel.start', url))
-        ctx.puts(ctx.message('core.tunnel.will_timeout', seconds_to_hm(seconds_remaining)))
-        ctx.puts(ctx.message('core.tunnel.signup_suggestion', ShopifyCli::TOOL_NAME))
+        ctx.puts(ctx.message("core.tunnel.start", url))
+        ctx.puts(ctx.message("core.tunnel.will_timeout", seconds_to_hm(seconds_remaining)))
+        ctx.puts(ctx.message("core.tunnel.signup_suggestion", ShopifyCli::TOOL_NAME))
       end
       url
     end
@@ -89,7 +89,7 @@ module ShopifyCli
     #
     def auth(ctx, token)
       install(ctx)
-      ctx.system(File.join(ShopifyCli.cache_dir, 'ngrok'), 'authtoken', token)
+      ctx.system(File.join(ShopifyCli.cache_dir, "ngrok"), "authtoken", token)
     end
 
     ##
@@ -125,13 +125,13 @@ module ShopifyCli
     def install(ctx)
       ngrok = "ngrok#{ctx.executable_file_extension}"
       return if File.exist?(File.join(ShopifyCli.cache_dir, ngrok))
-      check_prereq_command(ctx, 'curl')
-      check_prereq_command(ctx, ctx.linux? ? 'unzip' : 'tar')
+      check_prereq_command(ctx, "curl")
+      check_prereq_command(ctx, ctx.linux? ? "unzip" : "tar")
       spinner = CLI::UI::SpinGroup.new
-      spinner.add('Installing ngrok...') do
-        zip_dest = File.join(ShopifyCli.cache_dir, 'ngrok.zip')
+      spinner.add("Installing ngrok...") do
+        zip_dest = File.join(ShopifyCli.cache_dir, "ngrok.zip")
         unless File.exist?(zip_dest)
-          ctx.system('curl', '-o', zip_dest, DOWNLOAD_URLS[ctx.os], chdir: ShopifyCli.cache_dir)
+          ctx.system("curl", "-o", zip_dest, DOWNLOAD_URLS[ctx.os], chdir: ShopifyCli.cache_dir)
         end
         args = if ctx.linux?
           %W(unzip -u #{zip_dest})
@@ -145,7 +145,7 @@ module ShopifyCli
 
       # final check to see if ngrok is accessible
       unless File.exist?(File.join(ShopifyCli.cache_dir, ngrok))
-        ctx.abort(ctx.message('core.tunnel.error.ngrok', ngrok, ShopifyCli.cache_dir))
+        ctx.abort(ctx.message("core.tunnel.error.ngrok", ngrok, ShopifyCli.cache_dir))
       end
     end
 
@@ -157,7 +157,7 @@ module ShopifyCli
     end
 
     def ngrok_command(port)
-      "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug #{port}"
+      "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug #{port}"
     end
 
     def seconds_to_hm(seconds)
@@ -173,15 +173,15 @@ module ShopifyCli
 
     def restart_ngrok(ctx, port)
       unless ShopifyCli::ProcessSupervision.stop(:ngrok)
-        ctx.abort(ctx.message('core.tunnel.error.stop'))
+        ctx.abort(ctx.message("core.tunnel.error.stop"))
       end
       start_ngrok(ctx, port)
     end
 
     def check_prereq_command(ctx, command)
       cmd_path = ctx.which(command)
-      ctx.abort(ctx.message('core.tunnel.error.prereq_command_required', command)) if cmd_path.nil?
-      ctx.done(ctx.message('core.tunnel.prereq_command_location', command, cmd_path))
+      ctx.abort(ctx.message("core.tunnel.error.prereq_command_required", command)) if cmd_path.nil?
+      ctx.done(ctx.message("core.tunnel.prereq_command_location", command, cmd_path))
     end
 
     class LogParser # :nodoc:
@@ -199,7 +199,7 @@ module ShopifyCli
           sleep(1)
         end
 
-        raise FetchUrlError, Context.message('core.tunnel.error.url_fetch_failure') unless url
+        raise FetchUrlError, Context.message("core.tunnel.error.url_fetch_failure") unless url
       end
 
       def parse

--- a/lib/shopify-cli/version.rb
+++ b/lib/shopify-cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCli
-  VERSION = '1.6.0'
+  VERSION = "1.6.0"
 end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -8,7 +8,7 @@ Thread.report_on_exception = false
 # require_relative 'support/ruby_backports'
 
 # See bin/load_shopify.rb
-ENV['PATH'] = ENV['PATH'].split(':').select { |p| p.start_with?('/', '~') }.join(':') unless defined?($original_env)
+ENV["PATH"] = ENV["PATH"].split(":").select { |p| p.start_with?("/", "~") }.join(":") unless defined?($original_env)
 
 # Load vendor and CLI UI/Kit.
 # Nothing else should be loaded at this point and nothing else should be added to the load path on boot
@@ -21,10 +21,10 @@ deps.each do |dep|
   $LOAD_PATH.unshift(vendor_path) unless $LOAD_PATH.include?(vendor_path)
 end
 
-require 'cli/ui'
-require 'cli/kit'
-require 'smart_properties'
-require_relative 'shopify-cli/version'
+require "cli/ui"
+require "cli/kit"
+require "smart_properties"
+require_relative "shopify-cli/version"
 
 # Enable stdout routing. At this point all calls to STDOUT (and STDERR) will go through this class.
 # See https://github.com/Shopify/cli-ui/blob/master/lib/cli/ui/stdout_router.rb for more info
@@ -39,16 +39,16 @@ CLI::UI::StdoutRouter.enable
 module ShopifyCli
   extend CLI::Kit::Autocall
 
-  TOOL_NAME         = 'shopify'
-  TOOL_FULL_NAME    = 'Shopify CLI'
-  ROOT              = File.expand_path('../..', __FILE__)
-  PROJECT_TYPES_DIR = File.join(ROOT, 'lib', 'project_types')
-  TEMP_DIR          = File.join(ROOT, '.tmp')
+  TOOL_NAME         = "shopify"
+  TOOL_FULL_NAME    = "Shopify CLI"
+  ROOT              = File.expand_path("../..", __FILE__)
+  PROJECT_TYPES_DIR = File.join(ROOT, "lib", "project_types")
+  TEMP_DIR          = File.join(ROOT, ".tmp")
 
   # programmer emoji if default install location, else wrench emoji
-  EMOJI    = ROOT == '/opt/shopify' ? "\u{1f469}\u{200d}\u{1f4bb}" : "\u{1f527}"
+  EMOJI    = ROOT == "/opt/shopify" ? "\u{1f469}\u{200d}\u{1f4bb}" : "\u{1f527}"
   # shrug or boom emoji
-  FAILMOJI = ROOT == '/opt/shopify' ? "\u{1f937}" : "\u{1f4a5}"
+  FAILMOJI = ROOT == "/opt/shopify" ? "\u{1f937}" : "\u{1f4a5}"
 
   # Exit management in `shopify-app-cli` follows the management set out by CLI Kit.
   # https://github.com/Shopify/cli-kit/blob/master/lib/cli/kit.rb
@@ -94,47 +94,47 @@ module ShopifyCli
     )
   end
 
-  autoload :AdminAPI, 'shopify-cli/admin_api'
-  autoload :API, 'shopify-cli/api'
-  autoload :Command, 'shopify-cli/command'
-  autoload :Commands, 'shopify-cli/commands'
-  autoload :Context, 'shopify-cli/context'
-  autoload :Core, 'shopify-cli/core'
-  autoload :DB, 'shopify-cli/db'
-  autoload :Feature, 'shopify-cli/feature'
-  autoload :Form, 'shopify-cli/form'
-  autoload :Git, 'shopify-cli/git'
-  autoload :Helpers, 'shopify-cli/helpers'
-  autoload :Heroku, 'shopify-cli/heroku'
-  autoload :JsDeps, 'shopify-cli/js_deps'
-  autoload :JsSystem, 'shopify-cli/js_system'
-  autoload :MethodObject, 'shopify-cli/method_object'
-  autoload :Log, 'shopify-cli/log'
-  autoload :OAuth, 'shopify-cli/oauth'
-  autoload :Options, 'shopify-cli/options'
-  autoload :PartnersAPI, 'shopify-cli/partners_api'
-  autoload :ProcessSupervision, 'shopify-cli/process_supervision'
-  autoload :Project, 'shopify-cli/project'
-  autoload :ProjectType, 'shopify-cli/project_type'
-  autoload :ResolveConstant, 'shopify-cli/resolve_constant'
-  autoload :Resources, 'shopify-cli/resources'
-  autoload :Result, 'shopify-cli/result'
-  autoload :Shopifolk, 'shopify-cli/shopifolk'
-  autoload :SubCommand, 'shopify-cli/sub_command'
-  autoload :Task, 'shopify-cli/task'
-  autoload :Tasks, 'shopify-cli/tasks'
-  autoload :Tunnel, 'shopify-cli/tunnel'
+  autoload :AdminAPI, "shopify-cli/admin_api"
+  autoload :API, "shopify-cli/api"
+  autoload :Command, "shopify-cli/command"
+  autoload :Commands, "shopify-cli/commands"
+  autoload :Context, "shopify-cli/context"
+  autoload :Core, "shopify-cli/core"
+  autoload :DB, "shopify-cli/db"
+  autoload :Feature, "shopify-cli/feature"
+  autoload :Form, "shopify-cli/form"
+  autoload :Git, "shopify-cli/git"
+  autoload :Helpers, "shopify-cli/helpers"
+  autoload :Heroku, "shopify-cli/heroku"
+  autoload :JsDeps, "shopify-cli/js_deps"
+  autoload :JsSystem, "shopify-cli/js_system"
+  autoload :MethodObject, "shopify-cli/method_object"
+  autoload :Log, "shopify-cli/log"
+  autoload :OAuth, "shopify-cli/oauth"
+  autoload :Options, "shopify-cli/options"
+  autoload :PartnersAPI, "shopify-cli/partners_api"
+  autoload :ProcessSupervision, "shopify-cli/process_supervision"
+  autoload :Project, "shopify-cli/project"
+  autoload :ProjectType, "shopify-cli/project_type"
+  autoload :ResolveConstant, "shopify-cli/resolve_constant"
+  autoload :Resources, "shopify-cli/resources"
+  autoload :Result, "shopify-cli/result"
+  autoload :Shopifolk, "shopify-cli/shopifolk"
+  autoload :SubCommand, "shopify-cli/sub_command"
+  autoload :Task, "shopify-cli/task"
+  autoload :Tasks, "shopify-cli/tasks"
+  autoload :Tunnel, "shopify-cli/tunnel"
 
-  require 'shopify-cli/messages/messages'
+  require "shopify-cli/messages/messages"
   Context.load_messages(ShopifyCli::Messages::MESSAGES)
 
   def self.cache_dir
-    cache_dir = if ENV.key?('RUNNING_SHOPIFY_CLI_TESTS')
+    cache_dir = if ENV.key?("RUNNING_SHOPIFY_CLI_TESTS")
       TEMP_DIR
-    elsif ENV['LOCALAPPDATA'].nil?
-      File.join(File.expand_path(ENV.fetch('XDG_CACHE_HOME', '~/.cache')), TOOL_NAME)
+    elsif ENV["LOCALAPPDATA"].nil?
+      File.join(File.expand_path(ENV.fetch("XDG_CACHE_HOME", "~/.cache")), TOOL_NAME)
     else
-      File.join(File.expand_path(ENV['LOCALAPPDATA']), TOOL_NAME)
+      File.join(File.expand_path(ENV["LOCALAPPDATA"]), TOOL_NAME)
     end
 
     # Make sure the cache dir always exists
@@ -144,20 +144,20 @@ module ShopifyCli
   end
 
   def self.tool_config_path
-    if ENV.key?('RUNNING_SHOPIFY_CLI_TESTS')
+    if ENV.key?("RUNNING_SHOPIFY_CLI_TESTS")
       TEMP_DIR
-    elsif ENV['APPDATA'].nil?
-      File.join(File.expand_path(ENV.fetch('XDG_CONFIG_HOME', '~/.config')), TOOL_NAME)
+    elsif ENV["APPDATA"].nil?
+      File.join(File.expand_path(ENV.fetch("XDG_CONFIG_HOME", "~/.config")), TOOL_NAME)
     else
-      File.join(File.expand_path(ENV['APPDATA']), TOOL_NAME)
+      File.join(File.expand_path(ENV["APPDATA"]), TOOL_NAME)
     end
   end
 
   def self.log_file
-    File.join(tool_config_path, 'logs', 'log.log')
+    File.join(tool_config_path, "logs", "log.log")
   end
 
   def self.debug_log_file
-    File.join(tool_config_path, 'logs', 'debug.log')
+    File.join(tool_config_path, "logs", "debug.log")
   end
 end

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -1,11 +1,11 @@
-require_relative 'lib/shopify-cli/version'
+require_relative "lib/shopify-cli/version"
 
 Gem::Specification.new do |spec|
   spec.name = "shopify-cli"
   spec.version = ShopifyCli::VERSION
   spec.authors = ["Shopify"]
   spec.email = ["dev-tools-education@shopify.com"]
-  spec.license = 'MIT'
+  spec.license = "MIT"
 
   spec.summary = "Shopify CLI helps you build Shopify apps faster."
   spec.description = <<~HERE
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     %x(git ls-files -z).split("\x0").reject do |f|
       f.match(%r{^(test|spec|features|packaging)/}) ||
       f.match(%r{^bin/(update-deps|shopify.bat)$})
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib", "vendor"]
   spec.extensions = ["ext/shopify-cli/extconf.rb"]
 
-  spec.add_development_dependency('bundler', '~> 1.17')
-  spec.add_development_dependency('rake', '~> 12.3', '>= 12.3.3')
-  spec.add_development_dependency('minitest', '~> 5.0')
+  spec.add_development_dependency("bundler", "~> 1.17")
+  spec.add_development_dependency("rake", "~> 12.3", ">= 12.3.3")
+  spec.add_development_dependency("minitest", "~> 5.0")
 end

--- a/test/linux/Vagrantfile
+++ b/test/linux/Vagrantfile
@@ -1,41 +1,41 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.configure('2') do |config|
+Vagrant.configure("2") do |config|
   config.vm.network("forwarded_port", guest: 3456, host: 3456, host_ip: "127.0.0.1")
   config.vm.network("forwarded_port", guest: 8081, host: 8081, host_ip: "127.0.0.1")
   config.vm.network("forwarded_port", guest: 39351, host: 39351, host_ip: "127.0.0.1")
 
-  config.vm.define('ubuntu_chruby', autostart: false) do |chruby|
+  config.vm.define("ubuntu_chruby", autostart: false) do |chruby|
     chruby.vm.provision(
       "chruby_complete", type: "shell", run: "never",
       privileged: false, path: "provisioning/ubuntu-focal-chruby-complete.sh"
     )
-    chruby.vm.box = 'ubuntu/focal64'
+    chruby.vm.box = "ubuntu/focal64"
     chruby.vm.provider("virtualbox") do |vb|
       vb.gui = false
       vb.memory = "4096"
     end
   end
 
-  config.vm.define('ubuntu_rbenv', autostart: false) do |rbenv|
+  config.vm.define("ubuntu_rbenv", autostart: false) do |rbenv|
     rbenv.vm.provision(
       "rbenv_complete", type: "shell", run: "never",
       privileged: false, path: "provisioning/ubuntu-focal-rbenv-complete.sh"
     )
-    rbenv.vm.box = 'ubuntu/focal64'
+    rbenv.vm.box = "ubuntu/focal64"
     rbenv.vm.provider("virtualbox") do |vb|
       vb.gui = false
       vb.memory = "4096"
     end
   end
 
-  config.vm.define('ubuntu_rvm', autostart: false) do |rvm|
+  config.vm.define("ubuntu_rvm", autostart: false) do |rvm|
     rvm.vm.provision(
       "rvm_complete", type: "shell", run: "never",
       privileged: false, path: "provisioning/ubuntu-focal-rvm-complete.sh"
     )
-    rvm.vm.box = 'ubuntu/focal64'
+    rvm.vm.box = "ubuntu/focal64"
     rvm.vm.provider("virtualbox") do |vb|
       vb.gui = false
       vb.memory = "4096"

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -6,7 +6,7 @@ module Minitest
   end
 
   class Test
-    FIXTURE_DIR = File.expand_path('fixtures', File.dirname(__FILE__))
+    FIXTURE_DIR = File.expand_path("fixtures", File.dirname(__FILE__))
     CONFIG_FILE = CLI::Kit::Config.new(tool_name: ShopifyCli::TOOL_NAME).file
 
     include TestHelpers::Project
@@ -16,7 +16,7 @@ module Minitest
       if File.exist?(CONFIG_FILE)
         @config_sha_before = Digest::SHA256.hexdigest(File.read(CONFIG_FILE))
       end
-      project_context('project')
+      project_context("project")
       ::ShopifyCli::Project.clear
       super
     end
@@ -81,16 +81,16 @@ module Minitest
     private
 
     def stub_prompt_for_cli_updates
-      ShopifyCli::Config.stubs(:get_section).with("autoupdate").returns('enabled' => 'true')
+      ShopifyCli::Config.stubs(:get_section).with("autoupdate").returns("enabled" => "true")
     end
 
     def stub_new_version_check
       stub_request(:get, ShopifyCli::Context::GEM_LATEST_URI)
         .with(headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host' => 'rubygems.org',
-          'User-Agent' => 'Ruby',
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "rubygems.org",
+          "User-Agent" => "Ruby",
         })
         .to_return(status: 200, body: "{\"version\":\"#{ShopifyCli::VERSION}\"}", headers: {})
     end

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Commands
@@ -32,7 +32,7 @@ module Extension
 
       def test_aborts_and_informs_the_user_when_build_fails
         ShopifyCli::JsSystem.any_instance.stubs(:call).returns(false)
-        @context.expects(:abort).with(@context.message('build.build_failure_message'))
+        @context.expects(:abort).with(@context.message("build.build_failure_message"))
 
         run_build
       end
@@ -41,7 +41,7 @@ module Extension
 
       def run_build(*args)
         Build.ctx = @context
-        Build.call(args, 'build')
+        Build.call(args, "build")
       end
     end
   end

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Commands
@@ -13,11 +13,11 @@ module Extension
       def setup
         super
         @name = "My Ext"
-        @directory_name = 'my_ext'
+        @directory_name = "my_ext"
       end
 
       def test_prints_help
-        io = capture_io { run_cmd('create extension --help') }
+        io = capture_io { run_cmd("create extension --help") }
         assert_message_output(io: io, expected_content: [Extension::Commands::Create.help])
       end
 
@@ -30,7 +30,7 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('create.errors.directory_exists', @directory_name),
+          @context.message("create.errors.directory_exists", @directory_name),
         ])
       end
 
@@ -45,8 +45,8 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('create.ready_to_start', @directory_name, @name),
-          @context.message('create.learn_more', @test_extension_type.name),
+          @context.message("create.ready_to_start", @directory_name, @name),
+          @context.message("create.learn_more", @test_extension_type.name),
         ])
       end
 
@@ -60,7 +60,7 @@ module Extension
           run_create(%W(extension --name=#{@name} --type=#{@test_extension_type.identifier}))
         end
 
-        assert_message_output(io: io, expected_content: @context.message('create.try_again'))
+        assert_message_output(io: io, expected_content: @context.message("create.try_again"))
       end
 
       def test_help_does_not_load_extension_project_type
@@ -69,14 +69,14 @@ module Extension
         end
 
         output = io.join
-        refute_match(' extension ', output)
+        refute_match(" extension ", output)
       end
 
       private
 
       def run_create(arguments)
         Commands::Create.ctx = @context
-        Commands::Create.call(arguments, 'create', 'create')
+        Commands::Create.call(arguments, "create", "create")
       end
     end
   end

--- a/test/project_types/extension/commands/extension_command_test.rb
+++ b/test/project_types/extension/commands/extension_command_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Commands
@@ -30,13 +30,13 @@ module Extension
       end
 
       def test_extension_type_aborts_if_the_type_is_unknown
-        unknown_type = 'unknown_type'
+        unknown_type = "unknown_type"
         setup_temp_project(type_identifier: unknown_type)
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) { @command.extension_type }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('errors.unknown_type', unknown_type),
+          @context.message("errors.unknown_type", unknown_type),
         ])
       end
 

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Commands
@@ -83,15 +83,15 @@ module Extension
         io = capture_io { run_push }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('push.waiting_text'),
-          @context.message('push.success_confirmation', @title, 'May 07, 2020 19:01:56 UTC'),
-          @context.message('push.success_info', 'https://www.fakeurl.com'),
+          @context.message("push.waiting_text"),
+          @context.message("push.success_confirmation", @title, "May 07, 2020 19:01:56 UTC"),
+          @context.message("push.success_info", "https://www.fakeurl.com"),
         ])
       end
 
       def test_displays_time_the_draft_was_updated_at_in_utc
-        response_time = '2020-05-07T19:01:56-04:00'
-        expected_formatted_time_in_utc = 'May 07, 2020 23:01:56 UTC'
+        response_time = "2020-05-07T19:01:56-04:00"
+        expected_formatted_time_in_utc = "May 07, 2020 23:01:56 UTC"
 
         @version.last_user_interaction_at = Time.parse(response_time)
         Commands::Build.any_instance.stubs(:call)
@@ -101,15 +101,15 @@ module Extension
         io = capture_io { run_push }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('push.success_confirmation', @title, expected_formatted_time_in_utc),
+          @context.message("push.success_confirmation", @title, expected_formatted_time_in_utc),
         ])
       end
 
       def test_shows_error_messages_and_validation_errors_if_any_occurred_on_push
         @version.last_user_interaction_at = Time.parse("2020-05-07 19:01:56 UTC")
         @version.validation_errors = [
-          Models::ValidationError.new(field: %w(test_field), message: 'Error message'),
-          Models::ValidationError.new(field: %w(test_field1 test_field2), message: 'Error message2'),
+          Models::ValidationError.new(field: %w(test_field), message: "Error message"),
+          Models::ValidationError.new(field: %w(test_field1 test_field2), message: "Error message2"),
         ]
 
         Commands::Build.any_instance.stubs(:call)
@@ -119,10 +119,10 @@ module Extension
         io = capture_io { run_push }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('push.pushed_with_errors', 'May 07, 2020 19:01:56 UTC'),
-          '{{x}} test_field: Error message',
-          '{{x}} test_field2: Error message2',
-          @context.message('push.push_with_errors_info'),
+          @context.message("push.pushed_with_errors", "May 07, 2020 19:01:56 UTC"),
+          "{{x}} test_field: Error message",
+          "{{x}} test_field2: Error message2",
+          @context.message("push.push_with_errors_info"),
         ])
       end
 

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Commands
@@ -13,7 +13,7 @@ module Extension
       def setup
         super
         ShopifyCli::ProjectType.load_type(:extension)
-        setup_temp_project(api_key: '', api_secret: '', registration_id: nil)
+        setup_temp_project(api_key: "", api_secret: "", registration_id: nil)
 
         @app = Models::App.new(api_key: @api_key, secret: @api_secret)
         stub_get_app(app: @app, api_key: @app.api_key)
@@ -30,7 +30,7 @@ module Extension
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) { run_register_command }
 
-        assert_message_output(io: io, expected_content: @context.message('register.already_registered'))
+        assert_message_output(io: io, expected_content: @context.message("register.already_registered"))
       end
 
       def test_does_not_run_create_if_user_does_not_confirm
@@ -40,15 +40,15 @@ module Extension
 
         CLI::UI::Prompt
           .expects(:confirm)
-          .with(@context.message('register.confirm_question', @app.title))
+          .with(@context.message("register.confirm_question", @app.title))
           .returns(false)
           .once
 
         io = capture_io_and_assert_raises(ShopifyCli::AbortSilent) { run_register_command }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('register.confirm_abort'),
-          @context.message('register.confirm_info', @test_extension_type.name),
+          @context.message("register.confirm_abort"),
+          @context.message("register.confirm_info", @test_extension_type.name),
         ])
       end
 
@@ -67,7 +67,7 @@ module Extension
 
         CLI::UI::Prompt
           .expects(:confirm)
-          .with(@context.message('register.confirm_question', @app.title))
+          .with(@context.message("register.confirm_question", @app.title))
           .returns(true)
           .once
 
@@ -91,10 +91,10 @@ module Extension
         io = capture_io { run_register_command }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('register.confirm_info', @test_extension_type.name),
-          @context.message('register.waiting_text'),
-          @context.message('register.success', @project.title, @app.title),
-          @context.message('register.success_info'),
+          @context.message("register.confirm_info", @test_extension_type.name),
+          @context.message("register.waiting_text"),
+          @context.message("register.success", @project.title, @app.title),
+          @context.message("register.success_info"),
         ])
       end
 

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Commands
@@ -32,7 +32,7 @@ module Extension
           .with(yarn: Serve::YARN_SERVE_COMMAND, npm: Serve::NPM_SERVE_COMMAND)
           .returns(false)
           .once
-        @context.expects(:abort).with(@context.message('serve.serve_failure_message'))
+        @context.expects(:abort).with(@context.message("serve.serve_failure_message"))
 
         run_serve
       end
@@ -41,7 +41,7 @@ module Extension
 
       def run_serve(*args)
         Serve.ctx = @context
-        Serve.call(args, 'serve')
+        Serve.call(args, "serve")
       end
     end
   end

--- a/test/project_types/extension/commands/tunnel_test.rb
+++ b/test/project_types/extension/commands/tunnel_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Commands
@@ -15,21 +15,21 @@ module Extension
 
       def test_prints_help
         @context.expects(:puts).with(Tunnel.help)
-        run_tunnel('help')
+        run_tunnel("help")
       end
 
       def test_auth_errors_if_no_token_is_provided
         io = capture_io { run_tunnel(Tunnel::AUTH_SUBCOMMAND) }
 
         assert_message_output(io: io, expected_content: [
-          @context.message('tunnel.missing_token'),
+          @context.message("tunnel.missing_token"),
           Tunnel.help,
           Tunnel.extended_help,
         ])
       end
 
       def test_auth_runs_the_core_cli_tunnel_auth_if_token_is_present
-        fake_token = 'FAKE_TOKEN'
+        fake_token = "FAKE_TOKEN"
         ShopifyCli::Tunnel.expects(:auth).with(@context, fake_token).once
 
         capture_io { run_tunnel(Tunnel::AUTH_SUBCOMMAND, fake_token) }
@@ -48,7 +48,7 @@ module Extension
       end
 
       def test_start_aborts_if_an_invalid_port_is_provided
-        invalid_port = 'NOT_PORT'
+        invalid_port = "NOT_PORT"
 
         ShopifyCli::Tunnel.expects(:start).never
 
@@ -57,7 +57,7 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('tunnel.invalid_port', invalid_port),
+          @context.message("tunnel.invalid_port", invalid_port),
         ])
       end
 
@@ -72,23 +72,23 @@ module Extension
 
         io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
 
-        assert_message_output(io: io, expected_content: @context.message('tunnel.no_tunnel_running'))
+        assert_message_output(io: io, expected_content: @context.message("tunnel.no_tunnel_running"))
       end
 
       def test_status_outputs_the_running_tunnel_url_if_returned_by_tunnel_url
-        fake_url = 'http://12345.ngrok.io'
+        fake_url = "http://12345.ngrok.io"
         ShopifyCli::Tunnel.expects(:urls).returns([fake_url]).once
 
         io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
 
-        assert_message_output(io: io, expected_content: @context.message('tunnel.tunnel_running_at', fake_url))
+        assert_message_output(io: io, expected_content: @context.message("tunnel.tunnel_running_at", fake_url))
       end
 
       private
 
       def run_tunnel(*args)
         Tunnel.ctx = @context
-        Tunnel.call(args, 'tunnel')
+        Tunnel.call(args, "tunnel")
       end
     end
   end

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   class ExtensionProjectTest < MiniTest::Test
@@ -14,15 +14,15 @@ module Extension
       ExtensionProject.write_cli_file(context: new_context, type: @test_extension_type.identifier)
       ::ShopifyCli::Project.clear
 
-      assert File.exist?('.shopify-cli.yml')
+      assert File.exist?(".shopify-cli.yml")
       assert_equal :extension, ShopifyCli::Project.current_project_type
       assert_equal @test_extension_type.identifier, ExtensionProject.current.extension_type_identifier
     end
 
     def test_write_env_file_creates_env_file
-      api_key = '1234'
-      api_secret = '5678'
-      title = 'Test Title'
+      api_key = "1234"
+      api_secret = "5678"
+      title = "Test Title"
       registration_id = 55
 
       new_context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
@@ -37,7 +37,7 @@ module Extension
         registration_id: registration_id
       )
 
-      assert File.exist?('.env')
+      assert File.exist?(".env")
       project = ExtensionProject.current
       assert_equal api_key, project.app.api_key
       assert_equal api_secret, project.app.secret
@@ -46,19 +46,19 @@ module Extension
     end
 
     def test_ensures_registered_is_true_only_if_api_key_api_secret_and_registration_id_are_present
-      setup_temp_project(api_key: '', api_secret: '', title: 'title', registration_id: nil)
+      setup_temp_project(api_key: "", api_secret: "", title: "title", registration_id: nil)
       refute @project.registered?
 
-      setup_temp_project(api_key: '1234', api_secret: '', title: 'title', registration_id: nil)
+      setup_temp_project(api_key: "1234", api_secret: "", title: "title", registration_id: nil)
       refute @project.registered?
 
-      setup_temp_project(api_key: '1234', api_secret: '456', title: 'title', registration_id: nil)
+      setup_temp_project(api_key: "1234", api_secret: "456", title: "title", registration_id: nil)
       refute @project.registered?
 
-      setup_temp_project(api_key: '', api_secret: '', title: 'title', registration_id: 5)
+      setup_temp_project(api_key: "", api_secret: "", title: "title", registration_id: 5)
       refute @project.registered?
 
-      setup_temp_project(api_key: '1234', api_secret: '456', title: 'title', registration_id: 55)
+      setup_temp_project(api_key: "1234", api_secret: "456", title: "title", registration_id: 55)
       assert @project.registered?
     end
 
@@ -94,7 +94,7 @@ module Extension
       setup_temp_project(registration_id: 0)
       refute @project.registration_id?
 
-      setup_temp_project(registration_id: 'wrong')
+      setup_temp_project(registration_id: "wrong")
       refute @project.registration_id?
     end
   end

--- a/test/project_types/extension/extension_test_helpers.rb
+++ b/test/project_types/extension/extension_test_helpers.rb
@@ -2,19 +2,19 @@
 
 module Extension
   module ExtensionTestHelpers
-    autoload :FakeExtensionProject, 'project_types/extension/extension_test_helpers/fake_extension_project'
-    autoload :TestExtension, 'project_types/extension/extension_test_helpers/test_extension'
-    autoload :TestExtensionSetup, 'project_types/extension/extension_test_helpers/test_extension_setup'
-    autoload :TempProjectSetup, 'project_types/extension/extension_test_helpers/temp_project_setup'
-    autoload :Messages, 'project_types/extension/extension_test_helpers/messages'
-    autoload :DummyArgo, 'project_types/extension/extension_test_helpers/dummy_argo'
+    autoload :FakeExtensionProject, "project_types/extension/extension_test_helpers/fake_extension_project"
+    autoload :TestExtension, "project_types/extension/extension_test_helpers/test_extension"
+    autoload :TestExtensionSetup, "project_types/extension/extension_test_helpers/test_extension_setup"
+    autoload :TempProjectSetup, "project_types/extension/extension_test_helpers/temp_project_setup"
+    autoload :Messages, "project_types/extension/extension_test_helpers/messages"
+    autoload :DummyArgo, "project_types/extension/extension_test_helpers/dummy_argo"
 
     module Stubs
-      autoload :GetOrganizations, 'project_types/extension/extension_test_helpers/stubs/get_organizations'
-      autoload :GetApp, 'project_types/extension/extension_test_helpers/stubs/get_app'
-      autoload :CreateExtension, 'project_types/extension/extension_test_helpers/stubs/create_extension'
-      autoload :UpdateDraft, 'project_types/extension/extension_test_helpers/stubs/update_draft'
-      autoload :ArgoScript, 'project_types/extension/extension_test_helpers/stubs/argo_script'
+      autoload :GetOrganizations, "project_types/extension/extension_test_helpers/stubs/get_organizations"
+      autoload :GetApp, "project_types/extension/extension_test_helpers/stubs/get_app"
+      autoload :CreateExtension, "project_types/extension/extension_test_helpers/stubs/create_extension"
+      autoload :UpdateDraft, "project_types/extension/extension_test_helpers/stubs/update_draft"
+      autoload :ArgoScript, "project_types/extension/extension_test_helpers/stubs/argo_script"
     end
   end
 end

--- a/test/project_types/extension/extension_test_helpers/dummy_argo.rb
+++ b/test/project_types/extension/extension_test_helpers/dummy_argo.rb
@@ -2,7 +2,7 @@ module Extension
   module ExtensionTestHelpers
     class DummyArgo < Extension::Features::Argo
       GIT_TEMPLATE = "https://something"
-      RENDERER_PACKAGE = '@test-renderer-package'
+      RENDERER_PACKAGE = "@test-renderer-package"
       private_constant :GIT_TEMPLATE, :RENDERER_PACKAGE
 
       def git_template

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -14,7 +14,7 @@ module Extension
 
       def config
         {
-          'project_type' => 'extension',
+          "project_type" => "extension",
           ExtensionProjectKeys::EXTENSION_TYPE_KEY => type,
         }
       end

--- a/test/project_types/extension/extension_test_helpers/stubs/argo_script.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/argo_script.rb
@@ -23,7 +23,7 @@ module Extension
           directory = File.dirname(filepath)
 
           FileUtils.mkdir_p(directory)
-          File.open(filepath, 'w+') { |file| file.puts(script) }
+          File.open(filepath, "w+") { |file| file.puts(script) }
           yield
         ensure
           FileUtils.rm_r(directory)

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -8,7 +8,7 @@ module Extension
 
         def stub_create_extension(api_key:, type:, title:, config:, extension_context: nil)
           stub_partner_req(
-            'extension_create',
+            "extension_create",
             variables: {
               api_key: api_key,
               type: type,

--- a/test/project_types/extension/extension_test_helpers/stubs/get_app.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/get_app.rb
@@ -8,7 +8,7 @@ module Extension
 
         def stub_get_app(api_key:, app:)
           stub_partner_req(
-            'get_app_by_api_key',
+            "get_app_by_api_key",
             variables: {
               api_key: api_key,
             },

--- a/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
@@ -15,7 +15,7 @@ module Extension
 
         def stub_get_organizations(organizations)
           stub_partner_req(
-            'all_orgs_with_apps',
+            "all_orgs_with_apps",
             resp: {
               data: {
                 organizations: {
@@ -38,7 +38,7 @@ module Extension
             'businessName': name,
             'stores': {
               'nodes': [
-                { 'shopDomain': 'store.myshopify.com' },
+                { 'shopDomain': "store.myshopify.com" },
               ],
             },
             'apps': {

--- a/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
@@ -6,7 +6,7 @@ module Extension
       module UpdateDraft
         include TestHelpers::Partners
 
-        def stub_update_draft(registration_id:, config:, extension_context: nil, api_key: 'FAKE_API_KEY')
+        def stub_update_draft(registration_id:, config:, extension_context: nil, api_key: "FAKE_API_KEY")
           stub_partner_req(Tasks::UpdateDraft::GRAPHQL_FILE,
             variables: {
               api_key: api_key,
@@ -27,7 +27,7 @@ module Extension
                   registrationId: registration_id,
                   context: extension_context,
                   lastUserInteractionAt: Time.now.utc.to_s,
-                  location: 'https://www.fakeurl.com',
+                  location: "https://www.fakeurl.com",
                 },
                 Tasks::UserErrors::USER_ERRORS_FIELD => [],
               },

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -7,14 +7,14 @@ module Extension
       include ExtensionTestHelpers::TestExtensionSetup
 
       def setup_temp_project(
-        api_key: 'TEST_KEY',
-        api_secret: 'TEST_SECRET',
-        title: 'Test',
+        api_key: "TEST_KEY",
+        api_secret: "TEST_SECRET",
+        title: "Test",
         type_identifier: @test_extension_type.identifier,
         registration_id: 55
       )
 
-        @context = TestHelpers::FakeContext.new(root: '/fake/root')
+        @context = TestHelpers::FakeContext.new(root: "/fake/root")
         @api_key = api_key
         @api_secret = api_secret
         @title = title

--- a/test/project_types/extension/extension_test_helpers/test_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension.rb
@@ -1,33 +1,33 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Models
     module SpecificationHandlers
-      autoload(:Default, 'project_types/extension/models/specification_handlers/default')
+      autoload(:Default, "project_types/extension/models/specification_handlers/default")
     end
   end
 
   module ExtensionTestHelpers
     class TestExtension < Models::SpecificationHandlers::Default
-      IDENTIFIER = 'TEST_EXTENSION'
+      IDENTIFIER = "TEST_EXTENSION"
 
       def graphql_identifier
-        'TEST_EXTENSION_GQL'
+        "TEST_EXTENSION_GQL"
       end
 
       def name
-        'Test Extension'
+        "Test Extension"
       end
 
       def tagline
-        'An extension for testing'
+        "An extension for testing"
       end
 
       def config(_context)
         {
-          title: 'A Test Extension Title',
-          field: 'field_for_test_extension',
+          title: "A Test Extension Title",
+          field: "field_for_test_extension",
         }
       end
     end

--- a/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
@@ -9,11 +9,11 @@ module Extension
         @_original_extension_specifications = Extension.specifications
 
         Extension.specifications = Models::Specifications.new(
-          custom_handler_root: File.expand_path('../', __FILE__),
+          custom_handler_root: File.expand_path("../", __FILE__),
           custom_handler_namespace: ::Extension::ExtensionTestHelpers,
-          fetch_specifications: -> { [{ identifier: 'test_extension' }] }
+          fetch_specifications: -> { [{ identifier: "test_extension" }] }
         )
-        @test_extension_type = Extension.specifications['TEST_EXTENSION']
+        @test_extension_type = Extension.specifications["TEST_EXTENSION"]
 
         super
       end

--- a/test/project_types/extension/features/argo_config_test.rb
+++ b/test/project_types/extension/features/argo_config_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Features

--- a/test/project_types/extension/features/argo_dependencies_test.rb
+++ b/test/project_types/extension/features/argo_dependencies_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Features
@@ -14,60 +14,60 @@ module Extension
       end
 
       def test_nothing_is_raised_if_node_version_meets_minimum_major_and_minor_versions
-        mock_node_version('v10.11.12')
+        mock_node_version("v10.11.12")
         assert_nothing_raised(ShopifyCli::Abort) do
           ArgoDependencies.node_installed(min_major: 10, min_minor: 11).call(@context)
         end
 
-        mock_node_version('v10.11.12')
+        mock_node_version("v10.11.12")
         assert_nothing_raised(ShopifyCli::Abort) do
           ArgoDependencies.node_installed(min_major: 9, min_minor: 11).call(@context)
         end
 
-        mock_node_version('v10.11.12')
+        mock_node_version("v10.11.12")
         assert_nothing_raised(ShopifyCli::Abort) do
           ArgoDependencies.node_installed(min_major: 10, min_minor: 10).call(@context)
         end
       end
 
       def test_if_node_version_command_fails_abort_with_missing_node_message
-        mock_node_version('', success: false)
+        mock_node_version("", success: false)
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) do
           ArgoDependencies.node_installed(min_major: 11).call(@context)
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('features.argo.dependencies.node.node_not_installed'),
+          @context.message("features.argo.dependencies.node.node_not_installed"),
         ])
       end
 
       def test_if_node_exists_but_major_version_is_under_the_minimum_abort_with_message
-        mock_node_version('v10.11.12')
+        mock_node_version("v10.11.12")
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) do
           ArgoDependencies.node_installed(min_major: 11).call(@context)
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v11.x.x'),
+          @context.message("features.argo.dependencies.node.version_too_low", "v10.11.12", "v11.x.x"),
         ])
       end
 
       def test_if_major_version_is_the_minimum_version_abort_with_message_if_minor_version_is_under_the_minimum_version
-        mock_node_version('v10.11.12')
+        mock_node_version("v10.11.12")
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) do
           ArgoDependencies.node_installed(min_major: 10, min_minor: 12).call(@context)
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v10.12.x'),
+          @context.message("features.argo.dependencies.node.version_too_low", "v10.11.12", "v10.12.x"),
         ])
       end
 
       def test_if_major_version_is_the_above_the_minimum_version_do_not_check_minor_version
-        mock_node_version('v13.7.0')
+        mock_node_version("v13.7.0")
 
         assert_nothing_raised do
           ArgoDependencies.node_installed(min_major: 10, min_minor: 13).call(@context)

--- a/test/project_types/extension/features/argo_setup_step_test.rb
+++ b/test/project_types/extension/features/argo_setup_step_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Features
@@ -12,8 +12,8 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
 
-        @identifier = 'FAKE_ARGO_TYPE'
-        @directory = 'fake_directory'
+        @identifier = "FAKE_ARGO_TYPE"
+        @directory = "fake_directory"
         @system = ShopifyCli::JsSystem.new(ctx: @context)
       end
 
@@ -29,28 +29,28 @@ module Extension
 
       def test_all_step_types_catch_shopify_cli_abort_exceptions_and_output_their_message_and_return_false
         always_successful_io = capture_io do
-          refute call_step(ArgoSetupStep.always_successful { raise ShopifyCli::Abort, 'always_successful error' })
+          refute call_step(ArgoSetupStep.always_successful { raise ShopifyCli::Abort, "always_successful error" })
         end
 
         default_io = capture_io do
-          refute call_step(ArgoSetupStep.default { raise ShopifyCli::Abort, 'default_io error' })
+          refute call_step(ArgoSetupStep.default { raise ShopifyCli::Abort, "default_io error" })
         end
 
-        assert_message_output(io: always_successful_io, expected_content: 'always_successful error')
-        assert_message_output(io: default_io, expected_content: 'default_io error')
+        assert_message_output(io: always_successful_io, expected_content: "always_successful error")
+        assert_message_output(io: default_io, expected_content: "default_io error")
       end
 
       def test_all_step_types_catch_any_exceptions_and_output_their_message_and_return_false
         always_successful_io = capture_io do
-          refute call_step(ArgoSetupStep.always_successful { raise 'always_successful error' })
+          refute call_step(ArgoSetupStep.always_successful { raise "always_successful error" })
         end
 
         default_io = capture_io do
-          refute call_step(ArgoSetupStep.default { raise 'default_io error' })
+          refute call_step(ArgoSetupStep.default { raise "default_io error" })
         end
 
-        assert_message_output(io: always_successful_io, expected_content: '{{x}} always_successful error')
-        assert_message_output(io: default_io, expected_content: '{{x}} default_io error')
+        assert_message_output(io: always_successful_io, expected_content: "{{x}} always_successful error")
+        assert_message_output(io: default_io, expected_content: "{{x}} default_io error")
       end
 
       private

--- a/test/project_types/extension/features/argo_setup_steps_test.rb
+++ b/test/project_types/extension/features/argo_setup_steps_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Features
@@ -11,9 +11,9 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
 
-        @git_template = 'https://www.github.com/fake_template.git'
-        @identifier = 'FAKE_ARGO_TYPE'
-        @directory = 'fake_directory'
+        @git_template = "https://www.github.com/fake_template.git"
+        @identifier = "FAKE_ARGO_TYPE"
+        @directory = "fake_directory"
         @system = ShopifyCli::JsSystem.new(ctx: @context)
       end
 

--- a/test/project_types/extension/features/argo_setup_test.rb
+++ b/test/project_types/extension/features/argo_setup_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
-require 'pathname'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+require "pathname"
 
 module Extension
   module Features
@@ -12,10 +12,10 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
 
-        @git_template = 'https://www.github.com/fake_template.git'
+        @git_template = "https://www.github.com/fake_template.git"
         @initializer = ArgoSetup.new(git_template: @git_template)
-        @identifier = 'FAKE_ARGO_TYPE'
-        @directory = 'fake_directory'
+        @identifier = "FAKE_ARGO_TYPE"
+        @directory = "fake_directory"
 
         @passing_step = ArgoSetupStep.default { true }
         @failing_step = ArgoSetupStep.default { false }

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
-require 'base64'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+require "base64"
 
 module Extension
   module Features
@@ -14,50 +14,50 @@ module Extension
         ShopifyCli::ProjectType.load_type(:extension)
 
         @dummy_argo = ExtensionTestHelpers::DummyArgo.new(
-          git_template: 'dummy-template',
-          renderer_package_name: 'dummy-renderer',
+          git_template: "dummy-template",
+          renderer_package_name: "dummy-renderer",
         )
-        @result = 'fake result'
+        @result = "fake result"
         @error_message = "fake error"
-        @no_error = ''
-        @encoded_script = Base64.strict_encode64('var fake={}')
+        @no_error = ""
+        @encoded_script = Base64.strict_encode64("var fake={}")
       end
 
       def test_config_aborts_with_error_if_script_file_doesnt_exist
         File.stubs(:exist?).returns(false)
         stub_run_yarn_install_and_run_yarn_run_script_methods
-        @dummy_argo.stubs(:extract_argo_renderer_version).returns('0.0.1')
+        @dummy_argo.stubs(:extract_argo_renderer_version).returns("0.0.1")
         error = assert_raises ShopifyCli::Abort do
           @dummy_argo.config(@context)
         end
 
-        assert_includes error.message, @context.message('features.argo.missing_file_error')
+        assert_includes error.message, @context.message("features.argo.missing_file_error")
       end
 
       def test_config_aborts_with_error_if_script_serialization_fails
         stub_run_yarn_install_and_run_yarn_run_script_methods
-        @dummy_argo.stubs(:extract_argo_renderer_version).returns('0.0.1')
+        @dummy_argo.stubs(:extract_argo_renderer_version).returns("0.0.1")
         File.stubs(:exist?).returns(true)
         Base64.stubs(:strict_encode64).raises(IOError)
 
         error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
-        assert_includes error.message, @context.message('features.argo.script_prepare_error')
+        assert_includes error.message, @context.message("features.argo.script_prepare_error")
       end
 
       def test_config_aborts_with_error_if_file_read_fails
         stub_run_yarn_install_and_run_yarn_run_script_methods
-        @dummy_argo.stubs(:extract_argo_renderer_version).returns('0.0.1')
+        @dummy_argo.stubs(:extract_argo_renderer_version).returns("0.0.1")
         File.stubs(:exist?).returns(true)
         File.any_instance.stubs(:read).raises(IOError)
 
         error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
-        assert_includes error.message, @context.message('features.argo.script_prepare_error')
+        assert_includes error.message, @context.message("features.argo.script_prepare_error")
       end
 
       def test_config_encodes_script_into_context_if_it_exists
         with_stubbed_script(@context, Argo::SCRIPT_PATH) do
           stub_run_yarn_install_and_run_yarn_run_script_methods
-          @dummy_argo.stubs(:extract_argo_renderer_version).returns('0.0.1')
+          @dummy_argo.stubs(:extract_argo_renderer_version).returns("0.0.1")
           config = @dummy_argo.config(@context)
 
           assert_includes config.keys, :serialized_script
@@ -88,7 +88,7 @@ module Extension
           ✨  Done in 0.40s.
           '
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns('npm')
+          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("npm")
           Argo.any_instance.stubs(:run_list_command).returns(npm_list_result)
           ShopifyCli::JsSystem.any_instance.stubs(:call)
           config = @dummy_argo.config(@context)
@@ -107,7 +107,7 @@ module Extension
           error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
           assert_includes error
             .message, @context.message(
-              'features.argo.dependencies.argo_missing_renderer_package_error',
+              "features.argo.dependencies.argo_missing_renderer_package_error",
               @error_message
             )
         end
@@ -121,11 +121,11 @@ module Extension
           ShopifyCli::JsSystem.any_instance.stubs(:call).returns([@result, @no_error, mock(success?: true)])
           Argo.any_instance.stubs(:find_version_number).returns(invalid_version)
 
-          error_message = 'The renderer package version is not a valid SemVer Version (http://semver.org)'
+          error_message = "The renderer package version is not a valid SemVer Version (http://semver.org)"
           error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
           assert_includes error
             .message, @context.message(
-              'features.argo.dependencies.argo_renderer_package_invalid_version_error',
+              "features.argo.dependencies.argo_renderer_package_invalid_version_error",
               error_message
             )
         end
@@ -144,7 +144,7 @@ module Extension
           error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
           assert_includes error
             .message, @context.message(
-              'features.argo.dependencies.argo_missing_renderer_package_error',
+              "features.argo.dependencies.argo_missing_renderer_package_error",
               error_message
             )
         end
@@ -152,7 +152,7 @@ module Extension
 
       def test_runs_yarn_install_and_yarn_run_script_if_the_package_manager_is_yarn
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns('yarn')
+          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
           Argo.any_instance.expects(:run_yarn_install).returns(true).once
           Argo.any_instance.expects(:run_yarn_run_script).returns(true).once
           Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
@@ -163,7 +163,7 @@ module Extension
 
       def test_does_not_run_yarn_install_and_yarn_run_script_if_the_package_manager_is_npm
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns('npm')
+          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("npm")
           Argo.any_instance.expects(:run_yarn_install).never
           Argo.any_instance.expects(:run_yarn_run_script).never
           Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
@@ -174,29 +174,29 @@ module Extension
 
       def test_aborts_with_error_if_yarn_install_command_fails
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns('yarn')
+          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
           ShopifyCli::JsSystem.any_instance.stubs(:call).returns([@result, @error_message, mock(success?: false)])
           error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
           assert_includes error.message,
-            @context.message('features.argo.dependencies.yarn_install_error', @error_message)
+            @context.message("features.argo.dependencies.yarn_install_error", @error_message)
         end
       end
 
       def test_aborts_with_error_if_yarn_run_script_command_fails
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns('yarn')
+          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
           Argo.any_instance.stubs(:run_yarn_install).returns(true)
           ShopifyCli::JsSystem.any_instance.stubs(:call).returns([@result, @error_message, mock(success?: false)])
           error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
           assert_includes error.message,
-            @context.message('features.argo.dependencies.yarn_run_script_error', @error_message)
+            @context.message("features.argo.dependencies.yarn_run_script_error", @error_message)
         end
       end
 
       private
 
       def stub_run_yarn_install_and_run_yarn_run_script_methods
-        ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns('yarn')
+        ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
         Argo.any_instance.stubs(:run_yarn_install).returns(true)
         Argo.any_instance.stubs(:run_yarn_run_script).returns(true)
       end

--- a/test/project_types/extension/forms/create_test.rb
+++ b/test/project_types/extension/forms/create_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Forms
@@ -10,50 +10,50 @@ module Extension
 
       def setup
         super
-        @app = Models::App.new(title: 'Fake', api_key: '1234', secret: '4567', business_name: 'Fake Business')
+        @app = Models::App.new(title: "Fake", api_key: "1234", secret: "4567", business_name: "Fake Business")
       end
 
       def test_returns_defined_attributes_if_valid
         form = ask
-        assert_equal('test-extension', form.name)
+        assert_equal("test-extension", form.name)
         assert_equal form.type, @test_extension_type
       end
 
       def test_prompts_the_user_to_choose_a_name_if_no_name_was_provided
-        CLI::UI::Prompt.expects(:ask).with(@context.message('create.ask_name')).times(3).returns('A name')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("create.ask_name")).times(3).returns("A name")
         capture_io { ask(name: nil) }
         capture_io { ask(name: "") }
         capture_io { ask(name: " ") }
       end
 
       def test_reprompts_the_user_to_choose_a_name_until_valid_response_is_given
-        CLI::UI::Prompt.stubs(:ask).with(@context.message('create.ask_name'))
+        CLI::UI::Prompt.stubs(:ask).with(@context.message("create.ask_name"))
           .returns(nil, nil)
-          .then.returns('A name')
+          .then.returns("A name")
         ShopifyCli::Context.any_instance.expects(:puts).with(
-          @context.message('create.invalid_name', Models::Registration::MAX_TITLE_LENGTH)
+          @context.message("create.invalid_name", Models::Registration::MAX_TITLE_LENGTH)
         ).times(2)
 
         capture_io do
           form = ask(name: nil)
-          assert_equal('A name', form.name)
+          assert_equal("A name", form.name)
         end
       end
 
       def test_strips_whitespace_from_beginning_and_end_of_name
-        CLI::UI::Prompt.expects(:ask).with(@context.message('create.ask_name')).returns('  A name  ')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("create.ask_name")).returns("  A name  ")
         capture_io do
           form = ask(name: nil)
-          assert_equal('A name', form.name)
+          assert_equal("A name", form.name)
         end
       end
 
       def test_directory_name_is_a_lowercase_underscored_version_of_name
-        assert_equal 'demo', ask(name: 'Demo').directory_name
-        assert_equal 'spaces', ask(name: ' Spaces ').directory_name
-        assert_equal 'demo_extension', ask(name: 'Demo Extension').directory_name
-        assert_equal 'testlongstring', ask(name: 'TestLongString').directory_name
-        assert_equal 'double__spaces', ask(name: 'double  spaces').directory_name
+        assert_equal "demo", ask(name: "Demo").directory_name
+        assert_equal "spaces", ask(name: " Spaces ").directory_name
+        assert_equal "demo_extension", ask(name: "Demo Extension").directory_name
+        assert_equal "testlongstring", ask(name: "TestLongString").directory_name
+        assert_equal "double__spaces", ask(name: "double  spaces").directory_name
       end
 
       def test_accepts_any_valid_extension_type
@@ -67,14 +67,14 @@ module Extension
           .returns("#{@test_extension_type.name} #{@test_extension_type.tagline}")
           .once
 
-        io = capture_io { ask(type: 'unknown-type') }
+        io = capture_io { ask(type: "unknown-type") }
 
-        assert_match(@context.message('create.invalid_type'), io.join)
-        assert_match(@context.message('create.ask_type'), io.join)
+        assert_match(@context.message("create.invalid_type"), io.join)
+        assert_match(@context.message("create.ask_type"), io.join)
       end
 
       def test_prompts_the_user_to_choose_a_type_if_no_type_was_provided
-        CLI::UI::Prompt.expects(:ask).with(@context.message('create.ask_type'))
+        CLI::UI::Prompt.expects(:ask).with(@context.message("create.ask_type"))
 
         capture_io do
           ask(type: nil)
@@ -83,7 +83,7 @@ module Extension
 
       private
 
-      def ask(name: 'test-extension', type: @test_extension_type.identifier)
+      def ask(name: "test-extension", type: @test_extension_type.identifier)
         Create.ask(
           @context,
           [],

--- a/test/project_types/extension/forms/register_test.rb
+++ b/test/project_types/extension/forms/register_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Forms
@@ -11,7 +11,7 @@ module Extension
 
       def setup
         super
-        @app = Models::App.new(title: 'Fake', api_key: '1234', secret: '4567', business_name: 'Fake Business')
+        @app = Models::App.new(title: "Fake", api_key: "1234", secret: "4567", business_name: "Fake Business")
       end
 
       def test_aborts_and_informs_user_if_there_are_no_apps
@@ -22,8 +22,8 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('register.no_apps'),
-          @context.message('register.learn_about_apps'),
+          @context.message("register.no_apps"),
+          @context.message("register.learn_about_apps"),
         ])
       end
 
@@ -42,7 +42,7 @@ module Extension
       def test_prompts_the_user_to_choose_an_app_to_associate_with_extension_if_no_app_is_provided
         Tasks::GetApp.any_instance.expects(:call).never
         Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([@app]).once
-        CLI::UI::Prompt.expects(:ask).with(@context.message('register.ask_app'))
+        CLI::UI::Prompt.expects(:ask).with(@context.message("register.ask_app"))
 
         capture_io do
           ask(api_key: nil)
@@ -50,7 +50,7 @@ module Extension
       end
 
       def test_fails_with_invalid_api_key_to_associate_with_extension
-        api_key = '00001'
+        api_key = "00001"
 
         Tasks::GetApps.any_instance.expects(:call).never
         Tasks::GetApp
@@ -61,7 +61,7 @@ module Extension
 
         io = capture_io { ask(api_key: api_key) }
 
-        assert_match(@context.message('register.invalid_api_key', api_key), io.join)
+        assert_match(@context.message("register.invalid_api_key", api_key), io.join)
       end
 
       private

--- a/test/project_types/extension/messages/message_loading_test.rb
+++ b/test/project_types/extension/messages/message_loading_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Messages
@@ -13,13 +13,13 @@ module Extension
         ShopifyCli::ProjectType.load_type(:extension)
 
         @fake_messages = {
-          name: 'Fake Type',
-          tagline: 'Fake tagline',
+          name: "Fake Type",
+          tagline: "Fake tagline",
         }
 
         @fake_overrides = {
           build: {
-            frame_title: 'Overridden Title',
+            frame_title: "Overridden Title",
           },
         }
 

--- a/test/project_types/extension/models/registration_test.rb
+++ b/test/project_types/extension/models/registration_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Models
@@ -10,18 +10,18 @@ module Extension
       end
 
       def test_valid_title_returns_true_for_valid_title
-        assert Models::Registration.valid_title?('A title')
+        assert Models::Registration.valid_title?("A title")
       end
 
       def test_valid_title_returns_false_for_missing_title
         refute Models::Registration.valid_title?(nil)
-        refute Models::Registration.valid_title?('')
-        refute Models::Registration.valid_title?('  ')
+        refute Models::Registration.valid_title?("")
+        refute Models::Registration.valid_title?("  ")
       end
 
       def test_valid_title_returns_false_when_title_too_long
         refute Models::Registration.valid_title?(
-          Array.new(Registration::MAX_TITLE_LENGTH + 1, 'a').join
+          Array.new(Registration::MAX_TITLE_LENGTH + 1, "a").join
         )
       end
     end

--- a/test/project_types/extension/models/specification_handlers/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_post_purchase_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Models
@@ -12,12 +12,12 @@ module Extension
           Features::Argo.any_instance.stubs(:config).returns({})
           Features::ArgoConfig.stubs(:parse_yaml).returns({})
 
-          @identifier = 'CHECKOUT_POST_PURCHASE'
+          @identifier = "CHECKOUT_POST_PURCHASE"
           @checkout_post_purchase = Extension.specifications[@identifier]
         end
 
         def test_create_uses_standard_argo_create_implementation
-          directory_name = 'checkout_post_purchase'
+          directory_name = "checkout_post_purchase"
 
           Features::Argo.any_instance
             .expects(:create)
@@ -34,7 +34,7 @@ module Extension
 
         def test_config_merges_with_standard_argo_config_implementation
           script_content = "alert(true)"
-          metafields = [{ key: 'a-key', namespace: 'a-namespace' }]
+          metafields = [{ key: "a-key", namespace: "a-namespace" }]
 
           initial_config = { script_content: script_content }
           yaml_config = { "metafields": metafields }

--- a/test/project_types/extension/models/specification_handlers/default_test.rb
+++ b/test/project_types/extension/models/specification_handlers/default_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Models
@@ -17,14 +17,14 @@ module Extension
 
         def test_valid_determines_if_a_type_is_valid
           assert Extension.specifications.valid?(ExtensionTestHelpers::TestExtension::IDENTIFIER)
-          refute Extension.specifications.valid?('INVALID')
+          refute Extension.specifications.valid?("INVALID")
         end
 
         def test_tagline_returns_empty_string_if_not_defined_in_content
           base_type = Default.new(specification)
-          base_type.stubs(:identifier).returns('INVALID')
+          base_type.stubs(:identifier).returns("INVALID")
 
-          assert_equal '', base_type.tagline
+          assert_equal "", base_type.tagline
         end
 
         def test_valid_extension_contexts_returns_empty_array
@@ -42,7 +42,7 @@ module Extension
         private
 
         def specification
-          Models::Specification.new(identifier: 'test_extension')
+          Models::Specification.new(identifier: "test_extension")
         end
       end
     end

--- a/test/project_types/extension/models/specification_handlers/product_subscription_test.rb
+++ b/test/project_types/extension/models/specification_handlers/product_subscription_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Models
@@ -8,12 +8,12 @@ module Extension
         def setup
           super
           ShopifyCli::ProjectType.load_type(:extension)
-          @identifier = 'PRODUCT_SUBSCRIPTION'
+          @identifier = "PRODUCT_SUBSCRIPTION"
           @product_subscription = Extension.specifications[@identifier]
         end
 
         def test_create_uses_standard_argo_create_implementation
-          directory_name = 'product_subscription'
+          directory_name = "product_subscription"
 
           Features::Argo.any_instance
             .expects(:create)
@@ -30,7 +30,7 @@ module Extension
         end
 
         def test_custom_graphql_identifier
-          assert_equal 'SUBSCRIPTION_MANAGEMENT', @product_subscription.graphql_identifier
+          assert_equal "SUBSCRIPTION_MANAGEMENT", @product_subscription.graphql_identifier
         end
       end
     end

--- a/test/project_types/extension/models/specification_test.rb
+++ b/test/project_types/extension/models/specification_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Models
@@ -75,12 +75,12 @@ module Extension
 
       def valid_attributes
         {
-          identifier: 'test_extension',
+          identifier: "test_extension",
           features: {
             argo: {
-              surface_area: 'admin',
-              git_template: 'https://github.com/Shopify/argo-test-template.git',
-              renderer_package_name: '@shopify/argo-test',
+              surface_area: "admin",
+              git_template: "https://github.com/Shopify/argo-test-template.git",
+              renderer_package_name: "@shopify/argo-test",
             },
           },
         }

--- a/test/project_types/extension/models/specifications_test.rb
+++ b/test/project_types/extension/models/specifications_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module ExtensionTestHelpers; end
@@ -16,14 +16,14 @@ module Extension
 
       def test_supports_retrieving_all_specification_handlers
         specifications = build_specifications_domain(
-          specifications: { identifier: 'test_extension' }
+          specifications: { identifier: "test_extension" }
         )
-        assert_kind_of(SpecificationHandlers::Default, specifications['TEST_EXTENSION'])
+        assert_kind_of(SpecificationHandlers::Default, specifications["TEST_EXTENSION"])
       end
 
       def test_supports_retrieving_an_individual_specification_handler
         specifications = build_specifications_domain(
-          specifications: { identifier: 'test_extension' }
+          specifications: { identifier: "test_extension" }
         )
         assert specifications.each.to_a.all? do |handler|
           handler.is_a?(SpeficiationHandlers::Default)
@@ -34,7 +34,7 @@ module Extension
 
       def build_specifications_domain(specifications:)
         Specifications.new(
-          custom_handler_root: File.expand_path('../../extension_test_helpers/', __FILE__),
+          custom_handler_root: File.expand_path("../../extension_test_helpers/", __FILE__),
           custom_handler_namespace: ::Extension::ExtensionTestHelpers,
           fetch_specifications: -> { [specifications] }
         )

--- a/test/project_types/extension/models/validation_error_test.rb
+++ b/test/project_types/extension/models/validation_error_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Models
@@ -8,17 +8,17 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
 
-        @error = ValidationError.new(field: ['Hi'], message: 'message')
+        @error = ValidationError.new(field: ["Hi"], message: "message")
       end
 
       def test_field_only_accepts_an_array_of_strings
-        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: [1], message: '') }
-        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: [Object], message: '') }
-        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: ['field', 1], message: '') }
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: [1], message: "") }
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: [Object], message: "") }
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: ["field", 1], message: "") }
 
-        assert_nothing_raised { ValidationError.new(field: [], message: '') }
-        assert_nothing_raised { ValidationError.new(field: ['field'], message: '') }
-        assert_nothing_raised { ValidationError.new(field: %w(field1 field2), message: '') }
+        assert_nothing_raised { ValidationError.new(field: [], message: "") }
+        assert_nothing_raised { ValidationError.new(field: ["field"], message: "") }
+        assert_nothing_raised { ValidationError.new(field: %w(field1 field2), message: "") }
       end
 
       def test_is_validation_error_returns_true_if_an_object_is_a_validation_error

--- a/test/project_types/extension/project_type_default_configuration_test.rb
+++ b/test/project_types/extension/project_type_default_configuration_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Models

--- a/test/project_types/extension/tasks/configure_features_test.rb
+++ b/test/project_types/extension/tasks/configure_features_test.rb
@@ -22,7 +22,7 @@ module Extension
 
       def test_fails_when_surface_area_is_unknown
         result = ConfigureFeatures
-          .call(build_set_of_specification_attributes(surface_area: 'unknown'))
+          .call(build_set_of_specification_attributes(surface_area: "unknown"))
         assert_predicate(result, :failure?)
         assert_kind_of(ConfigureFeatures::UnknownSurfaceArea, result.error)
       end
@@ -37,40 +37,40 @@ module Extension
       end
 
       def test_correct_git_template_for_admin_extensions
-        set_of_attributes = build_set_of_specification_attributes(surface_area: 'admin')
+        set_of_attributes = build_set_of_specification_attributes(surface_area: "admin")
         result = ConfigureFeatures.call(set_of_attributes)
         assert_equal(
-          'https://github.com/Shopify/argo-admin-template.git',
+          "https://github.com/Shopify/argo-admin-template.git",
           result.value.dig(0, :features, :argo, :git_template)
         )
       end
 
       def test_correct_renderer_package_name_for_admin_extensions
-        set_of_attributes = build_set_of_specification_attributes(surface_area: 'admin')
+        set_of_attributes = build_set_of_specification_attributes(surface_area: "admin")
         result = ConfigureFeatures.call(set_of_attributes)
-        assert_equal '@shopify/argo-admin', result.value.dig(0, :features, :argo, :renderer_package_name)
+        assert_equal "@shopify/argo-admin", result.value.dig(0, :features, :argo, :renderer_package_name)
       end
 
       def test_correct_git_template_for_checkout_extensions
-        set_of_attributes = build_set_of_specification_attributes(surface_area: 'checkout')
+        set_of_attributes = build_set_of_specification_attributes(surface_area: "checkout")
         result = ConfigureFeatures.call(set_of_attributes)
         assert_equal(
-          'https://github.com/Shopify/argo-checkout-template.git',
+          "https://github.com/Shopify/argo-checkout-template.git",
           result.value.dig(0, :features, :argo, :git_template)
         )
       end
 
       def test_correct_renderer_package_name_for_checkout_extensions
-        set_of_attributes = build_set_of_specification_attributes(surface_area: 'checkout')
+        set_of_attributes = build_set_of_specification_attributes(surface_area: "checkout")
         result = ConfigureFeatures.call(set_of_attributes)
-        assert_equal '@shopify/argo-checkout', result.value.dig(0, :features, :argo, :renderer_package_name)
+        assert_equal "@shopify/argo-checkout", result.value.dig(0, :features, :argo, :renderer_package_name)
       end
 
       private
 
-      def build_set_of_specification_attributes(surface_area: 'admin')
+      def build_set_of_specification_attributes(surface_area: "admin")
         [{
-          identifier: 'test_extension',
+          identifier: "test_extension",
           features: {
             argo: {
               surface_area: surface_area,

--- a/test/project_types/extension/tasks/converters/app_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/app_converter_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Tasks
@@ -13,10 +13,10 @@ module Extension
           super
           ShopifyCli::ProjectType.load_type(:extension)
 
-          @api_key = 'fake_key'
-          @secret = 'fake_secret'
-          @title = 'Fake Title'
-          @organization_name = 'Organization One'
+          @api_key = "fake_key"
+          @secret = "fake_secret"
+          @title = "Fake Title"
+          @organization_name = "Organization One"
         end
 
         def test_from_hash_returns_nil_if_the_hash_is_nil

--- a/test/project_types/extension/tasks/converters/registration_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/registration_converter_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Tasks
@@ -14,9 +14,9 @@ module Extension
           ShopifyCli::ProjectType.load_type(:extension)
 
           @registration_id = 42
-          @fake_type = 'TEST_EXTENSION'
-          @fake_title = 'Fake Title'
-          @fake_extension_context = 'fake_context'
+          @fake_type = "TEST_EXTENSION"
+          @fake_title = "Fake Title"
+          @fake_extension_context = "fake_context"
           @last_user_interaction_at = Time.now.to_s
         end
 
@@ -25,7 +25,7 @@ module Extension
             Converters::RegistrationConverter.from_hash(@context, nil)
           end
 
-          assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+          assert_message_output(io: io, expected_content: @context.message("tasks.errors.parse_error"))
         end
 
         def test_from_hash_parses_registration_from_a_hash

--- a/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Tasks
@@ -24,15 +24,15 @@ module Extension
           end
 
           assert_message_output(io: io, expected_content: [
-            @context.message('tasks.errors.parse_error'),
+            @context.message("tasks.errors.parse_error"),
           ])
         end
 
         def test_from_hash_returns_parsed_validation_errors_if_valid
           fields = %w(config name)
-          message = 'error message'
+          message = "error message"
 
-          errors = [{ 'field' => fields, 'message' => message }]
+          errors = [{ "field" => fields, "message" => message }]
           parsed_validation_errors = ValidationErrorConverter.from_array(@context, errors)
 
           assert_equal 1, parsed_validation_errors.count
@@ -41,12 +41,12 @@ module Extension
         end
 
         def test_from_hash_returns_all_parsed_validation_errors_if_valid
-          message = 'error message'
-          message2 = 'error message 2'
+          message = "error message"
+          message2 = "error message 2"
 
           errors = [
-            { 'field' => %w(field1), 'message' => message },
-            { 'field' => %w(config name), 'message' => message2 },
+            { "field" => %w(field1), "message" => message },
+            { "field" => %w(config name), "message" => message2 },
           ]
           parsed_validation_messages = ValidationErrorConverter.from_array(@context, errors).map(&:message)
 

--- a/test/project_types/extension/tasks/converters/version_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/version_converter_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Tasks
@@ -13,11 +13,11 @@ module Extension
           super
           ShopifyCli::ProjectType.load_type(:extension)
 
-          @api_key = 'FAKE_API_KEY'
+          @api_key = "FAKE_API_KEY"
           @registration_id = 42
           @config = {}
-          @extension_context = 'fake#context'
-          @location = 'https://www.fakeurl.com'
+          @extension_context = "fake#context"
+          @location = "https://www.fakeurl.com"
           @last_user_interaction_at = Time.now.to_s
         end
 
@@ -26,7 +26,7 @@ module Extension
             Converters::VersionConverter.from_hash(@context, nil)
           end
 
-          assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+          assert_message_output(io: io, expected_content: @context.message("tasks.errors.parse_error"))
         end
 
         def test_from_hash_parses_a_version_from_a_hash

--- a/test/project_types/extension/tasks/create_extension_test.rb
+++ b/test/project_types/extension/tasks/create_extension_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Tasks
@@ -14,13 +14,13 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
 
-        @api_key = 'FAKE_API_KEY'
-        @fake_type = 'TEST_EXTENSION'
-        @fake_title = 'Fake Title'
+        @api_key = "FAKE_API_KEY"
+        @fake_type = "TEST_EXTENSION"
+        @fake_title = "Fake Title"
         @fake_config = {
-          field: 'with stuff',
+          field: "with stuff",
         }
-        @fake_extension_context = 'fake_context'
+        @fake_extension_context = "fake_context"
 
         @input = {
           api_key: @api_key,
@@ -60,11 +60,11 @@ module Extension
           )
         end
 
-        assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+        assert_message_output(io: io, expected_content: @context.message("tasks.errors.parse_error"))
       end
 
       def test_aborts_with_errors_if_user_errors_are_returned
-        user_errors = [{ field: ['field'], UserErrors::MESSAGE_FIELD => 'An error occurred on field' }]
+        user_errors = [{ field: ["field"], UserErrors::MESSAGE_FIELD => "An error occurred on field" }]
         stub_create_extension_failure(userErrors: user_errors, **@input)
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) do
@@ -78,7 +78,7 @@ module Extension
           )
         end
 
-        assert_message_output(io: io, expected_content: 'An error occurred on field')
+        assert_message_output(io: io, expected_content: "An error occurred on field")
       end
     end
   end

--- a/test/project_types/extension/tasks/get_app_test.rb
+++ b/test/project_types/extension/tasks/get_app_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Tasks
@@ -13,7 +13,7 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
         setup_temp_project
-        @app = Models::App.new(title: 'App One', api_key: '1234', secret: '5678')
+        @app = Models::App.new(title: "App One", api_key: "1234", secret: "5678")
       end
 
       def test_loads_app_into_a_single_app_model
@@ -21,9 +21,9 @@ module Extension
 
         app = Tasks::GetApp.call(context: @context, api_key: @app.api_key)
 
-        assert_equal 'App One', app.title
-        assert_equal '1234', app.api_key
-        assert_equal '5678', app.secret
+        assert_equal "App One", app.title
+        assert_equal "1234", app.api_key
+        assert_equal "5678", app.secret
       end
 
       def test_returns_nil_if_the_app_was_not_found

--- a/test/project_types/extension/tasks/get_apps_test.rb
+++ b/test/project_types/extension/tasks/get_apps_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Tasks
@@ -11,22 +11,22 @@ module Extension
       def setup
         super
         ShopifyCli::ProjectType.load_type(:extension)
-        @app = Models::App.new(title: 'App One', api_key: '1234', secret: '5678')
+        @app = Models::App.new(title: "App One", api_key: "1234", secret: "5678")
       end
 
       def test_loads_all_apps_into_a_list_from_organizations
         stub_get_organizations([
-          organization(name: 'Organization One', apps: [@app]),
+          organization(name: "Organization One", apps: [@app]),
         ])
 
         app_list = Tasks::GetApps.call(context: @context)
         app = app_list.first
 
         assert_equal 1, app_list.size
-        assert_equal 'Organization One', app.business_name
-        assert_equal 'App One', app.title
-        assert_equal '1234', app.api_key
-        assert_equal '5678', app.secret
+        assert_equal "Organization One", app.business_name
+        assert_equal "App One", app.title
+        assert_equal "1234", app.api_key
+        assert_equal "5678", app.secret
       end
 
       def test_returns_empty_array_if_there_are_no_organizations
@@ -37,7 +37,7 @@ module Extension
 
       def test_returns_empty_array_if_there_are_no_apps
         stub_get_organizations([
-          organization(name: 'Organization One', apps: []),
+          organization(name: "Organization One", apps: []),
         ])
 
         assert_empty(Tasks::GetApps.call(context: @context))
@@ -45,8 +45,8 @@ module Extension
 
       def test_can_handle_multiple_organizations_where_one_has_no_apps
         stub_get_organizations([
-          organization(name: 'Organization One', apps: [@app]),
-          organization(name: 'Organization Two', apps: []),
+          organization(name: "Organization One", apps: [@app]),
+          organization(name: "Organization Two", apps: []),
         ])
 
         assert_equal 1, Tasks::GetApps.call(context: @context).size

--- a/test/project_types/extension/tasks/update_draft_test.rb
+++ b/test/project_types/extension/tasks/update_draft_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'project_types/extension/extension_test_helpers'
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Tasks
@@ -14,11 +14,11 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
 
-        @api_key = 'FAKE_API_KEY'
+        @api_key = "FAKE_API_KEY"
         @registration_id = 42
         @config = {}
-        @extension_context = 'fake#context'
-        @location = 'https://www.fakeurl.com'
+        @extension_context = "fake#context"
+        @location = "https://www.fakeurl.com"
 
         @input = {
           api_key: @api_key,
@@ -56,11 +56,11 @@ module Extension
           )
         end
 
-        assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+        assert_message_output(io: io, expected_content: @context.message("tasks.errors.parse_error"))
       end
 
       def test_aborts_with_errors_if_user_errors_are_returned
-        user_errors = [{ field: ['field'], UserErrors::MESSAGE_FIELD => 'An error occurred on field' }]
+        user_errors = [{ field: ["field"], UserErrors::MESSAGE_FIELD => "An error occurred on field" }]
         stub_update_draft_failure(errors: user_errors, **@input)
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) do
@@ -73,7 +73,7 @@ module Extension
           )
         end
 
-        assert_message_output(io: io, expected_content: 'An error occurred on field')
+        assert_message_output(io: io, expected_content: "An error occurred on field")
       end
     end
   end

--- a/test/project_types/extension/tasks/user_errors_test.rb
+++ b/test/project_types/extension/tasks/user_errors_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module Extension
   module Tasks
@@ -25,21 +25,21 @@ module Extension
       def test_aborts_with_message_if_only_one_user_error_present
         fake_response = {
           UserErrors::USER_ERRORS_FIELD => [
-            { field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.' },
+            { field: ["field"], UserErrors::MESSAGE_FIELD => "An error has occurred." },
           ],
         }
 
-        @context.expects(:abort).with('An error has occurred.').once
+        @context.expects(:abort).with("An error has occurred.").once
         @test_user_errors.abort_if_user_errors(@context, fake_response)
       end
 
       def test_no_matter_how_many_errors_only_last_error_calls_abort
-        fake_errors = Array.new(6, { field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.' })
-        fake_errors << { field: ['field2'], UserErrors::MESSAGE_FIELD => 'Last error abort.' }
+        fake_errors = Array.new(6, { field: ["field"], UserErrors::MESSAGE_FIELD => "An error has occurred." })
+        fake_errors << { field: ["field2"], UserErrors::MESSAGE_FIELD => "Last error abort." }
         fake_response = { UserErrors::USER_ERRORS_FIELD => fake_errors }
 
-        @context.expects(:puts).with('{{x}} An error has occurred.').times(6)
-        @context.expects(:abort).with('Last error abort.').once
+        @context.expects(:puts).with("{{x}} An error has occurred.").times(6)
+        @context.expects(:abort).with("Last error abort.").once
 
         @test_user_errors.abort_if_user_errors(@context, fake_response)
       end
@@ -47,7 +47,7 @@ module Extension
       def test_aborts_with_parse_error_message_if_user_errors_parsing_fails
         fake_response = {
           UserErrors::USER_ERRORS_FIELD => [
-            { field: ['field'], wrong_message_field: 'An error has occurred.' },
+            { field: ["field"], wrong_message_field: "An error has occurred." },
           ],
         }
 

--- a/test/project_types/node/commands/connect_test.rb
+++ b/test/project_types/node/commands/connect_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
@@ -12,10 +12,10 @@ module Node
 
         ShopifyCli::Project.stubs(:has_current?).returns(false)
         ShopifyCli::Commands::Connect.any_instance.expects(:default_connect)
-          .with('node')
-          .returns('node-app')
+          .with("node")
+          .returns("node-app")
         context.expects(:done)
-          .with(context.message('node.connect.connected', 'node-app'))
+          .with(context.message("node.connect.connected", "node-app"))
 
         Node::Commands::Connect.new(context).call
       end
@@ -24,12 +24,12 @@ module Node
         context = ShopifyCli::Context.new
 
         context.expects(:puts)
-          .with(context.message('node.connect.production_warning'))
+          .with(context.message("node.connect.production_warning"))
         ShopifyCli::Commands::Connect.any_instance.expects(:default_connect)
-          .with('node')
-          .returns('node-app')
+          .with("node")
+          .returns("node-app")
         context.expects(:done)
-          .with(context.message('node.connect.connected', 'node-app'))
+          .with(context.message("node.connect.connected", "node-app"))
 
         Node::Commands::Connect.new(context).call
       end

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
-require 'semantic/semantic'
+require "project_types/node/test_helper"
+require "semantic/semantic"
 
 module Node
   module Commands
@@ -22,40 +22,40 @@ module Node
       APPTYPE
 
       def test_prints_help_with_no_name_argument
-        io = capture_io { run_cmd('create node --help') }
+        io = capture_io { run_cmd("create node --help") }
         assert_match(CLI::UI.fmt(Node::Commands::Create.help), io.join)
       end
 
       def test_check_node_installed
-        @context.expects(:which).with('node').returns(nil)
-        assert_raises ShopifyCli::Abort, 'node.create.error.node_required' do
+        @context.expects(:which).with("node").returns(nil)
+        assert_raises ShopifyCli::Abort, "node.create.error.node_required" do
           perform_command
         end
       end
 
       def test_check_get_node_version
-        @context.expects(:which).with('node').returns('/usr/bin/node')
-        @context.expects(:capture2e).with('node', '-v').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, 'node.create.error.node_version_failure' do
+        @context.expects(:which).with("node").returns("/usr/bin/node")
+        @context.expects(:capture2e).with("node", "-v").returns([nil, mock(success?: false)])
+        assert_raises ShopifyCli::Abort, "node.create.error.node_version_failure" do
           perform_command
         end
       end
 
       def test_check_npm_installed
-        @context.expects(:which).with('node').returns('/usr/bin/node')
-        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
-        @context.expects(:which).with('npm').returns(nil)
-        assert_raises ShopifyCli::Abort, 'node.create.error.npm_required' do
+        @context.expects(:which).with("node").returns("/usr/bin/node")
+        @context.expects(:capture2e).with("node", "-v").returns(["8.0.0", mock(success?: true)])
+        @context.expects(:which).with("npm").returns(nil)
+        assert_raises ShopifyCli::Abort, "node.create.error.npm_required" do
           perform_command
         end
       end
 
       def test_check_get_npm_version
-        @context.expects(:which).with('node').returns('/usr/bin/node')
-        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
-        @context.expects(:which).with('npm').returns('/usr/bin/npm')
-        @context.expects(:capture2e).with('npm', '-v').returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, 'node.create.error.npm_version_failure' do
+        @context.expects(:which).with("node").returns("/usr/bin/node")
+        @context.expects(:capture2e).with("node", "-v").returns(["8.0.0", mock(success?: true)])
+        @context.expects(:which).with("npm").returns("/usr/bin/npm")
+        @context.expects(:capture2e).with("npm", "-v").returns([nil, mock(success?: false)])
+        assert_raises ShopifyCli::Abort, "node.create.error.npm_version_failure" do
           perform_command
         end
       end
@@ -64,10 +64,10 @@ module Node
         create_test_app_directory_structure
 
         expect_node_npm_check_commands
-        @context.expects(:capture2).with('npm config get @shopify:registry').returns(
-          ['https://registry.yarnpkg.com', nil]
+        @context.expects(:capture2).with("npm config get @shopify:registry").returns(
+          ["https://registry.yarnpkg.com", nil]
         )
-        ShopifyCli::Git.expects(:clone).with('https://github.com/Shopify/shopify-app-node.git', 'test-app')
+        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
         ShopifyCli::JsDeps.expects(:install)
         ShopifyCli::Tasks::CreateApiClient.stubs(:call).returns({
           "apiKey" => "ljdlkajfaljf",
@@ -79,28 +79,28 @@ module Node
         perform_command
 
         refute File.exist?("test-app/.npmrc")
-        FileUtils.rm_r('test-app')
+        FileUtils.rm_r("test-app")
       end
 
       def test_check_default_npm_registry_is_not_production
         create_test_app_directory_structure
 
         expect_node_npm_check_commands
-        @context.expects(:capture2).with('npm config get @shopify:registry').returns(
-          ['https://badregistry.com', nil]
+        @context.expects(:capture2).with("npm config get @shopify:registry").returns(
+          ["https://badregistry.com", nil]
         )
         @context.expects(:system).with(
-          'npm',
-          '--userconfig',
-          './.npmrc',
-          'config',
-          'set',
-          '@shopify:registry',
-          'https://registry.yarnpkg.com',
-          chdir: @context.root + '/test-app'
+          "npm",
+          "--userconfig",
+          "./.npmrc",
+          "config",
+          "set",
+          "@shopify:registry",
+          "https://registry.yarnpkg.com",
+          chdir: @context.root + "/test-app"
         )
 
-        ShopifyCli::Git.expects(:clone).with('https://github.com/Shopify/shopify-app-node.git', 'test-app')
+        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
         ShopifyCli::JsDeps.expects(:install)
         ShopifyCli::Tasks::CreateApiClient.stubs(:call).returns({
           "apiKey" => "ljdlkajfaljf",
@@ -111,26 +111,26 @@ module Node
 
         perform_command
 
-        FileUtils.rm_r('test-app')
+        FileUtils.rm_r("test-app")
       end
 
       def test_can_create_new_app
         create_test_app_directory_structure
 
-        @context.stubs(:uname).returns('Mac')
+        @context.stubs(:uname).returns("Mac")
         expect_node_npm_check_commands
-        @context.expects(:capture2).with('npm config get @shopify:registry').returns(
-          ['https://registry.yarnpkg.com', nil]
+        @context.expects(:capture2).with("npm config get @shopify:registry").returns(
+          ["https://registry.yarnpkg.com", nil]
         )
-        ShopifyCli::Git.expects(:clone).with('https://github.com/Shopify/shopify-app-node.git', 'test-app')
+        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
         ShopifyCli::JsDeps.expects(:install)
 
         stub_partner_req(
-          'create_app',
+          "create_app",
           variables: {
             org: 42,
-            title: 'test-app',
-            type: 'public',
+            title: "test-app",
+            type: "public",
             app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
@@ -138,8 +138,8 @@ module Node
             'data': {
               'appCreate': {
                 'app': {
-                  'apiKey': 'newapikey',
-                  'apiSecretKeys': [{ 'secret': 'secret' }],
+                  'apiKey': "newapikey",
+                  'apiSecretKeys': [{ 'secret': "secret" }],
                 },
               },
             },
@@ -153,39 +153,39 @@ module Node
         refute File.exist?("test-app/.npmrc")
         refute File.exist?("test-app/.git")
         refute File.exist?("test-app/.github")
-        refute File.exist?('test-app/server/handlers/client.cli.js')
-        assert File.exist?('test-app/server/handlers/client.js')
+        refute File.exist?("test-app/server/handlers/client.cli.js")
+        assert File.exist?("test-app/server/handlers/client.js")
 
-        FileUtils.rm_r('test-app')
+        FileUtils.rm_r("test-app")
       end
 
       def test_can_create_new_app_registry_not_found
         create_test_app_directory_structure
 
-        @context.stubs(:uname).returns('Mac')
+        @context.stubs(:uname).returns("Mac")
         expect_node_npm_check_commands
-        @context.expects(:capture2).with('npm config get @shopify:registry').returns(
-          ['https://badregistry.com', nil]
+        @context.expects(:capture2).with("npm config get @shopify:registry").returns(
+          ["https://badregistry.com", nil]
         )
-        ShopifyCli::Git.expects(:clone).with('https://github.com/Shopify/shopify-app-node.git', 'test-app')
+        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
         @context.expects(:system).with(
-          'npm',
-          '--userconfig',
-          './.npmrc',
-          'config',
-          'set',
-          '@shopify:registry',
-          'https://registry.yarnpkg.com',
-          chdir: @context.root + '/test-app'
+          "npm",
+          "--userconfig",
+          "./.npmrc",
+          "config",
+          "set",
+          "@shopify:registry",
+          "https://registry.yarnpkg.com",
+          chdir: @context.root + "/test-app"
         )
         ShopifyCli::JsDeps.expects(:install)
 
         stub_partner_req(
-          'create_app',
+          "create_app",
           variables: {
             org: 42,
-            title: 'test-app',
-            type: 'public',
+            title: "test-app",
+            type: "public",
             app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
@@ -193,8 +193,8 @@ module Node
             'data': {
               'appCreate': {
                 'app': {
-                  'apiKey': 'newapikey',
-                  'apiSecretKeys': [{ 'secret': 'secret' }],
+                  'apiKey': "newapikey",
+                  'apiSecretKeys': [{ 'secret': "secret" }],
                 },
               },
             },
@@ -207,10 +207,10 @@ module Node
         assert_equal ENV_FILE, File.read("test-app/.env")
         refute File.exist?("test-app/.git")
         refute File.exist?("test-app/.github")
-        refute File.exist?('test-app/server/handlers/client.cli.js')
-        assert File.exist?('test-app/server/handlers/client.js')
+        refute File.exist?("test-app/server/handlers/client.cli.js")
+        assert File.exist?("test-app/server/handlers/client.js")
 
-        FileUtils.rm_r('test-app')
+        FileUtils.rm_r("test-app")
       end
 
       private
@@ -232,19 +232,19 @@ module Node
       end
 
       def expect_node_npm_check_commands
-        @context.expects(:which).with('node').returns('/usr/bin/node')
-        @context.expects(:capture2e).with('node', '-v').returns(['8.0.0', mock(success?: true)])
-        @context.expects(:which).with('npm').returns('/usr/bin/npm')
-        @context.expects(:capture2e).with('npm', '-v').returns(['1', mock(success?: true)])
+        @context.expects(:which).with("node").returns("/usr/bin/node")
+        @context.expects(:capture2e).with("node", "-v").returns(["8.0.0", mock(success?: true)])
+        @context.expects(:which).with("npm").returns("/usr/bin/npm")
+        @context.expects(:capture2e).with("npm", "-v").returns(["1", mock(success?: true)])
       end
 
       def create_test_app_directory_structure
-        FileUtils.mkdir_p('test-app')
-        FileUtils.mkdir_p('test-app/server/handlers')
-        FileUtils.touch('test-app/.git')
-        FileUtils.touch('test-app/.github')
-        FileUtils.touch('test-app/server/handlers/client.js')
-        FileUtils.touch('test-app/server/handlers/client.cli.js')
+        FileUtils.mkdir_p("test-app")
+        FileUtils.mkdir_p("test-app/server/handlers")
+        FileUtils.touch("test-app/.git")
+        FileUtils.touch("test-app/.github")
+        FileUtils.touch("test-app/server/handlers/client.js")
+        FileUtils.touch("test-app/server/handlers/client.cli.js")
       end
     end
   end

--- a/test/project_types/node/commands/deploy/heroku_test.rb
+++ b/test/project_types/node/commands/deploy/heroku_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
@@ -11,7 +11,7 @@ module Node
         def setup
           super
           File.stubs(:exist?)
-          File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, 'lib', 'project_types', 'node', 'cli.rb')).returns(true)
+          File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, "lib", "project_types", "node", "cli.rb")).returns(true)
           ShopifyCli::Context.any_instance.stubs(:os).returns(:mac)
           stub_successful_heroku_flow
         end
@@ -92,7 +92,7 @@ module Node
         def test_call_uses_existing_heroku_auth_if_available
           expects_heroku_whoami(status: true)
 
-          @context.expects(:puts).with(@context.message('node.deploy.heroku.authenticated_with_account', 'username'))
+          @context.expects(:puts).with(@context.message("node.deploy.heroku.authenticated_with_account", "username"))
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end
@@ -114,39 +114,39 @@ module Node
         end
 
         def test_call_uses_existing_heroku_app_if_available
-          expects_git_remote_get_url_heroku(status: true, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: true, remote: "heroku")
 
-          @context.expects(:puts).with(@context.message('node.deploy.heroku.app.selected', 'app-name'))
+          @context.expects(:puts).with(@context.message("node.deploy.heroku.app.selected", "app-name"))
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_lets_you_choose_existing_heroku_app
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
           expects_heroku_select_app(status: true)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('node.deploy.heroku.app.no_apps_found'))
+            .with(@context.message("node.deploy.heroku.app.no_apps_found"))
             .returns(:existing)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('node.deploy.heroku.app.name'))
-            .returns('app-name')
+            .with(@context.message("node.deploy.heroku.app.name"))
+            .returns("app-name")
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_choosing_existing_heroku_app_fails
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
           expects_heroku_select_app(status: false)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('node.deploy.heroku.app.no_apps_found'))
+            .with(@context.message("node.deploy.heroku.app.no_apps_found"))
             .returns(:existing)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('node.deploy.heroku.app.name'))
-            .returns('app-name')
+            .with(@context.message("node.deploy.heroku.app.name"))
+            .returns("app-name")
 
           assert_raises ShopifyCli::Abort do
             Node::Commands::Deploy::Heroku.new(@context).call
@@ -154,22 +154,22 @@ module Node
         end
 
         def test_call_lets_you_create_new_heroku_app
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
           expects_heroku_create(status: true)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('node.deploy.heroku.app.no_apps_found'))
+            .with(@context.message("node.deploy.heroku.app.no_apps_found"))
             .returns(:new)
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_creating_new_heroku_app_fails
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
           expects_heroku_create(status: false)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('node.deploy.heroku.app.no_apps_found'))
+            .with(@context.message("node.deploy.heroku.app.no_apps_found"))
             .returns(:new)
 
           assert_raises ShopifyCli::Abort do
@@ -180,7 +180,7 @@ module Node
         def test_call_doesnt_prompt_if_only_one_branch_exists
           expects_git_branch(status: true, multiple: false)
 
-          @context.expects(:puts).with(@context.message('node.deploy.heroku.git.branch_selected', 'master'))
+          @context.expects(:puts).with(@context.message("node.deploy.heroku.git.branch_selected", "master"))
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end
@@ -190,8 +190,8 @@ module Node
           expects_git_push_heroku(status: true, branch: "other_branch:master")
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('node.deploy.heroku.git.what_branch'))
-            .returns('other_branch')
+            .with(@context.message("node.deploy.heroku.git.what_branch"))
+            .returns("other_branch")
 
           Node::Commands::Deploy::Heroku.new(@context).call
         end

--- a/test/project_types/node/commands/deploy_test.rb
+++ b/test/project_types/node/commands/deploy_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands

--- a/test/project_types/node/commands/generate_test.rb
+++ b/test/project_types/node/commands/generate_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands

--- a/test/project_types/node/commands/open_test.rb
+++ b/test/project_types/node/commands/open_test.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
     class OpenTest < MiniTest::Test
       def setup
         super
-        project_context('app_types', 'node')
+        project_context("app_types", "node")
         @context.stubs(:system)
       end
 
       def test_run
-        @context.expects(:open_url!).with('https://example.com/auth?shop=my-test-shop.myshopify.com')
+        @context.expects(:open_url!).with("https://example.com/auth?shop=my-test-shop.myshopify.com")
         Node::Commands::Open.new(@context).call
       end
     end

--- a/test/project_types/node/commands/populate/customer_test.rb
+++ b/test/project_types/node/commands/populate/customer_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
@@ -8,20 +8,20 @@ module Node
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.stubs(:name).returns(['first', 'last'])
+          ShopifyCli::Helpers::Haikunator.stubs(:name).returns(["first", "last"])
           ShopifyCli::AdminAPI.expects(:query)
-            .with(@context, 'create_customer', shop: 'my-test-shop.myshopify.com', input: {
-              firstName: 'first',
-              lastName: 'last',
+            .with(@context, "create_customer", shop: "my-test-shop.myshopify.com", input: {
+              firstName: "first",
+              lastName: "last",
             })
-            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/customer_data.json'))))
+            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/customer_data.json"))))
           ShopifyCli::API.expects(:gid_to_id).returns(12345678)
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns('1.00')
+          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
           @context.expects(:done).with(
             "first last added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/customers/12345678}}"
           )
-          run_cmd('populate customers -c 1')
+          run_cmd("populate customers -c 1")
         end
       end
     end

--- a/test/project_types/node/commands/populate/draft_order_test.rb
+++ b/test/project_types/node/commands/populate/draft_order_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
@@ -9,24 +9,24 @@ module Node
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.stubs(:title).returns('fake order')
+          ShopifyCli::Helpers::Haikunator.stubs(:title).returns("fake order")
           ShopifyCli::AdminAPI.expects(:query)
-            .with(@context, 'create_draft_order', shop: 'my-test-shop.myshopify.com', input: {
+            .with(@context, "create_draft_order", shop: "my-test-shop.myshopify.com", input: {
               lineItems: [{
                 originalUnitPrice: "1.00",
                 quantity: 1,
-                weight: { value: 10, unit: 'GRAMS' },
-                title: 'fake order',
+                weight: { value: 10, unit: "GRAMS" },
+                title: "fake order",
               }],
             })
-            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/draft_order_data.json'))))
+            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/draft_order_data.json"))))
           ShopifyCli::API.expects(:gid_to_id).returns(12345678)
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns('1.00')
+          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
           @context.expects(:done).with(
             "DraftOrder added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/draft_orders/12345678}}"
           )
-          run_cmd('populate draftorders -c 1')
+          run_cmd("populate draftorders -c 1")
         end
       end
     end

--- a/test/project_types/node/commands/populate/product_test.rb
+++ b/test/project_types/node/commands/populate/product_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
@@ -8,20 +8,20 @@ module Node
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.expects(:title).returns('fake product')
-          ShopifyCli::Helpers::Haikunator.expects(:title).returns('fake producttwo')
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns('1.00')
-          return_data = JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/product_data.json')))
+          ShopifyCli::Helpers::Haikunator.expects(:title).returns("fake product")
+          ShopifyCli::Helpers::Haikunator.expects(:title).returns("fake producttwo")
+          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
+          return_data = JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/product_data.json")))
           ShopifyCli::AdminAPI.expects(:query)
-            .with(@context, 'create_product', shop: 'my-test-shop.myshopify.com', input: {
-              'title': 'fake product',
-              variants: [{ price: '1.00' }],
+            .with(@context, "create_product", shop: "my-test-shop.myshopify.com", input: {
+              'title': "fake product",
+              variants: [{ price: "1.00" }],
             })
             .returns(return_data)
           ShopifyCli::AdminAPI.expects(:query)
-            .with(@context, 'create_product', shop: 'my-test-shop.myshopify.com', input: {
-              'title': 'fake producttwo',
-              variants: [{ price: '1.00' }],
+            .with(@context, "create_product", shop: "my-test-shop.myshopify.com", input: {
+              'title': "fake producttwo",
+              variants: [{ price: "1.00" }],
             })
             .returns(return_data)
           ShopifyCli::API.expects(:gid_to_id).returns(12345678).twice
@@ -29,7 +29,7 @@ module Node
             "fake product added to {{green:my-test-shop.myshopify.com}} at" \
             " {{underline:https://my-test-shop.myshopify.com/admin/products/12345678}}"
           ).twice
-          run_cmd('populate products -c 2')
+          run_cmd("populate products -c 2")
         end
       end
     end

--- a/test/project_types/node/commands/populate_test.rb
+++ b/test/project_types/node/commands/populate_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
@@ -7,12 +7,12 @@ module Node
       def setup
         super
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
-        project_context('app_types', 'node')
+        project_context("app_types", "node")
       end
 
       def test_without_arguments_calls_help
         @context.expects(:puts).with(Node::Commands::Populate.help)
-        run_cmd('populate')
+        run_cmd("populate")
       end
     end
   end

--- a/test/project_types/node/commands/serve_test.rb
+++ b/test/project_types/node/commands/serve_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
@@ -8,17 +8,17 @@ module Node
 
       def setup
         super
-        project_context('app_types', 'node')
+        project_context("app_types", "node")
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
         @context.stubs(:system)
       end
 
       def test_server_command
-        ShopifyCli::Tunnel.stubs(:start).returns('https://example.com')
+        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update)
         @context.expects(:system).with(
-          'npm run dev',
+          "npm run dev",
           env: {
             "SHOPIFY_API_KEY" => "mykey",
             "SHOPIFY_API_SECRET" => "mysecretkey",
@@ -28,15 +28,15 @@ module Node
             "PORT" => "8081",
           }
         )
-        run_cmd('serve')
+        run_cmd("serve")
       end
 
       def test_server_command_with_invalid_host_url
-        ShopifyCli::Tunnel.stubs(:start).returns('garbage://example.com')
+        ShopifyCli::Tunnel.stubs(:start).returns("garbage://example.com")
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call).never
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).never
         @context.expects(:system).with(
-          'npm run dev',
+          "npm run dev",
           env: {
             "SHOPIFY_API_KEY" => "mykey",
             "SHOPIFY_API_SECRET" => "mysecretkey",
@@ -48,29 +48,29 @@ module Node
         ).never
 
         assert_raises ShopifyCli::Abort do
-          run_cmd('serve')
+          run_cmd("serve")
         end
       end
 
       def test_open_while_run
-        ShopifyCli::Tunnel.stubs(:start).returns('https://example.com')
+        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
-          @context, :host, 'https://example.com'
+          @context, :host, "https://example.com"
         )
         @context.expects(:puts).with(
           "\n" +
-          @context.message('node.serve.open_info', 'https://example.com/auth?shop=my-test-shop.myshopify.com') +
+          @context.message("node.serve.open_info", "https://example.com/auth?shop=my-test-shop.myshopify.com") +
           "\n"
         )
-        run_cmd('serve')
+        run_cmd("serve")
       end
 
       def test_update_env_with_host
         ShopifyCli::Tunnel.expects(:start).never
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
-          @context, :host, 'https://example-foo.com'
+          @context, :host, "https://example-foo.com"
         )
         run_cmd('serve --host="https://example-foo.com"')
       end

--- a/test/project_types/node/commands/tunnel_test.rb
+++ b/test/project_types/node/commands/tunnel_test.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module Node
   module Commands
     class TunnelTest < MiniTest::Test
       def test_auth
         ShopifyCli::Tunnel.any_instance.expects(:auth)
-        run_cmd('tunnel auth adfhauf98q7rtqhfkajf')
+        run_cmd("tunnel auth adfhauf98q7rtqhfkajf")
       end
 
       def test_auth_no_token
         ShopifyCli::Tunnel.any_instance.expects(:auth).never
-        run_cmd('tunnel auth')
+        run_cmd("tunnel auth")
       end
 
       def test_start
         ShopifyCli::Tunnel.any_instance.expects(:start)
-        run_cmd('tunnel start')
+        run_cmd("tunnel start")
       end
 
       def test_stop
         ShopifyCli::Tunnel.any_instance.expects(:stop)
-        run_cmd('tunnel stop')
+        run_cmd("tunnel stop")
       end
     end
   end

--- a/test/project_types/node/forms/create_test.rb
+++ b/test/project_types/node/forms/create_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Node
   module Forms
@@ -15,21 +15,21 @@ module Node
 
       def test_returns_all_defined_attributes_if_valid
         form = ask
-        assert_equal('test_app', form.name)
-        assert_equal('Test App', form.title)
+        assert_equal("test_app", form.name)
+        assert_equal("Test App", form.title)
         assert_equal(42, form.organization_id)
-        assert_equal('shop.myshopify.com', form.shop_domain)
+        assert_equal("shop.myshopify.com", form.shop_domain)
       end
 
       def test_title_can_be_provided_by_flag
-        form = ask(title: 'My New App')
-        assert_equal('my_new_app', form.name)
-        assert_equal('My New App', form.title)
+        form = ask(title: "My New App")
+        assert_equal("my_new_app", form.name)
+        assert_equal("My New App", form.title)
       end
 
       def test_type_can_be_provided_by_flag
-        form = ask(type: 'public')
-        assert_equal('public', form.type)
+        form = ask(type: "public")
+        assert_equal("public", form.type)
       end
 
       def test_type_is_validated
@@ -37,17 +37,17 @@ module Node
           form = ask(type: "not_a_type")
           assert_nil(form)
         end
-        assert_match(@context.message('node.forms.create.error.invalid_app_type', 'not_a_type'), io.join)
+        assert_match(@context.message("node.forms.create.error.invalid_app_type", "not_a_type"), io.join)
       end
 
       def test_type_is_prompted
-        CLI::UI::Prompt.expects(:ask).with(@context.message('node.forms.create.app_type.select')).returns('public')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("node.forms.create.app_type.select")).returns("public")
         ask(type: nil)
       end
 
       def test_user_will_be_prompted_if_more_than_one_organization
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: {
             data: {
               organizations: {
@@ -55,15 +55,15 @@ module Node
                   {
                     'id': 421,
                     'businessName': "one",
-                    'stores': { 'nodes': [{ 'shopDomain': 'store.myshopify.com' }] },
+                    'stores': { 'nodes': [{ 'shopDomain': "store.myshopify.com" }] },
                   },
                   {
                     'id': 431,
                     'businessName': "two",
                     'stores': {
                       'nodes': [
-                        { 'shopDomain': 'other.myshopify.com', 'transferDisabled': true },
-                        { 'shopDomain': 'yet-another.myshopify.com' },
+                        { 'shopDomain': "other.myshopify.com", 'transferDisabled': true },
+                        { 'shopDomain': "yet-another.myshopify.com" },
                       ],
                     },
                   },
@@ -75,19 +75,19 @@ module Node
         CLI::UI::Prompt.expects(:ask).returns(431)
         form = ask(org_id: nil, shop: nil)
         assert_equal(431, form.organization_id)
-        assert_equal('other.myshopify.com', form.shop_domain)
+        assert_equal("other.myshopify.com", form.shop_domain)
       end
 
       def test_will_auto_pick_with_only_one_org
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: {
             data: {
               organizations: {
                 nodes: [{
                   'id': 421,
                   'businessName': "hoopy froods",
-                  'stores': { 'nodes': [{ 'shopDomain': 'next.myshopify.com', 'transferDisabled': true }] },
+                  'stores': { 'nodes': [{ 'shopDomain': "next.myshopify.com", 'transferDisabled': true }] },
                 }],
               },
             },
@@ -96,17 +96,17 @@ module Node
         io = capture_io do
           form = ask(org_id: nil, shop: nil)
           assert_equal(421, form.organization_id)
-          assert_equal('next.myshopify.com', form.shop_domain)
+          assert_equal("next.myshopify.com", form.shop_domain)
         end
         assert_match(
-          CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.organization', 'hoopy froods', 421)),
+          CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.organization", "hoopy froods", 421)),
           io.join,
         )
       end
 
       def test_organization_will_be_fetched_if_id_is_provided_but_not_shop
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 123 },
           resp: {
             data: {
@@ -114,7 +114,7 @@ module Node
                 nodes: [
                   {
                     id: 123,
-                    stores: { nodes: [{ shopDomain: 'shopdomain.myshopify.com', 'transferDisabled': true }] },
+                    stores: { nodes: [{ shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true }] },
                   },
                 ],
               },
@@ -123,12 +123,12 @@ module Node
         )
         form = ask(org_id: 123, shop: nil)
         assert_equal(123, form.organization_id)
-        assert_equal('shopdomain.myshopify.com', form.shop_domain)
+        assert_equal("shopdomain.myshopify.com", form.shop_domain)
       end
 
       def test_it_will_fail_if_no_orgs_are_available
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: { data: { organizations: { nodes: [] } } },
         )
 
@@ -136,13 +136,13 @@ module Node
           form = ask(org_id: nil, shop: nil)
           assert_nil(form)
         end
-        assert_match(@context.message('core.tasks.select_org_and_shop.error.partners_notice'), io.join)
-        assert_match(@context.message('core.tasks.select_org_and_shop.error.no_organizations'), io.join)
+        assert_match(@context.message("core.tasks.select_org_and_shop.error.partners_notice"), io.join)
+        assert_match(@context.message("core.tasks.select_org_and_shop.error.no_organizations"), io.join)
       end
 
       def test_returns_no_shop_if_none_are_available
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 123 },
           resp: {
             data: {
@@ -158,13 +158,13 @@ module Node
           assert_nil form.shop_domain
         end
         log = io.join
-        assert_match(CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.error.no_development_stores')), log)
-        assert_match(CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.create_store', 123)), log)
+        assert_match(CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.error.no_development_stores")), log)
+        assert_match(CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.create_store", 123)), log)
       end
 
       def test_autopicks_only_shop
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 123 },
           resp: {
             data: {
@@ -172,7 +172,7 @@ module Node
                 nodes: [
                   {
                     id: 123,
-                    stores: { nodes: [{ shopDomain: 'shopdomain.myshopify.com', 'transferDisabled': true }] },
+                    stores: { nodes: [{ shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true }] },
                   },
                 ],
               },
@@ -181,16 +181,16 @@ module Node
         )
         io = capture_io do
           form = ask(org_id: 123, shop: nil)
-          assert_equal('shopdomain.myshopify.com', form.shop_domain)
+          assert_equal("shopdomain.myshopify.com", form.shop_domain)
         end
         assert_match(CLI::UI.fmt(
-          @context.message('core.tasks.select_org_and_shop.development_store', 'shopdomain.myshopify.com')
+          @context.message("core.tasks.select_org_and_shop.development_store", "shopdomain.myshopify.com")
         ), io.join)
       end
 
       def test_prompts_user_to_pick_from_shops
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 123 },
           resp: {
             data: {
@@ -199,9 +199,9 @@ module Node
                   {
                     id: 123,
                     stores: { nodes: [
-                      { shopDomain: 'shopdomain.myshopify.com', 'transferDisabled': true },
-                      { shopDomain: 'shop.myshopify.com', 'convertableToPartnerTest': true },
-                      { shopDomain: 'other.myshopify.com' },
+                      { shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true },
+                      { shopDomain: "shop.myshopify.com", 'convertableToPartnerTest': true },
+                      { shopDomain: "other.myshopify.com" },
                     ] },
                   },
                 ],
@@ -212,17 +212,17 @@ module Node
 
         CLI::UI::Prompt.expects(:ask)
           .with(
-            @context.message('core.tasks.select_org_and_shop.development_store_select'),
+            @context.message("core.tasks.select_org_and_shop.development_store_select"),
             options: %w(shopdomain.myshopify.com shop.myshopify.com)
           )
-          .returns('selected')
+          .returns("selected")
         form = ask(org_id: 123, shop: nil)
-        assert_equal('selected', form.shop_domain)
+        assert_equal("selected", form.shop_domain)
       end
 
       private
 
-      def ask(title: 'Test App', org_id: 42, shop: 'shop.myshopify.com', type: 'custom')
+      def ask(title: "Test App", org_id: 42, shop: "shop.myshopify.com", type: "custom")
         Create.ask(
           @context,
           [],

--- a/test/project_types/rails/commands/connect_test.rb
+++ b/test/project_types/rails/commands/connect_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -12,10 +12,10 @@ module Rails
 
         ShopifyCli::Project.expects(:has_current?).returns(false)
         ShopifyCli::Commands::Connect.any_instance.expects(:default_connect)
-          .with('rails')
-          .returns('rails-app')
+          .with("rails")
+          .returns("rails-app")
         context.expects(:done)
-          .with(context.message('rails.connect.connected', 'rails-app'))
+          .with(context.message("rails.connect.connected", "rails-app"))
 
         Rails::Commands::Connect.new(context).call
       end
@@ -25,12 +25,12 @@ module Rails
 
         ShopifyCli::Project.stubs(:current_project_type).returns(:rails)
         context.expects(:puts)
-          .with(context.message('rails.connect.production_warning'))
+          .with(context.message("rails.connect.production_warning"))
         ShopifyCli::Commands::Connect.any_instance.expects(:default_connect)
-          .with('rails')
-          .returns('rails-app')
+          .with("rails")
+          .returns("rails-app")
         context.expects(:done)
-          .with(context.message('rails.connect.connected', 'rails-app'))
+          .with(context.message("rails.connect.connected", "rails-app"))
 
         Rails::Commands::Connect.new(context).call
       end

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
-require 'semantic/semantic'
+require "project_types/rails/test_helper"
+require "semantic/semantic"
 
 module Rails
   module Commands
@@ -22,17 +22,17 @@ module Rails
       APPTYPE
 
       def test_prints_help_with_no_name_argument
-        io = capture_io { run_cmd('create rails --help') }
+        io = capture_io { run_cmd("create rails --help") }
         assert_match(CLI::UI.fmt(Rails::Commands::Create.help), io.join)
       end
 
       def test_will_abort_if_bad_ruby
-        Ruby.expects(:version).returns(Semantic::Version.new('2.3.7'))
+        Ruby.expects(:version).returns(Semantic::Version.new("2.3.7"))
         assert_raises ShopifyCli::Abort do
           perform_command
         end
 
-        Ruby.expects(:version).returns(Semantic::Version.new('3.1.0'))
+        Ruby.expects(:version).returns(Semantic::Version.new("3.1.0"))
         assert_raises ShopifyCli::Abort do
           perform_command
         end
@@ -44,27 +44,27 @@ module Rails
         gem_path = create_gem_path_and_binaries
         Gem.stubs(:gem_home).returns(gem_path)
 
-        Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
-        Gem.expects(:install).with(@context, 'rails', '<6.1').returns(true)
-        Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
+        Ruby.expects(:version).returns(Semantic::Version.new("2.5.0"))
+        Gem.expects(:install).with(@context, "rails", "<6.1").returns(true)
+        Gem.expects(:install).with(@context, "bundler", "~>2.0").returns(true)
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails db:create),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails db:migrate RAILS_ENV=development),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails webpacker:install),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
 
         stub_partner_req(
-          'create_app',
+          "create_app",
           variables: {
             org: 42,
-            title: 'test-app',
-            type: 'public',
+            title: "test-app",
+            type: "public",
             app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
@@ -72,8 +72,8 @@ module Rails
             'data': {
               'appCreate': {
                 'app': {
-                  'apiKey': 'newapikey',
-                  'apiSecretKeys': [{ 'secret': 'secret' }],
+                  'apiKey': "newapikey",
+                  'apiSecretKeys': [{ 'secret': "secret" }],
                 },
               },
             },
@@ -87,7 +87,7 @@ module Rails
         assert_equal Create::USER_AGENT_CODE, File.read("test-app/config/initializers/user_agent.rb")
 
         delete_gem_path_and_binaries
-        FileUtils.rm_r('test-app')
+        FileUtils.rm_r("test-app")
       end
 
       def test_can_create_new_app_with_db_flag
@@ -96,27 +96,27 @@ module Rails
         gem_path = create_gem_path_and_binaries
         Gem.stubs(:gem_home).returns(gem_path)
 
-        Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
-        Gem.expects(:install).with(@context, 'rails', '<6.1').returns(true)
-        Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
+        Ruby.expects(:version).returns(Semantic::Version.new("2.5.0"))
+        Gem.expects(:install).with(@context, "rails", "<6.1").returns(true)
+        Gem.expects(:install).with(@context, "bundler", "~>2.0").returns(true)
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=postgresql test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails db:create),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails db:migrate RAILS_ENV=development),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails webpacker:install),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
 
         stub_partner_req(
-          'create_app',
+          "create_app",
           variables: {
             org: 42,
-            title: 'test-app',
-            type: 'public',
+            title: "test-app",
+            type: "public",
             app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
@@ -124,18 +124,18 @@ module Rails
             'data': {
               'appCreate': {
                 'app': {
-                  'apiKey': 'newapikey',
-                  'apiSecretKeys': [{ 'secret': 'secret' }],
+                  'apiKey': "newapikey",
+                  'apiSecretKeys': [{ 'secret': "secret" }],
                 },
               },
             },
           }
         )
 
-        perform_command('--db=postgresql')
+        perform_command("--db=postgresql")
 
         delete_gem_path_and_binaries
-        FileUtils.rm_r('test-app')
+        FileUtils.rm_r("test-app")
       end
 
       def test_can_create_new_app_with_rails_opts_flag
@@ -144,27 +144,27 @@ module Rails
         gem_path = create_gem_path_and_binaries
         Gem.stubs(:gem_home).returns(gem_path)
 
-        Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
-        Gem.expects(:install).with(@context, 'rails', '<6.1').returns(true)
-        Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
+        Ruby.expects(:version).returns(Semantic::Version.new("2.5.0"))
+        Gem.expects(:install).with(@context, "rails", "<6.1").returns(true)
+        Gem.expects(:install).with(@context, "bundler", "~>2.0").returns(true)
         expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 --edge -J test-app))
         expect_command(%W(#{gem_path}/bin/bundle install),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails db:create),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails db:migrate RAILS_ENV=development),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
         expect_command(%W(#{gem_path}/bin/rails webpacker:install),
-          chdir: File.join(@context.root, 'test-app'))
+          chdir: File.join(@context.root, "test-app"))
 
         stub_partner_req(
-          'create_app',
+          "create_app",
           variables: {
             org: 42,
-            title: 'test-app',
-            type: 'public',
+            title: "test-app",
+            type: "public",
             app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
@@ -172,48 +172,48 @@ module Rails
             'data': {
               'appCreate': {
                 'app': {
-                  'apiKey': 'newapikey',
-                  'apiSecretKeys': [{ 'secret': 'secret' }],
+                  'apiKey': "newapikey",
+                  'apiSecretKeys': [{ 'secret': "secret" }],
                 },
               },
             },
           }
         )
 
-        perform_command('--rails-opts=--edge -J')
+        perform_command("--rails-opts=--edge -J")
 
         delete_gem_path_and_binaries
-        FileUtils.rm_r('test-app')
+        FileUtils.rm_r("test-app")
       end
 
       def test_create_fails_if_path_exists
-        FileUtils.mkdir_p('test-app')
-        FileUtils.mkdir_p('test-app/config/initializers')
+        FileUtils.mkdir_p("test-app")
+        FileUtils.mkdir_p("test-app/config/initializers")
 
         gem_path = create_gem_path_and_binaries
         Gem.stubs(:gem_home).returns(gem_path)
 
-        Ruby.expects(:version).returns(Semantic::Version.new('2.5.0'))
-        Gem.expects(:install).with(@context, 'rails', '<6.1').returns(true)
-        Gem.expects(:install).with(@context, 'bundler', '~>2.0').returns(true)
+        Ruby.expects(:version).returns(Semantic::Version.new("2.5.0"))
+        Gem.expects(:install).with(@context, "rails", "<6.1").returns(true)
+        Gem.expects(:install).with(@context, "bundler", "~>2.0").returns(true)
         Dir.stubs(:exist?).returns(true)
 
         exception = assert_raises ShopifyCli::Abort do
           perform_command
         end
         assert_equal(
-          "{{x}} " + @context.message('rails.create.error.dir_exists', 'test-app'),
+          "{{x}} " + @context.message("rails.create.error.dir_exists", "test-app"),
           exception.message
         )
 
         delete_gem_path_and_binaries
-        FileUtils.rm_r('test-app')
+        FileUtils.rm_r("test-app")
       end
 
       private
 
       def expect_command(command, chdir: @context.root)
-        process_status = stub('process_status', success?: true)
+        process_status = stub("process_status", success?: true)
         @context.expects(:system).with(*command, chdir: chdir).returns(process_status)
       end
 
@@ -238,25 +238,25 @@ module Rails
       end
 
       def create_gem_path_and_binaries
-        FileUtils.mkdir_p('gem/path/bin')
-        gem_path = File.expand_path('gem/path')
-        ['bundle', 'rails'].each do |f|
+        FileUtils.mkdir_p("gem/path/bin")
+        gem_path = File.expand_path("gem/path")
+        ["bundle", "rails"].each do |f|
           FileUtils.touch("#{gem_path}/bin/#{f}")
         end
         gem_path
       end
 
       def delete_gem_path_and_binaries
-        FileUtils.rm_r('gem')
+        FileUtils.rm_r("gem")
       end
 
       def create_mock_dirs
-        FileUtils.mkdir_p('test-app')
-        FileUtils.mkdir_p('test-app/config/initializers')
+        FileUtils.mkdir_p("test-app")
+        FileUtils.mkdir_p("test-app/config/initializers")
 
         # The dir needs to exist to simulate the command working, but we don't want to fail on the pre-create check
-        Dir.expects(:exist?).with(File.join(@context.root, 'test-app')).returns(false)
-        Dir.stubs(:exist?).with(File.join(ShopifyCli::ROOT, 'test')).returns(true)
+        Dir.expects(:exist?).with(File.join(@context.root, "test-app")).returns(false)
+        Dir.stubs(:exist?).with(File.join(ShopifyCli::ROOT, "test")).returns(true)
       end
     end
   end

--- a/test/project_types/rails/commands/deploy/heroku_test.rb
+++ b/test/project_types/rails/commands/deploy/heroku_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -11,13 +11,13 @@ module Rails
         def setup
           super
           File.stubs(:exist?)
-          File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, 'lib', 'project_types', 'rails', 'cli.rb')).returns(true)
+          File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, "lib", "project_types", "rails", "cli.rb")).returns(true)
           @context.stubs(:os).returns(:mac)
           stub_successful_heroku_flow
         end
 
         def test_call_raises_if_using_sqlite
-          expects_heroku_db_validated(status: false, db: 'sqlite')
+          expects_heroku_db_validated(status: false, db: "sqlite")
 
           assert_raises ShopifyCli::Abort do
             Rails::Commands::Deploy::Heroku.new(@context).call
@@ -33,7 +33,7 @@ module Rails
         end
 
         def test_call_validates_db_if_not_sqlite
-          expects_heroku_db_validated(status: true, db: 'mysql')
+          expects_heroku_db_validated(status: true, db: "mysql")
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
@@ -116,7 +116,7 @@ module Rails
         def test_call_uses_existing_heroku_auth_if_available
           expects_heroku_whoami(status: true)
 
-          @context.expects(:puts).with(@context.message('rails.deploy.heroku.authenticated_with_account', 'username'))
+          @context.expects(:puts).with(@context.message("rails.deploy.heroku.authenticated_with_account", "username"))
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
@@ -138,39 +138,39 @@ module Rails
         end
 
         def test_call_uses_existing_heroku_app_if_available
-          expects_git_remote_get_url_heroku(status: true, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: true, remote: "heroku")
 
-          @context.expects(:puts).with(@context.message('rails.deploy.heroku.authenticated_with_account', 'username'))
+          @context.expects(:puts).with(@context.message("rails.deploy.heroku.authenticated_with_account", "username"))
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_lets_you_choose_existing_heroku_app
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
           expects_heroku_select_app(status: true)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('rails.deploy.heroku.app.no_apps_found'))
+            .with(@context.message("rails.deploy.heroku.app.no_apps_found"))
             .returns(:existing)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('rails.deploy.heroku.app.name'))
-            .returns('app-name')
+            .with(@context.message("rails.deploy.heroku.app.name"))
+            .returns("app-name")
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_choosing_existing_heroku_app_fails
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
           expects_heroku_select_app(status: false)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('rails.deploy.heroku.app.no_apps_found'))
+            .with(@context.message("rails.deploy.heroku.app.no_apps_found"))
             .returns(:existing)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('rails.deploy.heroku.app.name'))
-            .returns('app-name')
+            .with(@context.message("rails.deploy.heroku.app.name"))
+            .returns("app-name")
 
           assert_raises ShopifyCli::Abort do
             Rails::Commands::Deploy::Heroku.new(@context).call
@@ -178,22 +178,22 @@ module Rails
         end
 
         def test_call_lets_you_create_new_heroku_app
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
           expects_heroku_create(status: true)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('rails.deploy.heroku.app.no_apps_found'))
+            .with(@context.message("rails.deploy.heroku.app.no_apps_found"))
             .returns(:new)
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
 
         def test_call_raises_if_creating_new_heroku_app_fails
-          expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
           expects_heroku_create(status: false)
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('rails.deploy.heroku.app.no_apps_found'))
+            .with(@context.message("rails.deploy.heroku.app.no_apps_found"))
             .returns(:new)
 
           assert_raises ShopifyCli::Abort do
@@ -204,7 +204,7 @@ module Rails
         def test_call_doesnt_prompt_if_only_one_branch_exists
           expects_git_branch(status: true, multiple: false)
 
-          @context.expects(:puts).with(@context.message('rails.deploy.heroku.git.branch_selected', 'master'))
+          @context.expects(:puts).with(@context.message("rails.deploy.heroku.git.branch_selected", "master"))
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end
@@ -214,8 +214,8 @@ module Rails
           expects_git_push_heroku(status: true, branch: "other_branch:master")
 
           CLI::UI::Prompt.expects(:ask)
-            .with(@context.message('rails.deploy.heroku.git.what_branch'))
-            .returns('other_branch')
+            .with(@context.message("rails.deploy.heroku.git.what_branch"))
+            .returns("other_branch")
 
           Rails::Commands::Deploy::Heroku.new(@context).call
         end

--- a/test/project_types/rails/commands/deploy_test.rb
+++ b/test/project_types/rails/commands/deploy_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands

--- a/test/project_types/rails/commands/generate.rb/webhook_test.rb
+++ b/test/project_types/rails/commands/generate.rb/webhook_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -9,23 +9,26 @@ module Rails
         include TestHelpers::Schema
 
         def test_with_existing_param
-          @context.expects(:system).with('bin/rails g shopify_app:add_webhook -t app/uninstalled -a https://example.com/webhooks/app/uninstalled')
-            .returns(mock(success?: true))
-          Rails::Commands::Generate::Webhook.new(@context).call(['APP_UNINSTALLED'], '')
+          @context.expects(:system).with(generate_command("app/uninstalled")).returns(mock(success?: true))
+          Rails::Commands::Generate::Webhook.new(@context).call(["APP_UNINSTALLED"], "")
         end
 
         def test_with_incorrect_param_expects_ask
-          CLI::UI::Prompt.expects(:ask).returns('APP_UNINSTALLED')
-          @context.expects(:system).with('bin/rails g shopify_app:add_webhook -t app/uninstalled -a https://example.com/webhooks/app/uninstalled')
-            .returns(mock(success?: true))
-          Rails::Commands::Generate::Webhook.new(@context).call(['create_webhook_fake'], '')
+          CLI::UI::Prompt.expects(:ask).returns("APP_UNINSTALLED")
+          @context.expects(:system).with(generate_command("app/uninstalled")).returns(mock(success?: true))
+          Rails::Commands::Generate::Webhook.new(@context).call(["create_webhook_fake"], "")
         end
 
         def test_with_selection
-          CLI::UI::Prompt.expects(:ask).returns('PRODUCT_CREATE')
-          @context.expects(:system).with('bin/rails g shopify_app:add_webhook -t product/create -a https://example.com/webhooks/product/create')
-            .returns(mock(success?: true))
-          Rails::Commands::Generate::Webhook.new(@context).call([], '')
+          CLI::UI::Prompt.expects(:ask).returns("PRODUCT_CREATE")
+          @context.expects(:system).with(generate_command("product/create")).returns(mock(success?: true))
+          Rails::Commands::Generate::Webhook.new(@context).call([], "")
+        end
+
+        private
+
+        def generate_command(type)
+          "bin/rails g shopify_app:add_webhook -t #{type} -a https://example.com/webhooks/#{type}"
         end
       end
     end

--- a/test/project_types/rails/commands/generate_test.rb
+++ b/test/project_types/rails/commands/generate_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -16,7 +16,7 @@ module Rails
         ShopifyCli::Context.any_instance.expects(:system).returns(failure)
 
         assert_raises(ShopifyCli::Abort) do
-          Rails::Commands::Generate.run_generate(['script'], 'test-name', @context)
+          Rails::Commands::Generate.run_generate(["script"], "test-name", @context)
         end
       end
     end

--- a/test/project_types/rails/commands/open_test.rb
+++ b/test/project_types/rails/commands/open_test.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
     class OpenTest < MiniTest::Test
       def setup
         super
-        project_context('app_types', 'rails')
+        project_context("app_types", "rails")
         @context.stubs(:system)
       end
 
       def test_run
-        @context.expects(:open_url!).with('https://example.com/login?shop=my-test-shop.myshopify.com')
+        @context.expects(:open_url!).with("https://example.com/login?shop=my-test-shop.myshopify.com")
         Rails::Commands::Open.new(@context).call
       end
     end

--- a/test/project_types/rails/commands/populate/customer_test.rb
+++ b/test/project_types/rails/commands/populate/customer_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -8,20 +8,20 @@ module Rails
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.stubs(:name).returns(['first', 'last'])
+          ShopifyCli::Helpers::Haikunator.stubs(:name).returns(["first", "last"])
           ShopifyCli::AdminAPI.expects(:query)
-            .with(@context, 'create_customer', shop: 'my-test-shop.myshopify.com', input: {
-              firstName: 'first',
-              lastName: 'last',
+            .with(@context, "create_customer", shop: "my-test-shop.myshopify.com", input: {
+              firstName: "first",
+              lastName: "last",
             })
-            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/customer_data.json'))))
+            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/customer_data.json"))))
           ShopifyCli::API.expects(:gid_to_id).returns(12345678)
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns('1.00')
+          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
           @context.expects(:done).with(
             "first last added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/customers/12345678}}"
           )
-          run_cmd('populate customers -c 1')
+          run_cmd("populate customers -c 1")
         end
       end
     end

--- a/test/project_types/rails/commands/populate/draft_order_test.rb
+++ b/test/project_types/rails/commands/populate/draft_order_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -9,24 +9,24 @@ module Rails
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.stubs(:title).returns('fake order')
+          ShopifyCli::Helpers::Haikunator.stubs(:title).returns("fake order")
           ShopifyCli::AdminAPI.expects(:query)
-            .with(@context, 'create_draft_order', shop: 'my-test-shop.myshopify.com', input: {
+            .with(@context, "create_draft_order", shop: "my-test-shop.myshopify.com", input: {
               lineItems: [{
                 originalUnitPrice: "1.00",
                 quantity: 1,
-                weight: { value: 10, unit: 'GRAMS' },
-                title: 'fake order',
+                weight: { value: 10, unit: "GRAMS" },
+                title: "fake order",
               }],
             })
-            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/draft_order_data.json'))))
+            .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/draft_order_data.json"))))
           ShopifyCli::API.expects(:gid_to_id).returns(12345678)
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns('1.00')
+          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
           @context.expects(:done).with(
             "DraftOrder added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/draft_orders/12345678}}"
           )
-          run_cmd('populate draftorders -c 1')
+          run_cmd("populate draftorders -c 1")
         end
       end
     end

--- a/test/project_types/rails/commands/populate/product_test.rb
+++ b/test/project_types/rails/commands/populate/product_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -8,20 +8,20 @@ module Rails
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.expects(:title).returns('fake product')
-          ShopifyCli::Helpers::Haikunator.expects(:title).returns('fake producttwo')
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns('1.00')
-          return_data = JSON.parse(File.read(File.join(FIXTURE_DIR, 'populate/product_data.json')))
+          ShopifyCli::Helpers::Haikunator.expects(:title).returns("fake product")
+          ShopifyCli::Helpers::Haikunator.expects(:title).returns("fake producttwo")
+          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
+          return_data = JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/product_data.json")))
           ShopifyCli::AdminAPI.expects(:query)
-            .with(@context, 'create_product', shop: 'my-test-shop.myshopify.com', input: {
-              'title': 'fake product',
-              variants: [{ price: '1.00' }],
+            .with(@context, "create_product", shop: "my-test-shop.myshopify.com", input: {
+              'title': "fake product",
+              variants: [{ price: "1.00" }],
             })
             .returns(return_data)
           ShopifyCli::AdminAPI.expects(:query)
-            .with(@context, 'create_product', shop: 'my-test-shop.myshopify.com', input: {
-              'title': 'fake producttwo',
-              variants: [{ price: '1.00' }],
+            .with(@context, "create_product", shop: "my-test-shop.myshopify.com", input: {
+              'title': "fake producttwo",
+              variants: [{ price: "1.00" }],
             })
             .returns(return_data)
           ShopifyCli::API.expects(:gid_to_id).returns(12345678).twice
@@ -29,7 +29,7 @@ module Rails
             "fake product added to {{green:my-test-shop.myshopify.com}} at" \
             " {{underline:https://my-test-shop.myshopify.com/admin/products/12345678}}"
           ).twice
-          run_cmd('populate products -c 2')
+          run_cmd("populate products -c 2")
         end
       end
     end

--- a/test/project_types/rails/commands/populate_test.rb
+++ b/test/project_types/rails/commands/populate_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -7,13 +7,13 @@ module Rails
       def setup
         super
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
-        project_context('app_types', 'rails')
+        project_context("app_types", "rails")
         ShopifyCli::ProjectType.load_type(:rails)
       end
 
       def test_without_arguments_calls_help
         @context.expects(:puts).with(Rails::Commands::Populate.help)
-        run_cmd('populate')
+        run_cmd("populate")
       end
     end
   end

--- a/test/project_types/rails/commands/serve_test.rb
+++ b/test/project_types/rails/commands/serve_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
@@ -8,43 +8,43 @@ module Rails
 
       def setup
         super
-        project_context('app_types', 'rails')
+        project_context("app_types", "rails")
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
         @context.stubs(:system)
       end
 
       def test_server_command
-        ShopifyCli::Tunnel.stubs(:start).returns('https://example.com')
+        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update)
-        @context.stubs(:getenv).with('GEM_HOME').returns('/gem/path')
-        @context.stubs(:getenv).with('GEM_PATH').returns('/gem/path')
+        @context.stubs(:getenv).with("GEM_HOME").returns("/gem/path")
+        @context.stubs(:getenv).with("GEM_PATH").returns("/gem/path")
         @context.expects(:system).with(
-          'bin/rails server',
+          "bin/rails server",
           env: {
             "SHOPIFY_API_KEY" => "api_key",
             "SHOPIFY_API_SECRET" => "secret",
             "SHOP" => "my-test-shop.myshopify.com",
             "SCOPES" => "write_products,write_customers,write_orders",
-            'PORT' => '8081',
-            'GEM_PATH' => '/gem/path',
+            "PORT" => "8081",
+            "GEM_PATH" => "/gem/path",
           }
         )
         Rails::Commands::Serve.new(@context).call
       end
 
       def test_server_command_with_invalid_host_url
-        ShopifyCli::Tunnel.stubs(:start).returns('garbage://example.com')
+        ShopifyCli::Tunnel.stubs(:start).returns("garbage://example.com")
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call).never
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).never
         @context.expects(:system).with(
-          'bin/rails server',
+          "bin/rails server",
           env: {
             "SHOPIFY_API_KEY" => "api_key",
             "SHOPIFY_API_SECRET" => "secret",
             "SHOP" => "my-test-shop.myshopify.com",
             "SCOPES" => "write_products,write_customers,write_orders",
-            'PORT' => '8081',
+            "PORT" => "8081",
           }
         ).never
 
@@ -54,14 +54,14 @@ module Rails
       end
 
       def test_open_while_run
-        ShopifyCli::Tunnel.stubs(:start).returns('https://example.com')
+        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
-          @context, :host, 'https://example.com'
+          @context, :host, "https://example.com"
         )
         @context.expects(:puts).with(
           "\n" +
-          @context.message('rails.serve.open_info', 'https://example.com/login?shop=my-test-shop.myshopify.com') +
+          @context.message("rails.serve.open_info", "https://example.com/login?shop=my-test-shop.myshopify.com") +
           "\n"
         )
         Rails::Commands::Serve.new(@context).call
@@ -71,10 +71,10 @@ module Rails
         ShopifyCli::Tunnel.expects(:start).never
         ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
         ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
-          @context, :host, 'https://example-foo.com'
+          @context, :host, "https://example-foo.com"
         )
         command = Rails::Commands::Serve.new(@context)
-        command.options.flags[:host] = 'https://example-foo.com'
+        command.options.flags[:host] = "https://example-foo.com"
         command.call
       end
     end

--- a/test/project_types/rails/commands/tunnel_test.rb
+++ b/test/project_types/rails/commands/tunnel_test.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Commands
     class TunnelTest < MiniTest::Test
       def test_auth
         ShopifyCli::Tunnel.any_instance.expects(:auth)
-        run_cmd('tunnel auth adfhauf98q7rtqhfkajf')
+        run_cmd("tunnel auth adfhauf98q7rtqhfkajf")
       end
 
       def test_auth_no_token
         ShopifyCli::Tunnel.any_instance.expects(:auth).never
-        run_cmd('tunnel auth')
+        run_cmd("tunnel auth")
       end
 
       def test_start
         ShopifyCli::Tunnel.any_instance.expects(:start)
-        run_cmd('tunnel start')
+        run_cmd("tunnel start")
       end
 
       def test_stop
         ShopifyCli::Tunnel.any_instance.expects(:stop)
-        run_cmd('tunnel stop')
+        run_cmd("tunnel stop")
       end
     end
   end

--- a/test/project_types/rails/forms/create_test.rb
+++ b/test/project_types/rails/forms/create_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   module Forms
@@ -14,22 +14,22 @@ module Rails
 
       def test_returns_all_defined_attributes_if_valid
         form = ask
-        assert_equal('test_app', form.name)
-        assert_equal('Test App', form.title)
+        assert_equal("test_app", form.name)
+        assert_equal("Test App", form.title)
         assert_equal(42, form.organization_id)
-        assert_equal('shop.myshopify.com', form.shop_domain)
-        assert_equal('sqlite3', form.db)
+        assert_equal("shop.myshopify.com", form.shop_domain)
+        assert_equal("sqlite3", form.db)
       end
 
       def test_title_can_be_provided_by_flag
-        form = ask(title: 'My New App')
-        assert_equal('my_new_app', form.name)
-        assert_equal('My New App', form.title)
+        form = ask(title: "My New App")
+        assert_equal("my_new_app", form.name)
+        assert_equal("My New App", form.title)
       end
 
       def test_type_can_be_provided_by_flag
-        form = ask(type: 'public')
-        assert_equal('public', form.type)
+        form = ask(type: "public")
+        assert_equal("public", form.type)
       end
 
       def test_type_is_validated
@@ -37,17 +37,17 @@ module Rails
           form = ask(type: "not_a_type")
           assert_nil(form)
         end
-        assert_match(@context.message('rails.forms.create.error.invalid_app_type', 'not_a_type'), io.join)
+        assert_match(@context.message("rails.forms.create.error.invalid_app_type", "not_a_type"), io.join)
       end
 
       def test_type_is_prompted
-        CLI::UI::Prompt.expects(:ask).with(@context.message('rails.forms.create.app_type.select')).returns('public')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("rails.forms.create.app_type.select")).returns("public")
         ask(type: nil)
       end
 
       def test_db_can_be_provided_by_flag
-        form = ask(db: 'sqlite3')
-        assert_equal('sqlite3', form.db)
+        form = ask(db: "sqlite3")
+        assert_equal("sqlite3", form.db)
       end
 
       def test_db_is_validated
@@ -55,36 +55,36 @@ module Rails
           form = ask(db: "not_a_db")
           assert_nil(form)
         end
-        assert_match(@context.message('rails.forms.create.error.invalid_db_type', 'not_a_db'), io.join)
+        assert_match(@context.message("rails.forms.create.error.invalid_db_type", "not_a_db"), io.join)
       end
 
       def test_user_can_change_db_in_app
         CLI::UI::Prompt.expects(:confirm)
-          .with(@context.message('rails.forms.create.db.want_select'),
+          .with(@context.message("rails.forms.create.db.want_select"),
             default: false)
           .returns(true)
         CLI::UI::Prompt.expects(:ask)
-          .with(@context.message('rails.forms.create.db.select'))
-          .returns('mysql')
+          .with(@context.message("rails.forms.create.db.select"))
+          .returns("mysql")
         form = ask(db: nil)
-        assert_equal('mysql', form.db)
+        assert_equal("mysql", form.db)
       end
 
       def test_user_asked_if_they_want_to_change_db
         CLI::UI::Prompt.expects(:confirm)
-          .with(@context.message('rails.forms.create.db.want_select'),
+          .with(@context.message("rails.forms.create.db.want_select"),
             default: false)
           .returns(false)
         CLI::UI::Prompt.expects(:ask)
-          .with(@context.message('rails.forms.create.db.select'))
+          .with(@context.message("rails.forms.create.db.select"))
           .never
         form = ask(db: nil)
-        assert_equal('sqlite3', form.db)
+        assert_equal("sqlite3", form.db)
       end
 
       def test_user_will_be_prompted_if_more_than_one_organization
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: {
             data: {
               organizations: {
@@ -92,15 +92,15 @@ module Rails
                   {
                     'id': 421,
                     'businessName': "one",
-                    'stores': { 'nodes': [{ 'shopDomain': 'store.myshopify.com' }] },
+                    'stores': { 'nodes': [{ 'shopDomain': "store.myshopify.com" }] },
                   },
                   {
                     'id': 431,
                     'businessName': "two",
                     'stores': {
                       'nodes': [
-                        { 'shopDomain': 'other.myshopify.com', 'transferDisabled': true },
-                        { 'shopDomain': 'yet-another.myshopify.com' },
+                        { 'shopDomain': "other.myshopify.com", 'transferDisabled': true },
+                        { 'shopDomain': "yet-another.myshopify.com" },
                       ],
                     },
                   },
@@ -112,19 +112,19 @@ module Rails
         CLI::UI::Prompt.expects(:ask).returns(431)
         form = ask(org_id: nil, shop: nil)
         assert_equal(431, form.organization_id)
-        assert_equal('other.myshopify.com', form.shop_domain)
+        assert_equal("other.myshopify.com", form.shop_domain)
       end
 
       def test_will_auto_pick_with_only_one_org
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: {
             data: {
               organizations: {
                 nodes: [{
                   'id': 421,
                   'businessName': "hoopy froods",
-                  'stores': { 'nodes': [{ 'shopDomain': 'next.myshopify.com', 'transferDisabled': true }] },
+                  'stores': { 'nodes': [{ 'shopDomain': "next.myshopify.com", 'transferDisabled': true }] },
                 }],
               },
             },
@@ -133,17 +133,17 @@ module Rails
         io = capture_io do
           form = ask(org_id: nil, shop: nil)
           assert_equal(421, form.organization_id)
-          assert_equal('next.myshopify.com', form.shop_domain)
+          assert_equal("next.myshopify.com", form.shop_domain)
         end
         assert_match(
-          CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.organization', 'hoopy froods', 421)),
+          CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.organization", "hoopy froods", 421)),
           io.join,
         )
       end
 
       def test_organization_will_be_fetched_if_id_is_provided_but_not_shop
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 123 },
           resp: {
             data: {
@@ -151,7 +151,7 @@ module Rails
                 nodes: [
                   {
                     id: 123,
-                    stores: { nodes: [{ shopDomain: 'shopdomain.myshopify.com', 'transferDisabled': true }] },
+                    stores: { nodes: [{ shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true }] },
                   },
                 ],
               },
@@ -160,12 +160,12 @@ module Rails
         )
         form = ask(org_id: 123, shop: nil)
         assert_equal(123, form.organization_id)
-        assert_equal('shopdomain.myshopify.com', form.shop_domain)
+        assert_equal("shopdomain.myshopify.com", form.shop_domain)
       end
 
       def test_it_will_fail_if_no_orgs_are_available
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: { data: { organizations: { nodes: [] } } },
         )
 
@@ -173,13 +173,13 @@ module Rails
           form = ask(org_id: nil, shop: nil)
           assert_nil(form)
         end
-        assert_match(@context.message('core.tasks.select_org_and_shop.error.partners_notice'), io.join)
-        assert_match(@context.message('core.tasks.select_org_and_shop.error.no_organizations'), io.join)
+        assert_match(@context.message("core.tasks.select_org_and_shop.error.partners_notice"), io.join)
+        assert_match(@context.message("core.tasks.select_org_and_shop.error.no_organizations"), io.join)
       end
 
       def test_returns_no_shop_if_none_are_available
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 123 },
           resp: {
             data: {
@@ -195,13 +195,13 @@ module Rails
           assert_nil form.shop_domain
         end
         log = io.join
-        assert_match(CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.error.no_development_stores')), log)
-        assert_match(CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.create_store', 123)), log)
+        assert_match(CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.error.no_development_stores")), log)
+        assert_match(CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.create_store", 123)), log)
       end
 
       def test_autopicks_only_shop
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 123 },
           resp: {
             data: {
@@ -209,7 +209,7 @@ module Rails
                 nodes: [
                   {
                     id: 123,
-                    stores: { nodes: [{ shopDomain: 'shopdomain.myshopify.com', 'transferDisabled': true }] },
+                    stores: { nodes: [{ shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true }] },
                   },
                 ],
               },
@@ -218,16 +218,16 @@ module Rails
         )
         io = capture_io do
           form = ask(org_id: 123, shop: nil)
-          assert_equal('shopdomain.myshopify.com', form.shop_domain)
+          assert_equal("shopdomain.myshopify.com", form.shop_domain)
         end
         assert_match(CLI::UI.fmt(
-          @context.message('core.tasks.select_org_and_shop.development_store', 'shopdomain.myshopify.com')
+          @context.message("core.tasks.select_org_and_shop.development_store", "shopdomain.myshopify.com")
         ), io.join)
       end
 
       def test_prompts_user_to_pick_from_shops
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 123 },
           resp: {
             data: {
@@ -236,9 +236,9 @@ module Rails
                   {
                     id: 123,
                     stores: { nodes: [
-                      { shopDomain: 'shopdomain.myshopify.com', 'transferDisabled': true },
-                      { shopDomain: 'shop.myshopify.com', 'convertableToPartnerTest': true },
-                      { shopDomain: 'other.myshopify.com' },
+                      { shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true },
+                      { shopDomain: "shop.myshopify.com", 'convertableToPartnerTest': true },
+                      { shopDomain: "other.myshopify.com" },
                     ] },
                   },
                 ],
@@ -249,17 +249,17 @@ module Rails
 
         CLI::UI::Prompt.expects(:ask)
           .with(
-            @context.message('core.tasks.select_org_and_shop.development_store_select'),
+            @context.message("core.tasks.select_org_and_shop.development_store_select"),
             options: %w(shopdomain.myshopify.com shop.myshopify.com)
           )
-          .returns('selected')
+          .returns("selected")
         form = ask(org_id: 123, shop: nil)
-        assert_equal('selected', form.shop_domain)
+        assert_equal("selected", form.shop_domain)
       end
 
       private
 
-      def ask(title: 'Test App', org_id: 42, shop: 'shop.myshopify.com', type: 'custom', db: 'sqlite3')
+      def ask(title: "Test App", org_id: 42, shop: "shop.myshopify.com", type: "custom", db: "sqlite3")
         Create.ask(
           @context,
           [],

--- a/test/project_types/rails/gem_test.rb
+++ b/test/project_types/rails/gem_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   class GemTest < MiniTest::Test
@@ -8,43 +8,43 @@ module Rails
     def setup
       super
       @home = Dir.mktmpdir
-      @context.setenv('HOME', @home)
+      @context.setenv("HOME", @home)
     end
 
     def teardown
-      @context.setenv('GEM_HOME', nil)
-      @context.setenv('GEM_PATH', nil)
+      @context.setenv("GEM_HOME", nil)
+      @context.setenv("GEM_PATH", nil)
       super
     end
 
     def test_install_installs_with_gem_home_unpopulated
-      @context.expects(:system).with('gem', 'install', 'mygem')
-      Gem.install(@context, 'mygem')
+      @context.expects(:system).with("gem", "install", "mygem")
+      Gem.install(@context, "mygem")
     end
 
     def test_install_installs_gem_with_version
-      @context.expects(:system).with('gem', 'install', 'mygem', '-v', '> 5.0.0')
-      Gem.install(@context, 'mygem', '> 5.0.0')
+      @context.expects(:system).with("gem", "install", "mygem", "-v", "> 5.0.0")
+      Gem.install(@context, "mygem", "> 5.0.0")
     end
 
     def test_install_installs_with_gem_home_populated
-      @context.setenv('GEM_HOME', "#{@home}/.gem/ruby/#{RUBY_VERSION}")
-      @context.expects(:system).with('gem', 'install', 'mygem')
-      Gem.install(@context, 'mygem')
+      @context.setenv("GEM_HOME", "#{@home}/.gem/ruby/#{RUBY_VERSION}")
+      @context.expects(:system).with("gem", "install", "mygem")
+      Gem.install(@context, "mygem")
     end
 
     def test_install_does_not_install_if_installed
-      @context.setenv('GEM_HOME', "#{@home}/.gem/ruby/#{RUBY_VERSION}")
-      @context.setenv('GEM_PATH', "")
+      @context.setenv("GEM_HOME", "#{@home}/.gem/ruby/#{RUBY_VERSION}")
+      @context.setenv("GEM_PATH", "")
       Dir.expects(:glob).with("#{@home}/.gem/ruby/#{RUBY_VERSION}/gems/mygem-*").returns([
         "#{@home}/.gem/ruby/#{RUBY_VERSION}/gems/mygem-1.0.0",
       ]).at_least_once
-      @context.expects(:system).with('gem', 'install', 'mygem').never
-      Gem.install(@context, 'mygem')
+      @context.expects(:system).with("gem", "install", "mygem").never
+      Gem.install(@context, "mygem")
     end
 
     def test_gem_home_returns_proper_path
-      @context.expects(:capture2e).with('gem', 'environment', 'home').returns(
+      @context.expects(:capture2e).with("gem", "environment", "home").returns(
         ["#{@home}/.gem/ruby/#{RUBY_VERSION}\n", mock(success?: true)]
       )
       assert_equal("#{@home}/.gem/ruby/#{RUBY_VERSION}", Gem.gem_home(@context))
@@ -53,10 +53,10 @@ module Rails
     def test_gem_path_returns_proper_path
       tmpdir1 = Dir.mktmpdir
       tmpdir2 = Dir.mktmpdir
-      @context.expects(:capture2e).with('gem', 'environment', 'home').returns(
+      @context.expects(:capture2e).with("gem", "environment", "home").returns(
         ["#{@home}/.gem/ruby/#{RUBY_VERSION}\n", mock(success?: true)]
       )
-      @context.expects(:capture2e).with('gem', 'environment', 'path').returns(
+      @context.expects(:capture2e).with("gem", "environment", "path").returns(
         ["#{tmpdir1}:#{tmpdir2}\n", mock(success?: true)]
       )
       assert_equal("#{@home}/.gem/ruby/#{RUBY_VERSION}:#{tmpdir1}:#{tmpdir2}", Gem.gem_path(@context))

--- a/test/project_types/rails/ruby_test.rb
+++ b/test/project_types/rails/ruby_test.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'project_types/rails/test_helper'
+require "project_types/rails/test_helper"
 
 module Rails
   class RubyTest < MiniTest::Test
     def test_ruby_matches
       context = ShopifyCli::Context.new(env: {})
-      context.expects(:capture2).with('ruby', '-v').returns(
-        ['ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin18]', nil]
+      context.expects(:capture2).with("ruby", "-v").returns(
+        ["ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin18]", nil]
       )
       version = Ruby.version(context)
       assert_equal(2, version.major)

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'project_types/script/test_helper'
+require "project_types/script/test_helper"
 
 module Script
   module Commands
@@ -13,10 +13,10 @@ module Script
         super
         ShopifyCli::Core::Monorail.stubs(:log).yields
         @context = TestHelpers::FakeContext.new
-        @language = 'assemblyscript'
-        @script_name = 'name'
-        @ep_type = 'discount'
-        @description = 'description'
+        @language = "assemblyscript"
+        @script_name = "name"
+        @ep_type = "discount"
+        @description = "description"
         @script_project = TestHelpers::FakeScriptProject.new(
           language: @language,
           extension_point_type: @ep_type,
@@ -27,8 +27,8 @@ module Script
       end
 
       def test_prints_help_with_no_name_argument
-        root = File.expand_path(__dir__ + '../../../../..')
-        FakeFS::FileSystem.clone(root + '/lib/project_types/script/config/extension_points.yml')
+        root = File.expand_path(__dir__ + "../../../../..")
+        FakeFS::FileSystem.clone(root + "/lib/project_types/script/config/extension_points.yml")
         @script_name = nil
         io = capture_io { perform_command }
         assert_match(CLI::UI.fmt(Script::Commands::Create.help), io.join)
@@ -45,7 +45,7 @@ module Script
 
         @context
           .expects(:puts)
-          .with(@context.message('script.create.change_directory_notice', @script_project.script_name))
+          .with(@context.message("script.create.change_directory_notice", @script_project.script_name))
         perform_command
       end
 
@@ -53,7 +53,7 @@ module Script
         Script::Layers::Application::ExtensionPoints.expects(:types).returns(%w(ep1 ep2))
         ShopifyCli::Context
           .expects(:message)
-          .with('script.create.help', ShopifyCli::TOOL_NAME, '{{cyan:ep1}}, {{cyan:ep2}}')
+          .with("script.create.help", ShopifyCli::TOOL_NAME, "{{cyan:ep1}}, {{cyan:ep2}}")
         Script::Commands::Create.help
       end
 
@@ -95,7 +95,7 @@ module Script
 
         UI::ErrorHandler.expects(:pretty_print_and_raise).with(
           error,
-          failed_op: @context.message('script.create.error.operation_failed')
+          failed_op: @context.message("script.create.error.operation_failed")
         )
 
         ScriptProject.expects(:cleanup).never
@@ -115,7 +115,7 @@ module Script
           language: @language,
         }
 
-        run_cmd("create script #{args.map { |k, v| "--#{k}=#{v}" }.join(' ')}")
+        run_cmd("create script #{args.map { |k, v| "--#{k}=#{v}" }.join(" ")}")
       end
 
       def perform_command

--- a/test/project_types/script/commands/disable_test.rb
+++ b/test/project_types/script/commands/disable_test.rb
@@ -9,10 +9,10 @@ module Script
         super
         @cmd = Disable
         @cmd.ctx = @context
-        @ep_type = 'discount'
-        @script_name = 'script'
-        @api_key = 'apikey'
-        @shop_domain = 'my-test-shop.myshopify.com'
+        @ep_type = "discount"
+        @script_name = "script"
+        @api_key = "apikey"
+        @shop_domain = "my-test-shop.myshopify.com"
         @script_project = TestHelpers::FakeScriptProject.new(
           language: @language,
           extension_point_type: @ep_type,
@@ -43,7 +43,7 @@ module Script
       def test_help
         ShopifyCli::Context
           .expects(:message)
-          .with('script.disable.help', ShopifyCli::TOOL_NAME)
+          .with("script.disable.help", ShopifyCli::TOOL_NAME)
         Script::Commands::Disable.help
       end
 

--- a/test/project_types/script/commands/enable_test.rb
+++ b/test/project_types/script/commands/enable_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/script/test_helper'
+require "project_types/script/test_helper"
 
 module Script
   module Commands
@@ -11,10 +11,10 @@ module Script
         @cmd = Enable
         @cmd.ctx = @context
         @configuration = { entries: [] }
-        @ep_type = 'discount'
-        @script_name = 'script'
-        @api_key = 'apikey'
-        @shop_domain = 'my-test-shop.myshopify.com'
+        @ep_type = "discount"
+        @script_name = "script"
+        @api_key = "apikey"
+        @shop_domain = "my-test-shop.myshopify.com"
         @script_project = TestHelpers::FakeScriptProject.new(
           language: @language,
           extension_point_type: @ep_type,
@@ -39,7 +39,7 @@ module Script
       def test_help
         ShopifyCli::Context
           .expects(:message)
-          .with('script.enable.help', ShopifyCli::TOOL_NAME)
+          .with("script.enable.help", ShopifyCli::TOOL_NAME)
         Script::Commands::Enable.help
       end
 
@@ -59,7 +59,7 @@ module Script
         @context
           .expects(:puts)
           .with(@context.message(
-            'script.enable.script_enabled',
+            "script.enable.script_enabled",
             api_key: @api_key,
             shop_domain: @shop_domain,
             type: @ep_type.capitalize,
@@ -69,7 +69,7 @@ module Script
 
         @context
           .expects(:puts)
-          .with(@context.message('script.enable.info'))
+          .with(@context.message("script.enable.info"))
           .never
 
         assert_raises StandardError do
@@ -124,7 +124,7 @@ module Script
       def test_should_call_error_handler_when_given_invalid_config_props
         Script::UI::ErrorHandler.expects(:pretty_print_and_raise).with(
           instance_of(Errors::InvalidConfigProps),
-          failed_op: @context.message('script.enable.error.operation_failed')
+          failed_op: @context.message("script.enable.error.operation_failed")
         )
 
         capture_io do
@@ -213,7 +213,7 @@ module Script
         @context
           .expects(:puts)
           .with(@context.message(
-            'script.enable.script_enabled',
+            "script.enable.script_enabled",
             api_key: @api_key,
             shop_domain: @shop_domain,
             type: @ep_type.capitalize,
@@ -222,7 +222,7 @@ module Script
 
         @context
           .expects(:puts)
-          .with(@context.message('script.enable.info'))
+          .with(@context.message("script.enable.info"))
       end
 
       def perform_command_snake_case(config_props: nil, config_file_path: nil)

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'project_types/script/test_helper'
+require "project_types/script/test_helper"
 
 module Script
   module Commands
@@ -8,10 +8,10 @@ module Script
       def setup
         super
         @context = TestHelpers::FakeContext.new
-        @language = 'assemblyscript'
-        @script_name = 'name'
-        @ep_type = 'discount'
-        @api_key = 'apikey'
+        @language = "assemblyscript"
+        @script_name = "name"
+        @ep_type = "discount"
+        @api_key = "apikey"
         @script_project = TestHelpers::FakeScriptProject.new(
           language: @language,
           extension_point_type: @ep_type,
@@ -31,14 +31,14 @@ module Script
 
         @context
           .expects(:puts)
-          .with(@context.message('script.push.script_pushed', api_key: @api_key))
+          .with(@context.message("script.push.script_pushed", api_key: @api_key))
         perform_command
       end
 
       def test_help
         ShopifyCli::Context
           .expects(:message)
-          .with('script.push.help', ShopifyCli::TOOL_NAME)
+          .with("script.push.help", ShopifyCli::TOOL_NAME)
         Script::Commands::Push.help
       end
 

--- a/test/project_types/script/forms/create_test.rb
+++ b/test/project_types/script/forms/create_test.rb
@@ -14,59 +14,59 @@ module Script
       end
 
       def test_returns_all_defined_attributes_if_valid
-        name = 'name'
-        description = 'my description'
-        extension_point = 'discount'
-        form = ask(name: name, description: description, extension_point: extension_point, language: 'assemblyscript')
+        name = "name"
+        description = "my description"
+        extension_point = "discount"
+        form = ask(name: name, description: description, extension_point: extension_point, language: "assemblyscript")
         assert_equal(form.name, name)
         assert_equal(form.extension_point, extension_point)
         assert_equal(form.description, description)
       end
 
       def test_asks_extension_point_if_no_flag
-        eps = ['discount', 'another']
+        eps = ["discount", "another"]
         Layers::Application::ExtensionPoints.stubs(:non_deprecated_types).returns(eps)
-        Layers::Application::ExtensionPoints.stubs(:languages).returns(['assemblyscript'])
+        Layers::Application::ExtensionPoints.stubs(:languages).returns(["assemblyscript"])
         CLI::UI::Prompt.expects(:ask).with(
-          @context.message('script.forms.create.select_extension_point'),
+          @context.message("script.forms.create.select_extension_point"),
           options: eps
         )
-        ask(name: 'name', description: 'my description', language: 'assemblyscript')
+        ask(name: "name", description: "my description", language: "assemblyscript")
       end
 
       def test_asks_name_if_no_flag
-        name = 'name'
-        CLI::UI::Prompt.expects(:ask).with(@context.message('script.forms.create.script_name')).returns(name)
-        form = ask(description: 'my description', extension_point: 'discount', language: 'assemblyscript')
+        name = "name"
+        CLI::UI::Prompt.expects(:ask).with(@context.message("script.forms.create.script_name")).returns(name)
+        form = ask(description: "my description", extension_point: "discount", language: "assemblyscript")
         assert_equal name, form.name
       end
 
       def test_asks_description_if_no_flag
-        description = 'description'
-        CLI::UI::Prompt.expects(:ask).with(@context.message('script.forms.create.description')).returns(description)
-        form = ask(name: 'name', extension_point: 'discount', language: 'assemblyscript')
+        description = "description"
+        CLI::UI::Prompt.expects(:ask).with(@context.message("script.forms.create.description")).returns(description)
+        form = ask(name: "name", extension_point: "discount", language: "assemblyscript")
         assert_equal description, form.description
       end
 
       def test_name_is_cleaned_after_prompt
-        name = 'name with space'
-        CLI::UI::Prompt.expects(:ask).with(@context.message('script.forms.create.script_name')).returns(name)
-        form = ask(description: 'my description', extension_point: 'discount', language: 'assemblyscript')
-        assert_equal 'name_with_space', form.name
+        name = "name with space"
+        CLI::UI::Prompt.expects(:ask).with(@context.message("script.forms.create.script_name")).returns(name)
+        form = ask(description: "my description", extension_point: "discount", language: "assemblyscript")
+        assert_equal "name_with_space", form.name
       end
 
       def test_name_is_cleaned_when_using_flag
         form = ask(
-          name: 'name with space',
-          description: 'my description',
-          extension_point: 'discount',
-          language: 'assemblyscript'
+          name: "name with space",
+          description: "my description",
+          extension_point: "discount",
+          language: "assemblyscript"
         )
-        assert_equal 'name_with_space', form.name
+        assert_equal "name_with_space", form.name
       end
 
       def test_invalid_name
-        name = 'na/me'
+        name = "na/me"
         CLI::UI::Prompt.expects(:ask).returns(name)
 
         assert_raises(Script::Errors::InvalidScriptNameError) { ask }
@@ -74,44 +74,44 @@ module Script
 
       def test_invalid_name_as_option
         assert_raises(Script::Errors::InvalidScriptNameError) do
-          ask(name: 'na/me', description: 'my description', language: 'assemblyscript')
+          ask(name: "na/me", description: "my description", language: "assemblyscript")
         end
       end
 
       def test_auto_selects_existing_language_if_only_one_exists
-        language = 'assemblyscript'
+        language = "assemblyscript"
         Layers::Application::ExtensionPoints.expects(:languages).returns(%w(assemblyscript))
         CLI::UI::Prompt.expects(:ask).never
-        form = ask(name: 'name', description: 'my description', extension_point: 'discount')
+        form = ask(name: "name", description: "my description", extension_point: "discount")
         assert_equal language, form.language
       end
 
       def test_prompts_for_language_when_multiple_options_exist_and_no_flag_passed
-        language = 'rust'
+        language = "rust"
         all_languages = %w(assemblyscript rust)
         Layers::Application::ExtensionPoints.expects(:languages).returns(all_languages)
         CLI::UI::Prompt
           .expects(:ask)
-          .with(@context.message('script.forms.create.select_language'), options: all_languages)
+          .with(@context.message("script.forms.create.select_language"), options: all_languages)
           .returns(language)
-        form = ask(name: 'name', description: 'my description', extension_point: 'discount')
+        form = ask(name: "name", description: "my description", extension_point: "discount")
         assert_equal language, form.language
       end
 
       def test_succeeds_when_requested_language_is_capitalized_and_supported
-        language = 'AssemblyScript'
+        language = "AssemblyScript"
         all_languages = %w(assemblyscript rust)
         Layers::Application::ExtensionPoints.expects(:languages).returns(all_languages)
-        form = ask(name: 'name', description: 'my description', extension_point: 'discount', language: language)
+        form = ask(name: "name", description: "my description", extension_point: "discount", language: language)
         assert_equal language.downcase, form.language
       end
 
       def test_raises_when_requested_language_is_not_supported
-        language = 'C++'
+        language = "C++"
         all_languages = %w(assemblyscript rust)
         Layers::Application::ExtensionPoints.expects(:languages).returns(all_languages)
         assert_raises(Script::Errors::InvalidLanguageError) do
-          ask(name: 'name', description: 'my description', extension_point: 'discount', language: language)
+          ask(name: "name", description: "my description", extension_point: "discount", language: language)
         end
       end
 

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -4,15 +4,15 @@ require "project_types/script/test_helper"
 
 describe Script::Layers::Application::BuildScript do
   include TestHelpers::FakeFS
-  describe '.call' do
-    let(:language) { 'assemblyscript' }
-    let(:extension_point_type) { 'discount' }
-    let(:script_name) { 'name' }
-    let(:description) { 'my description' }
-    let(:op_failed_msg) { 'msg' }
-    let(:content) { 'content' }
-    let(:compiled_type) { 'wasm' }
-    let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0', false) }
+  describe ".call" do
+    let(:language) { "assemblyscript" }
+    let(:extension_point_type) { "discount" }
+    let(:script_name) { "name" }
+    let(:description) { "my description" }
+    let(:op_failed_msg) { "msg" }
+    let(:content) { "content" }
+    let(:compiled_type) { "wasm" }
+    let(:metadata) { Script::Layers::Domain::Metadata.new("1", "0", false) }
     let(:task_runner) { stub(compiled_type: compiled_type, metadata: metadata) }
 
     subject do
@@ -25,8 +25,8 @@ describe Script::Layers::Application::BuildScript do
       )
     end
 
-    describe 'when build succeeds' do
-      it 'should return normally' do
+    describe "when build succeeds" do
+      it "should return normally" do
         CLI::UI::Frame.expects(:with_frame_color_override).never
         task_runner.expects(:build).returns(content)
         Script::Layers::Infrastructure::PushPackageRepository.any_instance.expects(:create_push_package).with(
@@ -34,16 +34,16 @@ describe Script::Layers::Application::BuildScript do
           script_name: script_name,
           description: description,
           script_content: content,
-          compiled_type: 'wasm',
+          compiled_type: "wasm",
           metadata: metadata
         )
         capture_io { subject }
       end
     end
 
-    describe 'when build raises' do
-      it 'should output message and raise BuildError' do
-        err_msg = 'some error message'
+    describe "when build raises" do
+      it "should output message and raise BuildError" do
+        err_msg = "some error message"
         CLI::UI::Frame.expects(:with_frame_color_override).yields.once
         task_runner.expects(:build).returns(content)
         Script::Layers::Infrastructure::PushPackageRepository

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -6,16 +6,16 @@ require "project_types/script/layers/infrastructure/fake_extension_point_reposit
 describe Script::Layers::Application::CreateScript do
   include TestHelpers::FakeFS
 
-  let(:language) { 'AssemblyScript' }
-  let(:extension_point_type) { 'discount' }
-  let(:script_name) { 'name' }
-  let(:compiled_type) { 'wasm' }
-  let(:description) { 'description' }
+  let(:language) { "AssemblyScript" }
+  let(:extension_point_type) { "discount" }
+  let(:script_name) { "name" }
+  let(:compiled_type) { "wasm" }
+  let(:description) { "description" }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
   let(:task_runner) { stub(compiled_type: compiled_type) }
   let(:project_creator) { stub }
-  let(:project_directory) { '/path' }
+  let(:project_directory) { "/path" }
   let(:script_project) do
     TestHelpers::FakeScriptProject.new(language: language, directory: project_directory, script_name: script_name)
   end
@@ -34,7 +34,7 @@ describe Script::Layers::Application::CreateScript do
       .returns(project_creator)
   end
 
-  describe '.call' do
+  describe ".call" do
     subject do
       Script::Layers::Application::CreateScript.call(
         ctx: @context,
@@ -45,7 +45,7 @@ describe Script::Layers::Application::CreateScript do
       )
     end
 
-    it 'should create a new script' do
+    it "should create a new script" do
       Script::Layers::Application::ExtensionPoints
         .expects(:get)
         .with(type: extension_point_type)
@@ -63,13 +63,13 @@ describe Script::Layers::Application::CreateScript do
       subject
     end
 
-    describe '.setup_project' do
+    describe ".setup_project" do
       subject do
         Script::Layers::Application::CreateScript
           .send(:setup_project, @context, language, script_name, ep, description)
       end
 
-      it 'should succeed and update ctx root' do
+      it "should succeed and update ctx root" do
         Script::ScriptProject.expects(:create).with(@context, script_name).once
         Script::ScriptProject
           .expects(:write)
@@ -88,13 +88,13 @@ describe Script::Layers::Application::CreateScript do
       end
     end
 
-    describe 'install_dependencies' do
+    describe "install_dependencies" do
       subject do
         Script::Layers::Application::CreateScript
           .send(:install_dependencies, @context, language, script_name, project_creator)
       end
 
-      it 'should return new script' do
+      it "should return new script" do
         Script::Layers::Application::ProjectDependencies
           .expects(:install)
           .with(ctx: @context, task_runner: task_runner)
@@ -103,16 +103,16 @@ describe Script::Layers::Application::CreateScript do
       end
     end
 
-    describe 'bootstrap' do
+    describe "bootstrap" do
       subject do
         Script::Layers::Application::CreateScript
           .send(:bootstrap, @context, project_creator)
       end
 
-      it 'should return new script' do
+      it "should return new script" do
         spinner = TestHelpers::FakeUI::FakeSpinner.new
-        spinner.expects(:update_title).with(@context.message('script.create.created'))
-        Script::UI::StrictSpinner.expects(:spin).with(@context.message('script.create.creating')).yields(spinner)
+        spinner.expects(:update_title).with(@context.message("script.create.created"))
+        Script::UI::StrictSpinner.expects(:spin).with(@context.message("script.create.creating")).yields(spinner)
         project_creator.expects(:bootstrap)
         capture_io { subject }
       end

--- a/test/project_types/script/layers/application/disable_script_test.rb
+++ b/test/project_types/script/layers/application/disable_script_test.rb
@@ -3,17 +3,17 @@
 require "project_types/script/test_helper"
 
 describe Script::Layers::Application::DisableScript do
-  describe '.call' do
-    let(:api_key) { 'api_key' }
-    let(:shop_domain) { 'shop_domain' }
-    let(:extension_point_type) { 'extension_point_type' }
+  describe ".call" do
+    let(:api_key) { "api_key" }
+    let(:shop_domain) { "shop_domain" }
+    let(:extension_point_type) { "extension_point_type" }
 
     subject do
       Script::Layers::Application::DisableScript
         .call(ctx: @context, api_key: api_key, shop_domain: shop_domain, extension_point_type: extension_point_type)
     end
 
-    it 'should authenticate and make disable request' do
+    it "should authenticate and make disable request" do
       Script::Layers::Infrastructure::ScriptService
         .any_instance
         .expects(:disable)

--- a/test/project_types/script/layers/application/enable_script_test.rb
+++ b/test/project_types/script/layers/application/enable_script_test.rb
@@ -3,12 +3,12 @@
 require "project_types/script/test_helper"
 
 describe Script::Layers::Application::EnableScript do
-  describe '.call' do
-    let(:api_key) { 'api_key' }
-    let(:shop_domain) { 'shop_domain' }
-    let(:configuration) { '{}' }
-    let(:extension_point_type) { 'extension_point_type' }
-    let(:title) { 'title' }
+  describe ".call" do
+    let(:api_key) { "api_key" }
+    let(:shop_domain) { "shop_domain" }
+    let(:configuration) { "{}" }
+    let(:extension_point_type) { "extension_point_type" }
+    let(:title) { "title" }
 
     subject do
       Script::Layers::Application::EnableScript.call(
@@ -21,7 +21,7 @@ describe Script::Layers::Application::EnableScript do
       )
     end
 
-    it 'should authenticate and make enable request' do
+    it "should authenticate and make enable request" do
       Script::Layers::Infrastructure::ScriptService.any_instance.expects(:enable).with(
         api_key: api_key,
         shop_domain: shop_domain,

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -6,9 +6,9 @@ require "project_types/script/layers/infrastructure/fake_extension_point_reposit
 describe Script::Layers::Application::ExtensionPoints do
   include TestHelpers::FakeFS
 
-  let(:script_name) { 'name' }
-  let(:extension_point_type) { 'discount' }
-  let(:deprecated_extension_point_type) { 'unit_limit_per_order' }
+  let(:script_name) { "name" }
+  let(:extension_point_type) { "discount" }
+  let(:deprecated_extension_point_type) { "unit_limit_per_order" }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
   let(:extension_point) { extension_point_repository.get_extension_point(extension_point_type) }
 
@@ -18,54 +18,54 @@ describe Script::Layers::Application::ExtensionPoints do
     Script::Layers::Infrastructure::ExtensionPointRepository.stubs(:new).returns(extension_point_repository)
   end
 
-  describe '.get' do
-    describe 'when extension point exists' do
-      it 'should return a valid extension point' do
+  describe ".get" do
+    describe "when extension point exists" do
+      it "should return a valid extension point" do
         ep = Script::Layers::Application::ExtensionPoints.get(type: extension_point_type)
         assert_equal extension_point, ep
       end
     end
 
-    describe 'when extension point does not exist' do
-      it 'should raise InvalidExtensionPointError' do
+    describe "when extension point does not exist" do
+      it "should raise InvalidExtensionPointError" do
         assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) do
-          Script::Layers::Application::ExtensionPoints.get(type: 'invalid')
+          Script::Layers::Application::ExtensionPoints.get(type: "invalid")
         end
       end
     end
   end
 
-  describe '.types' do
-    it 'should return an array of all types' do
+  describe ".types" do
+    it "should return an array of all types" do
       assert_equal %w(discount unit_limit_per_order), Script::Layers::Application::ExtensionPoints.types
     end
   end
 
-  describe '.non_deprecated_types' do
-    it 'should return an array of all non deprecated types' do
+  describe ".non_deprecated_types" do
+    it "should return an array of all non deprecated types" do
       assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.non_deprecated_types
     end
   end
 
-  describe '.deprecated_types' do
-    it 'should return an array of all deprecated types' do
+  describe ".deprecated_types" do
+    it "should return an array of all deprecated types" do
       assert_equal %w(unit_limit_per_order), Script::Layers::Application::ExtensionPoints.deprecated_types
     end
   end
 
-  describe '.languages' do
+  describe ".languages" do
     let(:type) { extension_point_type }
     subject { Script::Layers::Application::ExtensionPoints.languages(type: type) }
 
-    describe 'when ep does not exist' do
-      let(:type) { 'imaginary' }
+    describe "when ep does not exist" do
+      let(:type) { "imaginary" }
 
-      it 'should raise InvalidExtensionPointError' do
+      it "should raise InvalidExtensionPointError" do
         assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) { subject }
       end
     end
 
-    describe 'when beta language flag is enabled' do
+    describe "when beta language flag is enabled" do
       before do
         ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once
       end
@@ -75,7 +75,7 @@ describe Script::Layers::Application::ExtensionPoints do
       end
     end
 
-    describe 'when beta language flag is not enabled' do
+    describe "when beta language flag is not enabled" do
       before do
         ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(false).at_least_once
       end
@@ -86,26 +86,26 @@ describe Script::Layers::Application::ExtensionPoints do
     end
   end
 
-  describe '.supported_language?' do
+  describe ".supported_language?" do
     let(:type) { extension_point_type }
-    let(:language) { 'assemblyscript' }
+    let(:language) { "assemblyscript" }
     subject { Script::Layers::Application::ExtensionPoints.supported_language?(type: type, language: language) }
 
-    describe 'when ep does not exist' do
-      let(:type) { 'imaginary' }
+    describe "when ep does not exist" do
+      let(:type) { "imaginary" }
 
-      it 'should raise InvalidExtensionPointError' do
+      it "should raise InvalidExtensionPointError" do
         assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) { subject }
       end
     end
 
-    describe 'when beta language flag is enabled' do
+    describe "when beta language flag is enabled" do
       before do
         ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once
       end
 
       describe "when asking about supported language" do
-        let(:language) { 'assemblyscript' }
+        let(:language) { "assemblyscript" }
 
         it "should return true" do
           assert subject
@@ -113,7 +113,7 @@ describe Script::Layers::Application::ExtensionPoints do
       end
 
       describe "when asking about beta language" do
-        let(:language) { 'rust' }
+        let(:language) { "rust" }
 
         it "should return true" do
           assert subject
@@ -121,7 +121,7 @@ describe Script::Layers::Application::ExtensionPoints do
       end
 
       describe "when user capitalizes supported language" do
-        let(:language) { 'Rust' }
+        let(:language) { "Rust" }
 
         it "should return true" do
           assert subject
@@ -129,7 +129,7 @@ describe Script::Layers::Application::ExtensionPoints do
       end
 
       describe "when asking about unsupported language" do
-        let(:language) { 'english' }
+        let(:language) { "english" }
 
         it "should return false" do
           refute subject
@@ -137,13 +137,13 @@ describe Script::Layers::Application::ExtensionPoints do
       end
     end
 
-    describe 'when beta language flag is not enabled' do
+    describe "when beta language flag is not enabled" do
       before do
         ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(false).at_least_once
       end
 
       describe "when asking about supported language" do
-        let(:language) { 'assemblyscript' }
+        let(:language) { "assemblyscript" }
 
         it "should return true" do
           assert subject
@@ -151,7 +151,7 @@ describe Script::Layers::Application::ExtensionPoints do
       end
 
       describe "when asking about beta language" do
-        let(:language) { 'rust' }
+        let(:language) { "rust" }
 
         it "should return false" do
           refute subject
@@ -159,7 +159,7 @@ describe Script::Layers::Application::ExtensionPoints do
       end
 
       describe "when user capitalizes supported language" do
-        let(:language) { 'AssemblyScript' }
+        let(:language) { "AssemblyScript" }
 
         it "should return true" do
           assert subject
@@ -167,7 +167,7 @@ describe Script::Layers::Application::ExtensionPoints do
       end
 
       describe "when asking about unsupported language" do
-        let(:language) { 'english' }
+        let(:language) { "english" }
 
         it "should return false" do
           refute subject

--- a/test/project_types/script/layers/application/project_dependencies_test.rb
+++ b/test/project_types/script/layers/application/project_dependencies_test.rb
@@ -6,8 +6,8 @@ require "project_types/script/layers/infrastructure/fake_extension_point_reposit
 describe Script::Layers::Application::ProjectDependencies do
   include TestHelpers::FakeFS
 
-  let(:script_name) { 'name' }
-  let(:extension_point_type) { 'discount' }
+  let(:script_name) { "name" }
+  let(:extension_point_type) { "discount" }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
   let(:extension_point) { extension_point_repository.get_extension_point(extension_point_type) }
   let(:task_runner) { stub }
@@ -17,7 +17,7 @@ describe Script::Layers::Application::ProjectDependencies do
     Script::Layers::Infrastructure::TaskRunner.stubs(:for).returns(task_runner)
   end
 
-  describe '.install' do
+  describe ".install" do
     subject do
       capture_io do
         Script::Layers::Application::ProjectDependencies
@@ -50,7 +50,7 @@ describe Script::Layers::Application::ProjectDependencies do
       end
 
       describe "when dependency installer fails" do
-        let(:error_message) { 'some message' }
+        let(:error_message) { "some message" }
         before do
           task_runner.stubs(:install_dependencies)
             .raises(Script::Layers::Infrastructure::Errors::DependencyInstallError, error_message)

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -7,16 +7,16 @@ require "project_types/script/layers/infrastructure/fake_push_package_repository
 describe Script::Layers::Application::PushScript do
   include TestHelpers::FakeFS
 
-  let(:compiled_type) { 'wasm' }
-  let(:language) { 'AssemblyScript' }
-  let(:api_key) { 'api_key' }
+  let(:compiled_type) { "wasm" }
+  let(:language) { "AssemblyScript" }
+  let(:api_key) { "api_key" }
   let(:force) { true }
   let(:use_msgpack) { true }
-  let(:extension_point_type) { 'discount' }
-  let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0', use_msgpack) }
-  let(:schema_minor_version) { '0' }
-  let(:script_name) { 'name' }
-  let(:description) { 'my description' }
+  let(:extension_point_type) { "discount" }
+  let(:metadata) { Script::Layers::Domain::Metadata.new("1", "0", use_msgpack) }
+  let(:schema_minor_version) { "0" }
+  let(:script_name) { "name" }
+  let(:description) { "my description" }
   let(:project) do
     TestHelpers::FakeScriptProject.new(
       language: language,
@@ -28,7 +28,7 @@ describe Script::Layers::Application::PushScript do
   end
   let(:push_package_repository) { Script::Layers::Infrastructure::FakePushPackageRepository.new }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
-  let(:task_runner) { stub(compiled_type: 'wasm', metadata: metadata) }
+  let(:task_runner) { stub(compiled_type: "wasm", metadata: metadata) }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
 
   before do
@@ -44,16 +44,16 @@ describe Script::Layers::Application::PushScript do
       extension_point_type: extension_point_type,
       script_name: script_name,
       description: description,
-      script_content: 'content',
+      script_content: "content",
       compiled_type: compiled_type,
       metadata: metadata
     )
   end
 
-  describe '.call' do
+  describe ".call" do
     subject { Script::Layers::Application::PushScript.call(ctx: @context, force: force) }
 
-    it 'should prepare and push script' do
+    it "should prepare and push script" do
       script_service_instance = Script::Layers::Infrastructure::ScriptService.new(ctx: @context)
       Script::Layers::Application::ProjectDependencies
         .expects(:install).with(ctx: @context, task_runner: task_runner)

--- a/test/project_types/script/layers/domain/metadata_test.rb
+++ b/test/project_types/script/layers/domain/metadata_test.rb
@@ -44,7 +44,7 @@ describe Script::Layers::Domain::Metadata do
     describe "with missing schemaVersions" do
       it "should raise an appropriate error" do
         assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
-          Script::Layers::Domain::Metadata.create_from_json(ctx, '{}')
+          Script::Layers::Domain::Metadata.create_from_json(ctx, "{}")
         end
       end
     end

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -4,14 +4,14 @@ require "project_types/script/test_helper"
 
 describe Script::Layers::Domain::PushPackage do
   let(:extension_point_type) { "discount" }
-  let(:script_id) { 'id' }
+  let(:script_id) { "id" }
   let(:script_name) { "foo_script" }
   let(:description) { "my description" }
   let(:api_key) { "fake_key" }
   let(:force) { false }
   let(:script_content) { "(module)" }
   let(:compiled_type) { "wasm" }
-  let(:metadata) { Script::Layers::Domain::Metadata.new('1', '0', true) }
+  let(:metadata) { Script::Layers::Domain::Metadata.new("1", "0", true) }
   let(:push_package) do
     Script::Layers::Domain::PushPackage.new(
       id: id,

--- a/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
@@ -7,7 +7,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
 
   let(:script_name) { "myscript" }
   let(:language) { "AssemblyScript" }
-  let(:script_id) { 'id' }
+  let(:script_id) { "id" }
   let(:project) { TestHelpers::FakeProject.new }
   let(:context) { TestHelpers::FakeContext.new }
   let(:extension_point_type) { "discount" }
@@ -38,10 +38,10 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
     it "should write to npmrc" do
       context
         .expects(:system)
-        .with('npm', '--userconfig', './.npmrc', 'config', 'set', '@shopify:registry', 'https://registry.npmjs.com')
+        .with("npm", "--userconfig", "./.npmrc", "config", "set", "@shopify:registry", "https://registry.npmjs.com")
       context
         .expects(:system)
-        .with('npm', '--userconfig', './.npmrc', 'config', 'set', 'engine-strict', 'true')
+        .with("npm", "--userconfig", "./.npmrc", "config", "set", "engine-strict", "true")
       subject
     end
 

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'project_types/script/test_helper'
+require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
   include TestHelpers::FakeFS
 
   let(:ctx) { TestHelpers::FakeContext.new }
-  let(:script_id) { 'id' }
+  let(:script_id) { "id" }
   let(:script_name) { "foo" }
   let(:extension_point_config) do
     {
@@ -41,7 +41,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
     subject { as_task_runner.build }
 
     it "should raise an error if no build script is defined" do
-      File.expects(:read).with('package.json').once.returns(JSON.generate(package_json.delete(:scripts)))
+      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json.delete(:scripts)))
       assert_raises(Script::Layers::Infrastructure::Errors::BuildScriptNotFoundError) do
         subject
       end
@@ -49,17 +49,17 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
 
     it "should raise an error if the build script is not compliant" do
       package_json[:scripts][:build] = ""
-      File.expects(:read).with('package.json').once.returns(JSON.generate(package_json))
+      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
       assert_raises(Script::Layers::Infrastructure::Errors::InvalidBuildScriptError) do
         subject
       end
     end
 
     it "should raise an error if the generated web assembly is not found" do
-      File.expects(:read).with('package.json').once.returns(JSON.generate(package_json))
+      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
       ctx
         .expects(:file_exist?)
-        .with('build/foo.wasm')
+        .with("build/foo.wasm")
         .once
         .returns(false)
 
@@ -67,36 +67,36 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
         .expects(:capture2e)
         .with("npm run build")
         .once
-        .returns(['output', mock(success?: true)])
+        .returns(["output", mock(success?: true)])
 
       assert_raises(Script::Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError) { subject }
     end
 
     it "should trigger the compilation process" do
       wasm = "some compiled code"
-      File.expects(:read).with('package.json').once.returns(JSON.generate(package_json))
-      File.expects(:read).with('build/foo.wasm').once.returns(wasm)
+      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
+      File.expects(:read).with("build/foo.wasm").once.returns(wasm)
 
       ctx
         .expects(:capture2e)
         .with("npm run build")
         .once
-        .returns(['output', mock(success?: true)])
+        .returns(["output", mock(success?: true)])
 
       ctx
         .expects(:file_exist?)
-        .with('build/foo.wasm')
+        .with("build/foo.wasm")
         .once
         .returns(true)
 
-      ctx.expects('rm').with('build/foo.wasm').once
+      ctx.expects("rm").with("build/foo.wasm").once
 
       assert_equal wasm, subject
     end
 
     it "should raise error without command output on failure" do
-      output = 'error_output'
-      File.expects(:read).with('package.json').once.returns(JSON.generate(package_json))
+      output = "error_output"
+      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
       File.expects(:read).never
       ctx
         .stubs(:capture2e)
@@ -206,7 +206,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
 
     describe "when capture2e fails" do
       it "should raise error" do
-        msg = 'error message'
+        msg = "error message"
         ctx.expects(:capture2e).returns([msg, mock(success?: false)])
         assert_raises Script::Layers::Infrastructure::Errors::DependencyInstallError, msg do
           subject
@@ -223,18 +223,18 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
         JSON.dump(
           {
             schemaVersions: {
-              example: { major: '1', minor: '0' },
+              example: { major: "1", minor: "0" },
             },
           },
         )
       end
 
       it "should return a proper metadata object" do
-        File.expects(:read).with('build/metadata.json').once.returns(metadata_json)
+        File.expects(:read).with("build/metadata.json").once.returns(metadata_json)
 
         ctx
           .expects(:file_exist?)
-          .with('build/metadata.json')
+          .with("build/metadata.json")
           .once
           .returns(true)
 

--- a/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
@@ -31,9 +31,9 @@ describe Script::Layers::Infrastructure::ExtensionPointRepository do
   end
 
   describe ".extension_point_types" do
-    it 'should return the ep keys' do
+    it "should return the ep keys" do
       subject.stubs(:extension_point_configs).returns({ "discount" => {}, "other" => {} })
-      assert_equal ['discount', 'other'], subject.send(:extension_point_types)
+      assert_equal ["discount", "other"], subject.send(:extension_point_types)
     end
   end
 end

--- a/test/project_types/script/layers/infrastructure/project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/project_creator_test.rb
@@ -16,7 +16,7 @@ describe Script::Layers::Infrastructure::ProjectCreator do
     end
     let(:extension_point) { Script::Layers::Domain::ExtensionPoint.new("discount", extension_point_config) }
     subject do
-      Script::Layers::Infrastructure::ProjectCreator.for(@context, language, extension_point, script_name, '/path')
+      Script::Layers::Infrastructure::ProjectCreator.for(@context, language, extension_point, script_name, "/path")
     end
 
     describe "when the script language does match an entry in the registry" do

--- a/test/project_types/script/layers/infrastructure/rust_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/rust_project_creator_test.rb
@@ -7,7 +7,7 @@ describe Script::Layers::Infrastructure::RustProjectCreator do
 
   let(:script_name) { "payment_filter_rs" }
   let(:language) { "rust" }
-  let(:script_id) { 'id' }
+  let(:script_id) { "id" }
   let(:script) { Script::Layers::Domain::Script.new(script_id, script_name, extension_point, language) }
   let(:project) { TestHelpers::FakeProject.new }
   let(:context) { TestHelpers::FakeContext.new }
@@ -66,11 +66,11 @@ describe Script::Layers::Infrastructure::RustProjectCreator do
         .returns(system_output(msg: "", success: true))
       context.expects(:rm_rf).with(".git")
       type = extension_point.type
-      source = File.join(script_name, File.join(type, 'default'))
+      source = File.join(script_name, File.join(type, "default"))
       FileUtils.expects(:copy_entry).with(source, script_name)
       context.expects(:rm_rf).with(type)
-      File.expects(:read).with('Cargo.toml').returns("name = payment-filter-default")
-      File.expects(:write).with('Cargo.toml', "name = #{script_name}")
+      File.expects(:read).with("Cargo.toml").returns("name = payment-filter-default")
+      File.expects(:write).with("Cargo.toml", "name = #{script_name}")
 
       subject
     end

--- a/test/project_types/script/layers/infrastructure/rust_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/rust_task_runner_test.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'project_types/script/test_helper'
+require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
   include TestHelpers::FakeFS
   let(:ctx) { TestHelpers::FakeContext.new }
-  let(:script_id) { 'id' }
+  let(:script_id) { "id" }
   let(:script_name) { "foo" }
   let(:extension_point_config) do
     {
@@ -89,18 +89,18 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
         JSON.dump(
           {
             schemaVersions: {
-              example: { major: '1', minor: '0' },
+              example: { major: "1", minor: "0" },
             },
           },
         )
       end
 
       it "should return a proper metadata object" do
-        File.expects(:read).with('build/metadata.json').once.returns(metadata_json)
+        File.expects(:read).with("build/metadata.json").once.returns(metadata_json)
 
         ctx
           .expects(:file_exist?)
-          .with('build/metadata.json')
+          .with("build/metadata.json")
           .once
           .returns(true)
 

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'project_types/script/test_helper'
+require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::ScriptService do
   include TestHelpers::Partners
@@ -69,10 +69,10 @@ describe Script::Layers::Infrastructure::ScriptService do
     end
 
     before do
-      stub_load_query('script_service_proxy', script_service_proxy)
-      stub_load_query('app_script_update_or_create', app_script_update_or_create)
+      stub_load_query("script_service_proxy", script_service_proxy)
+      stub_load_query("app_script_update_or_create", app_script_update_or_create)
       stub_partner_req(
-        'script_service_proxy',
+        "script_service_proxy",
         variables: {
           api_key: api_key,
           variables: {
@@ -215,13 +215,13 @@ describe Script::Layers::Infrastructure::ScriptService do
     end
   end
 
-  describe '.enable' do
-    let(:api_key) { 'api_key' }
-    let(:shop_domain) { 'my.shop.com' }
-    let(:formatted_shop_domain) { 'my.shop.com' }
-    let(:configuration) { '{}' }
-    let(:extension_point_type) { 'discount' }
-    let(:title) { 'title' }
+  describe ".enable" do
+    let(:api_key) { "api_key" }
+    let(:shop_domain) { "my.shop.com" }
+    let(:formatted_shop_domain) { "my.shop.com" }
+    let(:configuration) { "{}" }
+    let(:extension_point_type) { "discount" }
+    let(:title) { "title" }
     let(:shop_script_update_or_create) do
       <<~HERE
         mutation ShopScriptUpdateOrCreate(
@@ -258,10 +258,10 @@ describe Script::Layers::Infrastructure::ScriptService do
     end
 
     before do
-      stub_load_query('script_service_proxy', script_service_proxy)
-      stub_load_query('shop_script_update_or_create', shop_script_update_or_create)
+      stub_load_query("script_service_proxy", script_service_proxy)
+      stub_load_query("shop_script_update_or_create", shop_script_update_or_create)
       stub_partner_req(
-        'script_service_proxy',
+        "script_service_proxy",
         variables: {
           api_key: api_key,
           shop_domain: formatted_shop_domain,
@@ -286,8 +286,8 @@ describe Script::Layers::Infrastructure::ScriptService do
       )
     end
 
-    describe 'when shop domain ends with /' do
-      let(:shop_domain) { 'my.shop.com/' }
+    describe "when shop domain ends with /" do
+      let(:shop_domain) { "my.shop.com/" }
       let(:script_service_response) do
         {
           "data" => {
@@ -304,12 +304,12 @@ describe Script::Layers::Infrastructure::ScriptService do
         }
       end
 
-      it 'should have no errors when shop domain is formatted' do
+      it "should have no errors when shop domain is formatted" do
         assert_equal(script_service_response, subject)
       end
     end
 
-    describe 'when successful' do
+    describe "when successful" do
       let(:script_service_response) do
         {
           "data" => {
@@ -326,61 +326,61 @@ describe Script::Layers::Infrastructure::ScriptService do
         }
       end
 
-      it 'should have no errors' do
+      it "should have no errors" do
         assert_equal(script_service_response, subject)
       end
     end
 
-    describe 'when failure' do
+    describe "when failure" do
       let(:tag) { nil }
       let(:script_service_response) do
         {
           "data" => {
             "shopScriptUpdateOrCreate" => {
               "shopScript" => {},
-              "userErrors" => [{ "message" => 'error', "tag" => tag }],
+              "userErrors" => [{ "message" => "error", "tag" => tag }],
             },
           },
         }
       end
 
-      describe 'when app script not found' do
+      describe "when app script not found" do
         let(:tag) { "app_script_not_found" }
 
-        it 'should raise AppScriptUndefinedError' do
+        it "should raise AppScriptUndefinedError" do
           assert_raises(Script::Layers::Infrastructure::Errors::AppScriptUndefinedError) { subject }
         end
       end
 
-      describe 'when app script not pushed' do
+      describe "when app script not pushed" do
         let(:tag) { "app_script_not_pushed" }
 
-        it 'should raise AppScriptNotPushedError' do
+        it "should raise AppScriptNotPushedError" do
           assert_raises(Script::Layers::Infrastructure::Errors::AppScriptNotPushedError) { subject }
         end
       end
 
-      describe 'when shop script conflict' do
+      describe "when shop script conflict" do
         let(:tag) { "shop_script_conflict" }
 
-        it 'should raise ShopScriptConflictError' do
+        it "should raise ShopScriptConflictError" do
           assert_raises(Script::Layers::Infrastructure::Errors::ShopScriptConflictError) { subject }
         end
       end
 
-      describe 'when general error' do
+      describe "when general error" do
         let(:script_service_response) do
           {
             "data" => {
               "shopScriptUpdateOrCreate" => {
                 "shopScript" => {},
-                "userErrors" => [{ "message" => 'error' }],
+                "userErrors" => [{ "message" => "error" }],
               },
             },
           }
         end
 
-        it 'should raise ScriptServiceUserError' do
+        it "should raise ScriptServiceUserError" do
           assert_raises(Script::Layers::Infrastructure::Errors::ScriptServiceUserError) { subject }
         end
       end
@@ -389,8 +389,8 @@ describe Script::Layers::Infrastructure::ScriptService do
 
   describe ".disable" do
     let(:extension_point_type) { "DISCOUNT" }
-    let(:shop_domain) { 'shop.myshopify.com' }
-    let(:formatted_shop_domain) { 'shop.myshopify.com' }
+    let(:shop_domain) { "shop.myshopify.com" }
+    let(:formatted_shop_domain) { "shop.myshopify.com" }
     let(:api_key) { "fake_key" }
     let(:shop_script_delete) do
       <<~HERE
@@ -420,10 +420,10 @@ describe Script::Layers::Infrastructure::ScriptService do
     end
 
     before do
-      stub_load_query('script_service_proxy', script_service_proxy)
-      stub_load_query('shop_script_delete', shop_script_delete)
+      stub_load_query("script_service_proxy", script_service_proxy)
+      stub_load_query("shop_script_delete", shop_script_delete)
       stub_partner_req(
-        'script_service_proxy',
+        "script_service_proxy",
         variables: {
           api_key: api_key,
           shop_domain: formatted_shop_domain,
@@ -444,8 +444,8 @@ describe Script::Layers::Infrastructure::ScriptService do
       )
     end
 
-    describe 'when shop domain ends with /' do
-      let(:shop_domain) { 'shop.myshopify.com' }
+    describe "when shop domain ends with /" do
+      let(:shop_domain) { "shop.myshopify.com" }
       let(:script_service_response) do
         {
           "data" => {
@@ -461,12 +461,12 @@ describe Script::Layers::Infrastructure::ScriptService do
         }
       end
 
-      it 'should have no errors when shop domain is formatted' do
+      it "should have no errors when shop domain is formatted" do
         assert_equal(script_service_response, subject)
       end
     end
 
-    describe 'when successful' do
+    describe "when successful" do
       let(:script_service_response) do
         {
           "data" => {
@@ -482,42 +482,42 @@ describe Script::Layers::Infrastructure::ScriptService do
         }
       end
 
-      it 'should have no errors' do
+      it "should have no errors" do
         assert_equal(script_service_response, subject)
       end
     end
 
-    describe 'when failure' do
-      describe 'when shop_script_not_found error' do
+    describe "when failure" do
+      describe "when shop_script_not_found error" do
         let(:script_service_response) do
           {
             "data" => {
               "shopScriptDelete" => {
                 "shopScript" => {},
-                "userErrors" => [{ "message" => 'error', "tag" => "shop_script_not_found" }],
+                "userErrors" => [{ "message" => "error", "tag" => "shop_script_not_found" }],
               },
             },
           }
         end
 
-        it 'should raise ShopScriptUndefinedError' do
+        it "should raise ShopScriptUndefinedError" do
           assert_raises(Script::Layers::Infrastructure::Errors::ShopScriptUndefinedError) { subject }
         end
       end
 
-      describe 'when other error' do
+      describe "when other error" do
         let(:script_service_response) do
           {
             "data" => {
               "shopScriptDelete" => {
                 "shopScript" => {},
-                "userErrors" => [{ "message" => 'error', "tag" => "other_error" }],
+                "userErrors" => [{ "message" => "error", "tag" => "other_error" }],
               },
             },
           }
         end
 
-        it 'should raise ShopScriptUndefinedError' do
+        it "should raise ShopScriptUndefinedError" do
           assert_raises(Script::Layers::Infrastructure::Errors::ScriptServiceUserError) { subject }
         end
       end

--- a/test/project_types/script/layers/infrastructure/task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/task_runner_test.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'project_types/script/test_helper'
+require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::TaskRunner do
   describe "build" do
-    let(:script_name) { 'script_name' }
+    let(:script_name) { "script_name" }
     subject { Script::Layers::Infrastructure::TaskRunner.for(@context, language, script_name) }
 
     describe "when the script language and compile type match an entry in the registry" do

--- a/test/project_types/script/script_project_test.rb
+++ b/test/project_types/script/script_project_test.rb
@@ -1,33 +1,33 @@
 # frozen_string_literal: true
 
-require 'project_types/script/test_helper'
+require "project_types/script/test_helper"
 
 module Script
   class ScriptProjectTest < MiniTest::Test
     def setup
       super
       @context = TestHelpers::FakeContext.new
-      @script_name = 'name'
-      @extension_point_type = 'ep_type'
+      @script_name = "name"
+      @extension_point_type = "ep_type"
     end
 
     def test_initialize
       ShopifyCli::Project
         .any_instance
         .expects(:load_yaml_file)
-        .with('.shopify-cli.yml')
+        .with(".shopify-cli.yml")
         .returns({
-          'extension_point_type' => @extension_point_type,
-          'script_name' => @script_name,
+          "extension_point_type" => @extension_point_type,
+          "script_name" => @script_name,
         })
 
       Script::Layers::Application::ExtensionPoints.expects(:supported_language?).returns(true)
-      ScriptProject.new(directory: 'testdir')
+      ScriptProject.new(directory: "testdir")
 
       assert_equal({
         "script_name" => @script_name,
         "extension_point_type" => @extension_point_type,
-        "language" => 'assemblyscript',
+        "language" => "assemblyscript",
       }, ShopifyCli::Core::Monorail.metadata)
     end
 
@@ -35,16 +35,16 @@ module Script
       ShopifyCli::Project
         .any_instance
         .expects(:load_yaml_file)
-        .with('.shopify-cli.yml')
+        .with(".shopify-cli.yml")
         .returns({
-          'extension_point_type' => @extension_point_type,
-          'script_name' => @script_name,
+          "extension_point_type" => @extension_point_type,
+          "script_name" => @script_name,
         })
 
       Script::Layers::Application::ExtensionPoints.stubs(:deprecated_types).returns([@extension_point_type])
 
       assert_raises Errors::DeprecatedEPError do
-        ScriptProject.new(directory: 'testdir')
+        ScriptProject.new(directory: "testdir")
       end
     end
 
@@ -115,19 +115,19 @@ module Script
     end
 
     def test_reads_language_from_config_file
-      language = 'Rust'
+      language = "Rust"
       Script::Layers::Application::ExtensionPoints.expects(:languages).returns(%(assemblyscript rust))
       ShopifyCli::Project
         .any_instance
         .expects(:load_yaml_file)
-        .with('.shopify-cli.yml')
+        .with(".shopify-cli.yml")
         .returns({
-          'extension_point_type' => @extension_point_type,
-          'script_name' => @script_name,
-          'language' => language,
+          "extension_point_type" => @extension_point_type,
+          "script_name" => @script_name,
+          "language" => language,
         })
 
-      script = ScriptProject.new(directory: 'testdir')
+      script = ScriptProject.new(directory: "testdir")
       assert_equal language.downcase, script.language
     end
 
@@ -136,31 +136,31 @@ module Script
       ShopifyCli::Project
         .any_instance
         .expects(:load_yaml_file)
-        .with('.shopify-cli.yml')
+        .with(".shopify-cli.yml")
         .returns({
-          'extension_point_type' => @extension_point_type,
-          'script_name' => @script_name,
+          "extension_point_type" => @extension_point_type,
+          "script_name" => @script_name,
         })
 
-      script = ScriptProject.new(directory: 'testdir')
-      assert_equal 'assemblyscript', script.language
+      script = ScriptProject.new(directory: "testdir")
+      assert_equal "assemblyscript", script.language
     end
 
     def test_unsupported_language_in_config_will_raise
-      language = 'C++'
+      language = "C++"
       Script::Layers::Application::ExtensionPoints.expects(:languages).returns(%(assemblyscript rust))
       ShopifyCli::Project
         .any_instance
         .expects(:load_yaml_file)
-        .with('.shopify-cli.yml')
+        .with(".shopify-cli.yml")
         .returns({
-          'extension_point_type' => @extension_point_type,
-          'script_name' => @script_name,
-          'language' => language,
+          "extension_point_type" => @extension_point_type,
+          "script_name" => @script_name,
+          "language" => language,
         })
 
       assert_raises(Script::Errors::InvalidLanguageError) do
-        ScriptProject.new(directory: 'testdir')
+        ScriptProject.new(directory: "testdir")
       end
     end
   end

--- a/test/project_types/script/test_helpers.rb
+++ b/test/project_types/script/test_helpers.rb
@@ -1,3 +1,3 @@
 module TestHelpers
-  autoload :FakeScriptProject, 'project_types/script/test_helpers/fake_script_project'
+  autoload :FakeScriptProject, "project_types/script/test_helpers/fake_script_project"
 end

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -59,7 +59,7 @@ describe Script::UI::ErrorHandler do
 
   describe ".pretty_print_and_raise" do
     let(:err) { nil }
-    let(:failed_op) { 'message' }
+    let(:failed_op) { "message" }
     subject { Script::UI::ErrorHandler.pretty_print_and_raise(err, failed_op: failed_op) }
 
     describe "when exception is not in list" do
@@ -98,14 +98,14 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when InvalidContextError" do
-        let(:err) { Script::Errors::InvalidContextError.new('') }
+        let(:err) { Script::Errors::InvalidContextError.new("") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when InvalidConfigProps" do
-        let(:err) { Script::Errors::InvalidConfigProps.new('') }
+        let(:err) { Script::Errors::InvalidConfigProps.new("") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
@@ -140,28 +140,28 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when ScriptProjectAlreadyExistsError" do
-        let(:err) { Script::Errors::ScriptProjectAlreadyExistsError.new('/') }
+        let(:err) { Script::Errors::ScriptProjectAlreadyExistsError.new("/") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when InvalidLanguageError" do
-        let(:err) { Script::Layers::Domain::Errors::InvalidExtensionPointError.new('ruby') }
+        let(:err) { Script::Layers::Domain::Errors::InvalidExtensionPointError.new("ruby") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when InvalidExtensionPointError" do
-        let(:err) { Script::Layers::Domain::Errors::InvalidExtensionPointError.new('') }
+        let(:err) { Script::Layers::Domain::Errors::InvalidExtensionPointError.new("") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
       describe "when ScriptNotFoundError" do
-        let(:err) { Script::Layers::Domain::Errors::ScriptNotFoundError.new('ep type', 'name') }
+        let(:err) { Script::Layers::Domain::Errors::ScriptNotFoundError.new("ep type", "name") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
@@ -217,7 +217,7 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when ScriptRepushError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::ScriptRepushError.new('api_key') }
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptRepushError.new("api_key") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end

--- a/test/project_types/script/ui/printing_spinner_test.rb
+++ b/test/project_types/script/ui/printing_spinner_test.rb
@@ -4,9 +4,9 @@ require "project_types/script/test_helper"
 
 describe Script::UI::PrintingSpinner do
   describe ".spin" do
-    let(:ctx_root) { '/some/dir/here' }
+    let(:ctx_root) { "/some/dir/here" }
     let(:ctx) { TestHelpers::FakeContext.new(root: ctx_root) }
-    let(:title) { 'title' }
+    let(:title) { "title" }
 
     it "yields a block with a ctx parameter" do
       capture_io do

--- a/test/project_types/script/ui/strict_spinner_test.rb
+++ b/test/project_types/script/ui/strict_spinner_test.rb
@@ -4,7 +4,7 @@ require "project_types/script/test_helper"
 
 describe Script::UI::StrictSpinner do
   describe ".spin" do
-    let(:title) { 'title' }
+    let(:title) { "title" }
 
     describe "when an error is thrown in the block" do
       it "should abort" do

--- a/test/project_types/theme/commands/connect_test.rb
+++ b/test/project_types/theme/commands/connect_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Commands
@@ -19,22 +19,22 @@ module Theme
 
           Theme::Forms::Connect.expects(:ask)
             .with(context, [], {})
-            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
-                                                              password: 'boop',
-                                                              themeid: '2468',
-                                                              name: 'my_theme',
+            .returns(Theme::Forms::Connect.new(context, [], { store: "shop.myshopify.com",
+                                                              password: "boop",
+                                                              themeid: "2468",
+                                                              name: "my_theme",
                                                               env: nil }))
 
-          context.expects(:dir_exist?).with('my_theme').returns(false)
+          context.expects(:dir_exist?).with("my_theme").returns(false)
           Themekit.expects(:connect)
-            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
+            .with(context, store: "shop.myshopify.com", password: "boop", themeid: "2468", env: nil)
             .returns(true)
-          context.expects(:done).with(context.message('theme.connect.connected',
-            'my_theme',
-            'shop.myshopify.com',
-            File.join(context.root, 'my_theme')))
+          context.expects(:done).with(context.message("theme.connect.connected",
+            "my_theme",
+            "shop.myshopify.com",
+            File.join(context.root, "my_theme")))
 
-          Theme::Commands::Connect.new(context).call([], 'connect')
+          Theme::Commands::Connect.new(context).call([], "connect")
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
       end
@@ -45,25 +45,25 @@ module Theme
           ShopifyCli::Project.expects(:has_current?).returns(false).twice
 
           Theme::Forms::Connect.expects(:ask)
-            .with(context, [], { env: 'test' })
-            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
-                                                              password: 'boop',
-                                                              themeid: '2468',
-                                                              name: 'my_theme',
-                                                              env: 'test' }))
+            .with(context, [], { env: "test" })
+            .returns(Theme::Forms::Connect.new(context, [], { store: "shop.myshopify.com",
+                                                              password: "boop",
+                                                              themeid: "2468",
+                                                              name: "my_theme",
+                                                              env: "test" }))
 
-          context.expects(:dir_exist?).with('my_theme').returns(false)
+          context.expects(:dir_exist?).with("my_theme").returns(false)
           Themekit.expects(:connect)
-            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: 'test')
+            .with(context, store: "shop.myshopify.com", password: "boop", themeid: "2468", env: "test")
             .returns(true)
-          context.expects(:done).with(context.message('theme.connect.connected',
-            'my_theme',
-            'shop.myshopify.com',
-            File.join(context.root, 'my_theme')))
+          context.expects(:done).with(context.message("theme.connect.connected",
+            "my_theme",
+            "shop.myshopify.com",
+            File.join(context.root, "my_theme")))
 
           command = Theme::Commands::Connect.new(context)
-          command.options.flags[:env] = 'test'
-          command.call([], 'connect')
+          command.options.flags[:env] = "test"
+          command.call([], "connect")
 
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
@@ -75,13 +75,13 @@ module Theme
           ShopifyCli::Project.expects(:has_current?).returns(true)
 
           Theme::Forms::Connect.expects(:ask).with(context, [], {}).never
-          context.expects(:dir_exist?).with('my_theme').never
+          context.expects(:dir_exist?).with("my_theme").never
           Themekit.expects(:connect)
-            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
+            .with(context, store: "shop.myshopify.com", password: "boop", themeid: "2468", env: nil)
             .never
 
           assert_raises CLI::Kit::Abort do
-            Theme::Commands::Connect.new(context).call([], 'connect')
+            Theme::Commands::Connect.new(context).call([], "connect")
           end
         end
       end
@@ -93,19 +93,19 @@ module Theme
 
           Theme::Forms::Connect.expects(:ask)
             .with(context, [], {})
-            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
-                                                              password: 'boop',
-                                                              themeid: '2468',
-                                                              name: 'my_theme',
+            .returns(Theme::Forms::Connect.new(context, [], { store: "shop.myshopify.com",
+                                                              password: "boop",
+                                                              themeid: "2468",
+                                                              name: "my_theme",
                                                               env: nil }))
 
-          context.expects(:dir_exist?).with('my_theme').returns(true)
+          context.expects(:dir_exist?).with("my_theme").returns(true)
           Themekit.expects(:connect)
-            .with(context, store: 'shop.myshopify.com', password: 'boop', themeid: '2468', env: nil)
+            .with(context, store: "shop.myshopify.com", password: "boop", themeid: "2468", env: nil)
             .never
 
           assert_raises CLI::Kit::Abort do
-            Theme::Commands::Connect.new(context).call([], 'connect')
+            Theme::Commands::Connect.new(context).call([], "connect")
           end
         end
       end
@@ -117,19 +117,19 @@ module Theme
 
           Theme::Forms::Connect.expects(:ask)
             .with(context, [], {})
-            .returns(Theme::Forms::Connect.new(context, [], { store: 'shop.myshopify.com',
-                                                              password: 'merp',
-                                                              themeid: '1357',
-                                                              name: 'your_theme',
+            .returns(Theme::Forms::Connect.new(context, [], { store: "shop.myshopify.com",
+                                                              password: "merp",
+                                                              themeid: "1357",
+                                                              name: "your_theme",
                                                               env: nil }))
 
-          context.expects(:dir_exist?).with('your_theme').returns(false)
+          context.expects(:dir_exist?).with("your_theme").returns(false)
           Themekit.expects(:connect)
-            .with(context, store: 'shop.myshopify.com', password: 'merp', themeid: '1357', env: nil)
+            .with(context, store: "shop.myshopify.com", password: "merp", themeid: "1357", env: nil)
             .returns(false)
 
           assert_raises CLI::Kit::Abort do
-            Theme::Commands::Connect.new(context).call([], 'connect')
+            Theme::Commands::Connect.new(context).call([], "connect")
           end
         end
       end

--- a/test/project_types/theme/commands/create_test.rb
+++ b/test/project_types/theme/commands/create_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Commands
@@ -17,20 +17,20 @@ module Theme
           context = ShopifyCli::Context.new
           Theme::Forms::Create.expects(:ask)
             .with(context, [], {})
-            .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
-                                                             store: 'shop.myshopify.com',
-                                                             title: 'My Theme',
-                                                             name: 'my_theme',
+            .returns(Theme::Forms::Create.new(context, [], { password: "boop",
+                                                             store: "shop.myshopify.com",
+                                                             title: "My Theme",
+                                                             name: "my_theme",
                                                              env: nil }))
           Themekit.expects(:create)
-            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme', env: nil)
+            .with(context, password: "boop", store: "shop.myshopify.com", name: "my_theme", env: nil)
             .returns(true)
-          context.expects(:done).with(context.message('theme.create.info.created',
-            'my_theme',
-            'shop.myshopify.com',
-            File.join(context.root, 'my_theme')))
+          context.expects(:done).with(context.message("theme.create.info.created",
+            "my_theme",
+            "shop.myshopify.com",
+            File.join(context.root, "my_theme")))
 
-          Theme::Commands::Create.new(context).call([], 'create')
+          Theme::Commands::Create.new(context).call([], "create")
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end
       end
@@ -39,23 +39,23 @@ module Theme
         FakeFS do
           context = ShopifyCli::Context.new
           Theme::Forms::Create.expects(:ask)
-            .with(context, [], { env: 'test' })
-            .returns(Theme::Forms::Create.new(context, [], { password: 'boop',
-                                                             store: 'shop.myshopify.com',
-                                                             title: 'My Theme',
-                                                             name: 'my_theme',
-                                                             env: 'test' }))
+            .with(context, [], { env: "test" })
+            .returns(Theme::Forms::Create.new(context, [], { password: "boop",
+                                                             store: "shop.myshopify.com",
+                                                             title: "My Theme",
+                                                             name: "my_theme",
+                                                             env: "test" }))
           Themekit.expects(:create)
-            .with(context, password: 'boop', store: 'shop.myshopify.com', name: 'my_theme', env: 'test')
+            .with(context, password: "boop", store: "shop.myshopify.com", name: "my_theme", env: "test")
             .returns(true)
-          context.expects(:done).with(context.message('theme.create.info.created',
-            'my_theme',
-            'shop.myshopify.com',
-            File.join(context.root, 'my_theme')))
+          context.expects(:done).with(context.message("theme.create.info.created",
+            "my_theme",
+            "shop.myshopify.com",
+            File.join(context.root, "my_theme")))
 
           command = Theme::Commands::Create.new(context)
-          command.options.flags[:env] = 'test'
-          command.call([], 'create')
+          command.options.flags[:env] = "test"
+          command.call([], "create")
 
           assert_equal SHOPIFYCLI_FILE, File.read(".shopify-cli.yml")
         end

--- a/test/project_types/theme/commands/deploy_test.rb
+++ b/test/project_types/theme/commands/deploy_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Commands
@@ -10,7 +10,7 @@ module Theme
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(true)
         Themekit.expects(:deploy).with(context, flags: [], env: nil).returns(true)
-        context.expects(:done).with(context.message('theme.deploy.info.deployed'))
+        context.expects(:done).with(context.message("theme.deploy.info.deployed"))
 
         Theme::Commands::Deploy.new(context).call
       end
@@ -18,11 +18,11 @@ module Theme
       def test_can_specify_env
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        Themekit.expects(:deploy).with(context, flags: [], env: 'test').returns(true)
-        context.expects(:done).with(context.message('theme.deploy.info.deployed'))
+        Themekit.expects(:deploy).with(context, flags: [], env: "test").returns(true)
+        context.expects(:done).with(context.message("theme.deploy.info.deployed"))
 
         command = Theme::Commands::Deploy.new(context)
-        command.options.flags[:env] = 'test'
+        command.options.flags[:env] = "test"
         command.call
       end
 
@@ -40,7 +40,7 @@ module Theme
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(true)
         Themekit.expects(:deploy).with(context, flags: [], env: nil).returns(false)
-        context.expects(:done).with(context.message('theme.deploy.info.deployed')).never
+        context.expects(:done).with(context.message("theme.deploy.info.deployed")).never
 
         assert_raises CLI::Kit::Abort do
           Theme::Commands::Deploy.new(context).call

--- a/test/project_types/theme/commands/generate/env_test.rb
+++ b/test/project_types/theme/commands/generate/env_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Commands
@@ -10,7 +10,7 @@ module Theme
         resp = [200, { "themes" =>
                  [{ "id" => 2468, "name" => "my_theme" },
                   { "id" => 1357, "name" => "your_theme" }] }]
-        THEMES = resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+        THEMES = resp[1]["themes"].map { |theme| [theme["name"], theme["id"]] }.to_h
 
         CONFIG = { "development" =>
                    { "password" => "boop",
@@ -18,29 +18,29 @@ module Theme
                      "store" => "shop.myshopify.com" } }
 
         def test_prompts_for_credentials
-          File.write('config.yml', CONFIG.to_yaml)
+          File.write("config.yml", CONFIG.to_yaml)
           context = ShopifyCli::Context.new
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
-            .returns('office.myshopify.com')
+            .with(context.message("theme.generate.env.ask_store_default", "shop.myshopify.com"))
+            .returns("office.myshopify.com")
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
-            .returns('beep')
+            .with(context.message("theme.generate.env.ask_password_default", "boop"))
+            .returns("beep")
 
           Themekit.expects(:query_themes)
-            .with(context, store: 'office.myshopify.com', password: 'beep')
+            .with(context, store: "office.myshopify.com", password: "beep")
             .returns(THEMES)
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_theme'))
-            .returns('2468')
+            .with(context.message("theme.generate.env.ask_theme"))
+            .returns("2468")
 
           Themekit.expects(:generate_env)
             .with(context,
-              store: 'office.myshopify.com',
-              password: 'beep',
-              themeid: '2468',
+              store: "office.myshopify.com",
+              password: "beep",
+              themeid: "2468",
               env: nil)
             .returns(true)
 
@@ -49,29 +49,29 @@ module Theme
         end
 
         def test_can_use_default_shop_and_password
-          File.write('config.yml', CONFIG.to_yaml)
+          File.write("config.yml", CONFIG.to_yaml)
           context = ShopifyCli::Context.new
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
-            .returns('')
+            .with(context.message("theme.generate.env.ask_store_default", "shop.myshopify.com"))
+            .returns("")
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
-            .returns('')
+            .with(context.message("theme.generate.env.ask_password_default", "boop"))
+            .returns("")
 
           Themekit.expects(:query_themes)
-            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .with(context, store: "shop.myshopify.com", password: "boop")
             .returns(THEMES)
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_theme'))
-            .returns('2468')
+            .with(context.message("theme.generate.env.ask_theme"))
+            .returns("2468")
 
           Themekit.expects(:generate_env)
             .with(context,
-              store: 'shop.myshopify.com',
-              password: 'boop',
-              themeid: '2468',
+              store: "shop.myshopify.com",
+              password: "boop",
+              themeid: "2468",
               env: nil)
             .returns(true)
 
@@ -80,68 +80,68 @@ module Theme
         end
 
         def test_can_provide_credentials_with_flags
-          File.write('config.yml', CONFIG.to_yaml)
+          File.write("config.yml", CONFIG.to_yaml)
           context = ShopifyCli::Context.new
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
+            .with(context.message("theme.generate.env.ask_store_default", "shop.myshopify.com"))
             .never
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
+            .with(context.message("theme.generate.env.ask_password_default", "boop"))
             .never
 
           Themekit.expects(:query_themes)
-            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .with(context, store: "shop.myshopify.com", password: "boop")
             .never
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_theme'))
+            .with(context.message("theme.generate.env.ask_theme"))
             .never
 
           Themekit.expects(:generate_env)
             .with(context,
-              store: 'office.myshopify.com',
-              password: 'beep',
-              themeid: '2468',
+              store: "office.myshopify.com",
+              password: "beep",
+              themeid: "2468",
               env: nil)
             .returns(true)
 
           command = Theme::Commands::Generate::Env.new(context)
-          command.options.flags[:store] = 'office.myshopify.com'
-          command.options.flags[:password] = 'beep'
-          command.options.flags[:themeid] = '2468'
+          command.options.flags[:store] = "office.myshopify.com"
+          command.options.flags[:password] = "beep"
+          command.options.flags[:themeid] = "2468"
           command.call
         end
 
         def test_can_use_different_env
-          File.write('config.yml', CONFIG.to_yaml)
+          File.write("config.yml", CONFIG.to_yaml)
           context = ShopifyCli::Context.new
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_store_default', 'shop.myshopify.com'))
-            .returns('')
+            .with(context.message("theme.generate.env.ask_store_default", "shop.myshopify.com"))
+            .returns("")
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_password_default', 'boop'))
-            .returns('')
+            .with(context.message("theme.generate.env.ask_password_default", "boop"))
+            .returns("")
 
           Themekit.expects(:query_themes)
-            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .with(context, store: "shop.myshopify.com", password: "boop")
             .returns(THEMES)
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_theme'))
-            .returns('2468')
+            .with(context.message("theme.generate.env.ask_theme"))
+            .returns("2468")
 
           Themekit.expects(:generate_env)
             .with(context,
-              store: 'shop.myshopify.com',
-              password: 'boop',
-              themeid: '2468',
-              env: 'test')
+              store: "shop.myshopify.com",
+              password: "boop",
+              themeid: "2468",
+              env: "test")
             .returns(true)
 
           command = Theme::Commands::Generate::Env.new(context)
-          command.options.flags[:env] = 'test'
+          command.options.flags[:env] = "test"
           command.call
         end
 
@@ -149,25 +149,25 @@ module Theme
           context = ShopifyCli::Context.new
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_store'), allow_empty: false)
-            .returns('shop.myshopify.com')
+            .with(context.message("theme.generate.env.ask_store"), allow_empty: false)
+            .returns("shop.myshopify.com")
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_password'), allow_empty: false)
-            .returns('boop')
+            .with(context.message("theme.generate.env.ask_password"), allow_empty: false)
+            .returns("boop")
 
           Themekit.expects(:query_themes)
-            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .with(context, store: "shop.myshopify.com", password: "boop")
             .returns(THEMES)
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_theme'))
-            .returns('2468')
+            .with(context.message("theme.generate.env.ask_theme"))
+            .returns("2468")
 
           Themekit.expects(:generate_env)
             .with(context,
-              store: 'shop.myshopify.com',
-              password: 'boop',
-              themeid: '2468',
+              store: "shop.myshopify.com",
+              password: "boop",
+              themeid: "2468",
               env: nil)
             .returns(true)
 
@@ -179,15 +179,15 @@ module Theme
           context = ShopifyCli::Context.new
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_store'), allow_empty: false)
-            .returns('shop.myshopify.com')
+            .with(context.message("theme.generate.env.ask_store"), allow_empty: false)
+            .returns("shop.myshopify.com")
 
           CLI::UI::Prompt.expects(:ask)
-            .with(context.message('theme.generate.env.ask_password'), allow_empty: false)
-            .returns('boop')
+            .with(context.message("theme.generate.env.ask_password"), allow_empty: false)
+            .returns("boop")
 
           Themekit.expects(:query_themes)
-            .with(context, store: 'shop.myshopify.com', password: 'boop')
+            .with(context, store: "shop.myshopify.com", password: "boop")
             .returns({})
 
           assert_raises CLI::Kit::Abort do

--- a/test/project_types/theme/commands/generate_test.rb
+++ b/test/project_types/theme/commands/generate_test.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Commands
     class GenerateTest < MiniTest::Test
       def test_puts_help
         ShopifyCli::Context.expects(:message)
-          .with('theme.generate.help', ShopifyCli::TOOL_NAME)
+          .with("theme.generate.help", ShopifyCli::TOOL_NAME)
 
         Theme::Commands::Generate.new(@context).call
       end

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Commands
@@ -9,69 +9,69 @@ module Theme
       def test_can_push_entire_theme
         context = ShopifyCli::Context.new
         Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: nil).returns(true)
-        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+        context.expects(:done).with(context.message("theme.push.info.push", context.root))
 
-        Theme::Commands::Push.new(context).call([], 'push')
+        Theme::Commands::Push.new(context).call([], "push")
       end
 
       def test_can_push_individual_files
         context = ShopifyCli::Context.new
         Themekit.expects(:push)
-          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: nil, env: nil)
+          .with(context, files: ["file.liquid", "another_file.liquid"], flags: [], remove: nil, env: nil)
           .returns(true)
-        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+        context.expects(:done).with(context.message("theme.push.info.push", context.root))
 
-        Theme::Commands::Push.new(context).call(['file.liquid', 'another_file.liquid'], 'push')
+        Theme::Commands::Push.new(context).call(["file.liquid", "another_file.liquid"], "push")
       end
 
       def test_can_remove_files
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(true)
         Themekit.expects(:push)
-          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil)
+          .with(context, files: ["file.liquid", "another_file.liquid"], flags: [], remove: true, env: nil)
           .returns(true)
-        context.expects(:done).with(context.message('theme.push.info.remove', context.root))
+        context.expects(:done).with(context.message("theme.push.info.remove", context.root))
 
         command = Theme::Commands::Push.new(context)
-        command.options.flags['remove'] = true
-        command.call(['file.liquid', 'another_file.liquid'], 'push')
+        command.options.flags["remove"] = true
+        command.call(["file.liquid", "another_file.liquid"], "push")
       end
 
       def test_can_abort_remove
         context = ShopifyCli::Context.new
         CLI::UI::Prompt.expects(:confirm).returns(false)
         Themekit.expects(:push)
-          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil)
+          .with(context, files: ["file.liquid", "another_file.liquid"], flags: [], remove: true, env: nil)
           .never
 
         command = Theme::Commands::Push.new(context)
-        command.options.flags['remove'] = true
+        command.options.flags["remove"] = true
         assert_raises CLI::Kit::Abort do
-          command.call(['file.liquid', 'another_file.liquid'], 'push')
+          command.call(["file.liquid", "another_file.liquid"], "push")
         end
       end
 
       def test_can_add_flags
         context = ShopifyCli::Context.new
         Themekit.expects(:push)
-          .with(context, files: ['file.liquid', 'another_file.liquid'], flags: ['--nodelete'], remove: nil, env: nil)
+          .with(context, files: ["file.liquid", "another_file.liquid"], flags: ["--nodelete"], remove: nil, env: nil)
           .returns(true)
-        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+        context.expects(:done).with(context.message("theme.push.info.push", context.root))
 
         command = Theme::Commands::Push.new(context)
-        command.options.flags['nodelete'] = true
-        command.call(['file.liquid', 'another_file.liquid'], 'push')
+        command.options.flags["nodelete"] = true
+        command.call(["file.liquid", "another_file.liquid"], "push")
       end
 
       def test_can_specify_env
         context = ShopifyCli::Context.new
-        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: 'test')
+        Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: "test")
           .returns(true)
-        context.expects(:done).with(context.message('theme.push.info.push', context.root))
+        context.expects(:done).with(context.message("theme.push.info.push", context.root))
 
         command = Theme::Commands::Push.new(context)
-        command.options.flags[:env] = 'test'
-        command.call([], 'push')
+        command.options.flags[:env] = "test"
+        command.call([], "push")
       end
 
       def test_aborts_if_push_fails
@@ -79,7 +79,7 @@ module Theme
         Themekit.expects(:push).with(context, files: [], flags: [], remove: nil, env: nil).returns(false)
 
         assert_raises CLI::Kit::Abort do
-          Theme::Commands::Push.new(context).call([], 'push')
+          Theme::Commands::Push.new(context).call([], "push")
         end
       end
     end

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Commands
@@ -15,10 +15,10 @@ module Theme
 
       def test_can_specify_env
         context = ShopifyCli::Context.new
-        Themekit.expects(:serve).with(context, flags: [], env: 'test')
+        Themekit.expects(:serve).with(context, flags: [], env: "test")
 
         command = Theme::Commands::Serve.new(context)
-        command.options.flags[:env] = 'test'
+        command.options.flags[:env] = "test"
         command.call
       end
     end

--- a/test/project_types/theme/forms/connect_test.rb
+++ b/test/project_types/theme/forms/connect_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Forms
@@ -10,32 +10,32 @@ module Theme
                   "name" => "my_theme" },
                 { "id" => 1357,
                   "name" => "your_theme" }] }]
-      THEMES = resp[1]['themes'].map { |theme| [theme['name'], theme['id']] }.to_h
+      THEMES = resp[1]["themes"].map { |theme| [theme["name"], theme["id"]] }.to_h
 
       def test_returns_all_defined_attributes_if_valid
         Themekit.expects(:query_themes)
-          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .with(@context, store: "shop.myshopify.com", password: "boop")
           .returns(THEMES)
 
         form = ask
-        assert_equal('shop.myshopify.com', form.store)
-        assert_equal('boop', form.password)
-        assert_equal('2468', form.themeid)
-        assert_equal('my_theme', form.name)
+        assert_equal("shop.myshopify.com", form.store)
+        assert_equal("boop", form.password)
+        assert_equal("2468", form.themeid)
+        assert_equal("my_theme", form.name)
       end
 
       def test_env_can_be_provided_by_flag
         Themekit.expects(:query_themes)
-          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .with(@context, store: "shop.myshopify.com", password: "boop")
           .returns(THEMES)
 
-        form = ask(env: 'test')
-        assert_equal('test', form.env)
+        form = ask(env: "test")
+        assert_equal("test", form.env)
       end
 
       def test_env_nil_if_not_provided
         Themekit.expects(:query_themes)
-          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .with(@context, store: "shop.myshopify.com", password: "boop")
           .returns(THEMES)
 
         form = ask
@@ -44,55 +44,55 @@ module Theme
 
       def test_store_can_be_provided_by_flag
         Themekit.expects(:query_themes)
-          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .with(@context, store: "shop.myshopify.com", password: "boop")
           .returns(THEMES)
 
-        form = ask(store: 'shop.myshopify.com')
-        assert_equal('shop.myshopify.com', form.store)
+        form = ask(store: "shop.myshopify.com")
+        assert_equal("shop.myshopify.com", form.store)
       end
 
       def test_store_is_prompted
         Themekit.expects(:query_themes)
-          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .with(@context, store: "shop.myshopify.com", password: "boop")
           .returns(THEMES)
 
         CLI::UI::Prompt.expects(:ask)
-          .with(@context.message('theme.forms.ask_store'), allow_empty: false)
-          .returns('shop.myshopify.com')
+          .with(@context.message("theme.forms.ask_store"), allow_empty: false)
+          .returns("shop.myshopify.com")
         ask(store: nil)
       end
 
       def test_password_can_be_provided_by_flag
         Themekit.expects(:query_themes)
-          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .with(@context, store: "shop.myshopify.com", password: "boop")
           .returns(THEMES)
 
-        form = ask(password: 'boop')
-        assert_equal('boop', form.password)
+        form = ask(password: "boop")
+        assert_equal("boop", form.password)
       end
 
       def test_password_is_prompted
         Themekit.expects(:query_themes)
-          .with(@context, store: 'shop.myshopify.com', password: 'boop')
+          .with(@context, store: "shop.myshopify.com", password: "boop")
           .returns(THEMES)
 
-        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
-          .returns('boop')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("theme.forms.ask_password"), allow_empty: false)
+          .returns("boop")
         ask(password: nil)
       end
 
       def test_aborts_if_field_empty
-        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_store'), allow_empty: false)
-          .returns(' ')
-        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
-          .returns(' ')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("theme.forms.ask_store"), allow_empty: false)
+          .returns(" ")
+        CLI::UI::Prompt.expects(:ask).with(@context.message("theme.forms.ask_password"), allow_empty: false)
+          .returns(" ")
 
         assert_nil(ask(store: nil, password: nil, themeid: nil))
       end
 
       private
 
-      def ask(password: 'boop', store: 'shop.myshopify.com', themeid: '2468', env: nil)
+      def ask(password: "boop", store: "shop.myshopify.com", themeid: "2468", env: nil)
         Connect.ask(
           @context,
           [],

--- a/test/project_types/theme/forms/create_test.rb
+++ b/test/project_types/theme/forms/create_test.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Forms
     class CreateTest < MiniTest::Test
       def test_returns_all_defined_attributes_if_valid
         form = ask
-        assert_equal('shop.myshopify.com', form.store)
-        assert_equal('boop', form.password)
-        assert_equal('My Theme', form.title)
-        assert_equal('my_theme', form.name)
+        assert_equal("shop.myshopify.com", form.store)
+        assert_equal("boop", form.password)
+        assert_equal("My Theme", form.title)
+        assert_equal("my_theme", form.name)
       end
 
       def test_env_can_be_provided_by_flag
-        form = ask(env: 'test')
-        assert_equal('test', form.env)
+        form = ask(env: "test")
+        assert_equal("test", form.env)
       end
 
       def test_env_nil_if_not_provided
@@ -23,57 +23,57 @@ module Theme
       end
 
       def test_store_can_be_provided_by_flag
-        form = ask(store: 'shop.myshopify.com')
-        assert_equal('shop.myshopify.com', form.store)
+        form = ask(store: "shop.myshopify.com")
+        assert_equal("shop.myshopify.com", form.store)
       end
 
       def test_store_is_prompted
         CLI::UI::Prompt.expects(:ask)
-          .with(@context.message('theme.forms.ask_store'), allow_empty: false)
-          .returns('shop.myshopify.com')
+          .with(@context.message("theme.forms.ask_store"), allow_empty: false)
+          .returns("shop.myshopify.com")
         ask(store: nil)
       end
 
       def test_password_can_be_provided_by_flag
-        form = ask(password: 'boop')
-        assert_equal('boop', form.password)
+        form = ask(password: "boop")
+        assert_equal("boop", form.password)
       end
 
       def test_password_is_prompted
-        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
-          .returns('boop')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("theme.forms.ask_password"), allow_empty: false)
+          .returns("boop")
         ask(password: nil)
       end
 
       def test_title_can_be_provided_by_flag
-        form = ask(title: 'My Theme')
-        assert_equal('my_theme', form.name)
-        assert_equal('My Theme', form.title)
+        form = ask(title: "My Theme")
+        assert_equal("my_theme", form.name)
+        assert_equal("My Theme", form.title)
       end
 
       def test_title_is_prompted
-        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_title'), allow_empty: false)
-          .returns('My Theme')
-        assert_equal('my_theme', ask.name)
+        CLI::UI::Prompt.expects(:ask).with(@context.message("theme.forms.create.ask_title"), allow_empty: false)
+          .returns("My Theme")
+        assert_equal("my_theme", ask.name)
         ask(title: nil)
       end
 
       def test_aborts_if_field_empty
-        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_store'), allow_empty: false)
-          .returns(' ')
-        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.ask_password'), allow_empty: false)
-          .returns(' ')
-        CLI::UI::Prompt.expects(:ask).with(@context.message('theme.forms.create.ask_title'), allow_empty: false)
-          .returns(' ')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("theme.forms.ask_store"), allow_empty: false)
+          .returns(" ")
+        CLI::UI::Prompt.expects(:ask).with(@context.message("theme.forms.ask_password"), allow_empty: false)
+          .returns(" ")
+        CLI::UI::Prompt.expects(:ask).with(@context.message("theme.forms.create.ask_title"), allow_empty: false)
+          .returns(" ")
         @context.expects(:abort)
-          .with(@context.message('theme.forms.errors', 'store, password, title'.capitalize))
+          .with(@context.message("theme.forms.errors", "store, password, title".capitalize))
 
         ask(store: nil, password: nil, title: nil)
       end
 
       private
 
-      def ask(title: 'My Theme', password: 'boop', store: 'shop.myshopify.com', env: nil)
+      def ask(title: "My Theme", password: "boop", store: "shop.myshopify.com", env: nil)
         Create.ask(
           @context,
           [],

--- a/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
+++ b/test/project_types/theme/tasks/ensure_themekit_installed_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   module Tasks
@@ -27,13 +27,13 @@ module Theme
         stub_releases
         stub_themekit_file_write
         CLI::UI.expects(:confirm)
-          .with(@context.message('theme.tasks.ensure_themekit_installed.auto_update'))
+          .with(@context.message("theme.tasks.ensure_themekit_installed.auto_update"))
           .returns(true)
         ShopifyCli::Feature.expects(:set).with(:themekit_auto_update, true)
         stub_time_check
 
-        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('boop')
-        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT)
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns("boop")
+        FileUtils.expects(:chmod).with("+x", Themekit::THEMEKIT)
         ShopifyCli::Feature.expects(:enabled?).returns(true)
 
         EnsureThemekitInstalled.call(@context)
@@ -44,31 +44,31 @@ module Theme
         stub_releases
         stub_themekit_file_write
 
-        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns('mlem')
-        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+        Digest::MD5.expects(:file).with(Themekit::THEMEKIT).returns("mlem")
+        FileUtils.expects(:chmod).with("+x", Themekit::THEMEKIT).never
         File.expects(:exist?).with(Themekit::THEMEKIT).returns(true)
         FileUtils.expects(:rm).with(Themekit::THEMEKIT)
 
         assert_raises(ShopifyCli::Abort,
-          @context.message('theme.tasks.ensure_themekit_installed.errors.digest_fail')) do
+          @context.message("theme.tasks.ensure_themekit_installed.errors.digest_fail")) do
           EnsureThemekitInstalled.call(@context)
         end
       end
 
       def test_fails_gracefully_if_network_errors
         stat = mock
-        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(['out', stat])
+        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(["out", stat])
         stat.stubs(:success?).returns(false)
         stub_request(:get, EnsureThemekitInstalled::URL).to_return(status: 504)
 
         @context.expects(:capture2e)
-          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
+          .with("curl", "-o", Themekit::THEMEKIT, "http://www.website.ca")
           .never
         Digest::MD5.expects(:file).with(Themekit::THEMEKIT).never
-        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+        FileUtils.expects(:chmod).with("+x", Themekit::THEMEKIT).never
 
         assert_raises(ShopifyCli::Abort,
-          @context.message('theme.tasks.ensure_themekit_installed.errors.releases_fail')) do
+          @context.message("theme.tasks.ensure_themekit_installed.errors.releases_fail")) do
           EnsureThemekitInstalled.call(@context)
         end
       end
@@ -79,16 +79,16 @@ module Theme
 
         stat = mock
         @context.expects(:capture2e)
-          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
-          .returns(['out', stat])
+          .with("curl", "-o", Themekit::THEMEKIT, "http://www.website.ca")
+          .returns(["out", stat])
         stat.stubs(:success?).returns(false)
 
         Digest::MD5.expects(:file).with(Themekit::THEMEKIT).never
-        FileUtils.expects(:chmod).with('+x', Themekit::THEMEKIT).never
+        FileUtils.expects(:chmod).with("+x", Themekit::THEMEKIT).never
         File.expects(:exist?).with(Themekit::THEMEKIT).returns(true)
         FileUtils.expects(:rm).with(Themekit::THEMEKIT)
 
-        assert_raises(ShopifyCli::Abort, @context.message('theme.tasks.ensure_themekit_installed.errors.write_fail')) do
+        assert_raises(ShopifyCli::Abort, @context.message("theme.tasks.ensure_themekit_installed.errors.write_fail")) do
           EnsureThemekitInstalled.call(@context)
         end
       end
@@ -117,7 +117,7 @@ module Theme
           .never
 
         assert_raises(ShopifyCli::Abort,
-          @context.message('theme.tasks.ensure_themekit_installed.errors.update_fail')) do
+          @context.message("theme.tasks.ensure_themekit_installed.errors.update_fail")) do
           EnsureThemekitInstalled.call(@context)
         end
       end
@@ -126,7 +126,7 @@ module Theme
 
       def stub_check_executable(status = false)
         stat = mock
-        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(['out', stat])
+        @context.expects(:capture2e).with(Themekit::THEMEKIT).returns(["out", stat])
         stat.stubs(:success?).returns(status)
       end
 
@@ -134,22 +134,22 @@ module Theme
         stub_request(:get, EnsureThemekitInstalled::URL)
           .to_return(body: { "platforms": [
             {
-              "name": 'darwin-amd64',
-              "version": '123',
-              "url": 'http://www.website.ca',
-              "digest": 'boop',
+              "name": "darwin-amd64",
+              "version": "123",
+              "url": "http://www.website.ca",
+              "digest": "boop",
             },
             {
-              "name": 'linux-amd64',
-              "version": '123',
-              "url": 'http://www.website.ca',
-              "digest": 'boop',
+              "name": "linux-amd64",
+              "version": "123",
+              "url": "http://www.website.ca",
+              "digest": "boop",
             },
             {
-              "name": 'windows-amd64',
-              "version": '123',
-              "url": 'http://www.website.ca',
-              "digest": 'boop',
+              "name": "windows-amd64",
+              "version": "123",
+              "url": "http://www.website.ca",
+              "digest": "boop",
             },
           ] }.to_json)
       end
@@ -157,8 +157,8 @@ module Theme
       def stub_themekit_file_write
         stat = mock
         @context.expects(:capture2e)
-          .with('curl', '-o', Themekit::THEMEKIT, 'http://www.website.ca')
-          .returns(['out', stat])
+          .with("curl", "-o", Themekit::THEMEKIT, "http://www.website.ca")
+          .returns(["out", stat])
         stat.stubs(:success?).returns(true)
       end
 

--- a/test/project_types/theme/themekit_test.rb
+++ b/test/project_types/theme/themekit_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'project_types/theme/test_helper'
+require "project_types/theme/test_helper"
 
 module Theme
   class ThemekitTest < MiniTest::Test
@@ -11,7 +11,7 @@ module Theme
                   "name" => "your_theme" }] }]
 
     def test_add_flags_successful
-      flags = { 'key': 'value' }
+      flags = { 'key': "value" }
       assert(Themekit.add_flags(flags), ["--key=value"])
     end
 
@@ -21,14 +21,14 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'new',
-          '--no-update-notifier',
-          '--password=boop',
-          '--store=shop.myshopify.com',
-          '--name=My Theme')
+          "new",
+          "--no-update-notifier",
+          "--password=boop",
+          "--store=shop.myshopify.com",
+          "--name=My Theme")
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.create(context, password: 'boop', store: 'shop.myshopify.com', name: 'My Theme', env: nil))
+      assert(Themekit.create(context, password: "boop", store: "shop.myshopify.com", name: "My Theme", env: nil))
     end
 
     def test_create_theme_unsuccessful
@@ -37,14 +37,14 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'new',
-          '--no-update-notifier',
-          '--password=boop',
-          '--store=shop.com',
-          '--name=My Theme')
+          "new",
+          "--no-update-notifier",
+          "--password=boop",
+          "--store=shop.com",
+          "--name=My Theme")
         .returns(stat)
       stat.stubs(:success?).returns(false)
-      refute(Themekit.create(context, password: 'boop', store: 'shop.com', name: 'My Theme', env: nil))
+      refute(Themekit.create(context, password: "boop", store: "shop.com", name: "My Theme", env: nil))
     end
 
     def test_push_deploy_successful
@@ -53,8 +53,8 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'deploy',
-          '--no-update-notifier')
+          "deploy",
+          "--no-update-notifier")
         .returns(stat)
       stat.stubs(:success?).returns(true)
       assert(Themekit.push(context, files: [], flags: [], remove: nil, env: nil))
@@ -66,8 +66,8 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'deploy',
-          '--no-update-notifier')
+          "deploy",
+          "--no-update-notifier")
         .returns(stat)
       stat.stubs(:success?).returns(true)
       assert(Themekit.push(context, files: nil, flags: nil, remove: nil, env: nil))
@@ -79,13 +79,13 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'remove',
-          '--no-update-notifier',
-          'file.liquid',
-          'another_file.liquid')
+          "remove",
+          "--no-update-notifier",
+          "file.liquid",
+          "another_file.liquid")
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil))
+      assert(Themekit.push(context, files: ["file.liquid", "another_file.liquid"], flags: [], remove: true, env: nil))
     end
 
     def test_push_successful_with_flags
@@ -94,12 +94,12 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'deploy',
-          '--no-update-notifier',
-          '--allow-live')
+          "deploy",
+          "--no-update-notifier",
+          "--allow-live")
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.push(context, files: [], flags: ['--allow-live'], remove: nil, env: nil))
+      assert(Themekit.push(context, files: [], flags: ["--allow-live"], remove: nil, env: nil))
     end
 
     def test_push_deploy_unsuccessful
@@ -108,8 +108,8 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'deploy',
-          '--no-update-notifier')
+          "deploy",
+          "--no-update-notifier")
         .returns(stat)
       stat.stubs(:success?).returns(false)
       refute(Themekit.push(context, files: [], flags: [], remove: nil, env: nil))
@@ -121,13 +121,13 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'remove',
-          '--no-update-notifier',
-          'file.liquid',
-          'another_file.liquid')
+          "remove",
+          "--no-update-notifier",
+          "file.liquid",
+          "another_file.liquid")
         .returns(stat)
       stat.stubs(:success?).returns(false)
-      refute(Themekit.push(context, files: ['file.liquid', 'another_file.liquid'], flags: [], remove: true, env: nil))
+      refute(Themekit.push(context, files: ["file.liquid", "another_file.liquid"], flags: [], remove: true, env: nil))
     end
 
     def test_deploy_successful
@@ -135,12 +135,12 @@ module Theme
       stat = mock
 
       Themekit.expects(:push).with(context, flags: nil, env: nil).returns(true)
-      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+      context.expects(:done).with(context.message("theme.deploy.info.pushed"))
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'publish',
-          '--no-update-notifier')
+          "publish",
+          "--no-update-notifier")
         .returns(stat)
       stat.stubs(:success?).returns(true)
 
@@ -151,18 +151,18 @@ module Theme
       context = ShopifyCli::Context.new
       stat = mock
 
-      Themekit.expects(:push).with(context, flags: ['--allow-live'], env: nil).returns(true)
-      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+      Themekit.expects(:push).with(context, flags: ["--allow-live"], env: nil).returns(true)
+      context.expects(:done).with(context.message("theme.deploy.info.pushed"))
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'publish',
-          '--no-update-notifier',
-          '--allow-live')
+          "publish",
+          "--no-update-notifier",
+          "--allow-live")
         .returns(stat)
       stat.stubs(:success?).returns(true)
 
-      assert(Themekit.deploy(context, flags: ['--allow-live'], env: nil))
+      assert(Themekit.deploy(context, flags: ["--allow-live"], env: nil))
     end
 
     def test_deploy_push_fail
@@ -170,8 +170,8 @@ module Theme
 
       Themekit.expects(:push).with(context, flags: nil, env: nil).returns(false)
       context.expects(:system).with(Themekit::THEMEKIT,
-        'publish',
-        '--no-update-notifier').never
+        "publish",
+        "--no-update-notifier").never
 
       assert_raises CLI::Kit::Abort do
         Themekit.deploy(context, env: nil)
@@ -183,12 +183,12 @@ module Theme
       stat = mock
 
       Themekit.expects(:push).with(context, flags: nil, env: nil).returns(true)
-      context.expects(:done).with(context.message('theme.deploy.info.pushed'))
+      context.expects(:done).with(context.message("theme.deploy.info.pushed"))
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'publish',
-          '--no-update-notifier')
+          "publish",
+          "--no-update-notifier")
         .returns(stat)
       stat.stubs(:success?).returns(false)
 
@@ -200,14 +200,14 @@ module Theme
       stat = mock
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'get',
-          '--no-update-notifier',
-          '--password=boop',
-          '--store=shop.com',
-          '--themeid=2468')
+          "get",
+          "--no-update-notifier",
+          "--password=boop",
+          "--store=shop.com",
+          "--themeid=2468")
         .returns(stat)
       stat.stubs(:success?).returns(true)
-      assert(Themekit.connect(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
+      assert(Themekit.connect(context, store: "shop.com", password: "boop", themeid: "2468", env: nil))
     end
 
     def test_connect_unsuccessful
@@ -215,14 +215,14 @@ module Theme
       stat = mock
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'get',
-          '--no-update-notifier',
-          '--password=boop',
-          '--store=shop.com',
-          '--themeid=2468')
+          "get",
+          "--no-update-notifier",
+          "--password=boop",
+          "--store=shop.com",
+          "--themeid=2468")
         .returns(stat)
       stat.stubs(:success?).returns(false)
-      refute(Themekit.connect(context, store: 'shop.com', password: 'boop', themeid: '2468', env: nil))
+      refute(Themekit.connect(context, store: "shop.com", password: "boop", themeid: "2468", env: nil))
     end
 
     def test_serve_successful
@@ -231,16 +231,16 @@ module Theme
 
       context.expects(:capture2e)
         .with(Themekit::THEMEKIT,
-          'open',
-          '--no-update-notifier')
-        .returns(['out', stat])
+          "open",
+          "--no-update-notifier")
+        .returns(["out", stat])
       stat.stubs(:success?).returns(true)
-      context.expects(:puts).with('out')
+      context.expects(:puts).with("out")
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'watch',
-          '--no-update-notifier')
+          "watch",
+          "--no-update-notifier")
 
       Themekit.serve(context, env: nil)
     end
@@ -251,19 +251,19 @@ module Theme
 
       context.expects(:capture2e)
         .with(Themekit::THEMEKIT,
-          'open',
-          '--no-update-notifier')
-        .returns(['out', stat])
+          "open",
+          "--no-update-notifier")
+        .returns(["out", stat])
       stat.stubs(:success?).returns(true)
-      context.expects(:puts).with('out')
+      context.expects(:puts).with("out")
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'watch',
-          '--no-update-notifier',
-          '--allow-live')
+          "watch",
+          "--no-update-notifier",
+          "--allow-live")
 
-      Themekit.serve(context, flags: ['--allow-live'], env: nil)
+      Themekit.serve(context, flags: ["--allow-live"], env: nil)
     end
 
     def test_aborts_serve_if_open_fails
@@ -272,16 +272,16 @@ module Theme
 
       context.expects(:capture2e)
         .with(Themekit::THEMEKIT,
-          'open',
-          '--no-update-notifier')
-        .returns(['out', stat])
+          "open",
+          "--no-update-notifier")
+        .returns(["out", stat])
       stat.stubs(:success?).returns(false)
-      context.expects(:puts).with('out')
+      context.expects(:puts).with("out")
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'watch',
-          '--no-update-notifier')
+          "watch",
+          "--no-update-notifier")
         .never
 
       assert_raises(ShopifyCli::Abort) do
@@ -294,8 +294,8 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'update',
-          '--no-update-notifier')
+          "update",
+          "--no-update-notifier")
         .returns(true)
 
       Themekit.update(context)
@@ -307,15 +307,15 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'configure',
-          '--no-update-notifier',
-          '--password=boop',
-          '--store=shop.myshopify.com',
-          '--themeid=2468')
+          "configure",
+          "--no-update-notifier",
+          "--password=boop",
+          "--store=shop.myshopify.com",
+          "--themeid=2468")
         .returns(stat)
       stat.stubs(:success?).returns(true)
 
-      Themekit.generate_env(context, store: 'shop.myshopify.com', password: 'boop', themeid: 2468, env: nil)
+      Themekit.generate_env(context, store: "shop.myshopify.com", password: "boop", themeid: 2468, env: nil)
     end
 
     def test_can_generate_env_with_env_flag
@@ -324,16 +324,16 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'configure',
-          '--no-update-notifier',
-          '--env=test',
-          '--password=boop',
-          '--store=shop.myshopify.com',
-          '--themeid=2468')
+          "configure",
+          "--no-update-notifier",
+          "--env=test",
+          "--password=boop",
+          "--store=shop.myshopify.com",
+          "--themeid=2468")
         .returns(stat)
       stat.stubs(:success?).returns(true)
 
-      Themekit.generate_env(context, store: 'shop.myshopify.com', password: 'boop', themeid: 2468, env: 'test')
+      Themekit.generate_env(context, store: "shop.myshopify.com", password: "boop", themeid: 2468, env: "test")
     end
 
     def test_generate_env_returns_false_if_bad_info
@@ -342,15 +342,15 @@ module Theme
 
       context.expects(:system)
         .with(Themekit::THEMEKIT,
-          'configure',
-          '--no-update-notifier',
-          '--password=boop',
-          '--store=shop.myshopify.com',
-          '--themeid=1357')
+          "configure",
+          "--no-update-notifier",
+          "--password=boop",
+          "--store=shop.myshopify.com",
+          "--themeid=1357")
         .returns(stat)
       stat.stubs(:success?).returns(false)
 
-      Themekit.generate_env(context, store: 'shop.myshopify.com', password: 'boop', themeid: 1357, env: nil)
+      Themekit.generate_env(context, store: "shop.myshopify.com", password: "boop", themeid: 1357, env: nil)
     end
 
     def test_can_query_themes
@@ -358,12 +358,12 @@ module Theme
 
       ShopifyCli::AdminAPI.expects(:rest_request)
         .with(context,
-          shop: 'shop.myshopify.com',
-          token: 'boop',
-          path: 'themes.json')
+          shop: "shop.myshopify.com",
+          token: "boop",
+          path: "themes.json")
         .returns(RESP)
 
-      Themekit.query_themes(context, store: 'shop.myshopify.com', password: 'boop')
+      Themekit.query_themes(context, store: "shop.myshopify.com", password: "boop")
     end
 
     def test_aborts_query_if_bad_password
@@ -371,13 +371,13 @@ module Theme
 
       ShopifyCli::AdminAPI.expects(:rest_request)
         .with(context,
-          shop: 'shop.myshopify.com',
-          token: 'meep',
-          path: 'themes.json')
+          shop: "shop.myshopify.com",
+          token: "meep",
+          path: "themes.json")
         .raises(ShopifyCli::API::APIRequestUnauthorizedError)
 
       assert_raises CLI::Kit::Abort do
-        Themekit.query_themes(context, store: 'shop.myshopify.com', password: 'meep')
+        Themekit.query_themes(context, store: "shop.myshopify.com", password: "meep")
       end
     end
 
@@ -386,13 +386,13 @@ module Theme
 
       ShopifyCli::AdminAPI.expects(:rest_request)
         .with(context,
-          shop: 'market.myshopify.com',
-          token: 'boop',
-          path: 'themes.json')
+          shop: "market.myshopify.com",
+          token: "boop",
+          path: "themes.json")
         .raises(StandardError)
 
       assert_raises CLI::Kit::Abort do
-        Themekit.query_themes(context, store: 'market.myshopify.com', password: 'boop')
+        Themekit.query_themes(context, store: "market.myshopify.com", password: "boop")
       end
     end
   end

--- a/test/shopify-cli/admin_api/populate_resource_command_test.rb
+++ b/test/shopify-cli/admin_api/populate_resource_command_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class AdminAPI
@@ -16,18 +16,18 @@ module ShopifyCli
       def test_with_schema_args_overrides_input
         @resource.expects(:run_mutation).times(1)
         @resource.call([
-          '-c 1', '--title="bad jeggings"', '--variants=[{price: "4.99"}]'
+          "-c 1", '--title="bad jeggings"', '--variants=[{price: "4.99"}]'
         ], nil)
-        assert_equal('"bad jeggings"', @resource.input['title'])
-        assert_equal('[{price: "4.99"}]', @resource.input['variants'])
+        assert_equal('"bad jeggings"', @resource.input["title"])
+        assert_equal('[{price: "4.99"}]', @resource.input["variants"])
       end
 
       def test_prompts_and_writes_to_env_if_no_shop
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "123", secret: "foo"))
         assert_nil(Project.current.env.shop)
         ShopifyCli::Tasks::SelectOrgAndShop.expects(:call)
           .with(@context)
-          .returns({ shop_domain: 'shopdomain.myshopify.com' })
+          .returns({ shop_domain: "shopdomain.myshopify.com" })
         Resources::EnvFile.any_instance.expects(:update)
         @resource.expects(:run_mutation).times(Rails::Commands::Populate::Product::DEFAULT_COUNT)
         @resource.call([], nil)
@@ -40,15 +40,15 @@ module ShopifyCli
 
       def test_populate_runs_mutation_count_number_of_times
         @resource.expects(:run_mutation).times(2)
-        @resource.call(['-c 2'], nil)
+        @resource.call(["-c 2"], nil)
       end
 
       def test_populate_runs_mutation_against_other_shop
         ShopifyCli::AdminAPI.expects(:query).with(
-          @context, 'create_product', has_entry(shop: 'my-other-test-shop.myshopify.com')
+          @context, "create_product", has_entry(shop: "my-other-test-shop.myshopify.com")
         ).returns(Hash.new)
         capture_io do
-          @resource.call(['--silent', '-c 1', '--shop=my-other-test-shop.myshopify.com'], nil)
+          @resource.call(["--silent", "-c 1", "--shop=my-other-test-shop.myshopify.com"], nil)
         end
       end
 
@@ -56,7 +56,7 @@ module ShopifyCli
         CLI::UI::Terminal.stubs(:height).returns(10000)
         @resource.expects(:run_mutation).never
         io = capture_io do
-          @resource.call(['-h'], nil)
+          @resource.call(["-h"], nil)
         end.join
         assert_match(/Product.*options/, io)
         assert_match(@resource.resource_options.help, io)

--- a/test/shopify-cli/admin_api/schema_test.rb
+++ b/test/shopify-cli/admin_api/schema_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class AdminAPI
@@ -21,7 +21,7 @@ module ShopifyCli
         ShopifyCli::DB.expects(:set).with(shopify_admin_schema: "{\"foo\":\"baz\"}")
         ShopifyCli::DB.expects(:get).with(:shopify_admin_schema).returns("{\"foo\":\"baz\"}")
         ShopifyCli::AdminAPI.expects(:query)
-          .with(@context, 'admin_introspection', shop: 'my-test-shop.myshopify.com')
+          .with(@context, "admin_introspection", shop: "my-test-shop.myshopify.com")
           .returns(foo: "baz")
         assert_equal({ "foo" => "baz" }, AdminAPI::Schema.get(@context))
       end
@@ -33,11 +33,11 @@ module ShopifyCli
       end
 
       def test_access
-        assert_equal(@test_obj.type('WebhookSubscriptionTopic'), @enum)
+        assert_equal(@test_obj.type("WebhookSubscriptionTopic"), @enum)
       end
 
       def test_get_names_from_enum
-        assert_equal(["APP_UNINSTALLED"], @test_obj.get_names_from_type('WebhookSubscriptionTopic'))
+        assert_equal(["APP_UNINSTALLED"], @test_obj.get_names_from_type("WebhookSubscriptionTopic"))
       end
     end
   end

--- a/test/shopify-cli/admin_api_test.rb
+++ b/test/shopify-cli/admin_api_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class AdminAPITest < MiniTest::Test
@@ -8,39 +8,39 @@ module ShopifyCli
       unstable_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
-        auth_header: 'X-Shopify-Access-Token',
-        token: 'token123',
+        auth_header: "X-Shopify-Access-Token",
+        token: "token123",
         url: "https://my-test-shop.myshopify.com/admin/api/unstable/graphql.json",
       ).returns(unstable_stub)
       unstable_stub.expects(:query)
-        .with('api_versions')
-        .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, 'api/versions.json'))))
+        .with("api_versions")
+        .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, "api/versions.json"))))
 
-      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123').twice
+      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns("token123").twice
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
-        auth_header: 'X-Shopify-Access-Token',
-        token: 'token123',
+        auth_header: "X-Shopify-Access-Token",
+        token: "token123",
         url: "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json",
       ).returns(api_stub)
-      api_stub.expects(:query).with('query', variables: {}).returns('response')
-      assert_equal 'response', AdminAPI.query(@context, 'query', shop: 'my-test-shop.myshopify.com')
+      api_stub.expects(:query).with("query", variables: {}).returns("response")
+      assert_equal "response", AdminAPI.query(@context, "query", shop: "my-test-shop.myshopify.com")
     end
 
     def test_query_calls_admin_api
-      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123')
+      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns("token123")
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
-        auth_header: 'X-Shopify-Access-Token',
-        token: 'token123',
+        auth_header: "X-Shopify-Access-Token",
+        token: "token123",
         url: "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json",
       ).returns(api_stub)
-      api_stub.expects(:query).with('query', variables: {}).returns('response')
+      api_stub.expects(:query).with("query", variables: {}).returns("response")
       assert_equal(
-        'response',
-        AdminAPI.query(@context, 'query', shop: 'my-test-shop.myshopify.com', api_version: '2019-04'),
+        "response",
+        AdminAPI.query(@context, "query", shop: "my-test-shop.myshopify.com", api_version: "2019-04"),
       )
     end
 
@@ -48,33 +48,33 @@ module ShopifyCli
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
-        auth_header: 'X-Shopify-Access-Token',
-        token: 'boop',
-        url: 'https://shop.myshopify.com/admin/api/unstable/data.json',
+        auth_header: "X-Shopify-Access-Token",
+        token: "boop",
+        url: "https://shop.myshopify.com/admin/api/unstable/data.json",
       ).returns(api_stub)
-      api_stub.expects(:request).with(url: 'https://shop.myshopify.com/admin/api/unstable/data.json',
+      api_stub.expects(:request).with(url: "https://shop.myshopify.com/admin/api/unstable/data.json",
                                       body: nil,
-                                      method: "GET").returns('response')
+                                      method: "GET").returns("response")
       assert_equal(
-        'response',
+        "response",
         AdminAPI.rest_request(@context,
-          shop: 'shop.myshopify.com',
-          path: 'data.json',
-          api_version: 'unstable',
-          token: 'boop'),
+          shop: "shop.myshopify.com",
+          path: "data.json",
+          api_version: "unstable",
+          token: "boop"),
       )
     end
 
     def test_query_can_reauth
-      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123').twice
+      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns("token123").twice
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
-        auth_header: 'X-Shopify-Access-Token',
-        token: 'token123',
+        auth_header: "X-Shopify-Access-Token",
+        token: "token123",
         url: "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json",
       ).returns(api_stub).twice
-      api_stub.expects(:query).with('query', variables: {}).returns('response')
+      api_stub.expects(:query).with("query", variables: {}).returns("response")
       api_stub.expects(:query).raises(API::APIRequestUnauthorizedError)
 
       @oauth_client = mock
@@ -82,32 +82,32 @@ module ShopifyCli
         .expects(:new)
         .with(
           ctx: @context,
-          service: 'admin',
-          client_id: 'apikey',
-          secret: 'secret',
+          service: "admin",
+          client_id: "apikey",
+          secret: "secret",
           scopes: nil,
           token_path: "/access_token",
-          options: { 'grant_options[]' => 'per user' },
+          options: { "grant_options[]" => "per user" },
         ).returns(@oauth_client)
       @oauth_client
         .expects(:authenticate)
         .with("https://my-test-shop.myshopify.com/admin/oauth")
 
-      AdminAPI.query(@context, 'query', shop: 'my-test-shop.myshopify.com', api_version: '2019-04')
+      AdminAPI.query(@context, "query", shop: "my-test-shop.myshopify.com", api_version: "2019-04")
     end
 
     def test_query_calls_admin_api_with_different_shop
-      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns('token123')
+      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns("token123")
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
-        auth_header: 'X-Shopify-Access-Token',
-        token: 'token123',
+        auth_header: "X-Shopify-Access-Token",
+        token: "token123",
         url: "https://other-test-shop.myshopify.com/admin/api/2019-04/graphql.json",
       ).returns(api_stub)
-      api_stub.expects(:query).with('query', variables: {}).returns('response')
-      assert_equal 'response', AdminAPI.query(
-        @context, 'query', shop: 'other-test-shop.myshopify.com', api_version: '2019-04'
+      api_stub.expects(:query).with("query", variables: {}).returns("response")
+      assert_equal "response", AdminAPI.query(
+        @context, "query", shop: "other-test-shop.myshopify.com", api_version: "2019-04"
       )
     end
   end

--- a/test/shopify-cli/api_test.rb
+++ b/test/shopify-cli/api_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'shopify-cli/http_request'
+require "test_helper"
+require "shopify-cli/http_request"
 
 module ShopifyCli
   class APITest < MiniTest::Test
@@ -22,28 +22,28 @@ module ShopifyCli
       MUTATION
       @api = API.new(
         ctx: @context,
-        auth_header: 'Auth',
-        token: 'faketoken',
+        auth_header: "Auth",
+        token: "faketoken",
         url: "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json",
       )
-      Git.stubs(:sha).returns('abcde')
-      @context.stubs(:uname).returns('Mac')
+      Git.stubs(:sha).returns("abcde")
+      @context.stubs(:uname).returns("Mac")
     end
 
     def test_mutation_makes_request_to_shopify
       headers = {
-        'User-Agent' => "Shopify App CLI #{ShopifyCli::VERSION} abcde | Mac",
-        'Auth' => 'faketoken',
+        "User-Agent" => "Shopify App CLI #{ShopifyCli::VERSION} abcde | Mac",
+        "Auth" => "faketoken",
       }
       uri = URI.parse("https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")
-      variables = { var_name: 'var_value' }
+      variables = { var_name: "var_value" }
       body = JSON.dump(query: @mutation.tr("\n", ""), variables: variables)
       File.stubs(:read)
         .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
-      response = stub('response', code: '200', body: '{}')
+      response = stub("response", code: "200", body: "{}")
       HttpRequest.expects(:post).with(uri, body, headers).returns(response)
-      @api.query('api/mutation', variables: variables)
+      @api.query("api/mutation", variables: variables)
     end
 
     def test_raises_error_with_invalid_url
@@ -52,93 +52,93 @@ module ShopifyCli
         .returns(@mutation)
       api = API.new(
         ctx: @context,
-        auth_header: 'Auth',
-        token: 'faketoken',
-        url: 'https//https://invalidurl',
+        auth_header: "Auth",
+        token: "faketoken",
+        url: "https//https://invalidurl",
       )
 
       assert_raises(ShopifyCli::Abort) do
-        api.query('api/mutation')
+        api.query("api/mutation")
       end
     end
 
     def test_query_fails_gracefully_with_internal_server_error
-      response = stub('response', code: '500', body: '{}')
+      response = stub("response", code: "500", body: "{}")
       HttpRequest.expects(:post).returns(response).times(4)
       File.stubs(:read)
         .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
 
-      @context.expects(:puts).with(@context.message('core.api.error.internal_server_error'))
-      @api.query('api/mutation')
+      @context.expects(:puts).with(@context.message("core.api.error.internal_server_error"))
+      @api.query("api/mutation")
       @api.stubs(:query).raises(API::APIRequestServerError)
       assert_raises(API::APIRequestServerError) do
-        @api.query('api/mutation')
+        @api.query("api/mutation")
       end
     end
 
     def test_query_fails_gracefully_with_internal_server_error_on_debug_mode
-      @context.stubs(:getenv).with('DEBUG').returns(true)
-      response = stub('response', code: '500', body: '{}')
+      @context.stubs(:getenv).with("DEBUG").returns(true)
+      response = stub("response", code: "500", body: "{}")
       HttpRequest.expects(:post).returns(response).times(4)
       File.stubs(:read)
         .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
 
-      @context.expects(:debug).with(@context.message('core.api.error.internal_server_error_debug', "500\n{}"))
-      @context.expects(:puts).with(@context.message('core.api.error.internal_server_error'))
-      @api.query('api/mutation')
+      @context.expects(:debug).with(@context.message("core.api.error.internal_server_error_debug", "500\n{}"))
+      @context.expects(:puts).with(@context.message("core.api.error.internal_server_error"))
+      @api.query("api/mutation")
       @api.stubs(:query).raises(API::APIRequestServerError)
       assert_raises(API::APIRequestServerError) do
-        @api.query('api/mutation')
+        @api.query("api/mutation")
       end
     end
 
     def test_query_fails_gracefully_with_unexpected_error
-      response = stub('response', code: '600', body: '{}')
+      response = stub("response", code: "600", body: "{}")
       HttpRequest.expects(:post).returns(response)
       File.stubs(:read)
         .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
 
-      @context.expects(:puts).with(@context.message('core.api.error.internal_server_error'))
-      @api.query('api/mutation')
+      @context.expects(:puts).with(@context.message("core.api.error.internal_server_error"))
+      @api.query("api/mutation")
       @api.stubs(:query).raises(API::APIRequestUnexpectedError)
       assert_raises(API::APIRequestUnexpectedError) do
-        @api.query('api/mutation')
+        @api.query("api/mutation")
       end
     end
 
     def test_load_query_can_load_project_type_queries
-      new_api = TestAPI.new(ctx: Context.new, token: 'blah', url: 'alsoblah')
+      new_api = TestAPI.new(ctx: Context.new, token: "blah", url: "alsoblah")
       ShopifyCli::Project.expects(:current_project_type).returns(:fake)
 
-      expected_path = File.join(ShopifyCli::ROOT, 'lib', 'project_types', 'fake', 'graphql', 'my_query.graphql')
+      expected_path = File.join(ShopifyCli::ROOT, "lib", "project_types", "fake", "graphql", "my_query.graphql")
       File.expects(:exist?).with(expected_path).returns(true)
-      File.expects(:read).with(expected_path).returns('content')
+      File.expects(:read).with(expected_path).returns("content")
 
-      assert_equal('content', new_api.call_load_query('my_query'))
+      assert_equal("content", new_api.call_load_query("my_query"))
     end
 
     def test_load_query_will_fall_back_to_core_queries
-      new_api = TestAPI.new(ctx: Context.new, token: 'blah', url: 'alsoblah')
+      new_api = TestAPI.new(ctx: Context.new, token: "blah", url: "alsoblah")
       ShopifyCli::Project.expects(:current_project_type).returns(:fake)
 
-      project_type_path = File.join(ShopifyCli::ROOT, 'lib', 'project_types', 'fake', 'graphql', 'my_query.graphql')
+      project_type_path = File.join(ShopifyCli::ROOT, "lib", "project_types", "fake", "graphql", "my_query.graphql")
       File.expects(:exist?).with(project_type_path).returns(false)
 
-      expected_path = File.join(ShopifyCli::ROOT, 'lib', 'graphql', 'my_query.graphql')
-      File.expects(:read).with(expected_path).returns('content')
+      expected_path = File.join(ShopifyCli::ROOT, "lib", "graphql", "my_query.graphql")
+      File.expects(:read).with(expected_path).returns("content")
 
-      assert_equal('content', new_api.call_load_query('my_query'))
+      assert_equal("content", new_api.call_load_query("my_query"))
     end
 
     def test_load_query_will_not_read_project_type_queries_if_not_in_project
-      new_api = TestAPI.new(ctx: Context.new, token: 'blah', url: 'alsoblah')
+      new_api = TestAPI.new(ctx: Context.new, token: "blah", url: "alsoblah")
       ShopifyCli::Project.expects(:current_project_type).returns(nil)
-      expected_path = File.join(ShopifyCli::ROOT, 'lib', 'graphql', 'my_query.graphql')
-      File.expects(:read).with(expected_path).returns('content')
-      assert_equal('content', new_api.call_load_query('my_query'))
+      expected_path = File.join(ShopifyCli::ROOT, "lib", "graphql", "my_query.graphql")
+      File.expects(:read).with(expected_path).returns("content")
+      assert_equal("content", new_api.call_load_query("my_query"))
     end
 
     def test_include_shopify_cli_header_if_acting_as_shopify_organization
@@ -147,12 +147,12 @@ module ShopifyCli
         .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
       mutation = JSON.dump(query: @mutation.tr("\n", ""), variables: {})
-      response = stub('response', code: '200', body: '{}')
+      response = stub("response", code: "200", body: "{}")
       HttpRequest
         .expects(:post)
-        .with(anything, mutation, has_entry({ 'X-Shopify-Cli-Employee' => '1' }))
+        .with(anything, mutation, has_entry({ "X-Shopify-Cli-Employee" => "1" }))
         .returns(response)
-      @api.query('api/mutation')
+      @api.query("api/mutation")
     end
   end
 end

--- a/test/shopify-cli/commands/command_test.rb
+++ b/test/shopify-cli/commands/command_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Commands
@@ -11,7 +11,7 @@ module ShopifyCli
       def test_non_existant
         io = capture_io do
           assert_raises(ShopifyCli::AbortSilent) do
-            run_cmd('foobar')
+            run_cmd("foobar")
           end
         end
 
@@ -20,7 +20,7 @@ module ShopifyCli
 
       def test_calls_help_with_h_flag
         io = capture_io do
-          run_cmd('create -h')
+          run_cmd("create -h")
         end
 
         assert_match(CLI::UI.fmt(Create.help), io.join)
@@ -28,7 +28,7 @@ module ShopifyCli
 
       def test_calls_help_with_subcommand_h_flag
         io = capture_io do
-          run_cmd('populate customer --help')
+          run_cmd("populate customer --help")
         end
 
         assert_match(CLI::UI.fmt(Node::Commands::Populate::Customer.help), io.join)

--- a/test/shopify-cli/commands/config_test.rb
+++ b/test/shopify-cli/commands/config_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Commands
@@ -14,65 +14,65 @@ module ShopifyCli
 
       def test_help_argument_calls_help
         @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
-        run_cmd('config help')
+        run_cmd("config help")
       end
 
       def test_feature_help_argument_calls_help
         @context.expects(:puts).with(ShopifyCli::Commands::Config::Feature.help)
-        run_cmd('config feature --help')
+        run_cmd("config feature --help")
       end
 
       def test_analytics_help_argument_calls_help
         @context.expects(:puts).with(ShopifyCli::Commands::Config::Analytics.help)
-        run_cmd('config analytics --help')
+        run_cmd("config analytics --help")
       end
 
       def test_no_arguments_calls_help
         @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
-        run_cmd('config')
+        run_cmd("config")
       end
 
       def test_no_feature_calls_help
         @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
-        run_cmd('config feature')
+        run_cmd("config feature")
       end
 
       def test_will_enable_a_feature_that_is_disabled
         ShopifyCli::Feature.disable(TEST_FEATURE)
-        @context.expects(:puts).with(@context.message('core.config.feature.enabled', TEST_FEATURE))
+        @context.expects(:puts).with(@context.message("core.config.feature.enabled", TEST_FEATURE))
         run_cmd("config feature #{TEST_FEATURE} --enable")
         assert ShopifyCli::Feature.enabled?(TEST_FEATURE)
       end
 
       def test_will_disable_a_feature_that_is_enabled
         ShopifyCli::Feature.enable(TEST_FEATURE)
-        @context.expects(:puts).with(@context.message('core.config.feature.disabled', TEST_FEATURE))
+        @context.expects(:puts).with(@context.message("core.config.feature.disabled", TEST_FEATURE))
         run_cmd("config feature #{TEST_FEATURE} --disable")
         refute ShopifyCli::Feature.enabled?(TEST_FEATURE)
       end
 
       def test_will_enable_analytics_that_is_disabled
-        ShopifyCli::Config.set('analytics', 'enabled', false)
+        ShopifyCli::Config.set("analytics", "enabled", false)
         run_cmd("config analytics --enable")
-        assert ShopifyCli::Config.get_bool('analytics', 'enabled')
+        assert ShopifyCli::Config.get_bool("analytics", "enabled")
       end
 
       def test_will_disable_analytics_that_is_enabled
-        ShopifyCli::Config.set('analytics', 'enabled', true)
+        ShopifyCli::Config.set("analytics", "enabled", true)
         run_cmd("config analytics --disable")
-        refute ShopifyCli::Config.get_bool('analytics', 'enabled')
+        refute ShopifyCli::Config.get_bool("analytics", "enabled")
       end
 
       def test_will_enable_shopifolk_beta_that_is_disabled
-        ShopifyCli::Config.set('shopifolk-beta', 'enabled', false)
+        ShopifyCli::Config.set("shopifolk-beta", "enabled", false)
         run_cmd("config shopifolk-beta --enable")
-        assert ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
+        assert ShopifyCli::Config.get_bool("shopifolk-beta", "enabled")
       end
 
       def test_will_disable_shopifolk_beta_that_is_enabled
-        ShopifyCli::Config.set('shopifolk-beta', 'enabled', true)
+        ShopifyCli::Config.set("shopifolk-beta", "enabled", true)
         run_cmd("config shopifolk-beta --disable")
-        refute ShopifyCli::Config.get_bool('shopifolk-beta', 'enabled')
+        refute ShopifyCli::Config.get_bool("shopifolk-beta", "enabled")
       end
     end
   end

--- a/test/shopify-cli/commands/connect_test.rb
+++ b/test/shopify-cli/commands/connect_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Commands
@@ -7,50 +7,50 @@ module ShopifyCli
 
       def test_runs_project_type_connect_if_exists
         ShopifyCli::Project.stubs(:has_current?).returns(false)
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
-        ShopifyCli::ProjectType.load_type('node')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("core.connect.project_type_select")).returns("node")
+        ShopifyCli::ProjectType.load_type("node")
         ::Node::Commands::Connect.expects(:call)
-          .with([], 'connect', 'connect')
+          .with([], "connect", "connect")
 
-        ShopifyCli::Commands::Connect.new(@context).call([], 'connect')
+        ShopifyCli::Commands::Connect.new(@context).call([], "connect")
       end
 
       def test_prompts_project_type_if_invalid_arg
         ShopifyCli::Project.stubs(:has_current?).returns(false)
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('node')
-        ShopifyCli::ProjectType.load_type('node')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("core.connect.project_type_select")).returns("node")
+        ShopifyCli::ProjectType.load_type("node")
         ::Node::Commands::Connect.expects(:call)
-          .with(['edge'], 'connect', 'connect')
+          .with(["edge"], "connect", "connect")
 
-        ShopifyCli::Commands::Connect.new(@context).call(['edge'], 'connect')
+        ShopifyCli::Commands::Connect.new(@context).call(["edge"], "connect")
       end
 
       def test_runs_default_behaviour_if_no_connect_command
         ShopifyCli::Project.stubs(:has_current?).returns(false)
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('edge')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("core.connect.project_type_select")).returns("edge")
         ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
         ShopifyCli::Project.expects(:write)
-        ShopifyCli::Commands::Connect.new(@context).call([], 'connect')
+        ShopifyCli::Commands::Connect.new(@context).call([], "connect")
       end
 
       def test_not_write_yml_when_current_project_exists_in_default
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.connect.project_type_select')).returns('edge')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("core.connect.project_type_select")).returns("edge")
         ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
         ShopifyCli::Project.expects(:write).never
-        ShopifyCli::Commands::Connect.new(@context).call([], 'connect')
+        ShopifyCli::Commands::Connect.new(@context).call([], "connect")
       end
 
       def test_outputs_warnings_if_already_connected_in_default
         context = ShopifyCli::Context.new
 
-        context.expects(:puts).with(context.message('core.connect.already_connected_warning'))
-        CLI::UI::Prompt.expects(:ask).with(context.message('core.connect.project_type_select')).returns('edge')
+        context.expects(:puts).with(context.message("core.connect.already_connected_warning"))
+        CLI::UI::Prompt.expects(:ask).with(context.message("core.connect.project_type_select")).returns("edge")
         ShopifyCli::Tasks::EnsureEnv.expects(:call).with(context, regenerate: true).returns(org_response)
         ShopifyCli::Project.expects(:write).never
 
-        context.expects(:done).with(context.message('core.connect.connected', 'app'))
+        context.expects(:done).with(context.message("core.connect.connected", "app"))
 
-        ShopifyCli::Commands::Connect.new(context).call([], 'connect')
+        ShopifyCli::Commands::Connect.new(context).call([], "connect")
       end
 
       private

--- a/test/shopify-cli/commands/create_test.rb
+++ b/test/shopify-cli/commands/create_test.rb
@@ -1,30 +1,30 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Commands
     class CreateTest < MiniTest::Test
       def test_help_loads_app_types
         io = capture_io do
-          run_cmd('create --help')
+          run_cmd("create --help")
         end
         output = io.join
-        assert_match('node', output)
-        assert_match('rails', output)
+        assert_match("node", output)
+        assert_match("rails", output)
       end
 
       def test_type_is_validated_and_will_call_help_on_bad_type
         io = capture_io do
-          run_cmd('create nope')
+          run_cmd("create nope")
         end
-        assert_match(CLI::UI.fmt(@context.message('core.create.error.invalid_app_type', 'nope')), io.join)
+        assert_match(CLI::UI.fmt(@context.message("core.create.error.invalid_app_type", "nope")), io.join)
       end
 
       def test_type_will_be_asked_for_if_not_provided
         ProjectType.load_type(:rails)
         Rails::Commands::Create.expects(:call)
         Rails::Commands::Create.expects(:ctx=)
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.create.project_type_select')).returns(:rails)
-        run_cmd('create')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("core.create.project_type_select")).returns(:rails)
+        run_cmd("create")
       end
     end
   end

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module Rails
   module Commands
@@ -33,26 +33,26 @@ module ShopifyCli
     class HelpTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Commands.register(:FakeCommand, 'fake', 'fake_path', true)
+        ShopifyCli::Commands.register(:FakeCommand, "fake", "fake_path", true)
       end
 
       def test_default_behavior_lists_tasks
         io = capture_io do
-          run_cmd('help')
+          run_cmd("help")
         end
         output = io.join
 
-        assert_match('Available core commands:', output)
+        assert_match("Available core commands:", output)
         assert_match(/Usage: .*shopify/, output)
       end
 
       def test_local_commands_available_within_a_project
-        Project.stubs(:current_project_type).returns('rails')
-        Project.stubs(:project_name).returns('myapp')
-        ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
+        Project.stubs(:current_project_type).returns("rails")
+        Project.stubs(:project_name).returns("myapp")
+        ShopifyCli::Commands.register("Rails::Commands::Fake", "fake_rails")
 
         io = capture_io do
-          run_cmd('help')
+          run_cmd("help")
         end
         output = io.join
 
@@ -61,10 +61,10 @@ module ShopifyCli
 
       def test_local_commands_not_available_outside_a_project
         Project.stubs(:current_project_type).returns(nil)
-        ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
+        ShopifyCli::Commands.register("Rails::Commands::Fake", "fake_rails")
 
         io = capture_io do
-          run_cmd('help')
+          run_cmd("help")
         end
         output = io.join
 
@@ -72,12 +72,12 @@ module ShopifyCli
       end
 
       def test_shows_current_project_path_and_type
-        Project.stubs(:current_project_type).returns('rails')
+        Project.stubs(:current_project_type).returns("rails")
         Project.stubs(:project_name).returns("my_app")
-        ShopifyCli::Commands.register('Rails::Commands::Fake', 'fake_rails')
+        ShopifyCli::Commands.register("Rails::Commands::Fake", "fake_rails")
 
         io = capture_io do
-          run_cmd('help')
+          run_cmd("help")
         end
         output = io.join
 
@@ -86,7 +86,7 @@ module ShopifyCli
 
       def test_extended_help_for_individual_command
         io = capture_io do
-          run_cmd('help fake')
+          run_cmd("help fake")
         end
         output = io.join
         assert_match(/basic help.*extended help/m, output)

--- a/test/shopify-cli/commands/logout_test.rb
+++ b/test/shopify-cli/commands/logout_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Commands
@@ -22,12 +22,12 @@ module ShopifyCli
         ShopifyCli::DB.expects(:exists?).with(:admin_exchange_token).returns(false)
         ShopifyCli::DB.expects(:del).with(:admin_exchange_token).never
 
-        run_cmd('logout')
+        run_cmd("logout")
       end
 
       def test_help_argument_calls_help
         @context.expects(:puts).with(ShopifyCli::Commands::Logout.help)
-        run_cmd('help logout')
+        run_cmd("help logout")
       end
     end
   end

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class ContextTest < MiniTest::Test
@@ -12,28 +12,28 @@ module ShopifyCli
 
     def test_write_writes_to_file_in_project
       @ctx.root = Dir.mktmpdir
-      @ctx.write('.env', 'foobar')
-      assert File.exist?(File.join(@ctx.root, '.env'))
+      @ctx.write(".env", "foobar")
+      assert File.exist?(File.join(@ctx.root, ".env"))
     end
 
     def test_mac_matches
-      @ctx.expects(:uname).returns('x86_64-apple-darwin19.3.0').times(3)
+      @ctx.expects(:uname).returns("x86_64-apple-darwin19.3.0").times(3)
       assert(@ctx.mac?)
       assert_equal(:mac, @ctx.os)
       refute(@ctx.linux?)
     end
 
     def test_linux_matches
-      @ctx.expects(:uname).returns('x86_64-pc-linux-gnu').times(3)
+      @ctx.expects(:uname).returns("x86_64-pc-linux-gnu").times(3)
       assert(@ctx.linux?)
       assert_equal(:linux, @ctx.os)
       refute(@ctx.mac?)
     end
 
     def test_open_url_outputs_url_to_open
-      url = 'http://cutekitties.com'
+      url = "http://cutekitties.com"
       @ctx.stubs(:mac?).returns(true)
-      @ctx.expects(:puts).with(@context.message('core.context.open_url', url))
+      @ctx.expects(:puts).with(@context.message("core.context.open_url", url))
       @ctx.open_url!(url)
     end
 
@@ -105,10 +105,10 @@ module ShopifyCli
     def mock_rubygems_https_call(response_body:)
       stub_request(:get, ShopifyCli::Context::GEM_LATEST_URI)
         .with(headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host' => 'rubygems.org',
-          'User-Agent' => 'Ruby',
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Host" => "rubygems.org",
+          "User-Agent" => "Ruby",
         })
         .to_return(status: 200, body: response_body, headers: {})
     end

--- a/test/shopify-cli/core/entry_point_test.rb
+++ b/test/shopify-cli/core/entry_point_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Core
@@ -10,7 +10,7 @@ module ShopifyCli
 
         Core::Executor.any_instance.expects(:call).with(
           ShopifyCli::Commands::Help,
-          'help',
+          "help",
           args.dup[1..-1]
         )
         EntryPoint.call(args, @context)

--- a/test/shopify-cli/core/executor_test.rb
+++ b/test/shopify-cli/core/executor_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Core
@@ -12,23 +12,23 @@ module ShopifyCli
           prerequisite_task :fake
 
           def call(*)
-            @ctx.puts('subcommand!')
+            @ctx.puts("subcommand!")
           end
         end
 
-        subcommand :FakeSubCommand, 'fakesub'
+        subcommand :FakeSubCommand, "fakesub"
 
         options do |parser, flags|
-          parser.on('-v', '--verbose', 'print verbosely') do |v|
+          parser.on("-v", "--verbose", "print verbosely") do |v|
             flags[:verbose] = v
           end
         end
 
         def call(_args, _name)
           if options.flags[:verbose]
-            @ctx.puts('verbose!')
+            @ctx.puts("verbose!")
           else
-            @ctx.puts('command!')
+            @ctx.puts("command!")
           end
         end
       end
@@ -42,27 +42,27 @@ module ShopifyCli
         executor = ShopifyCli::Core::Executor.new(@context, @registry, log_file: @log)
         reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
         reg.add(FakeCommand, :fake)
-        @context.expects(:puts).with('success!')
-        @context.expects(:puts).with('command!')
-        executor.call(FakeCommand, 'fake', [])
+        @context.expects(:puts).with("success!")
+        @context.expects(:puts).with("command!")
+        executor.call(FakeCommand, "fake", [])
       end
 
       def test_options
         executor = ShopifyCli::Core::Executor.new(@context, @registry, log_file: @log)
         reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
         reg.add(FakeCommand, :fake)
-        @context.expects(:puts).with('success!')
-        @context.expects(:puts).with('verbose!')
-        executor.call(FakeCommand, 'fake', ['-v'])
+        @context.expects(:puts).with("success!")
+        @context.expects(:puts).with("verbose!")
+        executor.call(FakeCommand, "fake", ["-v"])
       end
 
       def test_subcommand
         executor = ShopifyCli::Core::Executor.new(@context, @registry, log_file: @log)
         reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
         reg.add(FakeCommand, :fake)
-        @context.expects(:puts).with('success!')
-        @context.expects(:puts).with('subcommand!')
-        executor.call(FakeCommand, 'fake', ['fakesub'])
+        @context.expects(:puts).with("success!")
+        @context.expects(:puts).with("subcommand!")
+        executor.call(FakeCommand, "fake", ["fakesub"])
       end
     end
   end

--- a/test/shopify-cli/core/help_resolver_test.rb
+++ b/test/shopify-cli/core/help_resolver_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Core
@@ -6,13 +6,13 @@ module ShopifyCli
       def test_outputs_help_with_help_flag
         ShopifyCli::Commands::Help.expects(:call)
         assert_raises(ShopifyCli::AbortSilent) do
-          run_cmd('-h')
+          run_cmd("-h")
         end
       end
 
       def test_outputs_help_without_argument
         ShopifyCli::Commands::Help.expects(:call)
-        run_cmd('')
+        run_cmd("")
       end
     end
   end

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'timecop'
+require "test_helper"
+require "timecop"
 
 module ShopifyCli
   module Core
@@ -17,12 +17,12 @@ module ShopifyCli
 
       def test_log_prompts_for_consent_and_saves_answer
         enabled_and_consented(true, nil)
-        ShopifyCli::Config.expects(:get_section).with('analytics').returns({})
+        ShopifyCli::Config.expects(:get_section).with("analytics").returns({})
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        ShopifyCli::Config.expects(:set).with('analytics', 'enabled', true)
+        ShopifyCli::Config.expects(:set).with("analytics", "enabled", true)
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
+        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_doesnt_prompt_for_consent_if_not_enabled
@@ -31,16 +31,16 @@ module ShopifyCli
         CLI::UI::Prompt.expects(:confirm).never
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
+        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_doesnt_prompt_for_consent_if_already_answered
         enabled_and_consented(true, false)
-        ShopifyCli::Config.expects(:get_section).with('analytics').returns("enabled" => "true")
+        ShopifyCli::Config.expects(:get_section).with("analytics").returns("enabled" => "true")
         CLI::UI::Prompt.expects(:confirm).never
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
+        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_event_contains_schema_and_payload_values
@@ -51,15 +51,15 @@ module ShopifyCli
           stub_request(:post, Monorail::ENDPOINT_URI)
             .with(
               headers: {
-                'Content-Type': 'application/json; charset=utf-8',
+                'Content-Type': "application/json; charset=utf-8",
                 'X-Monorail-Edge-Event-Created-At-Ms': this_time.to_s,
                 'X-Monorail-Edge-Event-Sent-At-Ms': this_time.to_s,
               },
               body: JSON.dump({
                 schema_id: ShopifyCli::Core::Monorail::INVOCATIONS_SCHEMA,
                 payload: {
-                  project_type: 'fake',
-                  command: 'testcommand',
+                  project_type: "fake",
+                  command: "testcommand",
                   args: "arg argtwo",
                   time_start: this_time,
                   time_end: this_time,
@@ -78,9 +78,9 @@ module ShopifyCli
             )
             .to_return(status: 200)
 
-          ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) do
+          ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) do
             ShopifyCli::Core::Monorail.metadata[:foo] = "identifier"
-            'This is the block and result'
+            "This is the block and result"
           end
         end
       end
@@ -93,21 +93,21 @@ module ShopifyCli
           stub_request(:post, Monorail::ENDPOINT_URI)
             .with(
               headers: {
-                'Content-Type': 'application/json; charset=utf-8',
+                'Content-Type': "application/json; charset=utf-8",
                 'X-Monorail-Edge-Event-Created-At-Ms': this_time.to_s,
                 'X-Monorail-Edge-Event-Sent-At-Ms': this_time.to_s,
               },
               body: JSON.dump({
                 schema_id: ShopifyCli::Core::Monorail::INVOCATIONS_SCHEMA,
                 payload: {
-                  project_type: 'fake',
-                  command: 'testcommand',
+                  project_type: "fake",
+                  command: "testcommand",
                   args: "arg argtwo",
                   time_start: this_time,
                   time_end: this_time,
                   total_time: 0,
                   success: false,
-                  error_message: 'test error',
+                  error_message: "test error",
                   uname: RbConfig::CONFIG["host"],
                   cli_version: ShopifyCli::VERSION,
                   ruby_version: RUBY_VERSION,
@@ -120,8 +120,8 @@ module ShopifyCli
             .to_return(status: 200)
 
           begin
-            ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) do
-              raise 'test error'
+            ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) do
+              raise "test error"
             end
           rescue
           end
@@ -132,16 +132,16 @@ module ShopifyCli
         enabled_and_consented(true, true)
         Net::HTTP.expects(:start).once
 
-        result = ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
-        assert_equal('This is the block and result', result)
+        result = ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        assert_equal("This is the block and result", result)
       end
 
       def test_log_returns_the_result_if_not_sending_monorail_events
         enabled_and_consented(true, false)
         Net::HTTP.expects(:start).never
 
-        result = ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
-        assert_equal('This is the block and result', result)
+        result = ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        assert_equal("This is the block and result", result)
       end
 
       def test_log_sends_monorail_event_and_raises_exception_if_block_raises_exception
@@ -149,7 +149,7 @@ module ShopifyCli
         Net::HTTP.expects(:start).once
 
         assert_raises Exception do
-          ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { raise Exception }
+          ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { raise Exception }
         end
       end
 
@@ -157,38 +157,38 @@ module ShopifyCli
         enabled_and_consented(false, true)
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
+        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_doesnt_send_monorail_event_if_enabled_but_not_consented
         enabled_and_consented(true, false)
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
+        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_send_event_returns_result_if_monorail_returns_not_200
         enabled_and_consented(true, true)
         stub_request(:post, Monorail::ENDPOINT_URI).to_return(status: 500)
 
-        result = ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
-        assert_equal('This is the block and result', result)
+        result = ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        assert_equal("This is the block and result", result)
       end
 
       def test_log_send_event_returns_result_if_timeout_occurs
         enabled_and_consented(true, true)
         stub_request(:post, Monorail::ENDPOINT_URI).to_timeout
 
-        result = ShopifyCli::Core::Monorail.log('testcommand', %w(arg argtwo)) { 'This is the block and result' }
-        assert_equal('This is the block and result', result)
+        result = ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        assert_equal("This is the block and result", result)
       end
 
       private
 
       def enabled_and_consented(enabled, consented)
-        ShopifyCli::Config.stubs(:get_section).with('analytics').returns({ 'enabled' => consented.to_s })
+        ShopifyCli::Config.stubs(:get_section).with("analytics").returns({ "enabled" => consented.to_s })
         ShopifyCli::Context.any_instance.stubs(:system?).returns(enabled)
-        ShopifyCli::Config.stubs(:get_bool).with('analytics', 'enabled').returns(consented)
+        ShopifyCli::Config.stubs(:get_bool).with("analytics", "enabled").returns(consented)
       end
 
       def stub_shopify_org_confirmation(response: true)

--- a/test/shopify-cli/db_test.rb
+++ b/test/shopify-cli/db_test.rb
@@ -1,19 +1,19 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class DBTest < MiniTest::Test
     def test_set
       db = new_db
-      db.set(foo: 'bar', life: 42)
+      db.set(foo: "bar", life: 42)
       db.db.transaction do
-        assert_equal('bar', db.db[:foo])
+        assert_equal("bar", db.db[:foo])
         assert_equal(42, db.db[:life])
       end
     end
 
     def test_get
       db = new_db
-      assert_equal('value', db.get(:keyone))
+      assert_equal("value", db.get(:keyone))
       assert_equal(42, db.get(:keytwo))
     end
 
@@ -31,7 +31,7 @@ module ShopifyCli
 
     def test_del
       db = new_db
-      db.set(foo: 'bar', life: 42)
+      db.set(foo: "bar", life: 42)
       db.del(:keytwo, :foo)
       assert db.exists?(:keyone)
       assert db.exists?(:life)
@@ -52,7 +52,7 @@ module ShopifyCli
       db = DB.new(path: File.join(ShopifyCli::TEMP_DIR, ".test_db.pdb"))
       db.clear
       db.db.transaction do
-        db.db[:keyone] = 'value'
+        db.db[:keyone] = "value"
         db.db[:keytwo] = 42
       end
       db

--- a/test/shopify-cli/feature_test.rb
+++ b/test/shopify-cli/feature_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class FeatureTest < MiniTest::Test

--- a/test/shopify-cli/form_test.rb
+++ b/test/shopify-cli/form_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class FormTest < MiniTest::Test
@@ -7,7 +7,7 @@ module ShopifyCli
       flag_arguments :three, :four
 
       def ask
-        raise ShopifyCli::Abort, 'I was asked to raise' if three == 'raise'
+        raise ShopifyCli::Abort, "I was asked to raise" if three == "raise"
       end
     end
 
@@ -15,21 +15,21 @@ module ShopifyCli
       TestForm.any_instance.expects(:ask)
       form = TestForm.ask(
         @context,
-        ['a', 'b', 'c', 'd'],
-        three: 'one', four: 'two',
+        ["a", "b", "c", "d"],
+        three: "one", four: "two",
       )
-      assert_equal('a', form.one)
-      assert_equal('b', form.two)
-      assert_equal(['c', 'd'], form.xargs)
-      assert_equal('one', form.three)
-      assert_equal('two', form.four)
+      assert_equal("a", form.one)
+      assert_equal("b", form.two)
+      assert_equal(["c", "d"], form.xargs)
+      assert_equal("one", form.three)
+      assert_equal("two", form.four)
     end
 
     def test_that_the_form_returns_nil_if_not_all_pos_args_are_present
       TestForm.any_instance.expects(:ask).never
       form = TestForm.ask(
         @context,
-        ['a'],
+        ["a"],
         {}
       )
       assert_nil(form)
@@ -39,12 +39,12 @@ module ShopifyCli
       io = capture_io do
         form = TestForm.ask(
           @context,
-          ['a', 'b', 'c', 'd'],
-          three: 'raise', four: 'two',
+          ["a", "b", "c", "d"],
+          three: "raise", four: "two",
         )
         assert_nil(form)
       end
-      assert_match('I was asked to raise', io.join)
+      assert_match("I was asked to raise", io.join)
     end
   end
 end

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'open3'
+require "test_helper"
+require "open3"
 
 module ShopifyCli
   class GitTest < MiniTest::Test
@@ -16,24 +16,24 @@ module ShopifyCli
 
     def test_branches_returns_master_if_no_branches_exist
       @context.expects(:capture2e)
-        .with('git', 'branch', '--list', '--format=%(refname:short)')
-        .returns(['', @status_mock[:true]])
+        .with("git", "branch", "--list", "--format=%(refname:short)")
+        .returns(["", @status_mock[:true]])
 
-      assert_equal(['master'], ShopifyCli::Git.branches(@context))
+      assert_equal(["master"], ShopifyCli::Git.branches(@context))
     end
 
     def test_branches_returns_list_of_branches_if_multiple_exist
       @context.expects(:capture2e)
-        .with('git', 'branch', '--list', '--format=%(refname:short)')
+        .with("git", "branch", "--list", "--format=%(refname:short)")
         .returns(["master\nsecond_branch\n", @status_mock[:true]])
 
-      assert_equal(['master', 'second_branch'], ShopifyCli::Git.branches(@context))
+      assert_equal(["master", "second_branch"], ShopifyCli::Git.branches(@context))
     end
 
     def test_branches_raises_if_finding_branches_fails
       @context.stubs(:capture2e)
-        .with('git', 'branch', '--list', '--format=%(refname:short)')
-        .returns(['', @status_mock[:false]])
+        .with("git", "branch", "--list", "--format=%(refname:short)")
+        .returns(["", @status_mock[:false]])
 
       assert_raises ShopifyCli::Abort do
         ShopifyCli::Git.branches(@context)
@@ -60,9 +60,9 @@ module ShopifyCli
     end
 
     def test_sha_shortcut
-      fake_sha = ('c0ffee' * 6) + 'dead'
+      fake_sha = ("c0ffee" * 6) + "dead"
       in_repo do |_dir|
-        File.write('.git/HEAD', fake_sha)
+        File.write(".git/HEAD", fake_sha)
 
         assert_equal(fake_sha, ShopifyCli::Git.sha)
       end
@@ -77,30 +77,30 @@ module ShopifyCli
 
     def test_clones_git_repo
       Open3.expects(:popen3).with(
-        'git',
-        'clone',
-        '--single-branch',
-        'git@github.com:shopify/test.git',
-        'test-app',
-        '--progress'
+        "git",
+        "clone",
+        "--single-branch",
+        "git@github.com:shopify/test.git",
+        "test-app",
+        "--progress"
       ).returns(mock(success?: true))
       capture_io do
-        ShopifyCli::Git.clone('git@github.com:shopify/test.git', 'test-app', ctx: @context)
+        ShopifyCli::Git.clone("git@github.com:shopify/test.git", "test-app", ctx: @context)
       end
     end
 
     def test_clone_failure
       assert_raises(ShopifyCli::Abort) do
         Open3.expects(:popen3).with(
-          'git',
-          'clone',
-          '--single-branch',
-          'git@github.com:shopify/test.git',
-          'test-app',
-          '--progress'
+          "git",
+          "clone",
+          "--single-branch",
+          "git@github.com:shopify/test.git",
+          "test-app",
+          "--progress"
         ).returns(mock(success?: false))
         capture_io do
-          ShopifyCli::Git.clone('git@github.com:shopify/test.git', 'test-app', ctx: @context)
+          ShopifyCli::Git.clone("git@github.com:shopify/test.git", "test-app", ctx: @context)
         end
       end
     end
@@ -117,7 +117,7 @@ module ShopifyCli
     end
 
     def empty_commit
-      Context.new.capture3('git', 'commit', '-m', 'commit', '--allow-empty')
+      Context.new.capture3("git", "commit", "-m", "commit", "--allow-empty")
     end
 
     def stub_git_init(status:, commits:)
@@ -137,7 +137,7 @@ module ShopifyCli
       end
 
       @context.stubs(:capture2e)
-        .with('git', 'status')
+        .with("git", "status")
         .returns([output, @status_mock[:"#{status}"]])
     end
   end

--- a/test/shopify-cli/heroku_test.rb
+++ b/test/shopify-cli/heroku_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class HerokuTest < MiniTest::Test
@@ -11,15 +11,15 @@ module ShopifyCli
     end
 
     def test_app_uses_existing_heroku_app_if_available
-      expects_git_remote_get_url_heroku(status: true, remote: 'heroku')
+      expects_git_remote_get_url_heroku(status: true, remote: "heroku")
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 
-      assert_equal 'app-name', heroku_service.app
+      assert_equal "app-name", heroku_service.app
     end
 
     def test_app_returns_nil_if_choosing_existing_heroku_app_fails
-      expects_git_remote_get_url_heroku(status: false, remote: 'heroku')
+      expects_git_remote_get_url_heroku(status: false, remote: "heroku")
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 
@@ -181,7 +181,7 @@ module ShopifyCli
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 
-      assert_nil(heroku_service.select_existing_app('app-name'))
+      assert_nil(heroku_service.select_existing_app("app-name"))
     end
 
     def test_select_existing_app_using_non_full_path_heroku_lets_you_choose_existing_heroku_app
@@ -189,7 +189,7 @@ module ShopifyCli
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 
-      assert_nil(heroku_service.select_existing_app('app-name'))
+      assert_nil(heroku_service.select_existing_app("app-name"))
     end
 
     def test_select_existing_app_raises_if_choosing_existing_heroku_app_fails
@@ -198,7 +198,7 @@ module ShopifyCli
       heroku_service = ShopifyCli::Heroku.new(@context)
 
       assert_raises ShopifyCli::Abort do
-        heroku_service.select_existing_app('app-name')
+        heroku_service.select_existing_app("app-name")
       end
     end
 
@@ -207,7 +207,7 @@ module ShopifyCli
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 
-      assert_equal 'username', heroku_service.whoami
+      assert_equal "username", heroku_service.whoami
     end
 
     def test_whoami_using_non_full_path_heroku_returns_username_if_logged_in
@@ -215,7 +215,7 @@ module ShopifyCli
 
       heroku_service = ShopifyCli::Heroku.new(@context)
 
-      assert_equal 'username', heroku_service.whoami
+      assert_equal "username", heroku_service.whoami
     end
 
     def test_whoami_returns_nil_if_not_logged_in

--- a/test/shopify-cli/http_request_test.rb
+++ b/test/shopify-cli/http_request_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'shopify-cli/http_request'
+require "test_helper"
+require "shopify-cli/http_request"
 
 module ShopifyCli
   class HttpRequestTest < MiniTest::Test
@@ -12,11 +12,11 @@ module ShopifyCli
         .with(
           body: '{"query":"body content","variables":{"var_name":"var_value"}}',
           headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'User-Agent' => 'Ruby',
-            'Header-Name' => 'header_value',
+            "Accept" => "*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Content-Type" => "application/json",
+            "User-Agent" => "Ruby",
+            "Header-Name" => "header_value",
           }
         )
 
@@ -34,11 +34,11 @@ module ShopifyCli
         .with(
           body: '{"query":"body content","variables":{"var_name":"var_value"}}',
           headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'User-Agent' => 'Ruby',
-            'Header-Name' => 'header_value',
+            "Accept" => "*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Content-Type" => "application/json",
+            "User-Agent" => "Ruby",
+            "Header-Name" => "header_value",
           }
         )
 

--- a/test/shopify-cli/js_deps_test.rb
+++ b/test/shopify-cli/js_deps_test.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module ShopifyCli
   class JsDepsTest < MiniTest::Test
     def setup
       super
-      project_context('app_types', 'node')
+      project_context("app_types", "node")
       @node_fixture_dependencies = 37
     end
 
@@ -13,7 +13,7 @@ module ShopifyCli
       JsSystem.any_instance.stubs(:yarn?).returns(false)
       mock_install_call(
         command: %w(npm install --no-audit --quiet),
-        returns: ['', '', mock(success?: true)]
+        returns: ["", "", mock(success?: true)]
       )
 
       io = capture_io do
@@ -21,15 +21,15 @@ module ShopifyCli
       end
 
       output = io.join
-      assert_match(@context.message('core.js_deps.installing', 'npm'), output)
-      assert_match(@context.message('core.js_deps.installed'), output)
+      assert_match(@context.message("core.js_deps.installing", "npm"), output)
+      assert_match(@context.message("core.js_deps.installed"), output)
     end
 
     def test_install_with_npm_outputs_an_error_message_if_install_fails_and_returns_false
       JsSystem.any_instance.stubs(:yarn?).returns(false)
       mock_install_call(
         command: %w(npm install --no-audit --quiet),
-        returns: ['', mock(lines: ['error message']), mock(success?: false)]
+        returns: ["", mock(lines: ["error message"]), mock(success?: false)]
       )
 
       io = capture_io do
@@ -37,16 +37,16 @@ module ShopifyCli
       end
 
       output = io.join
-      assert_match(@context.message('core.js_deps.installing', 'npm'), output)
-      assert_match('error message', output)
-      assert_match(@context.message('core.js_deps.error.install_error'), output)
+      assert_match(@context.message("core.js_deps.installing", "npm"), output)
+      assert_match("error message", output)
+      assert_match(@context.message("core.js_deps.error.install_error"), output)
     end
 
     def test_installs_with_yarn_and_returns_true
       JsSystem.any_instance.stubs(:yarn?).returns(true)
       mock_install_call(
         command: %w(yarn install --silent),
-        returns: ['', '', mock(success?: true)]
+        returns: ["", "", mock(success?: true)]
       )
 
       io = capture_io do
@@ -54,15 +54,15 @@ module ShopifyCli
       end
 
       output = io.join
-      assert_match(@context.message('core.js_deps.installing', 'yarn'), output)
-      assert_match(@context.message('core.js_deps.installed'), output)
+      assert_match(@context.message("core.js_deps.installing", "yarn"), output)
+      assert_match(@context.message("core.js_deps.installed"), output)
     end
 
     def test_install_with_yarn_outputs_errors_and_an_error_message_if_install_fails_and_returns_false
       JsSystem.any_instance.stubs(:yarn?).returns(true)
       mock_install_call(
         command: %w(yarn install --silent),
-        returns: ['', mock(lines: ['error message']), mock(success?: false)]
+        returns: ["", mock(lines: ["error message"]), mock(success?: false)]
       )
 
       io = capture_io do
@@ -70,9 +70,9 @@ module ShopifyCli
       end
 
       output = io.join
-      assert_match(@context.message('core.js_deps.installing', 'yarn'), output)
-      assert_match('error message', output)
-      assert_match(@context.message('core.js_deps.error.install_error'), output)
+      assert_match(@context.message("core.js_deps.installing", "yarn"), output)
+      assert_match("error message", output)
+      assert_match(@context.message("core.js_deps.error.install_error"), output)
     end
 
     private

--- a/test/shopify-cli/js_system_test.rb
+++ b/test/shopify-cli/js_system_test.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-require 'project_types/node/test_helper'
+require "project_types/node/test_helper"
 
 module ShopifyCli
   class JsSystemTest < MiniTest::Test
     def setup
       super
-      project_context('app_types', 'node')
+      project_context("app_types", "node")
       @system = JsSystem.new(ctx: @context)
 
       @execution_mock = Minitest::Mock.new
@@ -34,7 +34,7 @@ module ShopifyCli
       @system.stubs(:yarn?).returns(true)
       mock_kit_system(JsSystem::YARN_CORE_COMMAND, *yarn_command)
 
-      @system.call(yarn: yarn_command, npm: ['npm'])
+      @system.call(yarn: yarn_command, npm: ["npm"])
     end
 
     def test_call_executes_npm_command_array_if_yarn_is_unavailable
@@ -43,30 +43,30 @@ module ShopifyCli
       @system.stubs(:yarn?).returns(false)
       mock_kit_system(JsSystem::NPM_CORE_COMMAND, *npm_command)
 
-      @system.call(yarn: ['yarn'], npm: npm_command)
+      @system.call(yarn: ["yarn"], npm: npm_command)
     end
 
     def test_call_executes_yarn_command_string_if_yarn_is_available
-      yarn_command = 'install'
+      yarn_command = "install"
 
       @system.stubs(:yarn?).returns(true)
       mock_kit_system(JsSystem::YARN_CORE_COMMAND, yarn_command)
 
-      @system.call(yarn: yarn_command, npm: 'npm')
+      @system.call(yarn: yarn_command, npm: "npm")
     end
 
     def test_call_executes_npm_command_string_if_yarn_is_unavailable
-      npm_command = 'install'
+      npm_command = "install"
 
       @system.stubs(:yarn?).returns(false)
       mock_kit_system(JsSystem::NPM_CORE_COMMAND, npm_command)
 
-      @system.call(yarn: 'yarn', npm: npm_command)
+      @system.call(yarn: "yarn", npm: npm_command)
     end
 
     def test_call_on_class_proxies_to_the_instance_version_of_call
-      yarn_command = 'yarn'
-      npm_command = 'npm'
+      yarn_command = "yarn"
+      npm_command = "npm"
       JsSystem.any_instance.expects(:call).with(yarn: yarn_command, npm: npm_command).once
 
       JsSystem.call(@context, yarn: yarn_command, npm: npm_command)
@@ -84,7 +84,7 @@ module ShopifyCli
     end
 
     def test_yarn_check_returns_false_if_yarn_lock_not_present
-      mock_yarn_check(lock_exists: false, response: '/usr/bin/yarn')
+      mock_yarn_check(lock_exists: false, response: "/usr/bin/yarn")
 
       refute JsSystem.yarn?(@context)
     end
@@ -96,20 +96,20 @@ module ShopifyCli
     end
 
     def test_yarn_check_returns_true_if_yarn_lock_present_and_which_yarn_call_succeeds
-      mock_yarn_check(lock_exists: true, response: '/usr/bin/yarn')
+      mock_yarn_check(lock_exists: true, response: "/usr/bin/yarn")
 
       assert JsSystem.yarn?(@context)
     end
 
     def test_call_hits_capture3_if_capture_reponse_set_to_true
-      yarn_command = 'list'
+      yarn_command = "list"
       @system.stubs(:yarn?).returns(true)
       CLI::Kit::System
         .expects(:capture3)
         .with(JsSystem::YARN_CORE_COMMAND, yarn_command, chdir: @context.root)
         .returns(true)
         .once
-      @system.call(yarn: yarn_command, npm: 'npm', capture_response: true)
+      @system.call(yarn: yarn_command, npm: "npm", capture_response: true)
     end
 
     private
@@ -117,12 +117,12 @@ module ShopifyCli
     def mock_yarn_check(response:, lock_exists:)
       @context
         .expects(:which)
-        .with('yarn')
+        .with("yarn")
         .returns(response)
         .once
       File
         .expects(:exist?)
-        .with(File.join(@context.root, 'yarn.lock'))
+        .with(File.join(@context.root, "yarn.lock"))
         .returns(lock_exists)
         .once
     end

--- a/test/shopify-cli/method_object_test.rb
+++ b/test/shopify-cli/method_object_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class MethodObjectTest < Minitest::Test

--- a/test/shopify-cli/oauth/servlet_test.rb
+++ b/test/shopify-cli/oauth/servlet_test.rb
@@ -1,6 +1,6 @@
-require 'test_helper'
-require 'ostruct'
-require 'webrick'
+require "test_helper"
+require "ostruct"
+require "webrick"
 
 module ShopifyCli
   module OAuthTests
@@ -11,18 +11,18 @@ module ShopifyCli
       def test_do_get
         server = new_server
         oauth = OpenStruct.new
-        servlet = OAuth::Servlet.new(server, oauth, 'state_token')
+        servlet = OAuth::Servlet.new(server, oauth, "state_token")
         resp = Response.new
-        servlet.do_GET(Request.new({ 'state' => 'state_token' }), resp)
-        assert_equal({ 'state' => 'state_token' }, oauth.response_query)
+        servlet.do_GET(Request.new({ "state" => "state_token" }), resp)
+        assert_equal({ "state" => "state_token" }, oauth.response_query)
         assert_equal(200, resp.status)
-        assert_match(Context.message('core.oauth.servlet.authenticated'), resp.body)
+        assert_match(Context.message("core.oauth.servlet.authenticated"), resp.body)
       end
 
       def test_oauth_error
         server = new_server
         oauth = OpenStruct.new
-        servlet = OAuth::Servlet.new(server, oauth, 'state_token')
+        servlet = OAuth::Servlet.new(server, oauth, "state_token")
         data = {
           "error" => "bad_request",
           "error_description" => "bad url callback",
@@ -31,22 +31,22 @@ module ShopifyCli
         servlet.do_GET(Request.new(data), resp)
         assert_equal(oauth.response_query, data)
         assert_equal(400, resp.status)
-        assert_match(Context.message('core.oauth.servlet.not_authenticated'), resp.body)
+        assert_match(Context.message("core.oauth.servlet.not_authenticated"), resp.body)
       end
 
       def test_invalid_state
         server = new_server
         oauth = OpenStruct.new
-        servlet = OAuth::Servlet.new(server, oauth, 'state_token')
+        servlet = OAuth::Servlet.new(server, oauth, "state_token")
         resp = Response.new
-        servlet.do_GET(Request.new({ 'state' => 'nope' }), resp)
+        servlet.do_GET(Request.new({ "state" => "nope" }), resp)
         assert_equal(oauth.response_query, {
           "state" => "nope",
           "error" => "invalid_state",
-          "error_description" => Context.message('core.oauth.servlet.invalid_state_response'),
+          "error_description" => Context.message("core.oauth.servlet.invalid_state_response"),
         })
         assert_equal(403, resp.status)
-        assert_match(Context.message('core.oauth.servlet.not_authenticated'), resp.body)
+        assert_match(Context.message("core.oauth.servlet.not_authenticated"), resp.body)
       end
 
       private

--- a/test/shopify-cli/oauth_test.rb
+++ b/test/shopify-cli/oauth_test.rb
@@ -1,25 +1,25 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class OAuthTest < MiniTest::Test
     def test_new
       client = oauth
-      assert_equal 'test', client.service
-      assert_equal 'key', client.client_id
-      assert_equal 'test,one', client.scopes
+      assert_equal "test", client.service
+      assert_equal "key", client.client_id
+      assert_equal "test,one", client.scopes
       assert_nil(client.secret)
       assert_equal({}, client.options)
 
-      client = oauth(secret: 'secret', options: { foo: :bar })
-      assert_equal 'key', client.client_id
-      assert_equal 'test,one', client.scopes
-      assert_equal 'secret', client.secret
+      client = oauth(secret: "secret", options: { foo: :bar })
+      assert_equal "key", client.client_id
+      assert_equal "test,one", client.scopes
+      assert_equal "secret", client.secret
       assert_equal({ foo: :bar }, client.options)
     end
 
     def test_authenticate_with_secret
       endpoint = "https://example.com/auth"
-      client = oauth(secret: 'secret')
+      client = oauth(secret: "secret")
       @context.expects(:open_url!)
       stub_auth_response(client)
 
@@ -37,15 +37,15 @@ module ShopifyCli
         code: "mycode",
         redirect_uri: OAuth::REDIRECT_HOST,
         client_id: client.client_id,
-        client_secret: 'secret',
+        client_secret: "secret",
       }
       stub_request(:post, "#{endpoint}/token")
         .with(body: URI.encode_www_form(token_query))
         .to_return(status: 200, body: token_resp, headers: {})
 
       client.authenticate(endpoint)
-      assert_equal('accesstoken123', client.store.get(:test_access_token))
-      assert_equal('refreshtoken123', client.store.get(:test_refresh_token))
+      assert_equal("accesstoken123", client.store.get(:test_access_token))
+      assert_equal("refreshtoken123", client.store.get(:test_refresh_token))
     end
 
     def test_authenticate_without_secret
@@ -75,13 +75,13 @@ module ShopifyCli
         .to_return(status: 200, body: token_resp, headers: {})
 
       client.authenticate(endpoint)
-      assert_equal('accesstoken123', client.store.get(:test_access_token))
-      assert_equal('refreshtoken123', client.store.get(:test_refresh_token))
+      assert_equal("accesstoken123", client.store.get(:test_access_token))
+      assert_equal("refreshtoken123", client.store.get(:test_refresh_token))
     end
 
     def test_request_exchange_token
       endpoint = "https://example.com/auth"
-      client = oauth(request_exchange: '123')
+      client = oauth(request_exchange: "123")
       @context.expects(:open_url!)
       stub_auth_response(client)
 
@@ -110,27 +110,27 @@ module ShopifyCli
         requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
         subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
         client_id: client.client_id,
-        audience: '123',
+        audience: "123",
         scope: client.scopes,
-        subject_token: 'accesstoken123',
+        subject_token: "accesstoken123",
       }
       stub_request(:post, "#{endpoint}/token")
         .with(body: URI.encode_www_form(token_query))
         .to_return(status: 200, body: '{"access_token":"exchangetoken123"}', headers: {})
 
       client.authenticate(endpoint)
-      assert_equal('accesstoken123', client.store.get(:test_access_token))
-      assert_equal('refreshtoken123', client.store.get(:test_refresh_token))
-      assert_equal('exchangetoken123', client.store.get(:test_exchange_token))
+      assert_equal("accesstoken123", client.store.get(:test_access_token))
+      assert_equal("refreshtoken123", client.store.get(:test_refresh_token))
+      assert_equal("exchangetoken123", client.store.get(:test_exchange_token))
     end
 
     def test_refresh_exchange_token
       endpoint = "https://example.com/auth"
-      client = oauth(request_exchange: '123')
+      client = oauth(request_exchange: "123")
       client.store.set(
-        test_access_token: 'accesstoken123',
-        test_refresh_token: 'refreshtoken123',
-        test_exchange_token: 'exchangetoken123',
+        test_access_token: "accesstoken123",
+        test_refresh_token: "refreshtoken123",
+        test_exchange_token: "exchangetoken123",
       )
 
       token_query = {
@@ -138,25 +138,25 @@ module ShopifyCli
         requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
         subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
         client_id: client.client_id,
-        audience: '123',
+        audience: "123",
         scope: client.scopes,
-        subject_token: 'accesstoken123',
+        subject_token: "accesstoken123",
       }
       stub_request(:post, "#{endpoint}/token")
         .with(body: URI.encode_www_form(token_query))
         .to_return(status: 200, body: '{"access_token":"exchangetoken456"}', headers: {})
 
       client.authenticate(endpoint)
-      assert_equal('exchangetoken456', client.store.get(:test_exchange_token))
+      assert_equal("exchangetoken456", client.store.get(:test_exchange_token))
     end
 
     def test_refresh_access_token_fallback
       endpoint = "https://example.com/auth"
-      client = oauth(request_exchange: '123')
+      client = oauth(request_exchange: "123")
       client.store.set(
-        test_access_token: 'accesstoken123',
-        test_refresh_token: 'refreshtoken123',
-        test_exchange_token: 'exchangetoken123',
+        test_access_token: "accesstoken123",
+        test_refresh_token: "refreshtoken123",
+        test_exchange_token: "exchangetoken123",
       )
 
       token_query = {
@@ -164,9 +164,9 @@ module ShopifyCli
         requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
         subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
         client_id: client.client_id,
-        audience: '123',
+        audience: "123",
         scope: client.scopes,
-        subject_token: 'accesstoken123',
+        subject_token: "accesstoken123",
       }
 
       stub_request(:post, "#{endpoint}/token")
@@ -175,8 +175,8 @@ module ShopifyCli
 
       token_query = {
         grant_type: :refresh_token,
-        access_token: 'accesstoken123',
-        refresh_token: 'refreshtoken123',
+        access_token: "accesstoken123",
+        refresh_token: "refreshtoken123",
         client_id: client.client_id,
       }
 
@@ -194,18 +194,18 @@ module ShopifyCli
         requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
         subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
         client_id: client.client_id,
-        audience: '123',
+        audience: "123",
         scope: client.scopes,
-        subject_token: 'accesstoken456',
+        subject_token: "accesstoken456",
       }
       stub_request(:post, "#{endpoint}/token")
         .with(body: URI.encode_www_form(token_query))
         .to_return(status: 200, body: '{"access_token":"exchangetoken456"}', headers: {})
 
       client.authenticate(endpoint)
-      assert_equal('accesstoken456', client.store.get(:test_access_token))
-      assert_equal('refreshtoken456', client.store.get(:test_refresh_token))
-      assert_equal('exchangetoken456', client.store.get(:test_exchange_token))
+      assert_equal("accesstoken456", client.store.get(:test_access_token))
+      assert_equal("refreshtoken456", client.store.get(:test_refresh_token))
+      assert_equal("exchangetoken456", client.store.get(:test_exchange_token))
     end
 
     def test_authenticate_with_invalid_request
@@ -213,8 +213,8 @@ module ShopifyCli
       client = oauth
       @context.expects(:open_url!)
       stub_server(client, {
-        'error' => 'err',
-        'error_description' => 'error',
+        "error" => "err",
+        "error_description" => "error",
       })
       stub_request(:post, "#{endpoint}/authorize")
       assert_raises OAuth::Error do
@@ -224,7 +224,7 @@ module ShopifyCli
 
     def test_authenticate_with_invalid_code
       endpoint = "https://example.com/auth"
-      client = oauth(secret: 'secret')
+      client = oauth(secret: "secret")
       @context.expects(:open_url!)
       stub_auth_response(client)
 
@@ -242,7 +242,7 @@ module ShopifyCli
         code: "mycode",
         redirect_uri: OAuth::REDIRECT_HOST,
         client_id: client.client_id,
-        client_secret: 'secret',
+        client_secret: "secret",
       }
       stub_request(:post, "#{endpoint}/token")
         .with(body: URI.encode_www_form(token_query))
@@ -264,17 +264,17 @@ module ShopifyCli
       db.clear
       OAuth.new({
         ctx: @context,
-        service: 'test',
-        client_id: 'key',
-        scopes: 'test,one',
+        service: "test",
+        client_id: "key",
+        scopes: "test,one",
         store: db,
       }.merge(args))
     end
 
     def stub_auth_response(client)
       stub_server(client, {
-        'code' => 'mycode',
-        'state' => client.state_token,
+        "code" => "mycode",
+        "state" => client.state_token,
       })
     end
 

--- a/test/shopify-cli/options_test.rb
+++ b/test/shopify-cli/options_test.rb
@@ -1,11 +1,11 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class OptionsTest < MiniTest::Test
     def setup
       super
       @block = proc do |parser, flags|
-        parser.on('-v', '--verbose', 'run verbosely') do |v|
+        parser.on("-v", "--verbose", "run verbosely") do |v|
           flags[:verbose] = v
         end
       end
@@ -13,7 +13,7 @@ module ShopifyCli
 
     def test_parses_subcommand_and_flags
       opts = Options.new
-      assert_equal ['subc', 'foo', 'bar'], opts.parse(@block, ['subc', '-v', 'foo', 'bar'])
+      assert_equal ["subc", "foo", "bar"], opts.parse(@block, ["subc", "-v", "foo", "bar"])
       assert opts.flags[:verbose]
     end
 
@@ -25,7 +25,7 @@ module ShopifyCli
     def test_parses_help_flag_and_sets_help_attribute
       block = proc {}
       opts = Options.new
-      opts.parse(block, ['-h'])
+      opts.parse(block, ["-h"])
       assert opts.help
     end
   end

--- a/test/shopify-cli/partners_api/organizations_test.rb
+++ b/test/shopify-cli/partners_api/organizations_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class PartnersAPI
@@ -8,7 +8,7 @@ module ShopifyCli
 
       def test_fetch_all_queries_partners
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: {
             data: {
               organizations: {
@@ -18,7 +18,7 @@ module ShopifyCli
                     stores: {
                       nodes: [
                         {
-                          shopDomain: 'shopdomain.myshopify.com',
+                          shopDomain: "shopdomain.myshopify.com",
                         },
                       ],
                     },
@@ -31,14 +31,14 @@ module ShopifyCli
 
         orgs = PartnersAPI::Organizations.fetch_all(@context)
         assert_equal(1, orgs.count)
-        assert_equal(42, orgs.first['id'])
-        assert_equal(1, orgs.first['stores'].count)
-        assert_equal('shopdomain.myshopify.com', orgs.first['stores'].first['shopDomain'])
+        assert_equal(42, orgs.first["id"])
+        assert_equal(1, orgs.first["stores"].count)
+        assert_equal("shopdomain.myshopify.com", orgs.first["stores"].first["shopDomain"])
       end
 
       def test_fetch_all_handles_no_shops
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: {
             data: { organizations: { nodes: [{ id: 42, stores: { nodes: [] } }] } },
           }
@@ -46,13 +46,13 @@ module ShopifyCli
 
         orgs = PartnersAPI::Organizations.fetch_all(@context)
         assert_equal(1, orgs.count)
-        assert_equal(42, orgs.first['id'])
-        assert_equal(0, orgs.first['stores'].count)
+        assert_equal(42, orgs.first["id"])
+        assert_equal(0, orgs.first["stores"].count)
       end
 
       def test_fetch_all_handles_no_orgs
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           resp: { data: { organizations: { nodes: [] } } }
         )
 
@@ -62,7 +62,7 @@ module ShopifyCli
 
       def test_fetch_queries_partners
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 42 },
           resp: {
             data: {
@@ -73,7 +73,7 @@ module ShopifyCli
                     stores: {
                       nodes: [
                         {
-                          shopDomain: 'shopdomain.myshopify.com',
+                          shopDomain: "shopdomain.myshopify.com",
                         },
                       ],
                     },
@@ -85,14 +85,14 @@ module ShopifyCli
         )
 
         org = PartnersAPI::Organizations.fetch(@context, id: 42)
-        assert_equal(42, org['id'])
-        assert_equal(1, org['stores'].count)
-        assert_equal('shopdomain.myshopify.com', org['stores'].first['shopDomain'])
+        assert_equal(42, org["id"])
+        assert_equal(1, org["stores"].count)
+        assert_equal("shopdomain.myshopify.com", org["stores"].first["shopDomain"])
       end
 
       def test_fetch_returns_nil_when_not_found
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 42 },
           resp: {
             data: {
@@ -109,7 +109,7 @@ module ShopifyCli
 
       def test_fetch_handles_no_shops
         stub_partner_req(
-          'find_organization',
+          "find_organization",
           variables: { id: 42 },
           resp: {
             data: {
@@ -126,13 +126,13 @@ module ShopifyCli
         )
 
         org = PartnersAPI::Organizations.fetch(@context, id: 42)
-        assert_equal(42, org['id'])
-        assert_equal(0, org['stores'].count)
+        assert_equal(42, org["id"])
+        assert_equal(0, org["stores"].count)
       end
 
       def test_fetch_org_with_app_info
         stub_partner_req(
-          'all_orgs_with_apps',
+          "all_orgs_with_apps",
           resp: {
             data: {
               organizations: {
@@ -142,12 +142,12 @@ module ShopifyCli
                     'businessName': "one",
                     'stores': {
                       'nodes': [
-                        { 'shopDomain': 'store.myshopify.com' },
+                        { 'shopDomain': "store.myshopify.com" },
                       ],
                     },
                     'apps': {
                       nodes: [{
-                        title: 'app',
+                        title: "app",
                         apiKey: 1234,
                         apiSecretKeys: [{
                           secret: 1233,
@@ -159,16 +159,16 @@ module ShopifyCli
                     'id': 431,
                     'businessName': "two",
                     'stores': { 'nodes': [
-                      { 'shopDomain': 'store.myshopify.com', 'shopName': 'store1' },
-                      { 'shopDomain': 'store2.myshopify.com', 'shopName': 'store2' },
+                      { 'shopDomain': "store.myshopify.com", 'shopName': "store1" },
+                      { 'shopDomain': "store2.myshopify.com", 'shopName': "store2" },
                     ] },
                     'apps': {
                       nodes: [{
                         id: 123,
-                        title: 'fake',
-                        apiKey: '1234',
+                        title: "fake",
+                        apiKey: "1234",
                         apiSecretKeys: [{
-                          secret: '1233',
+                          secret: "1233",
                         }],
                       }],
                     },
@@ -180,13 +180,13 @@ module ShopifyCli
         )
         orgs = PartnersAPI::Organizations.fetch_with_app(@context)
         assert_equal(2, orgs.count)
-        assert_equal(421, orgs.first['id'])
-        assert_equal('store.myshopify.com', orgs.first['stores'].first['shopDomain'])
+        assert_equal(421, orgs.first["id"])
+        assert_equal("store.myshopify.com", orgs.first["stores"].first["shopDomain"])
       end
 
       def test_fetch_org_with_empty_app_info
         stub_partner_req(
-          'all_orgs_with_apps',
+          "all_orgs_with_apps",
           resp: {
             data: {
               organizations: {
@@ -204,9 +204,9 @@ module ShopifyCli
         )
         orgs = PartnersAPI::Organizations.fetch_with_app(@context)
         assert_equal(1, orgs.count)
-        assert_equal(421, orgs.first['id'])
-        assert_equal(0, orgs.first['stores'].count)
-        assert_equal(0, orgs.first['apps'].count)
+        assert_equal(421, orgs.first["id"])
+        assert_equal(0, orgs.first["stores"].count)
+        assert_equal(0, orgs.first["apps"].count)
       end
     end
   end

--- a/test/shopify-cli/partners_api_test.rb
+++ b/test/shopify-cli/partners_api_test.rb
@@ -1,32 +1,32 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class PartnersAPITest < MiniTest::Test
     include TestHelpers::Project
 
     def test_query_calls_partners_api
-      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns('token123')
+      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns("token123")
       api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
-        token: 'token123',
+        token: "token123",
         url: "https://partners.shopify.com/api/cli/graphql",
       ).returns(api_stub)
-      api_stub.expects(:query).with('query', variables: {}).returns('response')
-      assert_equal 'response', PartnersAPI.query(@context, 'query')
+      api_stub.expects(:query).with("query", variables: {}).returns("response")
+      assert_equal "response", PartnersAPI.query(@context, "query")
     end
 
     def test_query_can_reauth
       Shopifolk.stubs(:check).returns(false)
-      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns('token123').twice
+      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns("token123").twice
 
       api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
-        token: 'token123',
+        token: "token123",
         url: "https://partners.shopify.com/api/cli/graphql",
       ).returns(api_stub).twice
-      api_stub.expects(:query).with('query', variables: {}).returns('response')
+      api_stub.expects(:query).with("query", variables: {}).returns("response")
       api_stub.expects(:query).raises(API::APIRequestUnauthorizedError)
 
       @oauth_client = mock
@@ -34,41 +34,41 @@ module ShopifyCli
         .expects(:new)
         .with(
           ctx: @context,
-          service: 'identity',
-          client_id: 'fbdb2649-e327-4907-8f67-908d24cfd7e3',
-          scopes: 'openid https://api.shopify.com/auth/partners.app.cli.access',
-          request_exchange: '271e16d403dfa18082ffb3d197bd2b5f4479c3fc32736d69296829cbb28d41a6',
+          service: "identity",
+          client_id: "fbdb2649-e327-4907-8f67-908d24cfd7e3",
+          scopes: "openid https://api.shopify.com/auth/partners.app.cli.access",
+          request_exchange: "271e16d403dfa18082ffb3d197bd2b5f4479c3fc32736d69296829cbb28d41a6",
         ).returns(@oauth_client)
       @oauth_client
         .expects(:authenticate)
         .with("https://accounts.shopify.com/oauth")
 
-      PartnersAPI.query(@context, 'query')
+      PartnersAPI.query(@context, "query")
     end
 
     def test_query_fails_gracefully_without_partners_account
-      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns('token123')
+      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns("token123")
       api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
-        token: 'token123',
+        token: "token123",
         url: "https://partners.shopify.com/api/cli/graphql",
       ).returns(api_stub)
       api_stub.expects(:query).raises(API::APIRequestNotFoundError)
-      @context.expects(:puts).with(@context.message('core.partners_api.error.account_not_found', ShopifyCli::TOOL_NAME))
-      PartnersAPI.query(@context, 'query')
+      @context.expects(:puts).with(@context.message("core.partners_api.error.account_not_found", ShopifyCli::TOOL_NAME))
+      PartnersAPI.query(@context, "query")
     end
 
     def test_query
-      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns('token123')
+      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns("token123")
       api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
-        token: 'token123',
+        token: "token123",
         url: "https://partners.shopify.com/api/cli/graphql",
       ).returns(api_stub)
-      api_stub.expects(:query).with('query', variables: {}).returns('response')
-      assert_equal 'response', PartnersAPI.query(@context, 'query')
+      api_stub.expects(:query).with("query", variables: {}).returns("response")
+      assert_equal "response", PartnersAPI.query(@context, "query")
     end
   end
 end

--- a/test/shopify-cli/process_supervision_test.rb
+++ b/test/shopify-cli/process_supervision_test.rb
@@ -1,23 +1,23 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class ProcessSuperVisionTest < MiniTest::Test
     def test_pid_has_expected_attributes
-      process = ProcessSupervision.new('web', pid: 1234)
+      process = ProcessSupervision.new("web", pid: 1234)
       assert_equal(1234, process.pid)
-      assert_equal('web', process.identifier)
+      assert_equal("web", process.identifier)
       assert_equal(
-        File.join(ShopifyCli.cache_dir, 'sv/web.pid'), process.pid_path
+        File.join(ShopifyCli.cache_dir, "sv/web.pid"), process.pid_path
       )
       assert_equal(
-        File.join(ShopifyCli.cache_dir, 'sv/web.log'), process.log_path
+        File.join(ShopifyCli.cache_dir, "sv/web.log"), process.log_path
       )
     end
 
     def test_start
       process = start
       assert process.alive?
-      assert ProcessSupervision.running?('example')
+      assert ProcessSupervision.running?("example")
       process.stop
     end
 
@@ -31,15 +31,15 @@ module ShopifyCli
     def test_stop
       process = start
       assert process.alive?
-      ProcessSupervision.stop('example')
+      ProcessSupervision.stop("example")
       refute process.alive?
-      refute ProcessSupervision.running?('example')
+      refute ProcessSupervision.running?("example")
     end
 
     private
 
     def start
-      process = ProcessSupervision.start('example', 'sleep 1')
+      process = ProcessSupervision.start("example", "sleep 1")
       Process.detach(process.pid)
       process
     end

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class ProjectTest < MiniTest::Test
@@ -32,23 +32,23 @@ module ShopifyCli
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       Dir.stubs(:pwd).returns(@context.root)
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
-      assert_equal :node, Project.current.config['project_type']
-      assert_equal 42, Project.current.config['organization_id']
-      refute Project.current.config['shopify_organization']
+      assert_equal :node, Project.current.config["project_type"]
+      assert_equal 42, Project.current.config["organization_id"]
+      refute Project.current.config["shopify_organization"]
     end
 
     def test_write_writes_yaml_with_shopify_organization_field
       create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(true)
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
-      assert Project.current.config['shopify_organization']
+      assert Project.current.config["shopify_organization"]
     end
 
     def test_write_writes_yaml_without_shopify_organization_field
       create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
-      refute Project.current.config['shopify_organization']
+      refute Project.current.config["shopify_organization"]
     end
 
     def test_write_includes_identifiers
@@ -61,7 +61,7 @@ module ShopifyCli
         other_option: true,
       )
       Project.clear
-      assert Project.current.config['other_option']
+      assert Project.current.config["other_option"]
     end
 
     def test_project_name_returns_name
@@ -102,7 +102,7 @@ module ShopifyCli
           HOST=baz
           AWSKEY=awskey
         CONTENT
-        File.write(File.join(dir, '.env'), content)
+        File.write(File.join(dir, ".env"), content)
         refute_nil(Project.current.env)
       end
     end

--- a/test/shopify-cli/project_type_test.rb
+++ b/test/shopify-cli/project_type_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class ProjectTypeTest < MiniTest::Test
@@ -21,28 +21,28 @@ module ShopifyCli
     def test_for_app_type_can_find_the_app_by_name
       assert_equal(ProjectType.for_app_type(:rails), Rails::Project)
       assert_equal(ProjectType.for_app_type(:node), Node::Project)
-      assert_equal(ProjectType.for_app_type('rails'), Rails::Project)
-      assert_equal(ProjectType.for_app_type('node'), Node::Project)
-      assert_nil(ProjectType.for_app_type('nope'))
+      assert_equal(ProjectType.for_app_type("rails"), Rails::Project)
+      assert_equal(ProjectType.for_app_type("node"), Node::Project)
+      assert_nil(ProjectType.for_app_type("nope"))
     end
 
     def test_project_filepath
       assert_equal(
-        Rails::Project.project_filepath('myfile'),
-        File.join(ShopifyCli::PROJECT_TYPES_DIR, 'rails', 'myfile')
+        Rails::Project.project_filepath("myfile"),
+        File.join(ShopifyCli::PROJECT_TYPES_DIR, "rails", "myfile")
       )
     end
 
     def test_duplicate_command
       assert_raises ShopifyCli::Abort, "Can't register duplicate core command" do
-        ProjectType.register_command('Nonsense::Module::Help', 'help')
+        ProjectType.register_command("Nonsense::Module::Help", "help")
       end
     end
 
     def test_register_command_does_not_call_if_shallow
       ShopifyCli::Commands.expects(:register).never
       Rails::Project.project_load_shallow = true
-      Rails::Project.register_command('Nonsense::Module::Help', 'help')
+      Rails::Project.register_command("Nonsense::Module::Help", "help")
     end
   end
 end

--- a/test/shopify-cli/resolve_constant_test.rb
+++ b/test/shopify-cli/resolve_constant_test.rb
@@ -10,12 +10,12 @@ module ShopifyCli
 
     def test_handles_seperators_correctly
       assert_equal OpenStruct, ResolveConstant.call(:open_struct).value
-      assert_equal OpenStruct, ResolveConstant.call('open-struct').value
+      assert_equal OpenStruct, ResolveConstant.call("open-struct").value
     end
 
     def test_traverse_namespace
-      assert_equal ::MiniTest::Test, ResolveConstant.call('mini_test/test').value
-      assert_equal ::MiniTest::Test, ResolveConstant.call('mini_test::test').value
+      assert_equal ::MiniTest::Test, ResolveConstant.call("mini_test/test").value
+      assert_equal ::MiniTest::Test, ResolveConstant.call("mini_test::test").value
     end
   end
 end

--- a/test/shopify-cli/resources/env_file_test.rb
+++ b/test/shopify-cli/resources/env_file_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Resources
@@ -8,28 +8,28 @@ module ShopifyCli
 
       def test_read_reads_env_content_from_file
         env_file = EnvFile.read
-        assert_equal('apikey', env_file.api_key)
-        assert_equal('secret', env_file.secret)
-        assert_equal('https://example.com', env_file.host)
-        assert_equal('my-test-shop.myshopify.com', env_file.shop)
-        assert_equal('awskey', env_file.extra['AWSKEY'])
+        assert_equal("apikey", env_file.api_key)
+        assert_equal("secret", env_file.secret)
+        assert_equal("https://example.com", env_file.host)
+        assert_equal("my-test-shop.myshopify.com", env_file.shop)
+        assert_equal("awskey", env_file.extra["AWSKEY"])
       end
 
       def test_parse_external_env
         env_file = EnvFile.parse_external_env
-        assert_equal('apikey', env_file[:api_key])
-        assert_equal('secret', env_file[:secret])
-        assert_equal('https://example.com', env_file[:host])
-        assert_equal('my-test-shop.myshopify.com', env_file[:shop])
-        assert_equal({ 'AWSKEY' => 'awskey' }, env_file[:extra])
+        assert_equal("apikey", env_file[:api_key])
+        assert_equal("secret", env_file[:secret])
+        assert_equal("https://example.com", env_file[:host])
+        assert_equal("my-test-shop.myshopify.com", env_file[:shop])
+        assert_equal({ "AWSKEY" => "awskey" }, env_file[:extra])
       end
 
       def test_write_writes_env_content_to_file
         env_file = EnvFile.new(
-          api_key: 'foo',
-          secret: 'bar',
-          host: 'baz',
-          extra: { 'AWSKEY' => 'awskey' },
+          api_key: "foo",
+          secret: "bar",
+          host: "baz",
+          extra: { "AWSKEY" => "awskey" },
         )
         content = <<~CONTENT
           SHOPIFY_API_KEY=foo
@@ -37,25 +37,25 @@ module ShopifyCli
           HOST=baz
           AWSKEY=awskey
         CONTENT
-        @context.expects(:write).with('.env', content)
-        @context.expects(:print_task).with('writing .env file')
+        @context.expects(:write).with(".env", content)
+        @context.expects(:print_task).with("writing .env file")
         env_file.write(@context)
       end
 
       def test_update_writes_new_value_to_file
         env_file = EnvFile.new(
-          api_key: 'foo',
-          secret: 'bar',
-          host: 'baz'
+          api_key: "foo",
+          secret: "bar",
+          host: "baz"
         )
         content = <<~CONTENT
           SHOPIFY_API_KEY=foo
           SHOPIFY_API_SECRET=bar
           HOST=boo
         CONTENT
-        @context.expects(:write).with('.env', content)
-        @context.expects(:print_task).with('writing .env file')
-        env_file.update(@context, :host, 'boo')
+        @context.expects(:write).with(".env", content)
+        @context.expects(:print_task).with("writing .env file")
+        env_file.update(@context, :host, "boo")
       end
     end
   end

--- a/test/shopify-cli/result_test.rb
+++ b/test/shopify-cli/result_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Result

--- a/test/shopify-cli/shopifolk_test.rb
+++ b/test/shopify-cli/shopifolk_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'fileutils'
+require "test_helper"
+require "fileutils"
 
 module ShopifyCli
   class ShopifolkTest < MiniTest::Test
@@ -7,8 +7,8 @@ module ShopifyCli
 
     def setup
       super
-      ShopifyCli::Config.set('shopifolk-beta', 'enabled', true)
-      ShopifyCli::Feature.disable('shopifolk')
+      ShopifyCli::Config.set("shopifolk-beta", "enabled", true)
+      ShopifyCli::Feature.disable("shopifolk")
     end
 
     def test_correct_features_is_shopifolk
@@ -19,21 +19,21 @@ module ShopifyCli
 
       ShopifyCli::Shopifolk.check
 
-      assert ShopifyCli::Config.get_bool('features', 'shopifolk')
+      assert ShopifyCli::Config.get_bool("features", "shopifolk")
     end
 
     def test_feature_always_returns_true
-      ShopifyCli::Feature.enable('shopifolk')
+      ShopifyCli::Feature.enable("shopifolk")
 
       assert ShopifyCli::Shopifolk.check
     end
 
     def test_no_gcloud_config_disables_shopifolk_feature
-      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
+      refute ShopifyCli::Config.get_bool("features", "shopifolk")
 
       ShopifyCli::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
+      refute ShopifyCli::Config.get_bool("features", "shopifolk")
     end
 
     def test_no_section_in_gcloud_config_disables_shopifolk_feature
@@ -41,7 +41,7 @@ module ShopifyCli
 
       ShopifyCli::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
+      refute ShopifyCli::Config.get_bool("features", "shopifolk")
     end
 
     def test_no_account_in_gcloud_config_disables_shopifolk_feature
@@ -49,7 +49,7 @@ module ShopifyCli
 
       ShopifyCli::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
+      refute ShopifyCli::Config.get_bool("features", "shopifolk")
     end
 
     def test_incorrect_email_in_gcloud_config_disables_shopifolk_feature
@@ -57,7 +57,7 @@ module ShopifyCli
 
       ShopifyCli::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
+      refute ShopifyCli::Config.get_bool("features", "shopifolk")
     end
 
     def test_incorrect_dev_path_disables_dev_shopifolk_feature
@@ -65,7 +65,7 @@ module ShopifyCli
 
       ShopifyCli::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool('features', 'shopifolk')
+      refute ShopifyCli::Config.get_bool("features", "shopifolk")
     end
 
     def test_setting_act_as_shopify_organization
@@ -80,7 +80,7 @@ module ShopifyCli
 
     def test_reading_shopify_organization_from_config
       Project.expects(:has_current?).returns(true)
-      project = stub('project', config: { 'shopify_organization' => true })
+      project = stub("project", config: { "shopify_organization" => true })
       Project.expects(:current).returns(project)
 
       assert ShopifyCli::Shopifolk.acting_as_shopify_organization?

--- a/test/shopify-cli/smoke_test.rb
+++ b/test/shopify-cli/smoke_test.rb
@@ -1,11 +1,11 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class SmokeTest < MiniTest::Test
     def test_exit_non_zero
       assert_nothing_raised do
         capture_io do
-          ShopifyCli::Core::EntryPoint.call(['help'])
+          ShopifyCli::Core::EntryPoint.call(["help"])
         end
       end
     end

--- a/test/shopify-cli/tasks/create_api_client_test.rb
+++ b/test/shopify-cli/tasks/create_api_client_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Tasks
@@ -12,11 +12,11 @@ module ShopifyCli
 
       def test_call_will_query_partners_dashboard
         stub_partner_req(
-          'create_app',
+          "create_app",
           variables: {
             org: 42,
-            title: 'Test app',
-            type: 'public',
+            title: "Test app",
+            type: "public",
             app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
@@ -24,8 +24,8 @@ module ShopifyCli
             'data': {
               'appCreate': {
                 'app': {
-                  'apiKey': 'newapikey',
-                  'apiSecretKeys': [{ 'secret': 'secret' }],
+                  'apiKey': "newapikey",
+                  'apiSecretKeys': [{ 'secret': "secret" }],
                 },
               },
             },
@@ -35,28 +35,28 @@ module ShopifyCli
         api_client = Tasks::CreateApiClient.call(
           @context,
           org_id: 42,
-          title: 'Test app',
-          type: 'public',
+          title: "Test app",
+          type: "public",
         )
 
         refute_nil(api_client)
-        assert_equal('newapikey', api_client['apiKey'])
+        assert_equal("newapikey", api_client["apiKey"])
         assert_equal("newapikey", ShopifyCli::Core::Monorail.metadata[:api_key])
       end
 
       def test_call_will_return_any_general_errors
         stub_partner_req(
-          'create_app',
+          "create_app",
           variables: {
             org: 42,
-            title: 'Test app',
-            type: 'public',
+            title: "Test app",
+            type: "public",
             app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {
             'errors': [
-              { 'field': 'title', 'message': 'is not a valid title' },
+              { 'field': "title", 'message': "is not a valid title" },
             ],
           }
         )
@@ -65,8 +65,8 @@ module ShopifyCli
           Tasks::CreateApiClient.call(
             @context,
             org_id: 42,
-            title: 'Test app',
-            type: 'public',
+            title: "Test app",
+            type: "public",
           )
         end
         assert_equal("{{x}} title is not a valid title", err.message)
@@ -74,11 +74,11 @@ module ShopifyCli
 
       def test_call_will_return_any_user_errors
         stub_partner_req(
-          'create_app',
+          "create_app",
           variables: {
             org: 42,
-            title: 'Test app',
-            type: 'public',
+            title: "Test app",
+            type: "public",
             app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
@@ -86,7 +86,7 @@ module ShopifyCli
             'data': {
               'appCreate': {
                 'userErrors': [
-                  { 'field': 'title', 'message': 'is not a valid title' },
+                  { 'field': "title", 'message': "is not a valid title" },
                 ],
               },
             },
@@ -97,8 +97,8 @@ module ShopifyCli
           Tasks::CreateApiClient.call(
             @context,
             org_id: 42,
-            title: 'Test app',
-            type: 'public',
+            title: "Test app",
+            type: "public",
           )
         end
         assert_equal("{{x}} title is not a valid title", err.message)

--- a/test/shopify-cli/tasks/ensure_dev_store_test.rb
+++ b/test/shopify-cli/tasks/ensure_dev_store_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Tasks
@@ -12,9 +12,9 @@ module ShopifyCli
 
       def test_outputs_if_shop_cant_be_queried
         stub_org_request
-        stub_env(domain: 'notther.myshopify.com')
+        stub_env(domain: "notther.myshopify.com")
         @context.expects(:puts).with(
-          @context.message('core.tasks.ensure_dev_store.could_not_verify_store', 'notther.myshopify.com')
+          @context.message("core.tasks.ensure_dev_store.could_not_verify_store", "notther.myshopify.com")
         )
         EnsureDevStore.call(@context)
       end
@@ -38,7 +38,7 @@ module ShopifyCli
         stub_env
         CLI::UI::Prompt.expects(:confirm).returns(true)
         stub_partner_req(
-          'convert_dev_to_test_store',
+          "convert_dev_to_test_store",
           variables: {
             input: {
               organizationID: 42,
@@ -47,26 +47,26 @@ module ShopifyCli
           }
         )
         @context.expects(:puts).with(
-          @context.message('core.tasks.ensure_dev_store.transfer_disabled', 'shopdomain.myshopify.com')
+          @context.message("core.tasks.ensure_dev_store.transfer_disabled", "shopdomain.myshopify.com")
         )
         EnsureDevStore.call(@context)
       end
 
       private
 
-      def stub_env(domain: 'shopdomain.myshopify.com')
+      def stub_env(domain: "shopdomain.myshopify.com")
         Project.current.stubs(:env).returns(
           Resources::EnvFile.new(
-            api_key: '123',
-            secret: 'kjhasas',
+            api_key: "123",
+            secret: "kjhasas",
             shop: domain,
           )
         )
       end
 
-      def stub_org_request(domain: 'shopdomain.myshopify.com', transfer_disabled: false)
+      def stub_org_request(domain: "shopdomain.myshopify.com", transfer_disabled: false)
         stub_partner_req(
-          'all_organizations',
+          "all_organizations",
           'resp': {
             'data': {
               'organizations': {

--- a/test/shopify-cli/tasks/ensure_env_test.rb
+++ b/test/shopify-cli/tasks/ensure_env_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Tasks
@@ -25,13 +25,13 @@ module ShopifyCli
           "apps" => [],
         }]
         ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(response)
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.tasks.ensure_env.app_name')).returns('new app')
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.tasks.ensure_env.app_type.select')).returns('public')
+        CLI::UI::Prompt.expects(:ask).with(@context.message("core.tasks.ensure_env.app_name")).returns("new app")
+        CLI::UI::Prompt.expects(:ask).with(@context.message("core.tasks.ensure_env.app_type.select")).returns("public")
         ShopifyCli::Tasks::CreateApiClient.expects(:call).with(
           @context,
           org_id: 421,
-          title: 'new app',
-          type: 'public',
+          title: "new app",
+          type: "public",
         ).returns({
           "apiKey" => 1235,
           "apiSecretKeys" => [{ "secret" => 1234 }],
@@ -126,10 +126,10 @@ module ShopifyCli
       private
 
       def expect_user_prompts
-        CLI::UI::Prompt.expects(:ask).with(@context.message('core.tasks.ensure_env.organization_select')).returns(101)
+        CLI::UI::Prompt.expects(:ask).with(@context.message("core.tasks.ensure_env.organization_select")).returns(101)
         CLI::UI::Prompt.expects(:ask).with(
-          @context.message('core.tasks.ensure_env.development_store_select')
-        ).returns('store.myshopify.com')
+          @context.message("core.tasks.ensure_env.development_store_select")
+        ).returns("store.myshopify.com")
       end
 
       def new_env_file_values

--- a/test/shopify-cli/tasks/ensure_loopback_url_test.rb
+++ b/test/shopify-cli/tasks/ensure_loopback_url_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Tasks
@@ -6,10 +6,10 @@ module ShopifyCli
       include TestHelpers::Partners
 
       def test_url_is_not_added_if_it_exists
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
-        api_key = '123'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "123", secret: "foo"))
+        api_key = "123"
         stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
@@ -17,8 +17,8 @@ module ShopifyCli
             data: {
               app: {
                 redirectUrlWhitelist: [
-                  'https://123abc.ngrok.io',
-                  'http://127.0.0.1:3456',
+                  "https://123abc.ngrok.io",
+                  "http://127.0.0.1:3456",
                 ],
               },
             },
@@ -28,10 +28,10 @@ module ShopifyCli
       end
 
       def test_url_is_added_if_it_is_not_there
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
-        api_key = '123'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "123", secret: "foo"))
+        api_key = "123"
         stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
@@ -39,7 +39,7 @@ module ShopifyCli
             data: {
               app: {
                 redirectUrlWhitelist: [
-                  'https://123abc.ngrok.io',
+                  "https://123abc.ngrok.io",
                 ],
               },
             },
@@ -47,12 +47,12 @@ module ShopifyCli
         )
 
         stub_partner_req(
-          'update_dashboard_urls',
+          "update_dashboard_urls",
           variables: {
             input: {
               redirectUrlWhitelist: [
-                'https://123abc.ngrok.io',
-                'http://127.0.0.1:3456',
+                "https://123abc.ngrok.io",
+                "http://127.0.0.1:3456",
               ],
               apiKey: api_key,
             },

--- a/test/shopify-cli/tasks/select_org_and_shop_test.rb
+++ b/test/shopify-cli/tasks/select_org_and_shop_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Tasks
@@ -19,26 +19,26 @@ module ShopifyCli
       def test_user_will_be_prompted_if_more_than_one_organization
         ShopifyCli::PartnersAPI::Organizations.expects(:fetch_all).with(@context).returns([
           {
-            'id' => 421,
-            'businessName' => "one",
-            'stores' => [{ 'shopDomain' => 'store.myshopify.com' }],
+            "id" => 421,
+            "businessName" => "one",
+            "stores" => [{ "shopDomain" => "store.myshopify.com" }],
           },
           {
-            'id' => 431,
-            'businessName' => "two",
-            'stores' => [
-              { 'shopDomain' => 'other.myshopify.com', 'transferDisabled' => true },
-              { 'shopDomain' => 'yet-another.myshopify.com' },
+            "id" => 431,
+            "businessName" => "two",
+            "stores" => [
+              { "shopDomain" => "other.myshopify.com", "transferDisabled" => true },
+              { "shopDomain" => "yet-another.myshopify.com" },
             ],
           },
         ])
         CLI::UI::Prompt.expects(:ask)
-          .with(@context.message('core.tasks.select_org_and_shop.organization_select'))
+          .with(@context.message("core.tasks.select_org_and_shop.organization_select"))
           .returns(431)
         form = call(org_id: nil, shop: nil)
         assert_equal(431, ShopifyCli::Core::Monorail.metadata[:organization_id])
         assert_equal(431, form[:organization_id])
-        assert_equal('other.myshopify.com', form[:shop_domain])
+        assert_equal("other.myshopify.com", form[:shop_domain])
       end
 
       def test_will_auto_pick_with_only_one_org
@@ -57,10 +57,10 @@ module ShopifyCli
         io = capture_io do
           form = call(org_id: nil, shop: nil)
           assert_equal(421, form[:organization_id])
-          assert_equal('next.myshopify.com', form[:shop_domain])
+          assert_equal("next.myshopify.com", form[:shop_domain])
         end
         assert_match(
-          CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.organization', 'hoopy froods', 421)),
+          CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.organization", "hoopy froods", 421)),
           io.join,
         )
       end
@@ -76,7 +76,7 @@ module ShopifyCli
         )
         form = call(org_id: 123, shop: nil)
         assert_equal(123, form[:organization_id])
-        assert_equal('shopdomain.myshopify.com', form[:shop_domain])
+        assert_equal("shopdomain.myshopify.com", form[:shop_domain])
       end
 
       def test_it_will_fail_if_no_orgs_are_available
@@ -87,8 +87,8 @@ module ShopifyCli
             form = call(org_id: nil, shop: nil)
             assert_nil(form)
           end
-          assert_match(@context.message('core.tasks.select_org_and_shop.error.partners_notice'), io.join)
-          assert_match(@context.message('core.tasks.select_org_and_shop.authentication_issue', ShopifyCli::TOOL_NAME),
+          assert_match(@context.message("core.tasks.select_org_and_shop.error.partners_notice"), io.join)
+          assert_match(@context.message("core.tasks.select_org_and_shop.authentication_issue", ShopifyCli::TOOL_NAME),
             io.join)
         end
       end
@@ -103,8 +103,8 @@ module ShopifyCli
           assert_nil form[:shop_domain]
         end
         log = io.join
-        assert_match(CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.error.no_development_stores')), log)
-        assert_match(CLI::UI.fmt(@context.message('core.tasks.select_org_and_shop.create_store', 123)), log)
+        assert_match(CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.error.no_development_stores")), log)
+        assert_match(CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.create_store", 123)), log)
       end
 
       def test_autopicks_only_shop
@@ -118,10 +118,10 @@ module ShopifyCli
         )
         io = capture_io do
           form = call(org_id: 123, shop: nil)
-          assert_equal('shopdomain.myshopify.com', form[:shop_domain])
+          assert_equal("shopdomain.myshopify.com", form[:shop_domain])
         end
         assert_match(CLI::UI.fmt(
-          @context.message('core.tasks.select_org_and_shop.development_store', 'shopdomain.myshopify.com')
+          @context.message("core.tasks.select_org_and_shop.development_store", "shopdomain.myshopify.com")
         ), io.join)
       end
 
@@ -139,12 +139,12 @@ module ShopifyCli
 
         CLI::UI::Prompt.expects(:ask)
           .with(
-            @context.message('core.tasks.select_org_and_shop.development_store_select'),
+            @context.message("core.tasks.select_org_and_shop.development_store_select"),
             options: %w(shopdomain.myshopify.com shop.myshopify.com)
           )
-          .returns('selected')
+          .returns("selected")
         form = call(org_id: 123, shop: nil)
-        assert_equal('selected', form[:shop_domain])
+        assert_equal("selected", form[:shop_domain])
       end
 
       def test_persists_organization_preference_if_chosen
@@ -178,7 +178,7 @@ module ShopifyCli
 
       private
 
-      def call(org_id: 421, shop: 'store.myshopify.com')
+      def call(org_id: 421, shop: "store.myshopify.com")
         SelectOrgAndShop.call(
           @context,
           organization_id: org_id,

--- a/test/shopify-cli/tasks/update_dashboard_urls_test.rb
+++ b/test/shopify-cli/tasks/update_dashboard_urls_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   module Tasks
@@ -6,20 +6,20 @@ module ShopifyCli
       include TestHelpers::Partners
 
       def test_url_is_not_transformed_if_same
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
-        api_key = '123'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "123", secret: "foo"))
+        api_key = "123"
         stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
           resp: {
             data: {
               app: {
-                applicationUrl: 'https://123abc.ngrok.io',
+                applicationUrl: "https://123abc.ngrok.io",
                 redirectUrlWhitelist: [
-                  'https://123abc.ngrok.io',
-                  'https://123abc.ngrok.io/callback/fake',
+                  "https://123abc.ngrok.io",
+                  "https://123abc.ngrok.io/callback/fake",
                 ],
               },
             },
@@ -27,27 +27,27 @@ module ShopifyCli
         )
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @context,
-          url: 'https://123abc.ngrok.io',
-          callback_url: '/callback/fake',
+          url: "https://123abc.ngrok.io",
+          callback_url: "/callback/fake",
         )
       end
 
       def test_url_is_transformed_if_different_and_callback_is_appended
         CLI::UI::Prompt.stubs(:confirm).returns(true)
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '1234', secret: 'foo'))
-        api_key = '1234'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "1234", secret: "foo"))
+        api_key = "1234"
         get_request = stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
           resp: {
             data: {
               app: {
-                applicationUrl: 'https://oldone123.ngrok.io',
+                applicationUrl: "https://oldone123.ngrok.io",
                 redirectUrlWhitelist: [
-                  'https://123abc.ngrok.io',
-                  'https://newone123.ngrok.io/callback/fake',
+                  "https://123abc.ngrok.io",
+                  "https://newone123.ngrok.io/callback/fake",
                 ],
               },
             },
@@ -55,19 +55,19 @@ module ShopifyCli
         )
 
         update_request = stub_partner_req(
-          'update_dashboard_urls',
+          "update_dashboard_urls",
           variables: {
             input: {
-              applicationUrl: 'https://newone123.ngrok.io',
-              redirectUrlWhitelist: ['https://newone123.ngrok.io', 'https://newone123.ngrok.io/callback/fake'],
+              applicationUrl: "https://newone123.ngrok.io",
+              redirectUrlWhitelist: ["https://newone123.ngrok.io", "https://newone123.ngrok.io/callback/fake"],
               apiKey: api_key,
             },
           },
         )
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @context,
-          url: 'https://newone123.ngrok.io',
-          callback_url: '/callback/fake',
+          url: "https://newone123.ngrok.io",
+          callback_url: "/callback/fake",
         )
         assert_requested(get_request)
         assert_requested(update_request)
@@ -75,21 +75,21 @@ module ShopifyCli
 
       def test_only_ngrok_urls_are_updated
         CLI::UI::Prompt.stubs(:confirm).returns(true)
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '1234', secret: 'foo'))
-        api_key = '1234'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "1234", secret: "foo"))
+        api_key = "1234"
         stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
           resp: {
             data: {
               app: {
-                applicationUrl: 'https://oldone123.ngrok.io',
+                applicationUrl: "https://oldone123.ngrok.io",
                 redirectUrlWhitelist: [
-                  'https://123abc.ngrok.io',
-                  'https://fake.fakeurl.com',
-                  'https://fake.fakeurl.com/callback/fake',
+                  "https://123abc.ngrok.io",
+                  "https://fake.fakeurl.com",
+                  "https://fake.fakeurl.com/callback/fake",
                 ],
               },
             },
@@ -97,15 +97,15 @@ module ShopifyCli
         )
 
         stub_partner_req(
-          'update_dashboard_urls',
+          "update_dashboard_urls",
           variables: {
             input: {
-              applicationUrl: 'https://newone123.ngrok.io',
+              applicationUrl: "https://newone123.ngrok.io",
               redirectUrlWhitelist: [
-                'https://newone123.ngrok.io',
-                'https://fake.fakeurl.com',
-                'https://fake.fakeurl.com/callback/fake',
-                'https://newone123.ngrok.io/callback/fake',
+                "https://newone123.ngrok.io",
+                "https://fake.fakeurl.com",
+                "https://fake.fakeurl.com/callback/fake",
+                "https://newone123.ngrok.io/callback/fake",
               ],
               apiKey: api_key,
             },
@@ -113,27 +113,27 @@ module ShopifyCli
         )
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @context,
-          url: 'https://newone123.ngrok.io',
-          callback_url: '/callback/fake',
+          url: "https://newone123.ngrok.io",
+          callback_url: "/callback/fake",
         )
       end
 
       def test_application_url_is_not_updated_if_user_says_no
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '1234', secret: 'foo'))
-        api_key = '1234'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "1234", secret: "foo"))
+        api_key = "1234"
         stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
           resp: {
             data: {
               app: {
-                applicationUrl: 'https://newone123.ngrok.io',
+                applicationUrl: "https://newone123.ngrok.io",
                 redirectUrlWhitelist: [
-                  'https://123abc.ngrok.io',
-                  'https://fake.fakeurl.com',
-                  'https://fake.fakeurl.com/callback/fake',
+                  "https://123abc.ngrok.io",
+                  "https://fake.fakeurl.com",
+                  "https://fake.fakeurl.com/callback/fake",
                 ],
               },
             },
@@ -141,10 +141,10 @@ module ShopifyCli
         )
 
         stub_partner_req(
-          'update_dashboard_urls',
+          "update_dashboard_urls",
           variables: {
             input: {
-              applicationUrl: 'https://newone123.ngrok.io',
+              applicationUrl: "https://newone123.ngrok.io",
               redirectUrlWhitelist: [
                 "https://myowndomain.io",
                 "https://fake.fakeurl.com",
@@ -158,27 +158,27 @@ module ShopifyCli
         CLI::UI::Prompt.expects(:confirm).returns(false)
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @context,
-          url: 'https://myowndomain.io',
-          callback_url: '/callback/fake',
+          url: "https://myowndomain.io",
+          callback_url: "/callback/fake",
         )
       end
 
       def test_application_url_is_updated_if_user_says_yes
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '1234', secret: 'foo'))
-        api_key = '1234'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "1234", secret: "foo"))
+        api_key = "1234"
         stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
           resp: {
             data: {
               app: {
-                applicationUrl: 'https://newone123.ngrok.io',
+                applicationUrl: "https://newone123.ngrok.io",
                 redirectUrlWhitelist: [
-                  'https://123abc.ngrok.io',
-                  'https://fake.fakeurl.com',
-                  'https://fake.fakeurl.com/callback/fake',
+                  "https://123abc.ngrok.io",
+                  "https://fake.fakeurl.com",
+                  "https://fake.fakeurl.com/callback/fake",
                 ],
               },
             },
@@ -186,10 +186,10 @@ module ShopifyCli
         )
 
         stub_partner_req(
-          'update_dashboard_urls',
+          "update_dashboard_urls",
           variables: {
             input: {
-              applicationUrl: 'https://myowndomain.io',
+              applicationUrl: "https://myowndomain.io",
               redirectUrlWhitelist: [
                 "https://myowndomain.io",
                 "https://fake.fakeurl.com",
@@ -203,24 +203,24 @@ module ShopifyCli
         CLI::UI::Prompt.expects(:confirm).returns(true)
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @context,
-          url: 'https://myowndomain.io',
-          callback_url: '/callback/fake',
+          url: "https://myowndomain.io",
+          callback_url: "/callback/fake",
         )
       end
 
       def test_whitelist_urls_are_updated_even_if_app_url_is_set
         CLI::UI::Prompt.stubs(:confirm).returns(true)
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
-        api_key = '123'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "123", secret: "foo"))
+        api_key = "123"
         get_request = stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
           resp: {
             data: {
               app: {
-                applicationUrl: 'https://oldone123.ngrok.io',
+                applicationUrl: "https://oldone123.ngrok.io",
                 redirectUrlWhitelist: [],
               },
             },
@@ -228,12 +228,12 @@ module ShopifyCli
         )
 
         update_request = stub_partner_req(
-          'update_dashboard_urls',
+          "update_dashboard_urls",
           variables: {
             input: {
-              applicationUrl: 'https://newone123.ngrok.io',
+              applicationUrl: "https://newone123.ngrok.io",
               redirectUrlWhitelist: [
-                'https://newone123.ngrok.io/callback/fake',
+                "https://newone123.ngrok.io/callback/fake",
               ],
               apiKey: api_key,
             },
@@ -241,28 +241,28 @@ module ShopifyCli
         )
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @context,
-          url: 'https://newone123.ngrok.io',
-          callback_url: '/callback/fake',
+          url: "https://newone123.ngrok.io",
+          callback_url: "/callback/fake",
         )
         assert_requested(get_request)
         assert_requested(update_request)
       end
 
       def test_user_is_prompted_to_update_application_url
-        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: '123', secret: 'foo'))
-        api_key = '123'
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "123", secret: "foo"))
+        api_key = "123"
         stub_partner_req(
-          'get_app_urls',
+          "get_app_urls",
           variables: {
             apiKey: api_key,
           },
           resp: {
             data: {
               app: {
-                applicationUrl: 'https://123abc.ngrok.io',
+                applicationUrl: "https://123abc.ngrok.io",
                 redirectUrlWhitelist: [
-                  'https://123abc.ngrok.io',
-                  'https://123abc.ngrok.io/callback/fake',
+                  "https://123abc.ngrok.io",
+                  "https://123abc.ngrok.io/callback/fake",
                 ],
               },
             },
@@ -270,13 +270,13 @@ module ShopifyCli
         )
 
         stub_partner_req(
-          'update_dashboard_urls',
+          "update_dashboard_urls",
           variables: {
             input: {
-              applicationUrl: 'https://123adifferenturl.ngrok.io',
+              applicationUrl: "https://123adifferenturl.ngrok.io",
               redirectUrlWhitelist: [
-                'https://123adifferenturl.ngrok.io',
-                'https://123adifferenturl.ngrok.io/callback/fake',
+                "https://123adifferenturl.ngrok.io",
+                "https://123adifferenturl.ngrok.io/callback/fake",
               ],
               apiKey: api_key,
             },
@@ -285,8 +285,8 @@ module ShopifyCli
         CLI::UI::Prompt.expects(:confirm).returns(true)
         ShopifyCli::Tasks::UpdateDashboardURLS.call(
           @context,
-          url: 'https://123adifferenturl.ngrok.io',
-          callback_url: '/callback/fake',
+          url: "https://123adifferenturl.ngrok.io",
+          callback_url: "/callback/fake",
         )
       end
     end

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 module ShopifyCli
   class TunnelTest < MiniTest::Test
@@ -8,8 +8,8 @@ module ShopifyCli
     end
 
     def test_auth_calls_ngrok_authtoken
-      @context.expects(:system).with("#{ShopifyCli.cache_dir}/ngrok", 'authtoken', 'token')
-      ShopifyCli::Tunnel.auth(@context, 'token')
+      @context.expects(:system).with("#{ShopifyCli.cache_dir}/ngrok", "authtoken", "token")
+      ShopifyCli::Tunnel.auth(@context, "token")
     end
 
     def test_start_running_returns_url
@@ -17,7 +17,7 @@ module ShopifyCli
         .with(:ngrok).returns(:true)
       with_log do
         ShopifyCli::Tunnel.start(@context)
-        assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context)
+        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context)
       end
     end
 
@@ -26,12 +26,12 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
-        @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
-        @context.expects(:puts).with(@context.message('core.tunnel.will_timeout', '7 hours 59 minutes'))
-        @context.expects(:puts).with(@context.message('core.tunnel.signup_suggestion', ShopifyCli::TOOL_NAME))
-        assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context)
+        @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
+        @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
+        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCli::TOOL_NAME))
+        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context)
       end
     end
 
@@ -40,19 +40,19 @@ module ShopifyCli
       with_log(time: start_time.to_s) do
         ShopifyCli::ProcessSupervision.expects(:start).twice.with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(
           ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000, time: start_time.to_s)
         ).then.returns(
           ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000)
         )
-        @context.expects(:puts).with(@context.message('core.tunnel.timed_out'))
+        @context.expects(:puts).with(@context.message("core.tunnel.timed_out"))
         ShopifyCli::ProcessSupervision.expects(:stop)
           .with(:ngrok).returns(true)
-        @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
-        @context.expects(:puts).with(@context.message('core.tunnel.will_timeout', '7 hours 59 minutes'))
-        @context.expects(:puts).with(@context.message('core.tunnel.signup_suggestion', ShopifyCli::TOOL_NAME))
-        assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context)
+        @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
+        @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
+        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCli::TOOL_NAME))
+        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context)
       end
     end
 
@@ -62,35 +62,35 @@ module ShopifyCli
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false"\
+          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false"\
             " -log=stdout -log-level=debug #{configured_port}"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
-        @context.expects(:puts).with(@context.message('core.tunnel.start', 'https://example.ngrok.io'))
-        @context.expects(:puts).with(@context.message('core.tunnel.will_timeout', '7 hours 59 minutes'))
-        @context.expects(:puts).with(@context.message('core.tunnel.signup_suggestion', ShopifyCli::TOOL_NAME))
-        assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context, port: configured_port)
+        @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
+        @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
+        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCli::TOOL_NAME))
+        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context, port: configured_port)
       end
     end
 
     def test_start_displays_url_with_account
-      with_log(fixture: 'ngrok_account') do
+      with_log(fixture: "ngrok_account") do
         ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(
-          @context.message('core.tunnel.start_with_account', 'https://example.ngrok.io', 'Tom Cruise')
+          @context.message("core.tunnel.start_with_account", "https://example.ngrok.io", "Tom Cruise")
         )
-        assert_equal 'https://example.ngrok.io', ShopifyCli::Tunnel.start(@context)
+        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context)
       end
     end
 
     def test_start_raises_error_on_ngrok_failure
-      with_log(fixture: 'ngrok_error') do
+      with_log(fixture: "ngrok_error") do
         ShopifyCli::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, 'ngrok')}\" http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
         assert_raises ShopifyCli::Tunnel::NgrokError do
           ShopifyCli::Tunnel.start(@context)
@@ -100,7 +100,7 @@ module ShopifyCli
 
     def test_stop_doesnt_stop_what_isnt_started
       ShopifyCli::ProcessSupervision.expects(:running?).with(:ngrok).returns(false)
-      @context.expects(:puts).with(@context.message('core.tunnel.not_running'))
+      @context.expects(:puts).with(@context.message("core.tunnel.not_running"))
       ShopifyCli::Tunnel.stop(@context)
     end
 
@@ -143,7 +143,7 @@ module ShopifyCli
 
     private
 
-    def with_log(fixture: 'ngrok', time: Time.now.strftime('%s'))
+    def with_log(fixture: "ngrok", time: Time.now.strftime("%s"))
       log_path = File.join(ShopifyCli::ROOT, "test/fixtures/#{fixture}.log")
       process = ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000, time: time)
       process.write
@@ -162,7 +162,7 @@ module ShopifyCli
 
     def fake_ngrok_api_response
       @ngrok_api_response ||= begin
-        JSON.parse(File.read(File.join(ShopifyCli::ROOT, 'test', 'fixtures', 'ngrok_api.json')))
+        JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test", "fixtures", "ngrok_api.json")))
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,19 +1,19 @@
-ENV['RUNNING_SHOPIFY_CLI_TESTS'] = 1.to_s
+ENV["RUNNING_SHOPIFY_CLI_TESTS"] = 1.to_s
 
-require 'rubygems'
-require 'bundler/setup'
-require 'shopify_cli'
-require 'byebug'
-require 'pry'
+require "rubygems"
+require "bundler/setup"
+require "shopify_cli"
+require "byebug"
+require "pry"
 
-require 'minitest/autorun'
-require 'minitest/reporters'
-require_relative 'test_helpers'
-require_relative 'minitest_ext'
-require 'fakefs/safe'
-require 'webmock/minitest'
+require "minitest/autorun"
+require "minitest/reporters"
+require_relative "test_helpers"
+require_relative "minitest_ext"
+require "fakefs/safe"
+require "webmock/minitest"
 
-require 'mocha/minitest'
+require "mocha/minitest"
 
 Mocha.configure do |c|
   c.stubbing_non_existent_method = :prevent

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 module TestHelpers
-  autoload :Constants, 'test_helpers/constants'
-  autoload :FakeTask, 'test_helpers/fake_task'
-  autoload :FakeContext, 'test_helpers/fake_context'
-  autoload :FakeFS, 'test_helpers/fake_fs'
-  autoload :FakeProject, 'test_helpers/fake_project'
-  autoload :FakeUI, 'test_helpers/fake_ui'
-  autoload :Heroku, 'test_helpers/heroku'
-  autoload :Partners, 'test_helpers/partners'
-  autoload :Project, 'test_helpers/project'
-  autoload :Schema, 'test_helpers/schema'
+  autoload :Constants, "test_helpers/constants"
+  autoload :FakeTask, "test_helpers/fake_task"
+  autoload :FakeContext, "test_helpers/fake_context"
+  autoload :FakeFS, "test_helpers/fake_fs"
+  autoload :FakeProject, "test_helpers/fake_project"
+  autoload :FakeUI, "test_helpers/fake_ui"
+  autoload :Heroku, "test_helpers/heroku"
+  autoload :Partners, "test_helpers/partners"
+  autoload :Project, "test_helpers/project"
+  autoload :Schema, "test_helpers/schema"
 end

--- a/test/test_helpers/fake_task.rb
+++ b/test/test_helpers/fake_task.rb
@@ -2,7 +2,7 @@ module TestHelpers
   module FakeTask
     class FakeTask < ShopifyCli::Task
       def call(ctx)
-        ctx.puts('success!')
+        ctx.puts("success!")
       end
     end
 

--- a/test/test_helpers/heroku.rb
+++ b/test/test_helpers/heroku.rb
@@ -9,8 +9,8 @@ module TestHelpers
         .returns(true)
 
       @context.stubs(:capture2e)
-        .with(heroku_command(full_path: full_path), '--version')
-        .returns(['', status_mock[:true]])
+        .with(heroku_command(full_path: full_path), "--version")
+        .returns(["", status_mock[:true]])
 
       # init
       init_output = <<~EOS
@@ -21,32 +21,32 @@ module TestHelpers
       EOS
 
       @context.stubs(:capture2e)
-        .with('git', 'status')
+        .with("git", "status")
         .returns([init_output, status_mock[:true]])
 
       # db validation
       @context.stubs(:capture2e)
         .with('bundle exec rails runner "puts ActiveRecord::Base.connection.adapter_name.downcase"')
-        .returns(['mysql', status_mock[:true]])
+        .returns(["mysql", status_mock[:true]])
 
       # whoami
       @context.stubs(:capture2e)
-        .with(heroku_command(full_path: full_path), 'whoami')
-        .returns(['username', status_mock[:true]])
+        .with(heroku_command(full_path: full_path), "whoami")
+        .returns(["username", status_mock[:true]])
 
       # heroku.app
       @context.stubs(:capture2e)
-        .with('git', 'remote', 'get-url', 'heroku')
+        .with("git", "remote", "get-url", "heroku")
         .returns([heroku_remote, status_mock[:true]])
 
       # git branches
       @context.stubs(:capture2e)
-        .with('git', 'branch', '--list', '--format=%(refname:short)')
+        .with("git", "branch", "--list", "--format=%(refname:short)")
         .returns(["master\n", status_mock[:true]])
 
       # deploy
       @context.stubs(:system)
-        .with('git', 'push', '-u', 'heroku', 'master:master')
+        .with("git", "push", "-u", "heroku", "master:master")
         .returns(status_mock[:true])
 
       # user outputs
@@ -56,11 +56,11 @@ module TestHelpers
     def expects_tar_heroku(status:)
       if status.nil?
         @context.expects(:system)
-          .with('tar', '-xf', download_path, chdir: ShopifyCli.cache_dir)
+          .with("tar", "-xf", download_path, chdir: ShopifyCli.cache_dir)
           .never
       else
         @context.expects(:system)
-          .with('tar', '-xf', download_path, chdir: ShopifyCli.cache_dir)
+          .with("tar", "-xf", download_path, chdir: ShopifyCli.cache_dir)
           .returns(status_mock[:"#{status}"])
       end
 
@@ -76,7 +76,7 @@ module TestHelpers
       output << "other_branch\n" if multiple
 
       @context.expects(:capture2e)
-        .with('git', 'branch', '--list', '--format=%(refname:short)')
+        .with("git", "branch", "--list", "--format=%(refname:short)")
         .returns([output, status_mock[:"#{status}"]])
     end
 
@@ -97,7 +97,7 @@ module TestHelpers
       end
 
       @context.expects(:capture2e)
-        .with('git', 'status')
+        .with("git", "status")
         .returns([output, status_mock[:"#{status}"]])
     end
 
@@ -109,13 +109,13 @@ module TestHelpers
       end
 
       @context.expects(:capture2e)
-        .with('git', 'remote', 'get-url', remote)
+        .with("git", "remote", "get-url", remote)
         .returns([output, status_mock[:"#{status}"]])
     end
 
     def expects_git_push_heroku(status:, branch:)
       @context.expects(:system)
-        .with('git', 'push', '-u', 'heroku', branch)
+        .with("git", "push", "-u", "heroku", branch)
         .returns(status_mock[:"#{status}"])
     end
 
@@ -126,19 +126,19 @@ module TestHelpers
       EOS
 
       @context.expects(:capture2e)
-        .with(heroku_command(full_path: full_path), 'create')
+        .with(heroku_command(full_path: full_path), "create")
         .returns([output, status_mock[:"#{status}"]])
     end
 
     def expects_heroku_login(status:, full_path: false)
       @context.expects(:system)
-        .with(heroku_command(full_path: full_path), 'login')
+        .with(heroku_command(full_path: full_path), "login")
         .returns(status_mock[:"#{status}"])
     end
 
     def expects_heroku_deploy(status:)
       @context.expects(:system)
-        .with('git', 'push', '-u', 'heroku', "master:master")
+        .with("git", "push", "-u", "heroku", "master:master")
         .returns(status_mock[:"#{status}"])
     end
 
@@ -157,13 +157,13 @@ module TestHelpers
     def expects_heroku_download(status:)
       if status.nil?
         @context.expects(:system)
-          .with('curl', '-o', download_path,
+          .with("curl", "-o", download_path,
             ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
             chdir: ShopifyCli.cache_dir)
           .never
       else
         @context.expects(:system)
-          .with('curl', '-o', download_path,
+          .with("curl", "-o", download_path,
             ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
             chdir: ShopifyCli.cache_dir)
           .returns(status_mock[:"#{status}"])
@@ -177,33 +177,33 @@ module TestHelpers
 
       if twice
         @context.expects(:capture2e)
-          .with(heroku_command(full_path: full_path), '--version')
-          .returns(['', status_mock[:"#{status}"]]).twice
+          .with(heroku_command(full_path: full_path), "--version")
+          .returns(["", status_mock[:"#{status}"]]).twice
       else
         @context.expects(:capture2e)
-          .with(heroku_command(full_path: full_path), '--version')
-          .returns(['', status_mock[:"#{status}"]])
+          .with(heroku_command(full_path: full_path), "--version")
+          .returns(["", status_mock[:"#{status}"]])
       end
     end
 
     def expects_heroku_select_app(status:, full_path: false)
       @context.expects(:system)
-        .with(heroku_command(full_path: full_path), 'git:remote', '-a', 'app-name')
+        .with(heroku_command(full_path: full_path), "git:remote", "-a", "app-name")
         .returns(status_mock[:"#{status}"])
     end
 
     def expects_heroku_whoami(status:, full_path: false)
-      output = status ? 'username' : nil
+      output = status ? "username" : nil
 
       @context.expects(:capture2e)
-        .with(heroku_command(full_path: full_path), 'whoami')
+        .with(heroku_command(full_path: full_path), "whoami")
         .returns([output, status_mock[:"#{status}"]])
     end
 
     private
 
     def download_filename
-      'heroku-darwin-x64.tar.gz'
+      "heroku-darwin-x64.tar.gz"
     end
 
     def download_path
@@ -213,14 +213,14 @@ module TestHelpers
     def heroku_command(full_path: false)
       if full_path
         File.stubs(:exist?).returns(true)
-        File.join(ShopifyCli.cache_dir, 'heroku', 'bin', 'heroku').to_s
+        File.join(ShopifyCli.cache_dir, "heroku", "bin", "heroku").to_s
       else
-        'heroku'
+        "heroku"
       end
     end
 
     def heroku_remote
-      'https://git.heroku.com/app-name.git'
+      "https://git.heroku.com/app-name.git"
     end
 
     def status_mock

--- a/test/test_helpers/partners.rb
+++ b/test/test_helpers/partners.rb
@@ -2,7 +2,7 @@
 module TestHelpers
   module Partners
     def setup
-      ShopifyCli::DB.set(identity_exchange_token: 'faketoken')
+      ShopifyCli::DB.set(identity_exchange_token: "faketoken")
       super
     end
 
@@ -12,12 +12,12 @@ module TestHelpers
     end
 
     def stub_partner_req(query, variables: {}, status: 200, resp: {})
-      filepaths = Dir[File.join(ShopifyCli::ROOT, 'lib', '**', 'graphql', "#{query}.graphql")]
+      filepaths = Dir[File.join(ShopifyCli::ROOT, "lib", "**", "graphql", "#{query}.graphql")]
       if filepaths.count > 1
         raise "Multiple queries in the codebase with filename #{query}.graphql, please rename your query."
       end
       stub_request(:post, "https://partners.shopify.com/api/cli/graphql").with(body: {
-        query: File.read(filepaths.first).tr("\n", ''),
+        query: File.read(filepaths.first).tr("\n", ""),
         variables: variables,
       }.to_json).to_return(status: status, body: resp.to_json)
     end

--- a/test/test_helpers/project.rb
+++ b/test/test_helpers/project.rb
@@ -2,7 +2,7 @@
 module TestHelpers
   module Project
     def setup
-      project_context('project')
+      project_context("project")
       super
     end
 
@@ -11,8 +11,8 @@ module TestHelpers
       @context = TestHelpers::FakeContext.new(
         root: root,
         env: {
-          'HOME' => '~',
-          'XDG_CONFIG_HOME' => root,
+          "HOME" => "~",
+          "XDG_CONFIG_HOME" => root,
         }
       )
       FileUtils.cd(@context.root)
@@ -20,7 +20,7 @@ module TestHelpers
 
     def teardown
       @context = nil
-      FileUtils.cd('/')
+      FileUtils.cd("/")
       super
     end
   end

--- a/vendor/gen/template/bin/update-deps
+++ b/vendor/gen/template/bin/update-deps
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH.unshift(File.expand_path("../../vendor/deps/cli-ui/lib", __FILE__))
-require 'open3'
-require 'fileutils'
+require "open3"
+require "fileutils"
 
 def fmt(tag, msg)
   # Not really CLI::UI.fmt compatible: no nesting support, for example.
@@ -27,7 +27,7 @@ def warn(msg)
 end
 
 def source_path
-  File.expand_path(ENV.fetch('SOURCE_ROOT', File.expand_path('../../..', __FILE__)))
+  File.expand_path(ENV.fetch("SOURCE_ROOT", File.expand_path("../../..", __FILE__)))
 end
 
 deps = %w(cli-ui cli-kit)
@@ -50,18 +50,18 @@ deps.each do |dep|
   dirty = false
 
   Dir.chdir(path) do
-    _, _, stat = Open3.capture3('git fetch origin master')
+    _, _, stat = Open3.capture3("git fetch origin master")
     bail("couldn't git fetch in dependency: {{yellow:#{dep}}}") unless stat.success?
 
-    head_sha, stat = Open3.capture2('git rev-parse HEAD')
+    head_sha, stat = Open3.capture2("git rev-parse HEAD")
     bail("couldn't determine HEAD: {{yellow:#{dep}}}") unless stat.success?
     head_sha.chomp!
 
-    fetch_head_sha, stat = Open3.capture2('git rev-parse FETCH_HEAD')
+    fetch_head_sha, stat = Open3.capture2("git rev-parse FETCH_HEAD")
     bail("couldn't determine FETCH_HEAD: {{yellow:#{dep}}}") unless stat.success?
     fetch_head_sha.chomp!
 
-    git_status, stat = Open3.capture2('git status --porcelain')
+    git_status, stat = Open3.capture2("git status --porcelain")
     bail("couldn't determine git status: {{yellow:#{dep}}}") unless stat.success?
 
     if head_sha != fetch_head_sha
@@ -84,8 +84,8 @@ deps.each do |dep|
   depdir = File.expand_path("../../vendor/deps/#{dep}", __FILE__)
   FileUtils.rm_rf(depdir)
   FileUtils.mkdir_p(depdir)
-  dstlib = File.expand_path('lib', depdir)
-  srclib = File.expand_path('lib', path)
+  dstlib = File.expand_path("lib", depdir)
+  srclib = File.expand_path("lib", path)
 
   FileUtils.cp_r(srclib, dstlib)
 


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/ruby-style-guide shipped a change that our CI picked up, and caused failures on new runs ([example](https://travis-ci.com/github/Shopify/shopify-app-cli/jobs/488588304)). Ideally that shouldn't happen but we're on the latest release and I guess they didn't bump a new version? 🤷 

### WHAT is this pull request doing?

- Most changes were auto generated by running `bundle exec rubocop .`
- The only manual change was editing [webhook_test.rb](https://github.com/Shopify/shopify-app-cli/compare/update-rubocop?expand=1#diff-db694ecb243459d5ba8179cc0db76c4ba3790c8093f8c4c9a6d71220e1e156b2) as the lines were too long

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
