### PR TITLE
[scripts] read and write wasm files using binread/binwrite

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -81,11 +81,11 @@ module Script
         end
 
         def bytecode
-          blob = format(BYTECODE_FILE, name: script_name)
-          raise Errors::WebAssemblyBinaryNotFoundError unless @ctx.file_exist?(blob)
+          filename = format(BYTECODE_FILE, name: script_name)
+          raise Errors::WebAssemblyBinaryNotFoundError unless ctx.file_exist?(filename)
 
-          contents = File.read(blob)
-          @ctx.rm(blob)
+          contents = ctx.binread(filename)
+          ctx.rm(filename)
 
           contents
         end

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -26,7 +26,7 @@ module Script
           build_file_path = file_path(script_project.script_name, compiled_type)
           raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
 
-          script_content = File.read(build_file_path)
+          script_content = ctx.binread(build_file_path)
 
           Domain::PushPackage.new(
             id: build_file_path,
@@ -43,7 +43,7 @@ module Script
 
         def write_to_path(path, content)
           ctx.mkdir_p(File.dirname(path))
-          ctx.write(path, content)
+          ctx.binwrite(path, content)
         end
 
         def file_path(script_name, compiled_type)

--- a/lib/project_types/script/layers/infrastructure/rust_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/rust_task_runner.rb
@@ -51,7 +51,7 @@ module Script
           binary_path = "target/#{BUILD_TARGET}/release/#{binary_name}"
           raise Errors::WebAssemblyBinaryNotFoundError unless ctx.file_exist?(binary_path)
 
-          File.read(binary_path)
+          ctx.binread(binary_path)
         end
       end
     end

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -144,6 +144,34 @@ module ShopifyCli
       File.write(ctx_path(fname), content)
     end
 
+    # will read a binary file relative to the context root unless the file path is absolute.
+    #
+    # #### Parameters
+    # * `fname` - filename of the file that you are reading, relative to root unless it is absolute.
+    #
+    # #### Example
+    #
+    #   @ctx.read('binary.out')
+    #
+    def binread(fname)
+      File.binread(ctx_path(fname))
+    end
+
+    # will write/overwrite a binary file with the provided contents, relative to the context root
+    # unless the file path is absolute.
+    #
+    # #### Parameters
+    # * `fname` - filename of the file that you are writing, relative to root unless it is absolute.
+    # * `content` - the body contents of the file that you are writing
+    #
+    # #### Example
+    #
+    #   @ctx.binwrite('binary.out', 'ASCII-8BIT encoded binary')
+    #
+    def binwrite(fname, content)
+      File.binwrite(ctx_path(fname), content)
+    end
+
     # will change directories and update the root, the filepath is relative to the command root unless absolute
     #
     # #### Parameters

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -75,7 +75,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
     it "should trigger the compilation process" do
       wasm = "some compiled code"
       File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
-      File.expects(:read).with("build/foo.wasm").once.returns(wasm)
+      ctx.expects(:binread).with("build/foo.wasm").once.returns(wasm)
 
       ctx
         .expects(:capture2e)

--- a/test/project_types/script/layers/infrastructure/rust_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/rust_task_runner_test.rb
@@ -2,7 +2,7 @@
 
 require "project_types/script/test_helper"
 
-describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
+describe Script::Layers::Infrastructure::RustTaskRunner do
   include TestHelpers::FakeFS
   let(:ctx) { TestHelpers::FakeContext.new }
   let(:script_id) { "id" }
@@ -71,8 +71,8 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
         .with("target/wasm32-unknown-unknown/release/#{script_name}.wasm")
         .returns(true)
 
-      File
-        .expects(:read)
+      ctx
+        .expects(:binread)
         .once
         .with("target/wasm32-unknown-unknown/release/#{script_name}.wasm")
         .returns("blob")

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -16,6 +16,24 @@ module ShopifyCli
       assert File.exist?(File.join(@ctx.root, ".env"))
     end
 
+    def test_binwrite_writes_to_file_in_project
+      @ctx.root = Dir.mktmpdir
+      filename = "bin.out"
+      binary = "\x0a"
+      filepath = File.join(@ctx.root, filename)
+      @ctx.binwrite(filename, binary)
+      assert File.exist?(filepath)
+      assert_equal binary, File.binread(filepath)
+    end
+
+    def test_binread_writes_to_file_in_project
+      @ctx.root = Dir.mktmpdir
+      filename = "bin.out"
+      binary = "\x0a"
+      File.write(File.join(@ctx.root, filename), binary)
+      assert_equal binary, @ctx.binread(filename)
+    end
+
     def test_mac_matches
       @ctx.expects(:uname).returns("x86_64-apple-darwin19.3.0").times(3)
       assert(@ctx.mac?)

--- a/test/test_helpers/fake_fs.rb
+++ b/test/test_helpers/fake_fs.rb
@@ -18,3 +18,11 @@ module TestHelpers
     end
   end
 end
+
+module FakeFS
+  class File
+    def self.binwrite(*args)
+      File.write(*args, mode: "wb:ASCII-8BIT")
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/1723

For windows, binary files need to be read/written using `File.binread` and `File.binwrite` instead of `File.read` and `File.write` as a `\x1A` sequence would indicate a file closure.

### WHAT is this pull request doing?

- Adds `binread` and `binwrite` methods to `Context`, which is how we handle manipulating the filesystem
- Reads and writes all wasm files using these new methods

### Update checklist
- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
