### PR TITLE
[scripts] Display config ui errors after a failed push

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -8,6 +8,26 @@ module Script
         class AppScriptNotPushedError < ScriptProjectError; end
         class AppScriptUndefinedError < ScriptProjectError; end
         class BuildError < ScriptProjectError; end
+        class ConfigUiSyntaxError < ScriptProjectError; end
+
+        class ConfigUiMissingKeysError < ScriptProjectError
+          attr_reader :filename, :missing_keys
+          def initialize(filename, missing_keys)
+            super()
+            @filename = filename
+            @missing_keys = missing_keys
+          end
+        end
+
+        class ConfigUiFieldsMissingKeysError < ScriptProjectError
+          attr_reader :filename, :missing_keys
+          def initialize(filename, missing_keys)
+            super()
+            @filename = filename
+            @missing_keys = missing_keys
+          end
+        end
+
         class DependencyInstallError < ScriptProjectError; end
         class EmptyResponseError < ScriptProjectError; end
         class ForbiddenError < ScriptProjectError; end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -41,6 +41,12 @@ module Script
 
           if user_errors.any? { |e| e["tag"] == "already_exists_error" }
             raise Errors::ScriptRepushError, api_key
+          elsif (e = user_errors.any? { |err| err["tag"] == "config_ui_syntax_error" })
+            raise Errors::ConfigUiSyntaxError, config_ui.filename
+          elsif (e = user_errors.find { |err| err["tag"] == "config_ui_missing_keys_error" })
+            raise Errors::ConfigUiMissingKeysError.new(config_ui.filename, e["message"])
+          elsif (e = user_errors.find { |err| err["tag"] == "config_ui_fields_missing_keys_error" })
+            raise Errors::ConfigUiFieldsMissingKeysError.new(config_ui.filename, e["message"])
           else
             raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
           end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -57,6 +57,17 @@ module Script
           missing_config_ui_definition_cause: "You are missing the UI configuration file %s.",
           missing_config_ui_definition_help: "Create this file and try again.",
 
+          config_ui_syntax_error_cause: "The UI configuration file %{filename} is not formatted properly.",
+          config_ui_syntax_error_help: "Fix the errors and try again.",
+
+          config_ui_missing_keys_error_cause: "The UI configuration file %{filename} is missing required keys: "\
+                                              "%{missing_keys}.",
+          config_ui_missing_keys_error_help: "Add the keys and try again.",
+
+          config_ui_fields_missing_keys_error_cause: "A field entry in the UI configuration file %{filename} is "\
+                                                     "missing required keys: %{missing_keys}.",
+          config_ui_fields_missing_keys_error_help: "Add the keys and try again.",
+
           script_not_found_cause: "Couldn't find script %s for extension point %s",
 
           service_failure_cause: "Internal service error.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -151,6 +151,32 @@ module Script
             cause_of_error: ShopifyCli::Context.message("script.error.build_error_cause"),
             help_suggestion: ShopifyCli::Context.message("script.error.build_error_help"),
           }
+        when Layers::Infrastructure::Errors::ConfigUiSyntaxError
+          {
+            cause_of_error: ShopifyCli::Context.message(
+              "script.error.config_ui_syntax_error_cause",
+              filename: e.message
+            ),
+            help_suggestion: ShopifyCli::Context.message("script.error.config_ui_syntax_error_help"),
+          }
+        when Layers::Infrastructure::Errors::ConfigUiMissingKeysError
+          {
+            cause_of_error: ShopifyCli::Context.message(
+              "script.error.config_ui_missing_keys_error_cause",
+              filename: e.filename,
+              missing_keys: e.missing_keys
+            ),
+            help_suggestion: ShopifyCli::Context.message("script.error.config_ui_missing_keys_error_help"),
+          }
+        when Layers::Infrastructure::Errors::ConfigUiFieldsMissingKeysError
+          {
+            cause_of_error: ShopifyCli::Context.message(
+              "script.error.config_ui_fields_missing_keys_error_cause",
+              filename: e.filename,
+              missing_keys: e.missing_keys
+            ),
+            help_suggestion: ShopifyCli::Context.message("script.error.config_ui_fields_missing_keys_error_help"),
+          }
         when Layers::Infrastructure::Errors::DependencyInstallError
           {
             cause_of_error: ShopifyCli::Context.message("script.error.dependency_install_cause"),

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -202,6 +202,27 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when ConfigUiSyntaxError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ConfigUiSyntaxError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when ConfigUiMissingKeysError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ConfigUiMissingKeysError.new("file", "keys") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when ConfigUiFieldsMissingKeysError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ConfigUiFieldsMissingKeysError.new("file", "keys") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when DependencyInstallError" do
         let(:err) { Script::Layers::Infrastructure::Errors::DependencyInstallError.new }
         it "should call display_and_raise" do


### PR DESCRIPTION
### WHY are these changes introduced?

Depends on https://github.com/Shopify/script-service/pull/2672
Part of https://github.com/Shopify/script-service/issues/2645


### WHAT is this pull request doing?

The server will tell us what is wrong with a user's config ui file if it prevents a push from succeeding. This PR catches those errors and displays a relevant message to the user. 

### 🎩 
Final error messages is TBD.

#### When a top level required key is missing
![image](https://user-images.githubusercontent.com/28009669/110855221-12f0d880-8284-11eb-8496-d02982b14fb7.png)

#### When a field is missing a required key
![image](https://user-images.githubusercontent.com/28009669/110855100-eccb3880-8283-11eb-9cca-0a56acf0e733.png)

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
