### PR TITLE
Remove autoload for non-existent ShopifyCli::Log

### DIFF
--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -110,7 +110,6 @@ module ShopifyCli
   autoload :JsSystem, "shopify-cli/js_system"
   autoload :MethodObject, "shopify-cli/method_object"
   autoload :LazyDelegator, "shopify-cli/lazy_delegator"
-  autoload :Log, "shopify-cli/log"
   autoload :OAuth, "shopify-cli/oauth"
   autoload :Options, "shopify-cli/options"
   autoload :PartnersAPI, "shopify-cli/partners_api"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

There is an autoload for `ShopifyCli::Log`, but no such file `"shopify-cli/log"`. Nobody never uses the constant, so the autoload is never observed to fail.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Removing the broken and unused autoload.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [ ] ~~I've considered possible cross-platform impacts (Mac, Linux, Windows).~~
