### PR TITLE
[scripts] Bump EP versions and use shopify_main

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -2,28 +2,28 @@ discount:
   deprecated: true
   assemblyscript:
     package: "@shopify/extension-point-as-discount"
-    sdk-version: "^7.0.0"
-    toolchain-version: "^4.0.0"
+    sdk-version: "^9.0.0"
+    toolchain-version: "^5.0.0"
 unit_limit_per_order:
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
-    sdk-version: "^7.0.0"
-    toolchain-version: "^4.0.0"
+    sdk-version: "^9.0.0"
+    toolchain-version: "^5.0.0"
 payment_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
-    sdk-version: "^7.0.0"
-    toolchain-version: "^4.0.0"
+    sdk-version: "^9.0.0"
+    toolchain-version: "^5.0.0"
   rust:
     beta: true
     package: "https://github.com/Shopify/scripts-apis-rs"
 shipping_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-shipping-filter"
-    sdk-version: "^7.0.0"
-    toolchain-version: "^4.0.0"
+    sdk-version: "^9.0.0"
+    toolchain-version: "^5.0.0"
 tax_filter:
   assemblyscript:
     package: "@shopify/extension-point-as-tax-filter"
-    sdk-version: "^7.0.0"
-    toolchain-version: "^4.0.0"
+    sdk-version: "^9.0.0"
+    toolchain-version: "^5.0.0"

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -50,8 +50,8 @@ module Script
                 "@shopify/scripts-sdk-as": "#{extension_point.sdks.assemblyscript.sdk_version}",
                 "@shopify/scripts-toolchain-as": "#{extension_point.sdks.assemblyscript.toolchain_version}",
                 "#{extension_point.sdks.assemblyscript.package}": "^#{extension_point_version}",
-                "@as-pect/cli": "4.0.0",
-                "assemblyscript": "^0.16.1"
+                "@as-pect/cli": "^6.0.0",
+                "assemblyscript": "^0.18.13"
               },
               "scripts": {
                 "test": "asp --summary --verbose",

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -51,7 +51,6 @@ module Script
                 "@shopify/scripts-toolchain-as": "#{extension_point.sdks.assemblyscript.toolchain_version}",
                 "#{extension_point.sdks.assemblyscript.package}": "^#{extension_point_version}",
                 "@as-pect/cli": "4.0.0",
-                "as-wasi": "^0.2.1",
                 "assemblyscript": "^0.16.1"
               },
               "scripts": {

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -56,7 +56,7 @@ module Script
               },
               "scripts": {
                 "test": "asp --summary --verbose",
-                "build": "shopify-scripts-toolchain-as build --src src/script.ts --binary build/#{script_name}.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date="
+                "build": "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/#{script_name}.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date="
               },
               "engines": {
                 "node": ">=#{MIN_NODE_VERSION}"

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -34,7 +34,9 @@ module Script
         def dependencies_installed?
           # Assuming if node_modules folder exist at root of script folder, all deps are installed
           return false unless ctx.dir_exist?("node_modules")
-          check_if_ep_dependencies_up_to_date!
+          # NOTE: Temporarily disable this dependency check, as the latest EP version with guest serialization enabled
+          # has breaking changes on user script.
+          # check_if_ep_dependencies_up_to_date!
           true
         end
 

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -34,9 +34,7 @@ module Script
         def dependencies_installed?
           # Assuming if node_modules folder exist at root of script folder, all deps are installed
           return false unless ctx.dir_exist?("node_modules")
-          # NOTE: Temporarily disable this dependency check, as the latest EP version with guest serialization enabled
-          # has breaking changes on user script.
-          # check_if_ep_dependencies_up_to_date!
+          check_if_ep_dependencies_up_to_date!
           true
         end
 

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -120,7 +120,7 @@ module Script
                                   "is needed to compile your script to WebAssembly.",
           # rubocop:disable Layout/LineLength
           build_script_suggestion: "\n\nFor example, your package.json needs the following command:" \
-            "\nbuild: npx shopify-scripts-toolchain-as build --src src/script.ts --binary build/<script_name>.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date=",
+            "\nbuild: npx shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/<script_name>.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date=",
 
           web_assembly_binary_not_found: "WebAssembly binary not found.",
           web_assembly_binary_not_found_suggestion: "No WebAssembly binary found." \

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -28,7 +28,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
   let(:package_json) do
     {
       scripts: {
-        build: "shopify-scripts-toolchain-as build --src src/script.ts -b script.wasm -- --lib node_modules",
+        build: "shopify-scripts-toolchain-as build --src src/shopify_main.ts -b script.wasm -- --lib node_modules",
       },
     }
   end


### PR DESCRIPTION
### WHY are these changes introduced?

This PR bumps the toolchain and SDK versions required by EPs. In addition, I've disabled the dependency check on `create` and `push`.

### WHAT is this pull request doing?

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
