### PR TITLE
Fixing typos and errors in documentation

### DIFF
--- a/lib/shopify-cli/method_object.rb
+++ b/lib/shopify-cli/method_object.rb
@@ -61,7 +61,7 @@ module ShopifyCli
       ##
       # creates a new instance and invokes `call`. Any positional argument
       # is forward to `call`. Keyword arguments are either forwarded to the
-      # inializer or to `call`. If the keyword argument matches the name of
+      # initializer or to `call`. If the keyword argument matches the name of
       # property, it is forwarded to the initializer, otherwise to call.
       #
       def call(*args, **kwargs)

--- a/lib/shopify-cli/result.rb
+++ b/lib/shopify-cli/result.rb
@@ -104,7 +104,7 @@ module ShopifyCli
       end
 
       ##
-      # raises an `UnexpectedSuccess` as a `Failure` does not carry an error
+      # raises an `UnexpectedSuccess` as a `Success` does not carry an error
       # value.
       #
       def error
@@ -221,8 +221,8 @@ module ShopifyCli
     #     .then { |data| data.values_at(:firstname, :lastname) } # Ignored
     #     .unwrap(Person.new("John", "Doe"))                     # => Person
     #
-    # Alternatively, we could resucue from the error and then proceed with the
-    # remanining transformations:
+    # Alternatively, we could rescue from the error and then proceed with the
+    # remaining transformations:
     #
     #   Person = Struct.new(:firstname, :lastname)
     #   Failure


### PR DESCRIPTION

### WHY are these changes introduced?

There are a few typos/errors in documentation of `MethodObject` and `Result` class

### WHAT is this pull request doing?

Fixing typos and errors in documentation.


### Update checklist
~~- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
~~- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).~~
