### PR TITLE
Pure Refactoring - Generic Extension Serve Command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (1.11.2)
+    mocha (1.12.0)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)

--- a/lib/project_types/extension/commands/extension_command.rb
+++ b/lib/project_types/extension/commands/extension_command.rb
@@ -8,6 +8,10 @@ module Extension
         @project ||= ExtensionProject.current
       end
 
+      def specification
+        specification_handler.specification
+      end
+
       def specification_handler
         @specification_handler ||= begin
           identifier = project.specification_identifier

--- a/lib/project_types/extension/models/specification.rb
+++ b/lib/project_types/extension/models/specification.rb
@@ -10,6 +10,9 @@ module Extension
           property! :surface, converts: :to_str
           property! :renderer_package_name, converts: :to_str
           property! :git_template, converts: :to_str
+          property! :serve_requires_api_key, accepts: [true, false], default: false, reader: :serve_requires_api_key?
+          property! :serve_requires_shop, accepts: [true, false], default: false, reader: :serve_requires_shop?
+          property! :required_beta_flags, accepts: Array, default: -> { [] }
         end
 
         def self.build(feature_set_attributes)
@@ -31,6 +34,16 @@ module Extension
 
       def graphql_identifier
         super || identifier
+      end
+
+      def feature?(name)
+        !!features[name]
+      end
+
+      def required_beta_flags
+        features.to_h.reduce([]) do |betas, (_, feature)|
+          betas + (feature.required_beta_flags || [])
+        end
       end
     end
   end

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -40,6 +40,9 @@ module Extension
           admin: {
             git_template: "https://github.com/Shopify/argo-admin-template.git",
             renderer_package_name: "@shopify/argo-admin",
+            serve_requires_api_key: true,
+            serve_requires_shop: true,
+            required_beta_flags: [:argo_admin_beta],
           },
           checkout: {
             git_template: "https://github.com/Shopify/argo-checkout-template.git",

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -26,7 +26,10 @@ module Extension
       def test_uses_js_system_to_run_npm_or_yarn_serve_commands
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
-          .with(yarn: Serve::YARN_SERVE_COMMAND, npm: Serve::NPM_SERVE_COMMAND)
+          .with do |commands|
+            assert_equal Serve::YARN_SERVE_COMMAND, commands.fetch(:yarn).first(Serve::YARN_SERVE_COMMAND.length)
+            assert_equal Serve::NPM_SERVE_COMMAND, commands.fetch(:npm).first(Serve::NPM_SERVE_COMMAND.length)
+          end
           .returns(true)
           .once
 
@@ -34,13 +37,8 @@ module Extension
       end
 
       def test_aborts_and_informs_the_user_when_serve_fails
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with(yarn: Serve::YARN_SERVE_COMMAND, npm: Serve::NPM_SERVE_COMMAND)
-          .returns(false)
-          .once
+        ShopifyCli::JsSystem.any_instance.expects(:call).returns(false).once
         @context.expects(:abort).with(@context.message("serve.serve_failure_message"))
-
         run_serve
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

To make the extension `serve` command more generic.

### WHAT is this pull request doing?

This PR makes the conditions controlling environment validation and server options more modular.

### Update checklist

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
