### PR TITLE
Remove Extension.specification accessor

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -81,14 +81,4 @@ module Extension
 
   autoload :ExtensionProjectKeys, Project.project_filepath("extension_project_keys")
   autoload :ExtensionProject, Project.project_filepath("extension_project")
-
-  def self.specifications
-    @specifications ||= Models::Specifications.new(
-      fetch_specifications: Tasks::FetchSpecifications
-    )
-  end
-
-  def self.specifications=(specifications)
-    @specifications = specifications
-  end
 end

--- a/test/project_types/extension/commands/extension_command_test.rb
+++ b/test/project_types/extension/commands/extension_command_test.rb
@@ -55,7 +55,6 @@ module Extension
 
       def test_accessing_the_extension_type_identifier_does_not_result_in_fetching_specifications
         setup_temp_project
-        Extension.specifications.expects(:[]).never
         @command.extension_type.identifier
       end
     end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -69,10 +69,6 @@ module Extension
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
         ExtensionProject.stubs(:reload)
 
-        Extension.specifications.stubs(:valid?).returns(true)
-        Extension.specifications.stubs(:[]).returns(DummySpecifications.build(
-          identifier: "test-extension", surface: "admin"
-        ))
         ExtensionProject.current.env.stubs(:shop).returns(" ")
 
         exception = assert_raises ShopifyCli::Abort do
@@ -88,10 +84,6 @@ module Extension
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
         ExtensionProject.stubs(:reload)
 
-        Extension.specifications.stubs(:valid?).returns(true)
-        Extension.specifications.stubs(:[]).returns(DummySpecifications.build(
-          identifier: "test-extension", surface: "admin"
-        ))
         ExtensionProject.current.env.stubs(:api_key).returns(" ")
 
         exception = assert_raises ShopifyCli::Abort do

--- a/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
@@ -6,20 +6,13 @@ module Extension
       def setup
         ShopifyCli::ProjectType.load_type(:extension)
 
-        @_original_extension_specifications = Extension.specifications
-
-        Extension.specifications = DummySpecifications.build(
+        specifications = DummySpecifications.build(
           custom_handler_root: File.expand_path("../", __FILE__),
           custom_handler_namespace: ::Extension::ExtensionTestHelpers,
         )
-        @test_extension_type = Extension.specifications["TEST_EXTENSION"]
+        @test_extension_type = specifications["TEST_EXTENSION"]
 
         super
-      end
-
-      def teardown
-        super
-        Extension.specifications = @_original_extension_specifications
       end
     end
   end

--- a/test/project_types/extension/models/specification_handlers/default_test.rb
+++ b/test/project_types/extension/models/specification_handlers/default_test.rb
@@ -8,18 +8,6 @@ module Extension
       class DefaultTest < MiniTest::Test
         include ExtensionTestHelpers::TestExtensionSetup
 
-        def test_can_load_type_by_identifier
-          assert_equal(
-            @test_extension_type.identifier,
-            Extension.specifications[@test_extension_type.identifier].identifier
-          )
-        end
-
-        def test_valid_determines_if_a_type_is_valid
-          assert Extension.specifications.valid?(ExtensionTestHelpers::TestExtension::IDENTIFIER)
-          refute Extension.specifications.valid?("INVALID")
-        end
-
         def test_tagline_returns_empty_string_if_not_defined_in_content
           base_type = Default.new(specification)
           base_type.stubs(:identifier).returns("INVALID")


### PR DESCRIPTION
### WHY are these changes introduced?

Cleanup production code that is no longer in use.

### WHAT is this pull request doing?

Specifications are now managed by the ExtensionCommand and AskType. The CLI no longer requires shared state to manage specifications. This commit therefore removes

* `Extensions.specifications`,
* `Extension.specifications=`, and
* all related calls in the test suite.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
