### PR TITLE
Feature: Add extension_creation_id to ExtensionProject, pass uuid to ArgoServe command

### DIFF
--- a/lib/graphql/extension_create.graphql
+++ b/lib/graphql/extension_create.graphql
@@ -1,7 +1,22 @@
-mutation ExtensionCreate($api_key: String!, $type: ExtensionType!, $title: String!, $config: JSON!, $extension_context: String) {
-  extensionCreate(input: {apiKey: $api_key, type: $type, title: $title, config: $config, context: $extension_context}) {
+mutation ExtensionCreate(
+  $api_key: String!
+  $type: ExtensionType!
+  $title: String!
+  $config: JSON!
+  $extension_context: String
+) {
+  extensionCreate(
+    input: {
+      apiKey: $api_key
+      type: $type
+      title: $title
+      config: $config
+      context: $extension_context
+    }
+  ) {
     extensionRegistration {
       id
+      uuid
       type
       title
       draftVersion {

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -50,6 +50,7 @@ module Extension
           api_key: app.api_key,
           api_secret: app.secret,
           registration_id: registration.id,
+          registration_uuid: registration.uuid,
           title: project.title
         )
       end

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -13,13 +13,16 @@ module Extension
         )
       end
 
-      def write_env_file(context:, title:, api_key: "", api_secret: "", registration_id: nil)
+      def write_env_file(
+        context:, title:, api_key: "", api_secret: "", registration_id: nil, registration_uuid: nil
+      )
         ShopifyCli::Resources::EnvFile.new(
           api_key: api_key,
           secret: api_secret,
           extra: {
             ExtensionProjectKeys::TITLE_KEY => title,
             ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id,
+            ExtensionProjectKeys::REGISTRATION_UUID_KEY => registration_uuid || generate_temporary_uuid,
           }.compact
         ).write(context)
 
@@ -63,8 +66,16 @@ module Extension
       get_extra_field(ExtensionProjectKeys::REGISTRATION_ID_KEY).to_i
     end
 
+    def registration_uuid
+      get_extra_field(ExtensionProjectKeys::REGISTRATION_UUID_KEY)
+    end
+
     def reload
       @env = nil
+    end
+
+    def self.generate_temporary_uuid
+      "dev-#{SecureRandom.uuid}"
     end
 
     private

--- a/lib/project_types/extension/extension_project_keys.rb
+++ b/lib/project_types/extension/extension_project_keys.rb
@@ -4,6 +4,7 @@ require "shopify_cli"
 module Extension
   module ExtensionProjectKeys
     REGISTRATION_ID_KEY = "EXTENSION_ID"
+    REGISTRATION_UUID_KEY = "EXTENSION_UUID"
     SPECIFICATION_IDENTIFIER_KEY = "EXTENSION_TYPE"
     TITLE_KEY = "EXTENSION_TITLE"
   end

--- a/lib/project_types/extension/features/argo_renderer_package.rb
+++ b/lib/project_types/extension/features/argo_renderer_package.rb
@@ -10,6 +10,7 @@ module Extension
         ARGO_CHECKOUT,
         ARGO_ADMIN,
       ].freeze
+      MINIMUM_ARGO_VERSION = "0.9.3".freeze
 
       property! :package_name, accepts: PACKAGE_NAMES
       property! :version, accepts: String
@@ -20,6 +21,11 @@ module Extension
 
       def admin?
         package_name == ARGO_ADMIN
+      end
+
+      def supports_uuid_flag?
+        return false if checkout?
+        Gem::Version.new(version) > Gem::Version.new(MINIMUM_ARGO_VERSION)
       end
     end
   end

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -61,6 +61,7 @@ module Extension
           options << "--shop=#{project.env.shop}" if required_fields.include?(:shop)
           options << "--apiKey=#{project.env.api_key}" if required_fields.include?(:api_key)
           options << "--argoVersion=#{renderer_package.version}" if renderer_package.admin?
+          options << "--uuid=#{project.registration_uuid}" if renderer_package.supports_uuid_flag?
         end
       end
     end

--- a/lib/project_types/extension/models/registration.rb
+++ b/lib/project_types/extension/models/registration.rb
@@ -7,6 +7,7 @@ module Extension
       include SmartProperties
 
       property! :id, accepts: Integer
+      property! :uuid, accepts: String
       property! :type, accepts: String
       property! :title, accepts: String
       property! :draft_version, accepts: Extension::Models::Version

--- a/lib/project_types/extension/tasks/converters/registration_converter.rb
+++ b/lib/project_types/extension/tasks/converters/registration_converter.rb
@@ -6,6 +6,7 @@ module Extension
     module Converters
       module RegistrationConverter
         ID_FIELD = "id"
+        UUID_FIELD = "uuid"
         TYPE_FIELD = "type"
         TITLE_FIELD = "title"
         DRAFT_VERSION_FIELD = "draftVersion"
@@ -15,6 +16,7 @@ module Extension
 
           Models::Registration.new(
             id: hash[ID_FIELD].to_i,
+            uuid: hash[UUID_FIELD],
             type: hash[TYPE_FIELD],
             title: hash[TITLE_FIELD],
             draft_version: VersionConverter.from_hash(context, hash[DRAFT_VERSION_FIELD])

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -52,6 +52,7 @@ module Extension
       def test_creates_the_extension_if_user_confirms
         registration = Models::Registration.new(
           id: 55,
+          uuid: "123",
           type: @test_extension_type.identifier,
           title: @project.title,
           draft_version: Models::Version.new(
@@ -82,6 +83,7 @@ module Extension
           api_key: @app.api_key,
           api_secret: @app.secret,
           registration_id: registration.id,
+          registration_uuid: registration.uuid,
           title: @project.title
         ).once
 

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -16,9 +16,15 @@ module Extension
         super
         stub_argo_enabled_shop
         api_key = "TEST"
-        setup_temp_project(api_key: api_key)
-        @argo_version = "0.0.1"
-        serve_args = ["--shop=my-test-shop.myshopify.com", "--apiKey=#{api_key}", "--argoVersion=#{@argo_version}"]
+        registration_uuid = "dev-123"
+        setup_temp_project(api_key: api_key, registration_uuid: registration_uuid)
+        @argo_version = "0.9.4"
+        serve_args = [
+          "--shop=my-test-shop.myshopify.com",
+          "--apiKey=#{api_key}",
+          "--argoVersion=#{@argo_version}",
+          "--uuid=#{registration_uuid}",
+        ]
         @yarn_serve_command = YARN_SERVE_COMMAND + serve_args
         @npm_serve_command = NPM_SERVE_COMMAND + %w(--) + serve_args
       end
@@ -32,6 +38,7 @@ module Extension
       end
 
       def test_uses_js_system_to_run_npm_or_yarn_serve_commands
+        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
           .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
@@ -42,6 +49,7 @@ module Extension
       end
 
       def test_aborts_and_informs_the_user_when_serve_fails
+        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
           .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
@@ -53,6 +61,7 @@ module Extension
       end
 
       def test_uses_js_system_to_run_npm_or_yarn_serve_commands_with_shop_argument_for_first_party
+        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
           .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
@@ -96,7 +105,7 @@ module Extension
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
+        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
       end
     end
   end

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -9,6 +9,7 @@ module Extension
       property :title
       property :type
       property :registration_id
+      property :registration_uuid
       property :api_key
       property :api_secret
 
@@ -27,6 +28,7 @@ module Extension
           extra: {
             ExtensionProjectKeys::TITLE_KEY => title,
             ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id,
+            ExtensionProjectKeys::REGISTRATION_UUID_KEY => registration_uuid,
           }
         )
       end

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "securerandom"
 
 module Extension
   module ExtensionTestHelpers
@@ -24,11 +25,13 @@ module Extension
 
         def stub_create_extension_success(**args)
           registration_id = rand(9999)
+          registration_uuid = SecureRandom.uuid
           stub_create_extension(**args) do |title, type|
             {
               extensionCreate: {
                 extensionRegistration: {
                   id: registration_id,
+                  uuid: registration_uuid,
                   type: type,
                   title: title,
                   draftVersion: {

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module Extension
   module ExtensionTestHelpers
     module TempProjectSetup
@@ -12,7 +11,8 @@ module Extension
         api_secret: "TEST_SECRET",
         title: "Test",
         type_identifier: @test_extension_type.identifier,
-        registration_id: 55
+        registration_id: 55,
+        registration_uuid: nil
       )
 
         @context = TestHelpers::FakeContext.new(root: "/fake/root")
@@ -21,13 +21,15 @@ module Extension
         @title = title
         @type = type_identifier
         @registration_id = registration_id
+        @registration_uuid = registration_uuid
 
         @project = FakeExtensionProject.new(
           api_key: @api_key,
           api_secret: @api_secret,
           title: @title,
           type: @type,
-          registration_id: @registration_id
+          registration_id: @registration_id,
+          registration_uuid: @registration_uuid,
         )
 
         ShopifyCli::Project.stubs(:current).returns(@project)

--- a/test/project_types/extension/features/argo_renderer_package_test.rb
+++ b/test/project_types/extension/features/argo_renderer_package_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Features
+    class ArgoRendererPackageTest < MiniTest::Test
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def test_checkout_is_returned_for_checkout_package
+        argo_renderer_package = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_CHECKOUT,
+          version: "1.2.3"
+        )
+        assert_predicate(argo_renderer_package, :checkout?)
+      end
+
+      def test_admin_is_returned_for_admin_package
+        argo_renderer_package = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
+          version: "1.2.3"
+        )
+        assert_predicate(argo_renderer_package, :admin?)
+      end
+
+      def test_argo_minimum_version_supports_uuid_flag
+        uuid_supported = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
+          version: "0.9.4"
+        )
+        uuid_unsupported = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
+          version: "0.1.2"
+        )
+        assert_predicate(uuid_supported, :supports_uuid_flag?)
+        refute_predicate(uuid_unsupported, :supports_uuid_flag?)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -9,61 +9,84 @@ module Extension
       include TestHelpers::FakeUI
       include ExtensionTestHelpers::TempProjectSetup
 
+      ARGO_ADMIN_TEMPLATE = "https://github.com/Shopify/argo-admin.git"
+      ARGO_CHECKOUT_TEMPLATE = "https://github.com/Shopify/argo-checkout.git"
+
       def setup
         super
-        @yarn_serve_command = ArgoServe::YARN_SERVE_COMMAND
-        @npm_serve_command = ArgoServe::NPM_SERVE_COMMAND + %w(--)
+        @api_key = "123abc"
+        @registration_uuid = "dev-123"
+        @argo_version = "0.9.4"
       end
 
-      def test_commands_called_with_no_args_when_no_required_fields
-        stub_argo_enabled_shop(api_key: "123")
-        specification = {
-          identifier: "test",
-          features: {
-            argo: {
-              surface: "checkout",
-              git_template: "https://github.com/Shopify/argo-checkout.git",
-              renderer_package_name: "@shopify/argo-checkout",
-            },
-          },
-        }
-        dummy_specification = Extension::Models::Specification.new(specification)
-        dummy_handler = Extension::Models::SpecificationHandlers::Default.new(dummy_specification)
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
+      def test_extensions_that_require_version_have_argo_version_command_line_argument
+        stub_argo_enabled_shop
+        dummy_handler = build_dummy_specification_handler(
+          renderer_package_version: @argo_version,
+          specification: admin_specification
+        )
 
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
-          .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
+          .with do |args|
+            assert_includes args.fetch(:yarn), "--argoVersion=#{@argo_version}"
+            assert_includes args.fetch(:npm), "--argoVersion=#{@argo_version}"
+          end
           .returns(true)
           .once
         ArgoServe.new(specification_handler: dummy_handler, context: @context).call
       end
 
-      def test_commands_called_with_required_args_when_required_fields_present
-        specification = {
-          identifier: "test",
-          features: {
-            argo: {
-              surface: "admin",
-              git_template: "https://github.com/Shopify/argo-admin.git",
-              renderer_package_name: "@shopify/argo-admin",
-              required_fields: [:shop, :api_key],
-              required_shop_beta_flags: [:argo_admin_beta],
-            },
-          },
-        }
-        dummy_specification = Extension::Models::Specification.new(specification)
-        dummy_handler = Extension::Models::SpecificationHandlers::Default.new(dummy_specification)
-        api_key = "123"
-        stub_argo_enabled_shop(api_key: api_key)
-
-        serve_args = ["--shop=my-test-shop.myshopify.com", "--apiKey=#{api_key}", "--argoVersion=0.0.1"]
-        yarn_with_args = @yarn_serve_command + serve_args
-        npm_with_args = @npm_serve_command + serve_args
+      def test_extension_versions_that_do_not_require_argo_version_do_not_have_argo_version_command_line_arg
+        stub_argo_enabled_shop
+        dummy_handler = build_dummy_specification_handler(
+          renderer_package_version: @argo_version,
+          specification: checkout_specification
+        )
 
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
-          .with(yarn: yarn_with_args, npm: npm_with_args)
+          .with do |args|
+            refute_includes(args.fetch(:yarn), "--argoVersion=#{@argo_version}")
+            refute_includes(args.fetch(:npm), "--argoVersion=#{@argo_version}")
+          end
+          .returns(true)
+          .once
+        ArgoServe.new(specification_handler: dummy_handler, context: @context).call
+      end
+
+      def test_extension_versions_that_support_uuid_have_uuid_command_line_argument
+        stub_argo_enabled_shop
+        dummy_handler = build_dummy_specification_handler(
+          renderer_package_version: @argo_version,
+          specification: admin_specification
+        )
+
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with do |args|
+            assert_includes args.fetch(:yarn), "--uuid=#{@registration_uuid}"
+            assert_includes args.fetch(:npm), "--uuid=#{@registration_uuid}"
+          end
+          .returns(true)
+          .once
+        ArgoServe.new(specification_handler: dummy_handler, context: @context).call
+      end
+
+      def test_extension_versions_that_do_not_support_uuid_do_not_have_uuid_command_line_argument
+        stub_argo_enabled_shop
+        unsupported_argo = "0.9.2"
+        dummy_handler = build_dummy_specification_handler(
+          renderer_package_version: unsupported_argo,
+          specification: admin_specification
+        )
+
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with do |args|
+            refute_includes(args.fetch(:yarn), "--uuid=#{@registration_uuid}")
+            refute_includes(args.fetch(:npm), "--uuid=#{@registration_uuid}")
+          end
           .returns(true)
           .once
         ArgoServe.new(specification_handler: dummy_handler, context: @context).call
@@ -71,13 +94,49 @@ module Extension
 
       private
 
-      def stub_argo_enabled_shop(api_key:)
+      def mock_specification(surface:, git_template:, renderer_package_name:, required_fields: [], betas: [])
+        {
+          identifier: "test",
+          features: {
+            argo: {
+              surface: surface,
+              git_template: git_template,
+              renderer_package_name: renderer_package_name,
+              required_fields: required_fields,
+              required_shop_beta_flags: betas,
+            },
+          },
+        }
+      end
+
+      def checkout_specification
+        mock_specification(surface: "checkout", git_template: ARGO_CHECKOUT_TEMPLATE,
+renderer_package_name: "@shopify/argo-checkout")
+      end
+
+      def admin_specification
+        mock_specification(surface: "admin", git_template: ARGO_ADMIN_TEMPLATE,
+renderer_package_name: "@shopify/argo-admin")
+      end
+
+      def stub_argo_enabled_shop(api_key: @api_key, registration_uuid: @registration_uuid, argo_version: @argo_version)
         ShopifyCli::Shopifolk.stubs(:check).returns(true)
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
-        setup_temp_project(api_key: api_key)
+        setup_temp_project(api_key: api_key, registration_uuid: registration_uuid)
+      end
+
+      def build_dummy_specification_handler(renderer_package_version:, specification:)
+        dummy_specification = Extension::Models::Specification.new(specification)
+        dummy_handler = Extension::Models::SpecificationHandlers::Default.new(dummy_specification)
+        dummy_handler.stubs(:renderer_package).returns(
+          Extension::Features::ArgoRendererPackage.new(
+            package_name: dummy_specification.features.argo.renderer_package_name,
+            version: renderer_package_version
+          )
+        )
+        dummy_handler
       end
     end
   end

--- a/test/project_types/extension/tasks/converters/registration_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/registration_converter_test.rb
@@ -14,6 +14,7 @@ module Extension
           ShopifyCli::ProjectType.load_type(:extension)
 
           @registration_id = 42
+          @registration_uuid = "123"
           @fake_type = "TEST_EXTENSION"
           @fake_title = "Fake Title"
           @fake_extension_context = "fake_context"
@@ -31,6 +32,7 @@ module Extension
         def test_from_hash_parses_registration_from_a_hash
           hash = {
             Converters::RegistrationConverter::ID_FIELD => @registration_id,
+            Converters::RegistrationConverter::UUID_FIELD => @registration_uuid,
             Converters::RegistrationConverter::TYPE_FIELD => @fake_type,
             Converters::RegistrationConverter::TITLE_FIELD => @fake_title,
             Converters::RegistrationConverter::DRAFT_VERSION_FIELD => {
@@ -43,6 +45,7 @@ module Extension
 
           assert_kind_of(Models::Registration, parsed_registration)
           assert_equal @registration_id, parsed_registration.id
+          assert_equal @registration_uuid, parsed_registration.uuid
           assert_equal @fake_type, parsed_registration.type
           assert_equal @fake_title, parsed_registration.title
           assert_equal @registration_id, parsed_registration.draft_version.registration_id


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/argo-admin-private/issues/1306

`argo-admin-cli` requires a `uuid` to be passed as a command line argument. This `uuid` needs to be the `registration_id`. However, `registration_id` is not always available, so we need a temporary uuid until the `registration_id` is available.

### WHAT is this pull request doing?

* Adds `--uuid` as a command line argument to ArgoServe command.
* Using the `registration_uuid` instead of `registration_id` so we do not have to create a temporary `extension_creation_id` field, and so we don't mess with the `registration_id`
* If no `registration_uuid` is available, a temporary on is created at registration `create`. This is later updated when the extension is registered on the `register` command.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- ~[ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~
- ~[ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).~
