### PR TITLE
Rename Scripts Configuration UI Definition Fields

### DIFF
--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -82,7 +82,7 @@ module Script
           require "yaml" # takes 20ms, so deferred as late as possible.
           YAML.dump({
             "version" => 1,
-            "type" => "single",
+            "inputMode" => "single",
             "title" => title,
             "description" => "",
             "fields" => [],

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -73,7 +73,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         let(:no_config_ui) { false }
         let(:expected_config_ui_filename) { "config-ui.yml" }
         let(:expected_config_ui_content) do
-          "---\nversion: 1\ntype: single\ntitle: #{script_name}\ndescription: ''\nfields: []\n"
+          "---\nversion: 1\ninputMode: single\ntitle: #{script_name}\ndescription: ''\nfields: []\n"
         end
 
         it "should create a new script project" do


### PR DESCRIPTION
### WHY are these changes introduced?

Some of the configuration UI definition fields for Scripts are being changed. The only relevant field in CLI is the top-level `type` field, which is being renamed to `inputMode`.

Backend PR: https://github.com/Shopify/script-service/pull/2939
Related issue: https://github.com/Shopify/script-service/issues/2860

**This PR depends on the Script Service PR: https://github.com/Shopify/script-service/pull/2939**

### WHAT is this pull request doing?

This PR updates the `type` field to `inputMode`

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
