### PR TITLE
Feature: Add argoVersion to serve command

### DIFF
--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -57,9 +57,11 @@ module Extension
       end
 
       def serve_options
+        requires_version = specification.features.argo.serve_requires_version?
         @serve_options ||= [].tap do |options|
           options << "--shop=#{project.env.shop}" if specification.features.argo.serve_requires_shop?
           options << "--apiKey=#{project.env.api_key}" if specification.features.argo.serve_requires_api_key?
+          options << "--argoVersion=#{specification_handler.argo_version}" if requires_version
         end
       end
     end

--- a/lib/project_types/extension/models/specification.rb
+++ b/lib/project_types/extension/models/specification.rb
@@ -12,6 +12,7 @@ module Extension
           property! :git_template, converts: :to_str
           property! :serve_requires_api_key, accepts: [true, false], default: false, reader: :serve_requires_api_key?
           property! :serve_requires_shop, accepts: [true, false], default: false, reader: :serve_requires_shop?
+          property! :serve_requires_version, accepts: [true, false], default: false, reader: :serve_requires_version?
           property! :required_beta_flags, accepts: Array, default: -> { [] }
         end
 

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -42,6 +42,10 @@ module Extension
           []
         end
 
+        def argo_version
+          argo.renderer_package_name
+        end
+
         protected
 
         def argo

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -42,6 +42,7 @@ module Extension
             renderer_package_name: "@shopify/argo-admin",
             serve_requires_api_key: true,
             serve_requires_shop: true,
+            serve_requires_version: true,
             required_beta_flags: [:argo_admin_beta],
           },
           checkout: {

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -48,7 +48,7 @@ module Extension
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
 
-        serve_args = ["--shop=my-test-shop.myshopify.com", "--apiKey=#{@api_key}"]
+        serve_args = ["--shop=my-test-shop.myshopify.com", "--apiKey=#{@api_key}", "--argoVersion=@shopify/argo-admin"]
         yarn_serve_command = Serve::YARN_SERVE_COMMAND + serve_args
         npm_serve_command = Serve::NPM_SERVE_COMMAND + %w(--) + serve_args
         ShopifyCli::JsSystem.any_instance


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/argo-admin-private/issues/1428

We need to pass the `argoVersion` to the `argo-admin-cli` via the `serve` command so argo knows what to render.

### WHAT is this pull request doing?

* Adds an `argo_version` public method to the Specification Handler, which just calls the private `argo` method and returns the `renderer_package_name`.
* This requires the flag `serve_requires_version` to be set to true in the Feature config

### Tophat 🎩 
1. Create a new extension (Product Subscription)
2. `cd` into your new extension and run `shopify serve`

You should see the `argoVersion` as an argument being passed to `argo-admin-cli`:

<img width="1106" alt="Screen Shot 2021-04-09 at 10 15 13 AM" src="https://user-images.githubusercontent.com/989784/114202404-c3eaa180-991c-11eb-8473-c564f9cd93a1.png">

👉 **PLEASE NOTE:** 👉 If you are using an old extension to tophat, you will need to update your packages to the latest version of `argo-admin-cli` (ver. 0.9.3), otherwise you will get an error that `argoVersion` is not an available option.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
