### PR TITLE
[scripts] Check if config-ui is nil during script-service push

### DIFF
--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -26,7 +26,7 @@ module Script
             extensionPointName: extension_point_type.upcase,
             title: script_name,
             description: description,
-            configUi: config_ui.content,
+            configUi: config_ui&.content,
             sourceCode: Base64.encode64(script_content),
             language: compiled_type,
             force: force,
@@ -42,11 +42,11 @@ module Script
           if user_errors.any? { |e| e["tag"] == "already_exists_error" }
             raise Errors::ScriptRepushError, api_key
           elsif (e = user_errors.any? { |err| err["tag"] == "config_ui_syntax_error" })
-            raise Errors::ConfigUiSyntaxError, config_ui.filename
+            raise Errors::ConfigUiSyntaxError, config_ui&.filename
           elsif (e = user_errors.find { |err| err["tag"] == "config_ui_missing_keys_error" })
-            raise Errors::ConfigUiMissingKeysError.new(config_ui.filename, e["message"])
+            raise Errors::ConfigUiMissingKeysError.new(config_ui&.filename, e["message"])
           elsif (e = user_errors.find { |err| err["tag"] == "config_ui_fields_missing_keys_error" })
-            raise Errors::ConfigUiFieldsMissingKeysError.new(config_ui.filename, e["message"])
+            raise Errors::ConfigUiFieldsMissingKeysError.new(config_ui&.filename, e["message"])
           else
             raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
           end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -12,7 +12,8 @@ describe Script::Layers::Infrastructure::ScriptService do
   let(:schema_major_version) { "1" }
   let(:schema_minor_version) { "0" }
   let(:use_msgpack) { true }
-  let(:config_ui) { Script::Layers::Domain::ConfigUi.new(filename: "filename", content: "content") }
+  let(:config_ui) { Script::Layers::Domain::ConfigUi.new(filename: "filename", content: expected_config_ui_content) }
+  let(:expected_config_ui_content) { "content" }
   let(:script_service_proxy) do
     <<~HERE
       query ProxyRequest($api_key: String, $shop_domain: String, $query: String!, $variables: String) {
@@ -82,7 +83,7 @@ describe Script::Layers::Infrastructure::ScriptService do
             extensionPointName: extension_point_type,
             title: script_name,
             description: description,
-            configUi: config_ui.content,
+            configUi: expected_config_ui_content,
             sourceCode: Base64.encode64(script_content),
             language: "AssemblyScript",
             force: false,
@@ -140,6 +141,15 @@ describe Script::Layers::Infrastructure::ScriptService do
 
       it "should post the form without scope" do
         assert_equal(script_service_response, subject)
+      end
+
+      describe "when config_ui is nil" do
+        let(:config_ui) { nil }
+        let(:expected_config_ui_content) { nil }
+
+        it "should succeed with a valid response" do
+          assert_equal(script_service_response, subject)
+        end
       end
     end
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `config_ui` entity will be nil if a script project is configured not to use it. So we need to safely navigate accessing its values during the script push.

### Update checklist
- [] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [] I've considered possible cross-platform impacts (Mac, Linux, Windows).
