### PR TITLE
[scripts] support specifying beta extension points

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -5,6 +5,7 @@ discount:
     sdk-version: "^9.0.0"
     toolchain-version: "^5.0.0"
 unit_limit_per_order:
+  beta: true
   assemblyscript:
     package: "@shopify/extension-point-as-unit-limit-per-order"
     sdk-version: "^9.0.0"
@@ -23,6 +24,7 @@ shipping_filter:
     sdk-version: "^9.0.0"
     toolchain-version: "^5.0.0"
 tax_filter:
+  beta: true
   assemblyscript:
     package: "@shopify/extension-point-as-tax-filter"
     sdk-version: "^9.0.0"

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -16,7 +16,7 @@ module Script
       def ask_extension_point
         CLI::UI::Prompt.ask(
           @ctx.message("script.forms.create.select_extension_point"),
-          options: Layers::Application::ExtensionPoints.visible_types
+          options: Layers::Application::ExtensionPoints.available_types
         )
       end
 

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -16,7 +16,7 @@ module Script
       def ask_extension_point
         CLI::UI::Prompt.ask(
           @ctx.message("script.forms.create.select_extension_point"),
-          options: Layers::Application::ExtensionPoints.non_deprecated_types
+          options: Layers::Application::ExtensionPoints.visible_types
         )
       end
 

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -12,9 +12,10 @@ module Script
           Infrastructure::ExtensionPointRepository.new.extension_point_types
         end
 
-        def self.non_deprecated_types
+        def self.visible_types
           Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
-            !ep.deprecated?
+            next false if ep.deprecated?
+            !ep.beta? || ShopifyCli::Feature.enabled?(:scripts_beta_extension_points)
           end.map(&:type)
         end
 

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -12,7 +12,7 @@ module Script
           Infrastructure::ExtensionPointRepository.new.extension_point_types
         end
 
-        def self.visible_types
+        def self.available_types
           Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
             next false if ep.deprecated?
             !ep.beta? || ShopifyCli::Feature.enabled?(:scripts_beta_extension_points)

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -4,13 +4,18 @@ module Script
   module Layers
     module Domain
       class ExtensionPoint
-        attr_reader :type, :deprecated, :sdks, :domain
+        attr_reader :type, :beta, :deprecated, :sdks, :domain
 
         def initialize(type, config)
           @type = type
+          @beta = config["beta"] || false
           @deprecated = config["deprecated"] || false
           @domain = config["domain"] || nil
           @sdks = ExtensionPointSDKs.new(config)
+        end
+
+        def beta?
+          @beta
         end
 
         def deprecated?

--- a/test/project_types/script/forms/create_test.rb
+++ b/test/project_types/script/forms/create_test.rb
@@ -23,7 +23,7 @@ module Script
 
       def test_asks_extension_point_if_no_flag
         eps = ["discount", "another"]
-        Layers::Application::ExtensionPoints.expects(:visible_types).returns(eps)
+        Layers::Application::ExtensionPoints.expects(:available_types).returns(eps)
         Layers::Application::ExtensionPoints.expects(:languages).returns(["assemblyscript"])
         CLI::UI::Prompt.expects(:ask).with(
           @context.message("script.forms.create.select_extension_point"),

--- a/test/project_types/script/forms/create_test.rb
+++ b/test/project_types/script/forms/create_test.rb
@@ -23,8 +23,8 @@ module Script
 
       def test_asks_extension_point_if_no_flag
         eps = ["discount", "another"]
-        Layers::Application::ExtensionPoints.stubs(:non_deprecated_types).returns(eps)
-        Layers::Application::ExtensionPoints.stubs(:languages).returns(["assemblyscript"])
+        Layers::Application::ExtensionPoints.expects(:visible_types).returns(eps)
+        Layers::Application::ExtensionPoints.expects(:languages).returns(["assemblyscript"])
         CLI::UI::Prompt.expects(:ask).with(
           @context.message("script.forms.create.select_extension_point"),
           options: eps

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -9,12 +9,14 @@ describe Script::Layers::Application::ExtensionPoints do
   let(:script_name) { "name" }
   let(:extension_point_type) { "discount" }
   let(:deprecated_extension_point_type) { "unit_limit_per_order" }
+  let(:beta_extension_point_type) { "tax_filter" }
   let(:extension_point_repository) { Script::Layers::Infrastructure::FakeExtensionPointRepository.new }
   let(:extension_point) { extension_point_repository.get_extension_point(extension_point_type) }
 
   before do
     extension_point_repository.create_extension_point(extension_point_type)
     extension_point_repository.create_deprecated_extension_point(deprecated_extension_point_type)
+    extension_point_repository.create_beta_extension_point(beta_extension_point_type)
     Script::Layers::Infrastructure::ExtensionPointRepository.stubs(:new).returns(extension_point_repository)
   end
 
@@ -37,13 +39,13 @@ describe Script::Layers::Application::ExtensionPoints do
 
   describe ".types" do
     it "should return an array of all types" do
-      assert_equal %w(discount unit_limit_per_order), Script::Layers::Application::ExtensionPoints.types
+      assert_equal %w(discount unit_limit_per_order tax_filter), Script::Layers::Application::ExtensionPoints.types
     end
   end
 
-  describe ".non_deprecated_types" do
-    it "should return an array of all non deprecated types" do
-      assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.non_deprecated_types
+  describe ".visible_types" do
+    it "should return an array of all ep types that are not deprecated or in beta" do
+      assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.visible_types
     end
   end
 

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -43,9 +43,9 @@ describe Script::Layers::Application::ExtensionPoints do
     end
   end
 
-  describe ".visible_types" do
+  describe ".available_types" do
     it "should return an array of all ep types that are not deprecated or in beta" do
-      assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.visible_types
+      assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.available_types
     end
   end
 

--- a/test/project_types/script/layers/infrastructure/fake_extension_point_repository.rb
+++ b/test/project_types/script/layers/infrastructure/fake_extension_point_repository.rb
@@ -14,6 +14,10 @@ module Script
           @cache[type] = Domain::ExtensionPoint.new(type, example_config(type))
         end
 
+        def create_beta_extension_point(type)
+          @cache[type] = Domain::ExtensionPoint.new(type, beta_config(type))
+        end
+
         def create_deprecated_extension_point(type)
           @cache[type] = Domain::ExtensionPoint.new(type, deprecated_config(type))
         end
@@ -35,6 +39,10 @@ module Script
         end
 
         private
+
+        def beta_config(type)
+          example_config(type).merge({ "beta" => true })
+        end
 
         def deprecated_config(type)
           example_config(type).merge({ "deprecated" => true })


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/2793

We want to be able to hide certain script EPs that are still in development from the user by default. To do this, we'll follow the same `beta` pattern that we have for EP language implementations.

### WHAT is this pull request doing?

- supports specifying an EP as `beta` within the `extension-points.yml` file.
- by default, we only display non-beta EPs during project creation
    - you can enable beta EPs by running `shopify config feature scripts_beta_extension_points --enable` 
- sets `unit_limit_per_order` and `tax_filter` EPs as beta
### Screenshots
#### Default EP prompt functionality
Only shows Non-Beta EPs.

<details>
<img src=https://user-images.githubusercontent.com/28009669/113762927-193d6d80-96e7-11eb-90bd-a6aaba4c3581.png />
</details>

#### Prompt when user has the EP beta feature enabled
Shows Beta + Non-Beta EPs.
<details>
<img src=https://user-images.githubusercontent.com/28009669/113763061-3ffba400-96e7-11eb-919e-8bb8de7bb372.png />
</details>