### PR TITLE
Remove subcommand calls from generate.rb under node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 Unreleased
 ------
+* [1181](https://github.com/Shopify/shopify-app-cli/pull/1181): Remove the subcommand references of the `generate` command for node apps (fixes [1176](https://github.com/Shopify/shopify-app-cli/issues/1176))
 
 Version 1.8.0
 -------------
-
 * [1119](https://github.com/Shopify/shopify-app-cli/pull/1119): Enable guest serialization for scripts
 
 Version 1.7.1

--- a/lib/project_types/node/commands/generate.rb
+++ b/lib/project_types/node/commands/generate.rb
@@ -4,10 +4,6 @@ require "shopify_cli"
 module Node
   module Commands
     class Generate < ShopifyCli::Command
-      subcommand :Page, "page", Project.project_filepath("commands/generate/page")
-      subcommand :Billing, "billing", Project.project_filepath("commands/generate/billing")
-      subcommand :Webhook, "webhook", Project.project_filepath("commands/generate/webhook")
-
       def call(*)
         @ctx.puts(self.class.help)
       end
@@ -18,24 +14,6 @@ module Node
 
       def self.extended_help
         help
-      end
-
-      def self.run_generate(script, name, ctx)
-        stat = ctx.system(script)
-        unless stat.success?
-          ctx.abort(response(stat.exitstatus, name, ctx))
-        end
-      end
-
-      def self.response(code, name, ctx)
-        case code
-        when 1
-          ctx.message("node.generate.error.generic", name)
-        when 2
-          ctx.message("node.generate.error.name_exists", name)
-        else
-          ctx.message("node.error.generic")
-        end
       end
     end
   end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #1176 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Remove `subcommand` calls from `generate.rb` under `node`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).