### PR TITLE
Fix partner proxy bypass

### DIFF
--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -117,13 +117,21 @@ module Script
               url: "https://script-service.myshopify.io/graphql",
               token: "",
               api_key: api_key,
-              shop_id: shop_domain.nil? ? nil : 1
+              shop_id: infer_shop_id(shop_domain)
             )
           end
 
           def auth_headers(*)
             tokens = { "APP_KEY" => api_key, "SHOP_ID" => shop_id }.compact.to_json
             { "X-Shopify-Authenticated-Tokens" => tokens }
+          end
+
+          private
+
+          def self.infer_shop_id(shop_domain)
+            return unless shop_domain
+
+            [shop_domain.to_i, 1].max
           end
         end
         private_constant(:ScriptServiceAPI)

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -117,7 +117,7 @@ module Script
               url: "https://script-service.myshopify.io/graphql",
               token: "",
               api_key: api_key,
-              shop_id: shop_domain&.to_i
+              shop_id: shop_domain.nil? ? nil : 1
             )
           end
 

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -121,17 +121,15 @@ module Script
             )
           end
 
-          def auth_headers(*)
-            tokens = { "APP_KEY" => api_key, "SHOP_ID" => shop_id }.compact.to_json
-            { "X-Shopify-Authenticated-Tokens" => tokens }
-          end
-
-          private
-
           def self.infer_shop_id(shop_domain)
             return unless shop_domain
 
             [shop_domain.to_i, 1].max
+          end
+
+          def auth_headers(*)
+            tokens = { "APP_KEY" => api_key, "SHOP_ID" => shop_id }.compact.to_json
+            { "X-Shopify-Authenticated-Tokens" => tokens }
           end
         end
         private_constant(:ScriptServiceAPI)


### PR DESCRIPTION
### WHY are these changes introduced?

When running through the end to end guide for the Scripts Platform on fresh installs of every service, I didn't find a way to get a script installed onto `shop1` without database manipulation or going through the process of installing an app.

Ideally we don't need to rely on Partners for our E2E

### WHAT is this pull request doing?

We used to use a flag `BYPASS_PARTNERS_PROXY` which allowed us to call Script Service directly when pushing and enabling Scripts. Somewhere along the line, this flag broke and now we always send a `0` as our `shop_id` due to this line `shop_id: shop_domain&.to_i`. I'm updating that line to send a 1, rather than trying to convert the shop domain string into an integer.

This should only effect local development. If there's a purpose to this line that I missed please let me know

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
