### PR TITLE
Lazy Delegator require delegate stdlib

### DIFF
--- a/lib/shopify-cli/lazy_delegator.rb
+++ b/lib/shopify-cli/lazy_delegator.rb
@@ -1,3 +1,5 @@
+require "delegate"
+
 module ShopifyCli
   ##
   # `LazyDelegator` defers initialization of its underlying delegatee until the


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a missing dependency

### WHAT is this pull request doing?

Depending on file load order, it is possible to run into an issue that can be traced back from a dependency not being loaded in time. This change ensures that `delegate` is being loaded before it is used by the `LazyDelegator` class.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
