### PR TITLE
Handle not being able to install a signal handler

### DIFF
--- a/vendor/deps/cli-kit/lib/cli/kit/executor.rb
+++ b/vendor/deps/cli-kit/lib/cli/kit/executor.rb
@@ -51,10 +51,17 @@ module CLI
         return yield unless Signal.list.key?(signal)
 
         begin
-          prev_handler = trap(signal, handler)
+          begin
+            prev_handler = trap(signal, handler)
+            installed = true
+          rescue ArgumentError
+            # If we couldn't install a signal handler because the signal is
+            # reserved, remember not to uninstall it later.
+            installed = false
+          end
           yield
         ensure
-          trap(signal, prev_handler)
+          trap(signal, prev_handler) if installed
         end
       end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

`Signal.trap` can't always install a signal handler. If it can't you need to remember not to try to uninstall it later.

Specific context is when running Ruby on the JVM, which reserves more signal handlers than MRI usually does.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Don't uninstall a signal handler you couldn't install.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
