### PR TITLE
[Fix] Add validation when serving argo-admin

### DIFF
--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -43,6 +43,7 @@ module Extension
 
       def validate_env
         @ctx.abort(@ctx.message("serve.serve_missing_information")) if
+          project.env.shop.nil? || project.env.api_key.nil? ||
           project.env.shop.strip.empty? || project.env.api_key.strip.empty?
       end
     end

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -10,9 +10,7 @@ module Extension
         if argo_admin?
           ShopifyCli::Tasks::EnsureEnv.call(@ctx, required: [:api_key, :secret, :shop])
           ShopifyCli::Tasks::EnsureDevStore.call(@ctx)
-          @ctx.abort(@ctx.message("serve.serve_missing_information")) if
-            project.env.shop.nil? || project.env.api_key.nil? ||
-            project.env.shop.strip.empty? || project.env.api_key.strip.empty?
+          validate_env
         end
 
         CLI::UI::Frame.open(@ctx.message("serve.frame_title")) do
@@ -41,6 +39,11 @@ module Extension
         ShopifyCli::Shopifolk.check &&
           ShopifyCli::Feature.enabled?(:argo_admin_beta) &&
           extension_type.specification.features&.argo&.surface == "admin"
+      end
+
+      def validate_env
+        @ctx.abort(@ctx.message("serve.serve_missing_information")) if
+          project.env.shop.strip.empty? || project.env.api_key.strip.empty?
       end
     end
   end

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -42,6 +42,7 @@ module Extension
       end
 
       def validate_env
+        ExtensionProject.reload
         @ctx.abort(@ctx.message("serve.serve_missing_information")) if
           project.env.shop.nil? || project.env.api_key.nil? ||
           project.env.shop.strip.empty? || project.env.api_key.strip.empty?

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -10,6 +10,9 @@ module Extension
         if argo_admin?
           ShopifyCli::Tasks::EnsureEnv.call(@ctx, required: [:api_key, :secret, :shop])
           ShopifyCli::Tasks::EnsureDevStore.call(@ctx)
+          @ctx.abort(@ctx.message("serve.serve_missing_information")) if
+            project.env.shop.nil? || project.env.api_key.nil? ||
+            project.env.shop.strip.empty? || project.env.api_key.strip.empty?
         end
 
         CLI::UI::Frame.open(@ctx.message("serve.frame_title")) do

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -23,6 +23,10 @@ module Extension
           }.compact
         ).write(context)
 
+        reload
+      end
+
+      def reload
         current.reload unless project_empty?
       end
 

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -57,6 +57,7 @@ module Extension
       serve: {
         frame_title: "Serving extension...",
         serve_failure_message: "Failed to run extension code.",
+        serve_missing_information: "Missing shop or api_key.",
       },
       tunnel: {
         missing_token: "{{x}} {{red:auth requires a token argument}}. "\

--- a/lib/shopify-cli/tasks/ensure_dev_store.rb
+++ b/lib/shopify-cli/tasks/ensure_dev_store.rb
@@ -5,7 +5,7 @@ module ShopifyCli
     class EnsureDevStore < ShopifyCli::Task
       def call(ctx)
         @ctx = ctx
-        return ctx.puts(ctx.message(
+        return ctx.abort(ctx.message(
           "core.tasks.ensure_dev_store.could_not_verify_store", project.env.shop
         )) if shop.nil?
         return if shop["transferDisabled"] == true

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -62,6 +62,118 @@ module Extension
         run_serve
       end
 
+      def test_raises_exception_if_shop_is_missing
+        ShopifyCli::Shopifolk.stubs(:check).returns(true)
+        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
+
+        Extension.specifications.stubs(:valid?).returns(true)
+        Extension.specifications.stubs(:[]).returns(
+          Models::SpecificationHandlers::Default.new(Models::Specification.new(
+            identifier: "test-extension",
+            features: {
+              argo: {
+                surface_area: "admin",
+                git_template: "https://github.com/Shopify/argo-admin-template.git",
+                renderer_package_name: "Shopify/argo-admin",
+              },
+            },
+          ))
+        )
+        ExtensionProject.current.env.stubs(:shop).returns(nil)
+
+        exception = assert_raises ShopifyCli::Abort do
+          run_serve
+        end
+
+        assert_includes exception.message, @context.message("serve.serve_missing_information")
+      end
+
+      def test_raises_exception_if_shop_is_empty
+        ShopifyCli::Shopifolk.stubs(:check).returns(true)
+        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
+
+        Extension.specifications.stubs(:valid?).returns(true)
+        Extension.specifications.stubs(:[]).returns(
+          Models::SpecificationHandlers::Default.new(Models::Specification.new(
+            identifier: "test-extension",
+            features: {
+              argo: {
+                surface_area: "admin",
+                git_template: "https://github.com/Shopify/argo-admin-template.git",
+                renderer_package_name: "Shopify/argo-admin",
+              },
+            },
+          ))
+        )
+        ExtensionProject.current.env.stubs(:shop).returns(" ")
+
+        exception = assert_raises ShopifyCli::Abort do
+          run_serve
+        end
+
+        assert_includes exception.message, @context.message("serve.serve_missing_information")
+      end
+
+      def test_raises_exception_if_api_key_is_missing
+        ShopifyCli::Shopifolk.stubs(:check).returns(true)
+        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
+
+        Extension.specifications.stubs(:valid?).returns(true)
+        Extension.specifications.stubs(:[]).returns(
+          Models::SpecificationHandlers::Default.new(Models::Specification.new(
+            identifier: "test-extension",
+            features: {
+              argo: {
+                surface_area: "admin",
+                git_template: "https://github.com/Shopify/argo-admin-template.git",
+                renderer_package_name: "Shopify/argo-admin",
+              },
+            },
+          ))
+        )
+        ExtensionProject.current.env.stubs(:api_key).returns(nil)
+
+        exception = assert_raises ShopifyCli::Abort do
+          run_serve
+        end
+
+        assert_includes exception.message, @context.message("serve.serve_missing_information")
+      end
+
+      def test_raises_exception_if_api_key_is_empty
+        ShopifyCli::Shopifolk.stubs(:check).returns(true)
+        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
+
+        Extension.specifications.stubs(:valid?).returns(true)
+        Extension.specifications.stubs(:[]).returns(
+          Models::SpecificationHandlers::Default.new(Models::Specification.new(
+            identifier: "test-extension",
+            features: {
+              argo: {
+                surface_area: "admin",
+                git_template: "https://github.com/Shopify/argo-admin-template.git",
+                renderer_package_name: "Shopify/argo-admin",
+              },
+            },
+          ))
+        )
+        ExtensionProject.current.env.stubs(:api_key).returns(" ")
+
+        exception = assert_raises ShopifyCli::Abort do
+          run_serve
+        end
+
+        assert_includes exception.message, @context.message("serve.serve_missing_information")
+      end
+
       private
 
       def run_serve(*args)

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -67,6 +67,7 @@ module Extension
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
+        ExtensionProject.stubs(:reload)
 
         Extension.specifications.stubs(:valid?).returns(true)
         Extension.specifications.stubs(:[]).returns(DummySpecifications.build(
@@ -85,6 +86,7 @@ module Extension
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
+        ExtensionProject.stubs(:reload)
 
         Extension.specifications.stubs(:valid?).returns(true)
         Extension.specifications.stubs(:[]).returns(DummySpecifications.build(

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -86,7 +86,6 @@ module Extension
         exception = assert_raises ShopifyCli::Abort do
           run_serve
         end
-
         assert_includes exception.message, @context.message("serve.serve_missing_information")
       end
 
@@ -114,7 +113,6 @@ module Extension
         exception = assert_raises ShopifyCli::Abort do
           run_serve
         end
-
         assert_includes exception.message, @context.message("serve.serve_missing_information")
       end
 
@@ -142,7 +140,6 @@ module Extension
         exception = assert_raises ShopifyCli::Abort do
           run_serve
         end
-
         assert_includes exception.message, @context.message("serve.serve_missing_information")
       end
 
@@ -170,7 +167,6 @@ module Extension
         exception = assert_raises ShopifyCli::Abort do
           run_serve
         end
-
         assert_includes exception.message, @context.message("serve.serve_missing_information")
       end
 

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -62,33 +62,6 @@ module Extension
         run_serve
       end
 
-      def test_raises_exception_if_shop_is_missing
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
-
-        Extension.specifications.stubs(:valid?).returns(true)
-        Extension.specifications.stubs(:[]).returns(
-          Models::SpecificationHandlers::Default.new(Models::Specification.new(
-            identifier: "test-extension",
-            features: {
-              argo: {
-                surface_area: "admin",
-                git_template: "https://github.com/Shopify/argo-admin-template.git",
-                renderer_package_name: "Shopify/argo-admin",
-              },
-            },
-          ))
-        )
-        ExtensionProject.current.env.stubs(:shop).returns(nil)
-
-        exception = assert_raises ShopifyCli::Abort do
-          run_serve
-        end
-        assert_includes exception.message, @context.message("serve.serve_missing_information")
-      end
-
       def test_raises_exception_if_shop_is_empty
         ShopifyCli::Shopifolk.stubs(:check).returns(true)
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
@@ -96,46 +69,10 @@ module Extension
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
 
         Extension.specifications.stubs(:valid?).returns(true)
-        Extension.specifications.stubs(:[]).returns(
-          Models::SpecificationHandlers::Default.new(Models::Specification.new(
-            identifier: "test-extension",
-            features: {
-              argo: {
-                surface_area: "admin",
-                git_template: "https://github.com/Shopify/argo-admin-template.git",
-                renderer_package_name: "Shopify/argo-admin",
-              },
-            },
-          ))
-        )
+        Extension.specifications.stubs(:[]).returns(DummySpecifications.build(
+          identifier: "test-extension", surface: "admin"
+        ))
         ExtensionProject.current.env.stubs(:shop).returns(" ")
-
-        exception = assert_raises ShopifyCli::Abort do
-          run_serve
-        end
-        assert_includes exception.message, @context.message("serve.serve_missing_information")
-      end
-
-      def test_raises_exception_if_api_key_is_missing
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
-
-        Extension.specifications.stubs(:valid?).returns(true)
-        Extension.specifications.stubs(:[]).returns(
-          Models::SpecificationHandlers::Default.new(Models::Specification.new(
-            identifier: "test-extension",
-            features: {
-              argo: {
-                surface_area: "admin",
-                git_template: "https://github.com/Shopify/argo-admin-template.git",
-                renderer_package_name: "Shopify/argo-admin",
-              },
-            },
-          ))
-        )
-        ExtensionProject.current.env.stubs(:api_key).returns(nil)
 
         exception = assert_raises ShopifyCli::Abort do
           run_serve
@@ -150,18 +87,9 @@ module Extension
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
 
         Extension.specifications.stubs(:valid?).returns(true)
-        Extension.specifications.stubs(:[]).returns(
-          Models::SpecificationHandlers::Default.new(Models::Specification.new(
-            identifier: "test-extension",
-            features: {
-              argo: {
-                surface_area: "admin",
-                git_template: "https://github.com/Shopify/argo-admin-template.git",
-                renderer_package_name: "Shopify/argo-admin",
-              },
-            },
-          ))
-        )
+        Extension.specifications.stubs(:[]).returns(DummySpecifications.build(
+          identifier: "test-extension", surface: "admin"
+        ))
         ExtensionProject.current.env.stubs(:api_key).returns(" ")
 
         exception = assert_raises ShopifyCli::Abort do

--- a/test/shopify-cli/tasks/ensure_dev_store_test.rb
+++ b/test/shopify-cli/tasks/ensure_dev_store_test.rb
@@ -13,10 +13,13 @@ module ShopifyCli
       def test_outputs_if_shop_cant_be_queried
         stub_org_request
         stub_env(domain: "notther.myshopify.com")
-        @context.expects(:puts).with(
-          @context.message("core.tasks.ensure_dev_store.could_not_verify_store", "notther.myshopify.com")
+
+        exception = assert_raises ShopifyCli::Abort do
+          EnsureDevStore.call(@context)
+        end
+        assert_includes exception.message, @context.message(
+          "core.tasks.ensure_dev_store.could_not_verify_store", "notther.myshopify.com"
         )
-        EnsureDevStore.call(@context)
       end
 
       def test_noop_if_already_transfer_disabled


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/argo-admin-private/issues/1404

This PR adds validation to fix cases that shop or apiKey are invalid. Ex: empty string, partner account doesn't have any shops, shop doesn't have any apps. 

### WHAT is this pull request doing?

- Add check for shop and api_key when running serve (under argo-admin-beta flag)

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
