### PR TITLE
[scripts] Add title field to a default config ui file

### DIFF
--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -27,11 +27,6 @@ module Script
           private
 
           DEFAULT_CONFIG_UI_FILENAME = "config-ui.yml"
-          DEFAULT_CONFIG = {
-            "version" => 1,
-            "type" => "single",
-            "fields" => [],
-          }
 
           def setup_project(ctx:, language:, script_name:, extension_point:, description:, no_config_ui:)
             ScriptProject.create(ctx, script_name)
@@ -48,7 +43,7 @@ module Script
               identifiers.merge!(config_ui_file: DEFAULT_CONFIG_UI_FILENAME)
               Infrastructure::ConfigUiRepository
                 .new(ctx: ctx)
-                .create_config_ui(DEFAULT_CONFIG_UI_FILENAME, YAML.dump(DEFAULT_CONFIG))
+                .create_config_ui(DEFAULT_CONFIG_UI_FILENAME, default_config_ui_content(script_name))
             end
 
             ScriptProject.write(
@@ -71,6 +66,15 @@ module Script
               project_creator.bootstrap
               spinner.update_title(ctx.message("script.create.created"))
             end
+          end
+
+          def default_config_ui_content(title)
+            YAML.dump({
+              "version" => 1,
+              "type" => "single",
+              "title" => title,
+              "fields" => [],
+            })
           end
         end
       end

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -91,7 +91,7 @@ describe Script::Layers::Application::CreateScript do
       describe "when no_config_ui is false" do
         let(:no_config_ui) { false }
         let(:expected_config_ui_filename) { "config-ui.yml" }
-        let(:expected_config_ui_content) { "---\nversion: 1\ntype: single\nfields: []\n" }
+        let(:expected_config_ui_content) { "---\nversion: 1\ntype: single\ntitle: #{script_name}\nfields: []\n" }
 
         it "should create a config_ui_file and store the filename in the project config" do
           Script::ScriptProject.expects(:create).with(@context, script_name).once


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/2706

### WHAT is this pull request doing?

Adds a title field to a scripts default config ui file.
