### PR TITLE
Feature: Add tunnel flag to ArgoServe

### DIFF
--- a/lib/graphql/extension_create.graphql
+++ b/lib/graphql/extension_create.graphql
@@ -1,7 +1,22 @@
-mutation ExtensionCreate($api_key: String!, $type: ExtensionType!, $title: String!, $config: JSON!, $extension_context: String) {
-  extensionCreate(input: {apiKey: $api_key, type: $type, title: $title, config: $config, context: $extension_context}) {
+mutation ExtensionCreate(
+  $api_key: String!
+  $type: ExtensionType!
+  $title: String!
+  $config: JSON!
+  $extension_context: String
+) {
+  extensionCreate(
+    input: {
+      apiKey: $api_key
+      type: $type
+      title: $title
+      config: $config
+      context: $extension_context
+    }
+  ) {
     extensionRegistration {
       id
+      uuid
       type
       title
       draftVersion {

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -36,6 +36,7 @@ module Extension
     autoload :UpdateDraft, Project.project_filepath("tasks/update_draft")
     autoload :FetchSpecifications, Project.project_filepath("tasks/fetch_specifications")
     autoload :ConfigureFeatures, Project.project_filepath("tasks/configure_features")
+    autoload :ChooseNextAvailablePort, Project.project_filepath("tasks/choose_next_available_port")
 
     module Converters
       autoload :RegistrationConverter, Project.project_filepath("tasks/converters/registration_converter")
@@ -59,6 +60,7 @@ module Extension
   module Features
     autoload :ArgoRendererPackage, Project.project_filepath("features/argo_renderer_package")
     autoload :ArgoServe, Project.project_filepath("features/argo_serve")
+    autoload :ArgoServeOptions, Project.project_filepath("features/argo_serve_options")
     autoload :ArgoSetup, Project.project_filepath("features/argo_setup")
     autoload :ArgoSetupStep, Project.project_filepath("features/argo_setup_step")
     autoload :ArgoSetupSteps, Project.project_filepath("features/argo_setup_steps")

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -50,6 +50,7 @@ module Extension
           api_key: app.api_key,
           api_secret: app.secret,
           registration_id: registration.id,
+          registration_uuid: registration.uuid,
           title: project.title
         )
       end

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -3,14 +3,20 @@
 module Extension
   module Commands
     class Serve < ExtensionCommand
+      options do |parser, flags|
+        parser.on("--tunnel=TUNNEL") { |tunnel| flags[:tunnel] = tunnel }
+      end
+
       def call(_args, _command_name)
-        specification_handler.serve(@ctx)
+        specification_handler.serve(@ctx, options.flags)
       end
 
       def self.help
         <<~HELP
           Serve your extension in a local simulator for development.
             Usage: {{command:#{ShopifyCli::TOOL_NAME} serve}}
+            Options:
+            {{command:--tunnel=TUNNEL}} Establish a tunnel (default: false)
         HELP
       end
     end

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -13,13 +13,16 @@ module Extension
         )
       end
 
-      def write_env_file(context:, title:, api_key: "", api_secret: "", registration_id: nil)
+      def write_env_file(
+        context:, title:, api_key: "", api_secret: "", registration_id: nil, registration_uuid: nil
+      )
         ShopifyCli::Resources::EnvFile.new(
           api_key: api_key,
           secret: api_secret,
           extra: {
             ExtensionProjectKeys::TITLE_KEY => title,
             ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id,
+            ExtensionProjectKeys::REGISTRATION_UUID_KEY => registration_uuid || generate_temporary_uuid,
           }.compact
         ).write(context)
 
@@ -63,8 +66,16 @@ module Extension
       get_extra_field(ExtensionProjectKeys::REGISTRATION_ID_KEY).to_i
     end
 
+    def registration_uuid
+      get_extra_field(ExtensionProjectKeys::REGISTRATION_UUID_KEY)
+    end
+
     def reload
       @env = nil
+    end
+
+    def self.generate_temporary_uuid
+      "dev-#{SecureRandom.uuid}"
     end
 
     private

--- a/lib/project_types/extension/extension_project_keys.rb
+++ b/lib/project_types/extension/extension_project_keys.rb
@@ -4,6 +4,7 @@ require "shopify_cli"
 module Extension
   module ExtensionProjectKeys
     REGISTRATION_ID_KEY = "EXTENSION_ID"
+    REGISTRATION_UUID_KEY = "EXTENSION_UUID"
     SPECIFICATION_IDENTIFIER_KEY = "EXTENSION_TYPE"
     TITLE_KEY = "EXTENSION_TITLE"
   end

--- a/lib/project_types/extension/features/argo_renderer_package.rb
+++ b/lib/project_types/extension/features/argo_renderer_package.rb
@@ -10,6 +10,7 @@ module Extension
         ARGO_CHECKOUT,
         ARGO_ADMIN,
       ].freeze
+      MINIMUM_ARGO_VERSION = "0.9.3".freeze
 
       property! :package_name, accepts: PACKAGE_NAMES
       property! :version, accepts: String
@@ -20,6 +21,11 @@ module Extension
 
       def admin?
         package_name == ARGO_ADMIN
+      end
+
+      def supports_uuid_flag?
+        return false if checkout?
+        Gem::Version.new(version) > Gem::Version.new(MINIMUM_ARGO_VERSION)
       end
     end
   end

--- a/lib/project_types/extension/features/argo_serve_options.rb
+++ b/lib/project_types/extension/features/argo_serve_options.rb
@@ -1,0 +1,39 @@
+module Extension
+  module Features
+    class ArgoServeOptions
+      include SmartProperties
+      property! :context, accepts: ShopifyCli::Context
+      property! :renderer_package, accepts: Features::ArgoRendererPackage
+      property! :required_fields, accepts: Array, default: []
+      property :public_url, default: ""
+
+      YARN_SERVE_COMMAND = %w(server)
+      NPM_SERVE_COMMAND = %w(run-script server)
+
+      def yarn_serve_command
+        YARN_SERVE_COMMAND + options
+      end
+
+      def npm_serve_command
+        NPM_SERVE_COMMAND  + ["--"] + options
+      end
+
+      def public_url_available?
+        !public_url.empty?
+      end
+
+      private
+
+      def options
+        project = ExtensionProject.current
+        @serve_options ||= [].tap do |options|
+          options << "--shop=#{project.env.shop}" if required_fields.include?(:shop)
+          options << "--apiKey=#{project.env.api_key}" if required_fields.include?(:api_key)
+          options << "--argoVersion=#{renderer_package.version}" if renderer_package.admin?
+          options << "--uuid=#{project.registration_uuid}" if renderer_package.supports_uuid_flag?
+          options << "--publicUrl=#{public_url}" if public_url_available?
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/registration.rb
+++ b/lib/project_types/extension/models/registration.rb
@@ -7,6 +7,7 @@ module Extension
       include SmartProperties
 
       property! :id, accepts: Integer
+      property! :uuid, accepts: String
       property! :type, accepts: String
       property! :title, accepts: String
       property! :draft_version, accepts: Extension::Models::Version

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -42,8 +42,8 @@ module Extension
           []
         end
 
-        def serve(context)
-          Features::ArgoServe.new(specification_handler: self, context: context).call
+        def serve(context, flags)
+          Features::ArgoServe.new(specification_handler: self, context: context, flags: flags).call
         end
 
         def renderer_package(context)

--- a/lib/project_types/extension/tasks/choose_next_available_port.rb
+++ b/lib/project_types/extension/tasks/choose_next_available_port.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "shopify_cli"
+require "socket"
+
+module Extension
+  module Tasks
+    class ChooseNextAvailablePort
+      include ShopifyCli::MethodObject
+
+      property! :from
+      property! :to, default: -> { from + 25 }
+      property! :host, default: "localhost"
+      property! :max_tries, default: 25
+
+      def call
+        available_port = port_range(from: from, to: to).find { |p| available?(host, p) }
+        raise ArgumentError, "Ports between #{from} and #{to} are unavailable" if available_port.nil?
+        available_port
+      end
+
+      private
+
+      def port_range(from:, to:)
+        (from...to)
+      end
+
+      def available?(host, port)
+        Socket.tcp(host, port, connect_timeout: 1) do |socket|
+          socket.close
+          false
+        end
+      rescue Errno::ECONNREFUSED
+        true
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/converters/registration_converter.rb
+++ b/lib/project_types/extension/tasks/converters/registration_converter.rb
@@ -6,6 +6,7 @@ module Extension
     module Converters
       module RegistrationConverter
         ID_FIELD = "id"
+        UUID_FIELD = "uuid"
         TYPE_FIELD = "type"
         TITLE_FIELD = "title"
         DRAFT_VERSION_FIELD = "draftVersion"
@@ -15,6 +16,7 @@ module Extension
 
           Models::Registration.new(
             id: hash[ID_FIELD].to_i,
+            uuid: hash[UUID_FIELD],
             type: hash[TYPE_FIELD],
             title: hash[TITLE_FIELD],
             draft_version: VersionConverter.from_hash(context, hash[DRAFT_VERSION_FIELD])

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -52,6 +52,7 @@ module Extension
       def test_creates_the_extension_if_user_confirms
         registration = Models::Registration.new(
           id: 55,
+          uuid: "123",
           type: @test_extension_type.identifier,
           title: @project.title,
           draft_version: Models::Version.new(
@@ -82,6 +83,7 @@ module Extension
           api_key: @app.api_key,
           api_secret: @app.secret,
           registration_id: registration.id,
+          registration_uuid: registration.uuid,
           title: @project.title
         ).once
 

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -16,9 +16,15 @@ module Extension
         super
         stub_argo_enabled_shop
         api_key = "TEST"
-        setup_temp_project(api_key: api_key)
-        @argo_version = "0.0.1"
-        serve_args = ["--shop=my-test-shop.myshopify.com", "--apiKey=#{api_key}", "--argoVersion=#{@argo_version}"]
+        registration_uuid = "dev-123"
+        setup_temp_project(api_key: api_key, registration_uuid: registration_uuid)
+        @argo_version = "0.9.4"
+        serve_args = [
+          "--shop=my-test-shop.myshopify.com",
+          "--apiKey=#{api_key}",
+          "--argoVersion=#{@argo_version}",
+          "--uuid=#{registration_uuid}",
+        ]
         @yarn_serve_command = YARN_SERVE_COMMAND + serve_args
         @npm_serve_command = NPM_SERVE_COMMAND + %w(--) + serve_args
       end
@@ -32,6 +38,7 @@ module Extension
       end
 
       def test_uses_js_system_to_run_npm_or_yarn_serve_commands
+        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
           .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
@@ -42,6 +49,7 @@ module Extension
       end
 
       def test_aborts_and_informs_the_user_when_serve_fails
+        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
           .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
@@ -53,6 +61,7 @@ module Extension
       end
 
       def test_uses_js_system_to_run_npm_or_yarn_serve_commands_with_shop_argument_for_first_party
+        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
           .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
@@ -96,7 +105,7 @@ module Extension
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
+        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
       end
     end
   end

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -9,6 +9,7 @@ module Extension
       property :title
       property :type
       property :registration_id
+      property :registration_uuid
       property :api_key
       property :api_secret
 
@@ -27,6 +28,7 @@ module Extension
           extra: {
             ExtensionProjectKeys::TITLE_KEY => title,
             ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id,
+            ExtensionProjectKeys::REGISTRATION_UUID_KEY => registration_uuid,
           }
         )
       end

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "securerandom"
 
 module Extension
   module ExtensionTestHelpers
@@ -24,11 +25,13 @@ module Extension
 
         def stub_create_extension_success(**args)
           registration_id = rand(9999)
+          registration_uuid = SecureRandom.uuid
           stub_create_extension(**args) do |title, type|
             {
               extensionCreate: {
                 extensionRegistration: {
                   id: registration_id,
+                  uuid: registration_uuid,
                   type: type,
                   title: title,
                   draftVersion: {

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module Extension
   module ExtensionTestHelpers
     module TempProjectSetup
@@ -12,7 +11,8 @@ module Extension
         api_secret: "TEST_SECRET",
         title: "Test",
         type_identifier: @test_extension_type.identifier,
-        registration_id: 55
+        registration_id: 55,
+        registration_uuid: nil
       )
 
         @context = TestHelpers::FakeContext.new(root: "/fake/root")
@@ -21,13 +21,15 @@ module Extension
         @title = title
         @type = type_identifier
         @registration_id = registration_id
+        @registration_uuid = registration_uuid
 
         @project = FakeExtensionProject.new(
           api_key: @api_key,
           api_secret: @api_secret,
           title: @title,
           type: @type,
-          registration_id: @registration_id
+          registration_id: @registration_id,
+          registration_uuid: @registration_uuid,
         )
 
         ShopifyCli::Project.stubs(:current).returns(@project)

--- a/test/project_types/extension/features/argo_renderer_package_test.rb
+++ b/test/project_types/extension/features/argo_renderer_package_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Features
+    class ArgoRendererPackageTest < MiniTest::Test
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def test_checkout_is_returned_for_checkout_package
+        argo_renderer_package = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_CHECKOUT,
+          version: "1.2.3"
+        )
+        assert_predicate(argo_renderer_package, :checkout?)
+      end
+
+      def test_admin_is_returned_for_admin_package
+        argo_renderer_package = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
+          version: "1.2.3"
+        )
+        assert_predicate(argo_renderer_package, :admin?)
+      end
+
+      def test_argo_minimum_version_supports_uuid_flag
+        uuid_supported = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
+          version: "0.9.4"
+        )
+        uuid_unsupported = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
+          version: "0.1.2"
+        )
+        assert_predicate(uuid_supported, :supports_uuid_flag?)
+        refute_predicate(uuid_unsupported, :supports_uuid_flag?)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -9,61 +9,84 @@ module Extension
       include TestHelpers::FakeUI
       include ExtensionTestHelpers::TempProjectSetup
 
+      ARGO_ADMIN_TEMPLATE = "https://github.com/Shopify/argo-admin.git"
+      ARGO_CHECKOUT_TEMPLATE = "https://github.com/Shopify/argo-checkout.git"
+
       def setup
         super
-        @yarn_serve_command = ArgoServe::YARN_SERVE_COMMAND
-        @npm_serve_command = ArgoServe::NPM_SERVE_COMMAND + %w(--)
+        @api_key = "123abc"
+        @registration_uuid = "dev-123"
+        @argo_version = "0.9.4"
       end
 
-      def test_commands_called_with_no_args_when_no_required_fields
-        stub_argo_enabled_shop(api_key: "123")
-        specification = {
-          identifier: "test",
-          features: {
-            argo: {
-              surface: "checkout",
-              git_template: "https://github.com/Shopify/argo-checkout.git",
-              renderer_package_name: "@shopify/argo-checkout",
-            },
-          },
-        }
-        dummy_specification = Extension::Models::Specification.new(specification)
-        dummy_handler = Extension::Models::SpecificationHandlers::Default.new(dummy_specification)
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
+      def test_extensions_that_require_version_have_argo_version_command_line_argument
+        stub_argo_enabled_shop
+        dummy_handler = build_dummy_specification_handler(
+          renderer_package_version: @argo_version,
+          specification: admin_specification
+        )
 
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
-          .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
+          .with do |args|
+            assert_includes args.fetch(:yarn), "--argoVersion=#{@argo_version}"
+            assert_includes args.fetch(:npm), "--argoVersion=#{@argo_version}"
+          end
           .returns(true)
           .once
         ArgoServe.new(specification_handler: dummy_handler, context: @context).call
       end
 
-      def test_commands_called_with_required_args_when_required_fields_present
-        specification = {
-          identifier: "test",
-          features: {
-            argo: {
-              surface: "admin",
-              git_template: "https://github.com/Shopify/argo-admin.git",
-              renderer_package_name: "@shopify/argo-admin",
-              required_fields: [:shop, :api_key],
-              required_shop_beta_flags: [:argo_admin_beta],
-            },
-          },
-        }
-        dummy_specification = Extension::Models::Specification.new(specification)
-        dummy_handler = Extension::Models::SpecificationHandlers::Default.new(dummy_specification)
-        api_key = "123"
-        stub_argo_enabled_shop(api_key: api_key)
-
-        serve_args = ["--shop=my-test-shop.myshopify.com", "--apiKey=#{api_key}", "--argoVersion=0.0.1"]
-        yarn_with_args = @yarn_serve_command + serve_args
-        npm_with_args = @npm_serve_command + serve_args
+      def test_extension_versions_that_do_not_require_argo_version_do_not_have_argo_version_command_line_arg
+        stub_argo_enabled_shop
+        dummy_handler = build_dummy_specification_handler(
+          renderer_package_version: @argo_version,
+          specification: checkout_specification
+        )
 
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
-          .with(yarn: yarn_with_args, npm: npm_with_args)
+          .with do |args|
+            refute_includes(args.fetch(:yarn), "--argoVersion=#{@argo_version}")
+            refute_includes(args.fetch(:npm), "--argoVersion=#{@argo_version}")
+          end
+          .returns(true)
+          .once
+        ArgoServe.new(specification_handler: dummy_handler, context: @context).call
+      end
+
+      def test_extension_versions_that_support_uuid_have_uuid_command_line_argument
+        stub_argo_enabled_shop
+        dummy_handler = build_dummy_specification_handler(
+          renderer_package_version: @argo_version,
+          specification: admin_specification
+        )
+
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with do |args|
+            assert_includes args.fetch(:yarn), "--uuid=#{@registration_uuid}"
+            assert_includes args.fetch(:npm), "--uuid=#{@registration_uuid}"
+          end
+          .returns(true)
+          .once
+        ArgoServe.new(specification_handler: dummy_handler, context: @context).call
+      end
+
+      def test_extension_versions_that_do_not_support_uuid_do_not_have_uuid_command_line_argument
+        stub_argo_enabled_shop
+        unsupported_argo = "0.9.2"
+        dummy_handler = build_dummy_specification_handler(
+          renderer_package_version: unsupported_argo,
+          specification: admin_specification
+        )
+
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with do |args|
+            refute_includes(args.fetch(:yarn), "--uuid=#{@registration_uuid}")
+            refute_includes(args.fetch(:npm), "--uuid=#{@registration_uuid}")
+          end
           .returns(true)
           .once
         ArgoServe.new(specification_handler: dummy_handler, context: @context).call
@@ -71,13 +94,49 @@ module Extension
 
       private
 
-      def stub_argo_enabled_shop(api_key:)
+      def mock_specification(surface:, git_template:, renderer_package_name:, required_fields: [], betas: [])
+        {
+          identifier: "test",
+          features: {
+            argo: {
+              surface: surface,
+              git_template: git_template,
+              renderer_package_name: renderer_package_name,
+              required_fields: required_fields,
+              required_shop_beta_flags: betas,
+            },
+          },
+        }
+      end
+
+      def checkout_specification
+        mock_specification(surface: "checkout", git_template: ARGO_CHECKOUT_TEMPLATE,
+renderer_package_name: "@shopify/argo-checkout")
+      end
+
+      def admin_specification
+        mock_specification(surface: "admin", git_template: ARGO_ADMIN_TEMPLATE,
+renderer_package_name: "@shopify/argo-admin")
+      end
+
+      def stub_argo_enabled_shop(api_key: @api_key, registration_uuid: @registration_uuid)
         ShopifyCli::Shopifolk.stubs(:check).returns(true)
         ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
-        setup_temp_project(api_key: api_key)
+        setup_temp_project(api_key: api_key, registration_uuid: registration_uuid)
+      end
+
+      def build_dummy_specification_handler(renderer_package_version:, specification:)
+        dummy_specification = Extension::Models::Specification.new(specification)
+        dummy_handler = Extension::Models::SpecificationHandlers::Default.new(dummy_specification)
+        dummy_handler.stubs(:renderer_package).returns(
+          Extension::Features::ArgoRendererPackage.new(
+            package_name: dummy_specification.features.argo.renderer_package_name,
+            version: renderer_package_version
+          )
+        )
+        dummy_handler
       end
     end
   end

--- a/test/project_types/extension/tasks/choose_next_available_port_test.rb
+++ b/test/project_types/extension/tasks/choose_next_available_port_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Tasks
+    class ChooseNextAvailablePortTest < MiniTest::Test
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def test_given_port_is_returned_when_available
+        socket = mock.tap { |s| s.expects(:close).once }
+        Socket.expects(:tcp).with("example.com", 12345, connect_timeout: 1).yields(socket).returns(true).once
+
+        port = Tasks::ChooseNextAvailablePort.new(from: 12345, host: "example.com").call
+        assert_predicate(port, :success?)
+        assert_equal(12345, port.value)
+      end
+
+      def test_returns_next_available_port_if_given_port_is_taken
+        socket = mock.tap { |s| s.expects(:close).twice }
+        Socket.expects(:tcp).with("example.com", 12345, connect_timeout: 1).yields(socket).returns(false).once
+        Socket.expects(:tcp).with("example.com", 12346, connect_timeout: 1).yields(socket).returns(true).once
+
+        port = Tasks::ChooseNextAvailablePort.new(from: 12345, host: "example.com").call
+        assert_predicate(port, :success?)
+        assert_equal(12346, port.value)
+      end
+
+      def test_aborts_after_max_tries_exceeded
+        socket = mock.tap { |s| s.expects(:close).twice }
+        Socket.expects(:tcp).with("example.com", 12345, connect_timeout: 1).yields(socket).returns(false)
+        Socket.expects(:tcp).with("example.com", 12346, connect_timeout: 1).yields(socket).returns(false)
+
+        port = Tasks::ChooseNextAvailablePort.new(from: 12345, host: "example.com", to: 12347).call
+        assert_predicate(port, :failure?)
+        port.error.tap do |error|
+          assert_kind_of(ArgumentError, error)
+          assert_equal("Ports between 12345 and 12347 are unavailable", error.message)
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/registration_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/registration_converter_test.rb
@@ -14,6 +14,7 @@ module Extension
           ShopifyCli::ProjectType.load_type(:extension)
 
           @registration_id = 42
+          @registration_uuid = "123"
           @fake_type = "TEST_EXTENSION"
           @fake_title = "Fake Title"
           @fake_extension_context = "fake_context"
@@ -31,6 +32,7 @@ module Extension
         def test_from_hash_parses_registration_from_a_hash
           hash = {
             Converters::RegistrationConverter::ID_FIELD => @registration_id,
+            Converters::RegistrationConverter::UUID_FIELD => @registration_uuid,
             Converters::RegistrationConverter::TYPE_FIELD => @fake_type,
             Converters::RegistrationConverter::TITLE_FIELD => @fake_title,
             Converters::RegistrationConverter::DRAFT_VERSION_FIELD => {
@@ -43,6 +45,7 @@ module Extension
 
           assert_kind_of(Models::Registration, parsed_registration)
           assert_equal @registration_id, parsed_registration.id
+          assert_equal @registration_uuid, parsed_registration.uuid
           assert_equal @fake_type, parsed_registration.type
           assert_equal @fake_title, parsed_registration.title
           assert_equal @registration_id, parsed_registration.draft_version.registration_id


### PR DESCRIPTION
### WHY are these changes introduced?

Closes: https://github.com/Shopify/shopify-app-cli/issues/1174

* Adds a `tunnel` flag to `shopify serve`
* If flag is true, a tunnel is created and passed as an argument to `argo-admin-cli`

### WHAT is this pull request doing?

* Some clean up, as ArgoServe is getting to big
* Moved serve options logic to its own class (ArgoServeOptions)
* Added a GetPort class under Tasks to find an open port for the tunnel (checks if default port used by argo is available)

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
