### PR TITLE
[scripts] Identify scripts through uuid

### DIFF
--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -26,6 +26,7 @@ mutation AppScriptUpdateOrCreate(
       tag
     }
     appScript {
+      uuid
       appKey
       configSchema
       extensionPointName

--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -7,7 +7,8 @@ mutation AppScriptUpdateOrCreate(
   $force: Boolean,
   $schemaMajorVersion: String,
   $schemaMinorVersion: String,
-  $useMsgpack: Boolean
+  $useMsgpack: Boolean,
+  $uuid: String
 ) {
   appScriptUpdateOrCreate(
     extensionPointName: $extensionPointName
@@ -18,7 +19,8 @@ mutation AppScriptUpdateOrCreate(
     force: $force
     schemaMajorVersion: $schemaMajorVersion
     schemaMinorVersion: $schemaMinorVersion
-    useMsgpack: $useMsgpack
+    useMsgpack: $useMsgpack,
+    uuid: $uuid
 ) {
     userErrors {
       field

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -20,7 +20,7 @@ module Script
                 metadata: task_runner.metadata,
               )
               uuid = package.push(Infrastructure::ScriptService.new(ctx: p_ctx), script_project.api_key, force)
-              script_project_repo.update_config(uuid: uuid)
+              script_project_repo.update_env(uuid: uuid)
               spinner.update_title(p_ctx.message("script.application.pushed"))
             end
           end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -6,7 +6,8 @@ module Script
       class PushScript
         class << self
           def call(ctx:, force:)
-            script_project = Infrastructure::ScriptProjectRepository.new(ctx: ctx).get
+            script_project_repo = Infrastructure::ScriptProjectRepository.new(ctx: ctx)
+            script_project = script_project_repo.get
             task_runner = Infrastructure::TaskRunner.for(ctx, script_project.language, script_project.script_name)
 
             ProjectDependencies.install(ctx: ctx, task_runner: task_runner)
@@ -18,7 +19,8 @@ module Script
                 compiled_type: task_runner.compiled_type,
                 metadata: task_runner.metadata,
               )
-              package.push(Infrastructure::ScriptService.new(ctx: p_ctx), script_project.api_key, force)
+              uuid = package.push(Infrastructure::ScriptService.new(ctx: p_ctx), script_project.api_key, force)
+              script_project_repo.update_config(uuid: uuid)
               spinner.update_title(p_ctx.message("script.application.pushed"))
             end
           end

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -5,6 +5,7 @@ module Script
     module Domain
       class PushPackage
         attr_reader :id,
+          :uuid,
           :extension_point_type,
           :script_name,
           :config_ui,
@@ -14,6 +15,7 @@ module Script
 
         def initialize(
           id:,
+          uuid:,
           extension_point_type:,
           script_name:,
           script_content:,
@@ -22,6 +24,7 @@ module Script
           config_ui:
         )
           @id = id
+          @uuid = uuid
           @extension_point_type = extension_point_type
           @script_name = script_name
           @script_content = script_content
@@ -32,6 +35,7 @@ module Script
 
         def push(script_service, api_key, force)
           script_service.push(
+            uuid: @uuid,
             extension_point_type: @extension_point_type,
             script_name: @script_name,
             script_content: @script_content,

--- a/lib/project_types/script/layers/domain/script_project.rb
+++ b/lib/project_types/script/layers/domain/script_project.rb
@@ -7,7 +7,6 @@ module Script
         include SmartProperties
 
         property! :id, accepts: String
-        property :uuid, accepts: String
         property :env, accepts: ShopifyCli::Resources::EnvFile
 
         property! :extension_point_type, accepts: String
@@ -27,7 +26,11 @@ module Script
         end
 
         def api_key
-          env[:api_key]
+          env&.api_key
+        end
+
+        def uuid
+          env&.extra&.[]("uuid")
         end
       end
     end

--- a/lib/project_types/script/layers/domain/script_project.rb
+++ b/lib/project_types/script/layers/domain/script_project.rb
@@ -7,6 +7,7 @@ module Script
         include SmartProperties
 
         property! :id, accepts: String
+        property :uuid, accepts: String
         property :env, accepts: ShopifyCli::Resources::EnvFile
 
         property! :extension_point_type, accepts: String

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -13,6 +13,7 @@ module Script
 
           Domain::PushPackage.new(
             id: build_file_path,
+            uuid: script_project.uuid,
             extension_point_type: script_project.extension_point_type,
             script_name: script_project.script_name,
             script_content: script_content,
@@ -30,6 +31,7 @@ module Script
 
           Domain::PushPackage.new(
             id: build_file_path,
+            uuid: script_project.uuid,
             extension_point_type: script_project.extension_point_type,
             script_name: script_project.script_name,
             script_content: script_content,

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -34,6 +34,7 @@ module Script
 
           Domain::ScriptProject.new(
             id: ctx.root,
+            uuid: nil,
             env: project.env,
             script_name: script_name,
             extension_point_type: extension_point_type,
@@ -46,6 +47,7 @@ module Script
           extension_point_type = project_config_value!("extension_point_type")
           script_name = project_config_value!("script_name")
           config_ui_file = project_config_value("config_ui_file")
+          uuid = project_config_value("uuid")
           language = project_config_value("language")&.downcase || default_language
 
           validate_metadata!(extension_point_type, language)
@@ -54,6 +56,7 @@ module Script
 
           Domain::ScriptProject.new(
             id: project.directory,
+            uuid: uuid,
             env: project.env,
             script_name: script_name,
             extension_point_type: extension_point_type,

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -27,6 +27,7 @@ module Script
             ctx,
             project_type: :script,
             organization_id: nil,
+            uuid: nil,
             extension_point_type: extension_point_type,
             script_name: script_name,
             language: language,

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -35,7 +35,7 @@ module Script
           resp_hash = script_service_request(query_name: query_name, api_key: api_key, variables: variables)
           user_errors = resp_hash["data"]["appScriptUpdateOrCreate"]["userErrors"]
 
-          return resp_hash if user_errors.empty?
+          return resp_hash["data"]["appScriptUpdateOrCreate"]["appScript"]["uuid"] if user_errors.empty?
 
           if user_errors.any? { |e| e["tag"] == "already_exists_error" }
             raise Errors::ScriptRepushError, api_key

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -11,6 +11,7 @@ module Script
         property! :ctx, accepts: ShopifyCli::Context
 
         def push(
+          uuid:,
           extension_point_type:,
           script_name:,
           script_content:,
@@ -22,6 +23,7 @@ module Script
         )
           query_name = "app_script_update_or_create"
           variables = {
+            uuid: uuid,
             extensionPointName: extension_point_type.upcase,
             title: script_name,
             configUi: config_ui&.content,

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -28,6 +28,7 @@ describe Script::Layers::Application::PushScript do
   let(:script_project_repository) { TestHelpers::FakeScriptProjectRepository.new }
   let(:task_runner) { stub(compiled_type: "wasm", metadata: metadata) }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
+  let(:uuid) { "uuid" }
 
   before do
     Script::Layers::Infrastructure::PushPackageRepository.stubs(:new).returns(push_package_repository)
@@ -61,8 +62,9 @@ describe Script::Layers::Application::PushScript do
       Script::Layers::Infrastructure::ScriptService
         .expects(:new).returns(script_service_instance)
       Script::Layers::Domain::PushPackage
-        .any_instance.expects(:push).with(script_service_instance, api_key, force)
+        .any_instance.expects(:push).with(script_service_instance, api_key, force).returns(uuid)
       capture_io { subject }
+      assert_equal uuid, script_project_repository.get.uuid
     end
   end
 end

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -3,7 +3,7 @@
 require "project_types/script/test_helper"
 
 describe Script::Layers::Domain::PushPackage do
-  let(:uuid) { 'uuid' }
+  let(:uuid) { "uuid" }
   let(:extension_point_type) { "discount" }
   let(:script_id) { "id" }
   let(:script_name) { "foo_script" }

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -3,6 +3,7 @@
 require "project_types/script/test_helper"
 
 describe Script::Layers::Domain::PushPackage do
+  let(:uuid) { 'uuid' }
   let(:extension_point_type) { "discount" }
   let(:script_id) { "id" }
   let(:script_name) { "foo_script" }
@@ -15,6 +16,7 @@ describe Script::Layers::Domain::PushPackage do
   let(:push_package) do
     Script::Layers::Domain::PushPackage.new(
       id: id,
+      uuid: uuid,
       extension_point_type: extension_point_type,
       script_name: script_name,
       config_ui: config_ui,
@@ -32,6 +34,7 @@ describe Script::Layers::Domain::PushPackage do
     it "should construct new PushPackage" do
       assert_equal id, subject.id
       assert_equal script_content, subject.script_content
+      assert_equal uuid, subject.uuid
     end
   end
 
@@ -44,7 +47,8 @@ describe Script::Layers::Domain::PushPackage do
           kwargs[:script_name] == script_name &&
           kwargs[:script_content] == script_content &&
           kwargs[:compiled_type] == compiled_type &&
-          kwargs[:api_key] == api_key
+          kwargs[:api_key] == api_key &&
+          kwargs[:uuid] == uuid
       end
       subject
     end

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -237,7 +237,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     end
     let(:args) do
       {
-        uuid: updated_uuid
+        uuid: updated_uuid,
       }
     end
 
@@ -257,11 +257,11 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     describe "when updating an immutable property" do
       let(:args) do
         {
-          extension_point_type: 'a',
-          language: 'b',
-          script_name: 'c',
-          project_type: 'd',
-          organization_id: 'e',
+          extension_point_type: "a",
+          language: "b",
+          script_name: "c",
+          project_type: "d",
+          organization_id: "e",
         }
       end
 

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -64,6 +64,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         capture_io { subject }
 
         assert_nil subject.env
+        assert_nil subject.uuid
         assert_equal script_name, subject.script_name
         assert_equal extension_point_type, subject.extension_point_type
         assert_equal language, subject.language
@@ -120,10 +121,12 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     let(:script_name) { "script_name" }
     let(:extension_point_type) { "tax_filter" }
     let(:language) { "assemblyscript" }
+    let(:uuid) { "uuid" }
     let(:config_ui_file) { "config-ui.yml" }
     let(:config_ui_content) { "---\nversion: 1" }
     let(:valid_config) do
       {
+        "uuid" => uuid,
         "extension_point_type" => "tax_filter",
         "script_name" => "script_name",
         "config_ui_file" => config_ui_file,
@@ -144,6 +147,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       it "should return the ScriptProject" do
         assert_equal current_project.directory, subject.id
         assert_nil subject.env
+        assert_equal uuid, subject.uuid
         assert_equal script_name, subject.script_name
         assert_equal extension_point_type, subject.extension_point_type
         assert_equal language, subject.language
@@ -169,8 +173,12 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     end
 
     describe "when project is missing metadata" do
+      def hash_except(config, *keys)
+        config.slice(*(config.keys - keys))
+      end
+
       describe "when missing extension_point_type" do
-        let(:actual_config) { valid_config.slice("config_ui_file", "script_name") }
+        let(:actual_config) { hash_except(valid_config, "extension_point_type") }
 
         it "should raise InvalidContextError" do
           assert_raises(Script::Layers::Infrastructure::Errors::InvalidContextError) { subject }
@@ -178,7 +186,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       end
 
       describe "when missing script_name" do
-        let(:actual_config) { valid_config.slice("extension_point_type", "config_ui_file") }
+        let(:actual_config) { hash_except(valid_config, "script_name") }
 
         it "should raise InvalidContextError" do
           assert_raises(Script::Layers::Infrastructure::Errors::InvalidContextError) { subject }
@@ -186,10 +194,19 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       end
 
       describe "when missing config_ui_file" do
-        let(:actual_config) { valid_config.slice("extension_point_type", "script_name") }
+        let(:actual_config) { hash_except(valid_config, "config_ui_file") }
 
         it "should succeed" do
           assert subject
+        end
+      end
+
+      describe "when missing uuid" do
+        let(:actual_config) { hash_except(valid_config, "uuid") }
+
+        it "should succeed" do
+          assert subject
+          assert_nil subject.uuid
         end
       end
     end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -121,7 +121,7 @@ describe Script::Layers::Infrastructure::ScriptService do
                 "configSchema" => nil,
                 "extensionPointName" => extension_point_type,
                 "title" => "foo2",
-                "uuid" => uuid_from_server
+                "uuid" => uuid_from_server,
               },
               "userErrors" => [],
             },

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -30,6 +30,7 @@ describe Script::Layers::Infrastructure::ScriptService do
     let(:script_name) { "foo_bar" }
     let(:script_content) { "(module)" }
     let(:api_key) { "fake_key" }
+    let(:uuid) { "uuid" }
     let(:app_script_update_or_create) do
       <<~HERE
         mutation AppScriptUpdateOrCreate(
@@ -117,6 +118,7 @@ describe Script::Layers::Infrastructure::ScriptService do
                 "configSchema" => nil,
                 "extensionPointName" => extension_point_type,
                 "title" => "foo2",
+                "uuid" => uuid
               },
               "userErrors" => [],
             },
@@ -133,7 +135,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       end
 
       it "should post the form without scope" do
-        assert_equal(script_service_response, subject)
+        assert_equal(uuid, subject)
       end
 
       describe "when config_ui is nil" do
@@ -141,7 +143,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         let(:expected_config_ui_content) { nil }
 
         it "should succeed with a valid response" do
-          assert_equal(script_service_response, subject)
+          assert_equal(uuid, subject)
         end
       end
     end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -30,7 +30,8 @@ describe Script::Layers::Infrastructure::ScriptService do
     let(:script_name) { "foo_bar" }
     let(:script_content) { "(module)" }
     let(:api_key) { "fake_key" }
-    let(:uuid) { "uuid" }
+    let(:uuid_from_config) { "uuid_from_config" }
+    let(:uuid_from_server) { "uuid_from_server" }
     let(:app_script_update_or_create) do
       <<~HERE
         mutation AppScriptUpdateOrCreate(
@@ -76,6 +77,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         variables: {
           api_key: api_key,
           variables: {
+            uuid: uuid_from_config,
             extensionPointName: extension_point_type,
             title: script_name,
             configUi: expected_config_ui_content,
@@ -94,6 +96,7 @@ describe Script::Layers::Infrastructure::ScriptService do
 
     subject do
       script_service.push(
+        uuid: uuid_from_config,
         extension_point_type: extension_point_type,
         metadata: Script::Layers::Domain::Metadata.new(
           schema_major_version,
@@ -118,7 +121,7 @@ describe Script::Layers::Infrastructure::ScriptService do
                 "configSchema" => nil,
                 "extensionPointName" => extension_point_type,
                 "title" => "foo2",
-                "uuid" => uuid
+                "uuid" => uuid_from_server
               },
               "userErrors" => [],
             },
@@ -135,7 +138,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       end
 
       it "should post the form without scope" do
-        assert_equal(uuid, subject)
+        assert_equal(uuid_from_server, subject)
       end
 
       describe "when config_ui is nil" do
@@ -143,7 +146,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         let(:expected_config_ui_content) { nil }
 
         it "should succeed with a valid response" do
-          assert_equal(uuid, subject)
+          assert_equal(uuid_from_server, subject)
         end
       end
     end

--- a/test/project_types/script/test_helpers/fake_push_package_repository.rb
+++ b/test/project_types/script/test_helpers/fake_push_package_repository.rb
@@ -15,6 +15,7 @@ module TestHelpers
       id = id(script_project.script_name, compiled_type)
       @cache[id] = Script::Layers::Domain::PushPackage.new(
         id: id,
+        uuid: script_project.uuid,
         extension_point_type: script_project.extension_point_type,
         script_name: script_project.script_name,
         script_content: script_content,

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -28,6 +28,13 @@ module TestHelpers
       @project
     end
 
+    def update_config(**args)
+      mutable_args = args.slice(*Script::Layers::Infrastructure::ScriptProjectRepository::MUTABLE_CONFIG_VALUES)
+
+      @project.uuid = mutable_args[:uuid]
+      @project
+    end
+
     class FakeConfigUiRepository
       def initialize
         @cache = {}

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -15,6 +15,7 @@ module TestHelpers
 
       @project = Script::Layers::Domain::ScriptProject.new(
         id: "/#{script_name}",
+        uuid: nil,
         env: env || ShopifyCli::Resources::EnvFile.new(api_key: "1234", secret: "shh"),
         script_name: script_name,
         extension_point_type: extension_point_type,

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -15,7 +15,6 @@ module TestHelpers
 
       @project = Script::Layers::Domain::ScriptProject.new(
         id: "/#{script_name}",
-        uuid: nil,
         env: env || ShopifyCli::Resources::EnvFile.new(api_key: "1234", secret: "shh"),
         script_name: script_name,
         extension_point_type: extension_point_type,
@@ -28,10 +27,11 @@ module TestHelpers
       @project
     end
 
-    def update_config(**args)
-      mutable_args = args.slice(*Script::Layers::Infrastructure::ScriptProjectRepository::MUTABLE_CONFIG_VALUES)
+    def update_env(**args)
+      args.slice(*Script::Layers::Infrastructure::ScriptProjectRepository::MUTABLE_ENV_VALUES).each do |key, value|
+        @project.env.extra[key.to_s] = value
+      end
 
-      @project.uuid = mutable_args[:uuid]
       @project
     end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/2904

We want to uniquely identify scripts. On initial push, the server gives us a `uuid` which we'll store in the `.env`. This `uuid` will now be the thing we use to identify a script.

Note that this change doesn't fully support multiple scripts per extension point and app. There are still some waiting server side tasks for that.

### WHAT is this pull request doing?

- Stores `uuid` in the `.env` after a successful push
- If present in the `.env`, send the `uuid` in the package during `push`