### PR TITLE
[Checkout extensibility] Add CheckoutArgoExtension type

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -131,6 +131,9 @@ module Extension
       checkout_post_purchase: {
         name: "Checkout Post Purchase",
       },
+      checkout_argo_extension: {
+        name: "Checkout Argo Extension",
+      },
     }
   end
 end

--- a/lib/project_types/extension/tasks/fetch_specifications.rb
+++ b/lib/project_types/extension/tasks/fetch_specifications.rb
@@ -7,6 +7,7 @@ module Extension
         [
           product_subscription_specification,
           checkout_post_purchase_specification,
+          checkout_argo_extension_specification,
         ]
       end
 
@@ -26,6 +27,17 @@ module Extension
       def checkout_post_purchase_specification
         {
           identifier: "checkout_post_purchase",
+          features: {
+            argo: {
+              surface_area: "checkout",
+            },
+          },
+        }
+      end
+
+      def checkout_argo_extension_specification
+        {
+          identifier: "checkout_argo_extension",
           features: {
             argo: {
               surface_area: "checkout",

--- a/test/project_types/extension/project_type_default_configuration_test.rb
+++ b/test/project_types/extension/project_type_default_configuration_test.rb
@@ -11,7 +11,7 @@ module Extension
       end
 
       def test_loads_all_extension_types_within_types_folder
-        extension_type_count = 2
+        extension_type_count = 3
         assert_equal extension_type_count, Extension.specifications.each.count
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/checkout-web/issues/3888

Part of the checkout extensibility effort, we are introducing an extension type for checkout. This extension type will allow partners to write Argo extensions that extend multiple extension points on a checkout.

### WHAT is this pull request doing?

Simply adding this new type following the same implementation as checkout post purchase extension. App developers will need to have the `checkout_argo_extension` beta flag enabled for the chosen organization and on the app they are registering this extension to.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
