### PR TITLE
[scripts] Safe access api_key from project env during script push

### DIFF
--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -16,7 +16,7 @@ module Script
         Layers::Application::PushScript.call(ctx: @ctx, force: options.flags.key?(:force))
         @ctx.puts(@ctx.message("script.push.script_pushed", api_key: api_key))
       rescue StandardError => e
-        msg = @ctx.message("script.push.error.operation_failed", api_key: ShopifyCli::Project.current.env.api_key)
+        msg = @ctx.message("script.push.error.operation_failed", api_key: ShopifyCli::Project.current.env&.api_key)
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: msg)
       end
 

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -42,6 +42,19 @@ module Script
         Script::Commands::Push.help
       end
 
+      def test_push_propagates_error_when_ensure_env_fails
+        ShopifyCli::Project.any_instance.expects(:env).returns(nil)
+
+        err_msg = "error message"
+        ShopifyCli::Tasks::EnsureEnv
+          .any_instance.expects(:call)
+          .with(@context, required: [:api_key, :secret, :shop])
+          .raises(StandardError.new(err_msg))
+
+        e = assert_raises(StandardError) { perform_command }
+        assert_equal err_msg, e.message
+      end
+
       private
 
       def perform_command


### PR DESCRIPTION
### WHY are these changes introduced?

If `EnsureEnv` fails (for example, if a request to Partners fails), then the `env` won't be created and `Project.current.env = nil` so `Project.current.env.api_key` raises. 

### WHAT is this pull request doing?

Safely access `api_key` in this case. 