### PR TITLE
[scripts] Add shipping and payment methods extension points

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -27,3 +27,16 @@ tax_filter:
     package: "@shopify/extension-point-as-tax-filter"
     sdk-version: "^9.0.0"
     toolchain-version: "^5.0.0"
+payment_methods:
+  domain: 'checkout'
+  assemblyscript:
+    package: "@shopify/scripts-checkout-apis"
+    toolchain-version: "^5.0.0"
+    sdk-version: "^9.0.0"
+shipping_methods:
+  domain: 'checkout'
+  assemblyscript:
+    package: "@shopify/scripts-checkout-apis"
+    sdk-version: "^9.0.0"
+    toolchain-version: "^5.0.0"
+

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -18,7 +18,7 @@ module Script
         end
 
         def dasherize_type
-          @type.gsub('_', '-')
+          @type.gsub("_", "-")
         end
       end
 

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -4,16 +4,21 @@ module Script
   module Layers
     module Domain
       class ExtensionPoint
-        attr_reader :type, :deprecated, :sdks
+        attr_reader :type, :deprecated, :sdks, :domain
 
         def initialize(type, config)
           @type = type
           @deprecated = config["deprecated"] || false
+          @domain = config["domain"] || nil
           @sdks = ExtensionPointSDKs.new(config)
         end
 
         def deprecated?
           @deprecated
+        end
+
+        def dasherize_type
+          @type.gsub('_', '-')
         end
       end
 

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -11,7 +11,8 @@ module Script
         property! :path_to_project, accepts: String
 
         BOOTSTRAP = "npx --no-install shopify-scripts-toolchain-as bootstrap --from %{extension_point} --dest %{base}"
-        BUILD = "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/%{script_name}.wasm --metadata build/metadata.json"
+        BUILD = "shopify-scripts-toolchain-as build --src src/shopify_main.ts " \
+        "--binary build/%{script_name}.wasm --metadata build/metadata.json"
         MIN_NODE_VERSION = "14.5.0"
         ASC_ARGS = "-- --lib node_modules --optimize --use Date="
 

--- a/test/project_types/script/layers/domain/extension_point_test.rb
+++ b/test/project_types/script/layers/domain/extension_point_test.rb
@@ -50,6 +50,31 @@ describe Script::Layers::Domain::ExtensionPoint do
       end
     end
 
+    describe "when a domain is not specified" do
+      subject { Script::Layers::Domain::ExtensionPoint.new(type, config) }
+      it "should construct a non-bounded extension point" do
+        assert_nil subject.domain
+      end
+    end
+
+    describe "when a domain is specified" do
+      let(:config_with_domain) { config.merge({ "domain" => "checkout" }) }
+      subject { Script::Layers::Domain::ExtensionPoint.new(type, config_with_domain) }
+      it "should construct a bounded extension point" do
+        assert_equal "checkout", subject.domain
+      end
+    end
+
+    describe ".dasherize_type" do
+      it "should replace all underscore occurrences with a dash" do
+        extension_point = Script::Layers::Domain::ExtensionPoint.new("foo_bar_baz", config)
+        assert_equal "foo-bar-baz", extension_point.dasherize_type
+        extension_point = Script::Layers::Domain::ExtensionPoint.new("foo", config)
+        assert_equal "foo", extension_point.dasherize_type
+      end
+    end
+
+
     describe "when multiple sdks are implemented" do
       subject { Script::Layers::Domain::ExtensionPoint.new(type, config_with_rust) }
       it "should construct new, non-deprecated ExtensionPoint" do

--- a/test/project_types/script/layers/domain/extension_point_test.rb
+++ b/test/project_types/script/layers/domain/extension_point_test.rb
@@ -74,7 +74,6 @@ describe Script::Layers::Domain::ExtensionPoint do
       end
     end
 
-
     describe "when multiple sdks are implemented" do
       subject { Script::Layers::Domain::ExtensionPoint.new(type, config_with_rust) }
       it "should construct new, non-deprecated ExtensionPoint" do

--- a/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
@@ -47,8 +47,18 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
 
     it "should write to package.json" do
       context.expects(:system).twice
+      context.expects(:capture2e).once.returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)])
+      context.expects(:write).with() do |_file, contents|
+        payload = JSON.parse(contents)
+        build = payload.dig("scripts", "build")
+        expected = [
+          "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/myscript.wasm --metadata build/metadata.json",
+          "-- --lib node_modules --optimize --use Date="
+        ].join(" ")
+        expected == build
+      end
+
       subject
-      assert context.file_exist?("package.json")
     end
 
     it "should fetch the latest extension point version" do
@@ -111,6 +121,46 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
         .returns(["", OpenStruct.new(success?: false)])
 
       assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+    end
+  end
+
+  describe "bootstrap extension points with domain" do
+    subject { project_creator.bootstrap }
+
+    let(:extension_point_config_with_domain) { extension_point_config.merge({ "domain" => "checkout" })}
+    let(:extension_point) { Script::Layers::Domain::ExtensionPoint.new(extension_point_type, extension_point_config_with_domain) }
+
+    it "should call the language toolchain with the appropriate domain arguments" do
+      context.expects(:capture2e)
+        .with(
+          "npx --no-install shopify-scripts-toolchain-as bootstrap --from #{extension_point.type} --dest #{script_name} --domain checkout"
+        )
+        .returns(["", OpenStruct.new(success?: true)])
+
+        subject
+    end
+  end
+
+  describe "dependencies for extension points with domain" do
+    subject { project_creator.setup_dependencies }
+
+    let(:extension_point_config_with_domain) { extension_point_config.merge({ "domain" => "checkout" })}
+    let(:extension_point) { Script::Layers::Domain::ExtensionPoint.new(extension_point_type, extension_point_config_with_domain) }
+
+    it "should create the build command in the package.json with the appropriate domain arguments" do
+      context.expects(:system).twice
+      context.expects(:capture2e).once.returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)])
+      context.expects(:write).with() do |_file, contents|
+        payload = JSON.parse(contents)
+        build = payload.dig("scripts", "build")
+        expected = [
+          "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/myscript.wasm --metadata build/metadata.json --domain checkout --ep discount",
+          "-- --lib node_modules --optimize --use Date="
+        ].join(" ")
+        expected == build
+      end
+
+      subject
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?
This PR adds support for shipping and payment methods extension points. These extension points are bounded to the checkout domain.

### WHAT is this pull request doing?
The main changes in this PR are

- Adding a `domain` attribute to the extension point object
- Using that attribute to determine how to bootstrap and build a script


An ideal 🎩 list:

- Ensure that "legacy" scripts work correctly (bootstrap, test, build)
- Ensure that domain scripts work correctly (bootstrap, test, build)



### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
