### PR TITLE
Cleanup - Follow new Specification Nomenclature

### DIFF
--- a/lib/project_types/extension/commands/extension_command.rb
+++ b/lib/project_types/extension/commands/extension_command.rb
@@ -8,16 +8,16 @@ module Extension
         @project ||= ExtensionProject.current
       end
 
-      def extension_type
-        @extension_type ||= begin
-          identifier = project.extension_type_identifier
+      def specification_handler
+        @specification_handler ||= begin
+          identifier = project.specification_identifier
           Models::LazySpecificationHandler.new(identifier) do
             specifications = Models::Specifications.new(
               fetch_specifications: Tasks::FetchSpecifications.new(api_key: project.app.api_key, context: @ctx)
             )
 
             unless specifications.valid?(identifier)
-              @ctx.abort(@ctx.message("errors.unknown_type", project.extension_type_identifier))
+              @ctx.abort(@ctx.message("errors.unknown_type", project.specification_identifier))
             end
 
             specifications[identifier]

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -59,8 +59,8 @@ module Extension
             context: @ctx,
             api_key: project.app.api_key,
             registration_id: project.registration_id,
-            config: extension_type.config(@ctx),
-            extension_context: extension_type.extension_context(@ctx)
+            config: specification_handler.config(@ctx),
+            extension_context: specification_handler.extension_context(@ctx)
           )
         end
       end

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -27,7 +27,7 @@ module Extension
       private
 
       def confirm_registration
-        @ctx.puts(@ctx.message("register.confirm_info", extension_type.name))
+        @ctx.puts(@ctx.message("register.confirm_info", specification_handler.name))
         CLI::UI::Prompt.confirm(@ctx.message("register.confirm_question"))
       end
 
@@ -37,10 +37,10 @@ module Extension
         Tasks::CreateExtension.call(
           context: @ctx,
           api_key: app.api_key,
-          type: extension_type.graphql_identifier,
+          type: specification_handler.graphql_identifier,
           title: project.title,
           config: {},
-          extension_context: extension_type.extension_context(@ctx)
+          extension_context: specification_handler.extension_context(@ctx)
         )
       end
 

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -38,7 +38,7 @@ module Extension
       def argo_admin?
         ShopifyCli::Shopifolk.check &&
           ShopifyCli::Feature.enabled?(:argo_admin_beta) &&
-          extension_type.specification.features&.argo&.surface == "admin"
+          specification_handler.specification.features&.argo&.surface == "admin"
       end
 
       def validate_env

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -9,7 +9,7 @@ module Extension
           context,
           project_type: :extension,
           organization_id: nil,
-          "#{ExtensionProjectKeys::EXTENSION_TYPE_KEY}": type
+          "#{ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY}": type
         )
       end
 
@@ -49,8 +49,8 @@ module Extension
       get_extra_field(ExtensionProjectKeys::TITLE_KEY)
     end
 
-    def extension_type_identifier
-      config[ExtensionProjectKeys::EXTENSION_TYPE_KEY]
+    def specification_identifier
+      config[ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY]
     end
 
     def registration_id?

--- a/lib/project_types/extension/extension_project_keys.rb
+++ b/lib/project_types/extension/extension_project_keys.rb
@@ -4,7 +4,7 @@ require "shopify_cli"
 module Extension
   module ExtensionProjectKeys
     REGISTRATION_ID_KEY = "EXTENSION_ID"
-    EXTENSION_TYPE_KEY = "EXTENSION_TYPE"
+    SPECIFICATION_IDENTIFIER_KEY = "EXTENSION_TYPE"
     TITLE_KEY = "EXTENSION_TITLE"
   end
 end

--- a/lib/project_types/extension/messages/message_loading.rb
+++ b/lib/project_types/extension/messages/message_loading.rb
@@ -16,7 +16,9 @@ module Extension
 
       def self.load_current_type_messages
         return unless ShopifyCli::Project.has_current?
-        messages_for_type(ShopifyCli::Project.current.config[Extension::ExtensionProjectKeys::EXTENSION_TYPE_KEY])
+        messages_for_type(
+          ShopifyCli::Project.current.config[Extension::ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY]
+        )
       end
 
       def self.messages_for_type(type_identifier)

--- a/test/project_types/extension/commands/extension_command_test.rb
+++ b/test/project_types/extension/commands/extension_command_test.rb
@@ -33,7 +33,7 @@ module Extension
         unknown_type = "unknown_type"
         setup_temp_project(type_identifier: unknown_type)
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) { @command.extension_type.features }
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) { @command.specification_handler.features }
 
         assert_message_output(io: io, expected_content: [
           @context.message("errors.unknown_type", unknown_type),
@@ -43,19 +43,19 @@ module Extension
       def test_extension_type_returns_a_lazy_specification_handler
         setup_temp_project
 
-        assert_kind_of(Models::LazySpecificationHandler, @command.extension_type)
+        assert_kind_of(Models::LazySpecificationHandler, @command.specification_handler)
       end
 
       def test_extension_type_memoizes_the_extension_type
         setup_temp_project
 
-        @command.extension_type.specification
-        @command.extension_type.specification
+        @command.specification_handler.specification
+        @command.specification_handler.specification
       end
 
       def test_accessing_the_extension_type_identifier_does_not_result_in_fetching_specifications
         setup_temp_project
-        @command.extension_type.identifier
+        @command.specification_handler.identifier
       end
     end
   end

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -16,7 +16,7 @@ module Extension
 
       assert File.exist?(".shopify-cli.yml")
       assert_equal :extension, ShopifyCli::Project.current_project_type
-      assert_equal @test_extension_type.identifier, ExtensionProject.current.extension_type_identifier
+      assert_equal @test_extension_type.identifier, ExtensionProject.current.specification_identifier
     end
 
     def test_write_env_file_creates_env_file
@@ -84,7 +84,7 @@ module Extension
     def test_extension_type_returns_the_set_type_identifier
       setup_temp_project
 
-      assert_equal @type, @project.extension_type_identifier
+      assert_equal @type, @project.specification_identifier
     end
 
     def test_detects_if_registration_id_is_missing_or_invalid

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -15,7 +15,7 @@ module Extension
       def config
         {
           "project_type" => "extension",
-          ExtensionProjectKeys::EXTENSION_TYPE_KEY => type,
+          ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY => type,
         }
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Improve code readability.

### WHAT is this pull request doing?

Pure refactoring. Behaviour should not be changed. I just replaced `extension_type_identifier` and `extension_type` with our new nomenclature.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
