### PR TITLE
Abort app generation if name contains Shopify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 1.7.1
 
 Version 1.7.0
 -----
+* [#1109](https://github.com/Shopify/shopify-app-cli/pull/1109): Abort app generation if name contains disallowed text.
 * [#1075](https://github.com/Shopify/shopify-app-cli/pull/1075): Add support for kebab-case flags
 
 Version 1.6.0

--- a/lib/project_types/node/forms/create.rb
+++ b/lib/project_types/node/forms/create.rb
@@ -8,14 +8,23 @@ module Node
 
       def ask
         self.title ||= CLI::UI::Prompt.ask(ctx.message("node.forms.create.app_name"))
+        self.name = format_name
         self.type = ask_type
-        self.name = self.title.downcase.split(" ").join("_")
         res = ShopifyCli::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
         self.organization_id = res[:organization_id]
         self.shop_domain = res[:shop_domain]
       end
 
       private
+
+      def format_name
+        name = title.downcase.split(" ").join("_")
+
+        if name.include?("shopify")
+          ctx.abort(ctx.message("node.forms.create.error.invalid_app_name"))
+        end
+        name
+      end
 
       def ask_type
         if type.nil?

--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -202,6 +202,7 @@ module Node
         forms: {
           create: {
             error: {
+              invalid_app_name: "App name cannot contain 'Shopify'",
               invalid_app_type: "Invalid app type %s",
             },
             app_name: "App name",

--- a/lib/project_types/rails/forms/create.rb
+++ b/lib/project_types/rails/forms/create.rb
@@ -20,8 +20,8 @@ module Rails
 
       def ask
         self.title ||= CLI::UI::Prompt.ask(ctx.message("rails.forms.create.app_name"))
+        self.name = format_name
         self.type = ask_type
-        self.name = self.title.downcase.split(" ").join("_")
         res = ShopifyCli::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
         self.organization_id = res[:organization_id]
         self.shop_domain = res[:shop_domain]
@@ -29,6 +29,16 @@ module Rails
       end
 
       private
+
+      def format_name
+        name = title.downcase.split(" ").join("_")
+
+        if name.include?("shopify")
+          ctx.abort(ctx.message("rails.forms.create.error.invalid_app_name"))
+        end
+
+        name
+      end
 
       def ask_type
         if type.nil?

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -257,6 +257,7 @@ module Rails
         forms: {
           create: {
             error: {
+              invalid_app_name: "App name cannot contain 'Shopify'",
               invalid_app_type: "Invalid app type %s",
               invalid_db_type: "Invalid database type %s",
             },

--- a/test/project_types/node/forms/create_test.rb
+++ b/test/project_types/node/forms/create_test.rb
@@ -27,6 +27,14 @@ module Node
         assert_equal("My New App", form.title)
       end
 
+      def test_aborts_if_title_includes_shopify
+        io = capture_io do
+          form = ask(title: "Shopify")
+          assert_nil(form)
+        end
+        assert_match(@context.message("node.forms.create.error.invalid_app_name"), io.join)
+      end
+
       def test_type_can_be_provided_by_flag
         form = ask(type: "public")
         assert_equal("public", form.type)

--- a/test/project_types/rails/forms/create_test.rb
+++ b/test/project_types/rails/forms/create_test.rb
@@ -27,6 +27,14 @@ module Rails
         assert_equal("My New App", form.title)
       end
 
+      def test_aborts_if_title_includes_shopify
+        io = capture_io do
+          form = ask(title: "Best Shopify Shipping App")
+          assert_nil(form)
+        end
+        assert_match(@context.message("rails.forms.create.error.invalid_app_name"), io.join)
+      end
+
       def test_type_can_be_provided_by_flag
         form = ask(type: "public")
         assert_equal("public", form.type)


### PR DESCRIPTION
**Paired with @carmelal 🥳**

### Why are these changes introduced?
Fixes #1004 for Rails as well as Node (issue only mentions Rails). <!--https://github.com/Shopify/shopify-app-cli/issues/1004-->

When generating a Rails or Node app, and specifying a name that includes 'shopify' (e.g. 'my-shopify-app'), a lot of app generation is done before the application name is checked and the generation is aborted.

### What is this pull request doing?
This pull request checks the application name and, if needed, aborts the app generation (with an error message) immediately after the app name is specified by the user. This saves time for the user and prevents the generation of an invalid app.

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
