### PR TITLE
Result.wrap(nil) and Result#unwrap(nil) support

### DIFF
--- a/lib/shopify-cli/result.rb
+++ b/lib/shopify-cli/result.rb
@@ -191,7 +191,7 @@ module ShopifyCli
       #    Success.new(1).unwrap(0) => 1
       #
       def unwrap(*args, &block)
-        raise ArgumentError, "expected either a fallback value or a block" unless args.one? ^ block
+        raise ArgumentError, "expected either a fallback value or a block" unless (args.length == 1) ^ block
         @value
       end
     end
@@ -336,7 +336,7 @@ module ShopifyCli
       # * `ArgumentError` if both a fallback argument and a block is provided
       #
       def unwrap(*args, &block)
-        raise ArgumentError, "expected either a fallback value or a block" unless args.one? ^ block
+        raise ArgumentError, "expected either a fallback value or a block" unless (args.length == 1) ^ block
         block ? block.call(@error) : args.pop
       end
     end
@@ -397,14 +397,14 @@ module ShopifyCli
     #   end
     #
     def self.wrap(*values, &block)
-      raise ArgumentError, "expected either a value or a block" unless values.one? ^ block
+      raise ArgumentError, "expected either a value or a block" unless (values.length == 1) ^ block
 
-      if values.one?
+      if values.length == 1
         values.pop.yield_self do |value|
           case value
           when Result::Success, Result::Failure
             value
-          when Exception
+          when NilClass, Exception
             Result.failure(value)
           else
             Result.success(value)

--- a/test/shopify-cli/result_test.rb
+++ b/test/shopify-cli/result_test.rb
@@ -46,6 +46,13 @@ module ShopifyCli
         end
       end
 
+      def test_allow_nil_to_be_wrapped
+        Result.wrap(nil).tap do |result|
+          assert_predicate(result, :failure?)
+          assert_nil result.error
+        end
+      end
+
       def test_call_does_not_require_any_positional_arguments
         Result.call { 1 }.tap do |result|
           assert_predicate(result, :success?)
@@ -76,6 +83,10 @@ module ShopifyCli
 
       def test_unwrap_returns_the_value
         assert_equal :value, Success.new(:value).unwrap {}
+      end
+
+      def test_unwrap_permits_nil_as_fallback_value
+        assert_nothing_raised { Success.new(:value).unwrap(nil) }
       end
 
       def test_additional_arguments_to_unwrap_are_ignored
@@ -170,6 +181,10 @@ module ShopifyCli
         assert_raises ArgumentError do
           Failure.new(:error).unwrap(:fallback) {}
         end
+      end
+
+      def test_unwrap_permits_nil_as_fallback_value
+        assert_nil Failure.new(:error).unwrap(nil)
       end
 
       def test_map_returns_itself


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure that `ShopifyCli::Result` properly handles wrapping and unwrapping of `nil`.

### WHAT is this pull request doing?

Changes the guard clause in `Result.wrap` and `Result::Failure#unwrap` to ensure that `nil` is considered a valid argument. Wrapping `nil` results in a `ShopifyCli::Result::Failure`.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
