### PR TITLE
[scripts] Create a default config ui file during project creation

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -9,6 +9,7 @@ module Script
         parser.on("--extension_point=EP_NAME") { |ep_name| flags[:extension_point] = ep_name }
         parser.on("--extension-point=EP_NAME") { |ep_name| flags[:extension_point] = ep_name }
         parser.on("--language=LANGUAGE") { |language| flags[:language] = language }
+        parser.on("--no-config-ui") { |no_config_ui| flags[:no_config_ui] = no_config_ui }
       end
 
       def call(args, _name)
@@ -26,7 +27,8 @@ module Script
           language: form.language,
           script_name: form.name,
           extension_point_type: form.extension_point,
-          description: form.description
+          description: form.description,
+          no_config_ui: options.flags.key?(:no_config_ui)
         )
         @ctx.puts(@ctx.message("script.create.change_directory_notice", project.script_name))
       rescue Script::Errors::ScriptProjectAlreadyExistsError => e

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -7,9 +7,16 @@ module Script
     module Application
       class CreateScript
         class << self
-          def call(ctx:, language:, script_name:, extension_point_type:, description:)
+          def call(ctx:, language:, script_name:, extension_point_type:, description:, no_config_ui:)
             extension_point = ExtensionPoints.get(type: extension_point_type)
-            project = setup_project(ctx, language, script_name, extension_point, description)
+            project = setup_project(
+              ctx: ctx,
+              language: language,
+              script_name: script_name,
+              extension_point: extension_point,
+              description: description,
+              no_config_ui: no_config_ui
+            )
             project_creator = Infrastructure::ProjectCreator
               .for(ctx, language, extension_point, script_name, project.directory)
             install_dependencies(ctx, language, script_name, project_creator)
@@ -19,16 +26,36 @@ module Script
 
           private
 
-          def setup_project(ctx, language, script_name, extension_point, description)
+          DEFAULT_CONFIG_UI_FILENAME = "ui-config.yml"
+          DEFAULT_CONFIG = {
+            "version" => 1,
+            "type" => "single",
+            "fields" => [],
+          }
+
+          def setup_project(ctx:, language:, script_name:, extension_point:, description:, no_config_ui:)
             ScriptProject.create(ctx, script_name)
+
+            identifiers = {
+              extension_point_type: extension_point.type,
+              script_name: script_name,
+              language: language,
+              description: description,
+            }
+
+            unless no_config_ui
+              require "yaml" # takes 20ms, so deferred as late as possible.
+              identifiers.merge!(config_ui_file: DEFAULT_CONFIG_UI_FILENAME)
+              Infrastructure::ConfigUiRepository
+                .new(ctx: ctx)
+                .create_config_ui(DEFAULT_CONFIG_UI_FILENAME, YAML.dump(DEFAULT_CONFIG))
+            end
+
             ScriptProject.write(
               ctx,
               project_type: :script,
               organization_id: nil, # TODO: can you provide this at creation
-              extension_point_type: extension_point.type,
-              script_name: script_name,
-              language: language,
-              description: description
+              **identifiers
             )
             ScriptProject.current
           end

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -26,7 +26,7 @@ module Script
 
           private
 
-          DEFAULT_CONFIG_UI_FILENAME = "ui-config.yml"
+          DEFAULT_CONFIG_UI_FILENAME = "config-ui.yml"
           DEFAULT_CONFIG = {
             "version" => 1,
             "type" => "single",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -136,6 +136,7 @@ module Script
               {{command:--name=NAME}} Script project name. Use any string.
               {{command:--description=DESCRIPTION}} Description of the project. Use any string.
               {{command:--extension-point=TYPE}} Extension point name. Allowed values: %2$s.
+              {{command:--no-config-ui}} Specify this option if you don’t want Scripts to render an interface in the Shopify admin.
           HELP
 
           error: {

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -23,6 +23,7 @@ module Script
           script_name: @script_name,
           description: @description
         )
+        @no_config_ui = false
         Layers::Application::ExtensionPoints.stubs(:languages).returns(%w(assemblyscript))
       end
 
@@ -40,7 +41,26 @@ module Script
           language: @language,
           script_name: @script_name,
           extension_point_type: @ep_type,
-          description: @description
+          description: @description,
+          no_config_ui: @no_config_ui
+        ).returns(@script_project)
+
+        @context
+          .expects(:puts)
+          .with(@context.message("script.create.change_directory_notice", @script_project.script_name))
+        perform_command
+      end
+
+      def test_can_create_new_script_with_no_config_ui
+        @no_config_ui = true
+
+        Script::Layers::Application::CreateScript.expects(:call).with(
+          ctx: @context,
+          language: @language,
+          script_name: @script_name,
+          extension_point_type: @ep_type,
+          description: @description,
+          no_config_ui: @no_config_ui
         ).returns(@script_project)
 
         @context
@@ -64,7 +84,8 @@ module Script
           language: @language,
           script_name: @script_name,
           extension_point_type: @ep_type,
-          description: @description
+          description: @description,
+          no_config_ui: @no_config_ui
         ).raises(StandardError)
 
         ScriptProject.expects(:cleanup).with(
@@ -90,7 +111,8 @@ module Script
           language: @language,
           script_name: @script_name,
           extension_point_type: @ep_type,
-          description: @description
+          description: @description,
+          no_config_ui: @no_config_ui
         ).raises(error)
 
         UI::ErrorHandler.expects(:pretty_print_and_raise).with(
@@ -121,7 +143,7 @@ module Script
       def perform_command
         run_cmd(
           "create script --name=#{@script_name} --description=#{@description}
-          --extension-point=#{@ep_type} --language=#{@language}"
+          --extension-point=#{@ep_type} --language=#{@language} #{@no_config_ui ? "--no-config-ui" : ""}"
         )
       end
     end

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -90,7 +90,7 @@ describe Script::Layers::Application::CreateScript do
 
       describe "when no_config_ui is false" do
         let(:no_config_ui) { false }
-        let(:expected_config_ui_filename) { "ui-config.yml" }
+        let(:expected_config_ui_filename) { "config-ui.yml" }
         let(:expected_config_ui_content) { "---\nversion: 1\ntype: single\nfields: []\n" }
 
         it "should create a config_ui_file and store the filename in the project config" do

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -2,6 +2,7 @@
 
 require "project_types/script/test_helper"
 require "project_types/script/layers/infrastructure/fake_extension_point_repository"
+require "project_types/script/layers/infrastructure/fake_config_ui_repository"
 
 describe Script::Layers::Application::CreateScript do
   include TestHelpers::FakeFS
@@ -11,7 +12,9 @@ describe Script::Layers::Application::CreateScript do
   let(:script_name) { "name" }
   let(:compiled_type) { "wasm" }
   let(:description) { "description" }
+  let(:no_config_ui) { false }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
+  let(:config_ui_repository) { Script::Layers::Infrastructure::FakeConfigUiRepository.new }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
   let(:task_runner) { stub(compiled_type: compiled_type) }
   let(:project_creator) { stub }
@@ -23,6 +26,8 @@ describe Script::Layers::Application::CreateScript do
   before do
     Script::ScriptProject.stubs(:current).returns(script_project)
     Script::Layers::Infrastructure::ExtensionPointRepository.stubs(:new).returns(extension_point_repository)
+    Script::Layers::Infrastructure::ConfigUiRepository.stubs(:new).returns(config_ui_repository)
+
     extension_point_repository.create_extension_point(extension_point_type)
     Script::Layers::Infrastructure::TaskRunner
       .stubs(:for)
@@ -41,7 +46,8 @@ describe Script::Layers::Application::CreateScript do
         language: language,
         script_name: script_name,
         extension_point_type: extension_point_type,
-        description: description
+        description: description,
+        no_config_ui: no_config_ui
       )
     end
 
@@ -52,8 +58,14 @@ describe Script::Layers::Application::CreateScript do
         .returns(ep)
       Script::Layers::Application::CreateScript
         .expects(:setup_project)
-        .with(@context, language, script_name, ep, description)
-        .returns(script_project)
+        .with(
+          ctx: @context,
+          language: language,
+          script_name: script_name,
+          extension_point: ep,
+          description: description,
+          no_config_ui: no_config_ui
+        ).returns(script_project)
       Script::Layers::Application::CreateScript
         .expects(:install_dependencies)
         .with(@context, language, script_name, project_creator)
@@ -65,25 +77,65 @@ describe Script::Layers::Application::CreateScript do
 
     describe ".setup_project" do
       subject do
-        Script::Layers::Application::CreateScript
-          .send(:setup_project, @context, language, script_name, ep, description)
+        Script::Layers::Application::CreateScript.send(
+          :setup_project,
+          ctx: @context,
+          language: language,
+          script_name: script_name,
+          extension_point: ep,
+          description: description,
+          no_config_ui: no_config_ui
+        )
       end
 
-      it "should succeed and update ctx root" do
-        Script::ScriptProject.expects(:create).with(@context, script_name).once
-        Script::ScriptProject
-          .expects(:write)
-          .with(
-            @context,
-            project_type: :script,
-            organization_id: nil,
-            extension_point_type: ep.type,
-            script_name: script_name,
-            language: language,
-            description: description
-          )
-        capture_io do
-          assert_equal script_project, subject
+      describe "when no_config_ui is false" do
+        let(:no_config_ui) { false }
+        let(:expected_config_ui_filename) { "ui-config.yml" }
+        let(:expected_config_ui_content) { "---\nversion: 1\ntype: single\nfields: []\n" }
+
+        it "should create a config_ui_file and store the filename in the project config" do
+          Script::ScriptProject.expects(:create).with(@context, script_name).once
+          Script::ScriptProject
+            .expects(:write)
+            .with(
+              @context,
+              project_type: :script,
+              organization_id: nil,
+              extension_point_type: ep.type,
+              script_name: script_name,
+              language: language,
+              description: description,
+              config_ui_file: expected_config_ui_filename
+            )
+          capture_io { subject }
+
+          config_ui = config_ui_repository.get_config_ui(expected_config_ui_filename)
+
+          refute_nil config_ui
+          assert_equal expected_config_ui_filename, config_ui.filename
+          assert_equal expected_config_ui_content, config_ui.content
+        end
+      end
+
+      describe "when no_config_ui is true" do
+        let(:no_config_ui) { true }
+
+        it "should write the config without config_ui_file field" do
+          Script::ScriptProject.expects(:create).with(@context, script_name).once
+          Script::ScriptProject
+            .expects(:write)
+            .with(
+              @context,
+              project_type: :script,
+              organization_id: nil,
+              extension_point_type: ep.type,
+              script_name: script_name,
+              language: language,
+              description: description,
+            )
+          capture_io do
+            assert_equal script_project, subject
+          end
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/2566

### WHAT is this pull request doing?

- During normal script project creation, a config ui yaml file will be created for the user by default at `ui-config.yml`.
- If the script developer does not want their script to be configurable in the admin, then during create they can use the `--no-config-ui` flag.  

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
