### PR TITLE
[scripts] Only display extension metadata errors when relevant

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -48,12 +48,6 @@ module Script
           end
         end
 
-        class ScriptServiceUserError < ScriptProjectError
-          def initialize(query_name, errors)
-            super("Failed performing #{query_name}. Errors: #{errors}.")
-          end
-        end
-
         class ShopAuthenticationError < ScriptProjectError; end
         class TaskRunnerNotFoundError < ScriptProjectError; end
         class BuildScriptNotFoundError < ScriptProjectError; end

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -52,7 +52,6 @@ module Script
         class TaskRunnerNotFoundError < ScriptProjectError; end
         class BuildScriptNotFoundError < ScriptProjectError; end
         class InvalidBuildScriptError < ScriptProjectError; end
-        class InvalidSchemaMetadataError < ScriptProjectError; end
 
         class WebAssemblyBinaryNotFoundError < ScriptProjectError
           def initialize

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -52,6 +52,7 @@ module Script
         class TaskRunnerNotFoundError < ScriptProjectError; end
         class BuildScriptNotFoundError < ScriptProjectError; end
         class InvalidBuildScriptError < ScriptProjectError; end
+        class InvalidSchemaMetadataError < ScriptProjectError; end
 
         class WebAssemblyBinaryNotFoundError < ScriptProjectError
           def initialize

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -46,7 +46,7 @@ module Script
           elsif (e = user_errors.find { |err| err["tag"] == "config_ui_fields_missing_keys_error" })
             raise Errors::ConfigUiFieldsMissingKeysError.new(config_ui&.filename, e["message"])
           elsif user_errors.find { |err| %w(not_use_msgpack_error schema_version_argument_error).include?(err["tag"]) }
-            raise Errors::InvalidSchemaMetadataError
+            raise Domain::Errors::MetadataValidationError
           else
             raise Errors::GraphqlError, user_errors
           end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -45,6 +45,8 @@ module Script
             raise Errors::ConfigUiMissingKeysError.new(config_ui&.filename, e["message"])
           elsif (e = user_errors.find { |err| err["tag"] == "config_ui_fields_missing_keys_error" })
             raise Errors::ConfigUiFieldsMissingKeysError.new(config_ui&.filename, e["message"])
+          elsif user_errors.find { |err| %w(not_use_msgpack_error schema_version_argument_error).include?(err["tag"]) }
+            raise Errors::InvalidSchemaMetadataError
           else
             raise Errors::GraphqlError, user_errors
           end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -46,7 +46,7 @@ module Script
           elsif (e = user_errors.find { |err| err["tag"] == "config_ui_fields_missing_keys_error" })
             raise Errors::ConfigUiFieldsMissingKeysError.new(config_ui&.filename, e["message"])
           else
-            raise Errors::ScriptServiceUserError.new(query_name, user_errors.to_s)
+            raise Errors::GraphqlError, user_errors
           end
         end
 
@@ -112,7 +112,7 @@ module Script
           when "app_not_installed_on_shop"
             raise Errors::AppNotInstalledError
           else
-            raise Errors::GraphqlError, response["errors"].map { |e| e["message"] }
+            raise Errors::GraphqlError, response["errors"]
           end
         end
 

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -73,9 +73,6 @@ module Script
           service_failure_cause: "Internal service error.",
           service_failure_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
 
-          user_error_cause: "Invalid script extension metadata.",
-          user_error_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
-
           metadata_validation_cause: "Invalid script extension metadata.",
           metadata_validation_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
 

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -115,8 +115,7 @@ module Script
             cause_of_error: ShopifyCli::Context.message("script.error.service_failure_cause"),
             help_suggestion: ShopifyCli::Context.message("script.error.service_failure_help"),
           }
-        when Layers::Domain::Errors::MetadataValidationError,
-          Layers::Infrastructure::Errors::InvalidSchemaMetadataError
+        when Layers::Domain::Errors::MetadataValidationError
           {
             cause_of_error: ShopifyCli::Context.message("script.error.metadata_validation_cause"),
             help_suggestion: ShopifyCli::Context.message("script.error.metadata_validation_help"),

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -188,18 +188,15 @@ module Script
           }
         when Layers::Infrastructure::Errors::GraphqlError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.graphql_error_cause", e.errors.join(", ")),
+            cause_of_error: ShopifyCli::Context.message(
+              "script.error.graphql_error_cause", JSON.pretty_generate(e.errors)
+            ),
             help_suggestion: ShopifyCli::Context.message("script.error.graphql_error_help"),
           }
         when Layers::Infrastructure::Errors::ScriptRepushError
           {
             cause_of_error: ShopifyCli::Context.message("script.error.script_repush_cause", e.api_key),
             help_suggestion: ShopifyCli::Context.message("script.error.script_repush_help"),
-          }
-        when Layers::Infrastructure::Errors::ScriptServiceUserError
-          {
-            cause_of_error: ShopifyCli::Context.message("script.error.user_error_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.user_error_help"),
           }
         when Layers::Infrastructure::Errors::ShopAuthenticationError
           {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -115,7 +115,8 @@ module Script
             cause_of_error: ShopifyCli::Context.message("script.error.service_failure_cause"),
             help_suggestion: ShopifyCli::Context.message("script.error.service_failure_help"),
           }
-        when Layers::Domain::Errors::MetadataValidationError
+        when Layers::Domain::Errors::MetadataValidationError,
+          Layers::Infrastructure::Errors::InvalidSchemaMetadataError
           {
             cause_of_error: ShopifyCli::Context.message("script.error.metadata_validation_cause"),
             help_suggestion: ShopifyCli::Context.message("script.error.metadata_validation_help"),

--- a/test/project_types/script/layers/domain/metadata_test.rb
+++ b/test/project_types/script/layers/domain/metadata_test.rb
@@ -7,20 +7,6 @@ describe Script::Layers::Domain::Metadata do
   let(:schema_minor_version) { "0" }
   let(:use_msgpack) { true }
   let(:ctx) { ShopifyCli::Context.new }
-  let(:raw_json) do
-    JSON.dump(
-      {
-        schemaVersions: {
-          example: {
-            major: schema_major_version, minor: schema_minor_version
-          },
-        },
-        flags: {
-          use_msgpack: true,
-        },
-      },
-    )
-  end
 
   describe ".new" do
     subject { Script::Layers::Domain::Metadata.new(schema_major_version, schema_minor_version, use_msgpack) }
@@ -32,8 +18,31 @@ describe Script::Layers::Domain::Metadata do
   end
 
   describe ".create_from_json" do
+    subject { Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json) }
+
+    describe "with invalid json" do
+      let(:raw_json) { "*" }
+
+      it "should raise an appropriate error" do
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) { subject }
+      end
+    end
+
     describe "with valid json" do
-      subject { Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json) }
+      let(:raw_json) do
+        JSON.dump(
+          {
+            schemaVersions: {
+              example: {
+                major: schema_major_version, minor: schema_minor_version
+              },
+            },
+            flags: {
+              use_msgpack: true,
+            },
+          },
+        )
+      end
 
       it "should construct new Metadata" do
         assert_equal schema_major_version, subject.schema_major_version
@@ -42,15 +51,15 @@ describe Script::Layers::Domain::Metadata do
     end
 
     describe "with missing schemaVersions" do
+      let(:raw_json) { "{}" }
+
       it "should raise an appropriate error" do
-        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
-          Script::Layers::Domain::Metadata.create_from_json(ctx, "{}")
-        end
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) { subject }
       end
     end
 
     describe "with multiple EPs" do
-      let(:raw_json_multiple_eps) do
+      let(:raw_json) do
         JSON.dump(
           {
             schemaVersions: {
@@ -62,14 +71,12 @@ describe Script::Layers::Domain::Metadata do
       end
 
       it "should raise an appropriate error" do
-        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
-          Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json_multiple_eps)
-        end
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) { subject }
       end
     end
 
     describe "with missing major version" do
-      let(:raw_json_no_major) do
+      let(:raw_json) do
         JSON.dump(
           {
             schemaVersions: {
@@ -80,14 +87,12 @@ describe Script::Layers::Domain::Metadata do
       end
 
       it "should raise an appropriate error" do
-        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
-          Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json_no_major)
-        end
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) { subject }
       end
     end
 
     describe "with missing minor version" do
-      let(:raw_json_no_minor) do
+      let(:raw_json) do
         JSON.dump(
           {
             schemaVersions: {
@@ -98,9 +103,7 @@ describe Script::Layers::Domain::Metadata do
       end
 
       it "should raise an appropriate error" do
-        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) do
-          Script::Layers::Domain::Metadata.create_from_json(ctx, raw_json_no_minor)
-        end
+        assert_raises(::Script::Layers::Domain::Errors::MetadataValidationError) { subject }
       end
     end
   end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -213,7 +213,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         end
       end
 
-      describe "when invalid_metadata" do
+      describe "when metadata is invalid" do
         let(:response) do
           {
             data: {
@@ -235,7 +235,7 @@ describe Script::Layers::Infrastructure::ScriptService do
           end
         end
 
-        describe "when invalid metadata" do
+        describe "when invalid schema version" do
           let(:error_tag) { "schema_version_argument_error" }
           it "should raise InvalidSchemaMetadataError error" do
             assert_raises(Script::Layers::Infrastructure::Errors::InvalidSchemaMetadataError) { subject }

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -230,15 +230,15 @@ describe Script::Layers::Infrastructure::ScriptService do
 
         describe "when not using msgpack" do
           let(:error_tag) { "not_use_msgpack_error" }
-          it "should raise InvalidSchemaMetadataError error" do
-            assert_raises(Script::Layers::Infrastructure::Errors::InvalidSchemaMetadataError) { subject }
+          it "should raise MetadataValidationError error" do
+            assert_raises(Script::Layers::Domain::Errors::MetadataValidationError) { subject }
           end
         end
 
         describe "when invalid schema version" do
           let(:error_tag) { "schema_version_argument_error" }
-          it "should raise InvalidSchemaMetadataError error" do
-            assert_raises(Script::Layers::Infrastructure::Errors::InvalidSchemaMetadataError) { subject }
+          it "should raise MetadataValidationError error" do
+            assert_raises(Script::Layers::Domain::Errors::MetadataValidationError) { subject }
           end
         end
       end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -189,7 +189,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         end
 
         it "should raise error" do
-          assert_raises(Script::Layers::Infrastructure::Errors::ScriptServiceUserError) { subject }
+          assert_raises(Script::Layers::Infrastructure::Errors::GraphqlError) { subject }
         end
       end
 

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -213,6 +213,36 @@ describe Script::Layers::Infrastructure::ScriptService do
         end
       end
 
+      describe "when invalid_metadata" do
+        let(:response) do
+          {
+            data: {
+              scriptServiceProxy: JSON.dump(
+                "data" => {
+                  "appScriptUpdateOrCreate" => {
+                    "userErrors" => [{ "message" => "error", "tag" => error_tag }],
+                  },
+                }
+              ),
+            },
+          }
+        end
+
+        describe "when not using msgpack" do
+          let(:error_tag) { "not_use_msgpack_error" }
+          it "should raise InvalidSchemaMetadataError error" do
+            assert_raises(Script::Layers::Infrastructure::Errors::InvalidSchemaMetadataError) { subject }
+          end
+        end
+
+        describe "when invalid metadata" do
+          let(:error_tag) { "schema_version_argument_error" }
+          it "should raise InvalidSchemaMetadataError error" do
+            assert_raises(Script::Layers::Infrastructure::Errors::InvalidSchemaMetadataError) { subject }
+          end
+        end
+      end
+
       describe "when response is empty" do
         let(:response) { nil }
 

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -153,6 +153,20 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when MetadataValidationError" do
+        let(:err) { Script::Layers::Domain::Errors::MetadataValidationError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when InvalidSchemaMetadataError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::InvalidSchemaMetadataError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when InvalidConfigUiDefinitionError" do
         let(:err) { Script::Layers::Domain::Errors::InvalidConfigUiDefinitionError.new("filename") }
         it "should call display_and_raise" do

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -160,13 +160,6 @@ describe Script::UI::ErrorHandler do
         end
       end
 
-      describe "when InvalidSchemaMetadataError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::InvalidSchemaMetadataError.new }
-        it "should call display_and_raise" do
-          should_call_display_and_raise
-        end
-      end
-
       describe "when InvalidConfigUiDefinitionError" do
         let(:err) { Script::Layers::Domain::Errors::InvalidConfigUiDefinitionError.new("filename") }
         it "should call display_and_raise" do


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/2623

Our error messages tend to suggest that the user `Ensures the 'shopify/scripts-toolchain-as' package is up to date` for many errors that are unrelated. This is because the current generalized error messages were updated. Instead, we should only tell the user to update the toolchain package when they need to, and fallback to the existing general error case.

### WHAT is this pull request doing?

- Checks the GraphQL error tag to only display invalid metadata errors when relevant.
- Improves the verbosity of the general error case by propagating the GraphQL error to the user. 

### Screenshots 🎩 
#### When schema metadata is invalid
- No content has changed here. This error message will only be shown for errors relating to invalid schema metadata
<details>
<img src="https://user-images.githubusercontent.com/28009669/113188695-5fe32180-9228-11eb-929e-c43f9037da53.png" />

</details>

#### General error case
- This uses the existing general GraphQL error case that we already have. The only difference is that we display the entire error returned (including the tag and the field if applicable) rather than just the message. Since this error case will mostly appear when case is mostly for internal devs working on a feature, these fields would be useful. 

<details>
<img src="https://user-images.githubusercontent.com/28009669/113187346-be0f0500-9226-11eb-9671-dd2b2cf9f160.png" />
</details>
