### PR TITLE
feature: add tunnel option to ArgoServe

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -38,6 +38,7 @@ module Extension
     autoload :UpdateDraft, Project.project_filepath("tasks/update_draft")
     autoload :FetchSpecifications, Project.project_filepath("tasks/fetch_specifications")
     autoload :ConfigureFeatures, Project.project_filepath("tasks/configure_features")
+    autoload :ChooseNextAvailablePort, Project.project_filepath("tasks/choose_next_available_port")
 
     module Converters
       autoload :RegistrationConverter, Project.project_filepath("tasks/converters/registration_converter")
@@ -61,6 +62,7 @@ module Extension
   module Features
     autoload :ArgoRendererPackage, Project.project_filepath("features/argo_renderer_package")
     autoload :ArgoServe, Project.project_filepath("features/argo_serve")
+    autoload :ArgoServeOptions, Project.project_filepath("features/argo_serve_options")
     autoload :ArgoSetup, Project.project_filepath("features/argo_setup")
     autoload :ArgoSetupStep, Project.project_filepath("features/argo_setup_step")
     autoload :ArgoSetupSteps, Project.project_filepath("features/argo_setup_steps")

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -55,8 +55,11 @@ module Extension
       end
 
       def start_tunnel_if_required(runtime_configuration)
-        tunnel_url = ShopifyCli::Tunnel.start(@ctx, port: runtime_configuration.port)
-        runtime_configuration.tap { |c| c.tunnel_url = tunnel_url }
+        if runtime_configuration.tunnel_requested?
+          tunnel_url = ShopifyCli::Tunnel.start(@ctx, port: runtime_configuration.port)
+          runtime_configuration.tap { |c| c.tunnel_url = tunnel_url }
+        end
+        runtime_configuration
       end
 
       def serve(runtime_configuration)

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -3,15 +3,69 @@
 module Extension
   module Commands
     class Serve < ExtensionCommand
+      DEFAULT_PORT = 39351
+
+      options do |parser, flags|
+        parser.on("-t", "--[no-]tunnel", "Establish an ngrok tunnel") { |tunnel| flags[:tunnel] = tunnel }
+      end
+
+      class RuntimeConfiguration
+        include SmartProperties
+
+        property! :tunnel_url, accepts: String, default: ""
+        property! :tunnel_requested, accepts: [true, false], reader: :tunnel_requested?, default: true
+        property! :port, accepts: (1...(2**16)), default: DEFAULT_PORT
+      end
+
       def call(_args, _command_name)
-        specification_handler.serve(@ctx)
+        config = RuntimeConfiguration.new(
+          tunnel_requested: tunnel_requested?
+        )
+
+        ShopifyCli::Result
+          .success(config)
+          .then(&method(:find_available_port))
+          .then(&method(:start_tunnel_if_required))
+          .then(&method(:serve))
+          .unwrap { |error| raise error }
       end
 
       def self.help
         <<~HELP
           Serve your extension in a local simulator for development.
             Usage: {{command:#{ShopifyCli::TOOL_NAME} serve}}
+            Options:
+            {{command:--tunnel=TUNNEL}} Establish an ngrok tunnel (default: false)
         HELP
+      end
+
+      private
+
+      def tunnel_requested?
+        tunnel = options.flags[:tunnel]
+        tunnel.nil? || !!tunnel
+      end
+
+      def find_available_port(runtime_configuration)
+        chosen_port = Tasks::ChooseNextAvailablePort
+          .call(from: runtime_configuration.port)
+          .unwrap { |_error| @ctx.abort(@ctx.message("serve.no_available_ports_found")) }
+
+        runtime_configuration.tap { |c| c.port = chosen_port }
+      end
+
+      def start_tunnel_if_required(runtime_configuration)
+        tunnel_url = ShopifyCli::Tunnel.start(@ctx, port: runtime_configuration.port)
+        runtime_configuration.tap { |c| c.tunnel_url = tunnel_url }
+      end
+
+      def serve(runtime_configuration)
+        specification_handler.serve(
+          context: @ctx,
+          tunnel_url: runtime_configuration.tunnel_url,
+          port: runtime_configuration.port
+        )
+        runtime_configuration
       end
     end
   end

--- a/lib/project_types/extension/features/argo_renderer_package.rb
+++ b/lib/project_types/extension/features/argo_renderer_package.rb
@@ -10,7 +10,7 @@ module Extension
       PACKAGE_NAMES = [
         ARGO_CHECKOUT,
         ARGO_ADMIN,
-        ARGO_POST_PURCHASE
+        ARGO_POST_PURCHASE,
       ].freeze
       MINIMUM_ARGO_VERSION = "0.9.3".freeze
 
@@ -22,7 +22,7 @@ module Extension
           pattern = /(?<name>#{PACKAGE_NAMES.join("|")})@(?<version>\d.*)$/
           match = package_manager_output.match(pattern)
           raise PackageNotFound, package_manager_output if match.nil?
-          return new(package_name: match[:name], version: match[:version].strip)
+          new(package_name: match[:name], version: match[:version].strip)
         end
       end
 
@@ -38,7 +38,7 @@ module Extension
       # Temporarily returns false in all cases as the argo webpack server is
       # unable to handle the UUID flag.
       def supports_uuid_flag?
-        return false
+        false
         # return false if checkout?
         # Gem::Version.new(version) > Gem::Version.new(MINIMUM_ARGO_VERSION)
       end

--- a/lib/project_types/extension/features/argo_serve_options.rb
+++ b/lib/project_types/extension/features/argo_serve_options.rb
@@ -1,0 +1,37 @@
+module Extension
+  module Features
+    class ArgoServeOptions
+      include SmartProperties
+      property! :context, accepts: ShopifyCli::Context
+      property  :port, accepts: Integer, default: 39351
+      property  :public_url, accepts: String, default: ""
+      property! :required_fields, accepts: Array, default: -> { [] }
+      property! :renderer_package, accepts: Features::ArgoRendererPackage
+
+      YARN_SERVE_COMMAND = %w(server)
+      NPM_SERVE_COMMAND = %w(run-script server)
+
+      def yarn_serve_command
+        YARN_SERVE_COMMAND + options
+      end
+
+      def npm_serve_command
+        NPM_SERVE_COMMAND  + ["--"] + options
+      end
+
+      private
+
+      def options
+        project = ExtensionProject.current
+        @serve_options ||= [].tap do |options|
+          options << "--port=#{port}"
+          options << "--shop=#{project.env.shop}" if required_fields.include?(:shop)
+          options << "--apiKey=#{project.env.api_key}" if required_fields.include?(:api_key)
+          options << "--argoVersion=#{renderer_package.version}" if renderer_package.admin?
+          options << "--uuid=#{project.registration_uuid}" if renderer_package.supports_uuid_flag?
+          options << "--publicUrl=#{public_url}" unless public_url.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -56,6 +56,7 @@ module Extension
       },
       serve: {
         frame_title: "Serving extension...",
+        no_available_ports_found: "No available ports found to run extension.",
         serve_failure_message: "Failed to run extension code.",
         serve_missing_information: "Missing shop or api_key.",
       },

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -50,8 +50,8 @@ module Extension
           false
         end
 
-        def serve(context)
-          Features::ArgoServe.new(specification_handler: self, context: context).call
+        def serve(context:, port:, tunnel_url:)
+          Features::ArgoServe.new(specification_handler: self, context: context, port: port, tunnel_url: tunnel_url).call
         end
 
         def renderer_package(context)

--- a/lib/project_types/extension/tasks/choose_next_available_port.rb
+++ b/lib/project_types/extension/tasks/choose_next_available_port.rb
@@ -8,9 +8,8 @@ module Extension
       include ShopifyCli::MethodObject
 
       property! :from
-      property! :to, default: -> { from + 25 }
+      property! :to, default: -> { from + 10 }
       property! :host, default: "localhost"
-      property! :max_tries, default: 25
 
       def call
         available_port = port_range(from: from, to: to).find { |p| available?(host, p) }
@@ -21,7 +20,7 @@ module Extension
       private
 
       def port_range(from:, to:)
-        (from...to)
+        (from..to)
       end
 
       def available?(host, port)

--- a/lib/project_types/extension/tasks/choose_next_available_port.rb
+++ b/lib/project_types/extension/tasks/choose_next_available_port.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "shopify_cli"
+require "socket"
+
+module Extension
+  module Tasks
+    class ChooseNextAvailablePort
+      include ShopifyCli::MethodObject
+
+      property! :from
+      property! :to, default: -> { from + 25 }
+      property! :host, default: "localhost"
+      property! :max_tries, default: 25
+
+      def call
+        available_port = port_range(from: from, to: to).find { |p| available?(host, p) }
+        raise ArgumentError, "Ports between #{from} and #{to} are unavailable" if available_port.nil?
+        available_port
+      end
+
+      private
+
+      def port_range(from:, to:)
+        (from...to)
+      end
+
+      def available?(host, port)
+        Socket.tcp(host, port, connect_timeout: 1) do |socket|
+          socket.close
+          false
+        end
+      rescue Errno::ECONNREFUSED
+        true
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -19,6 +19,22 @@ module Extension
         serve.specification_handler.expects(:serve)
         serve.call([], "serve")
       end
+
+      def test_error_raised_if_no_available_ports_found
+        serve = ::Extension::Commands::Serve.new(@context)
+
+        socket = mock.tap { |s| s.expects(:close).times(25) }
+        25.times do |i|
+          port = ::Extension::Commands::Serve::DEFAULT_PORT + i
+          Socket.expects(:tcp).with("localhost", port, connect_timeout: 1).yields(socket).returns(false)
+        end
+
+        error = assert_raises ShopifyCli::Abort do
+          serve.call([], "serve")
+        end
+
+        assert_includes error.message, @context.message("serve.no_available_ports_found")
+      end
     end
   end
 end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -23,11 +23,10 @@ module Extension
       def test_error_raised_if_no_available_ports_found
         serve = ::Extension::Commands::Serve.new(@context)
 
-        socket = mock.tap { |s| s.expects(:close).times(25) }
-        25.times do |i|
-          port = ::Extension::Commands::Serve::DEFAULT_PORT + i
-          Socket.expects(:tcp).with("localhost", port, connect_timeout: 1).yields(socket).returns(false)
-        end
+        Tasks::ChooseNextAvailablePort.expects(:call)
+          .with(from: ::Extension::Commands::Serve::DEFAULT_PORT)
+          .returns(ShopifyCli::Result.failure(ArgumentError))
+          .once
 
         error = assert_raises ShopifyCli::Abort do
           serve.call([], "serve")

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -128,7 +128,8 @@ module Extension
           ArgoRendererPackage.stubs(:from_package_manager).raises(Extension::PackageNotFound)
 
           error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
-          assert_includes error.message, @context.message("features.argo.dependencies.argo_missing_renderer_package_error")
+          assert_includes error.message,
+            @context.message("features.argo.dependencies.argo_missing_renderer_package_error")
         end
       end
 

--- a/test/project_types/extension/tasks/argo_serve_options_test.rb
+++ b/test/project_types/extension/tasks/argo_serve_options_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Tasks
+    class ArgoServeOptionsTest < MiniTest::Test
+      include ExtensionTestHelpers::TempProjectSetup
+      include TestHelpers::FakeUI
+
+      DEFAULT_PORT = 39351
+
+      def test_serve_options_include_port_when_no_port_given
+        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin)
+
+        assert_includes(options.yarn_serve_command, "--port=#{DEFAULT_PORT}")
+        assert_includes(options.npm_serve_command, "--port=#{DEFAULT_PORT}")
+      end
+
+      def test_serve_options_use_custom_port_if_one_is_given
+        custom_port = 12345
+        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin, port: custom_port)
+
+        assert_includes(options.yarn_serve_command, "--port=#{custom_port}")
+        assert_includes(options.npm_serve_command, "--port=#{custom_port}")
+      end
+
+      def test_default_serve_options_include_api_key_when_required
+        required_fields = [:api_key]
+        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin,
+          required_fields: required_fields)
+
+        assert_includes(options.yarn_serve_command, "--apiKey=apikey")
+        assert_includes(options.npm_serve_command, "--apiKey=apikey")
+      end
+
+      def test_default_serve_options_include_shop_when_required
+        required_fields = [:shop]
+
+        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin,
+          required_fields: required_fields)
+
+        assert_includes(options.yarn_serve_command, "--shop=my-test-shop.myshopify.com")
+        assert_includes(options.npm_serve_command, "--shop=my-test-shop.myshopify.com")
+      end
+
+      def test_serve_options_include_argo_version_if_renderer_package_is_admin
+        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin)
+
+        assert_includes(options.yarn_serve_command, "--argoVersion=0.1.2")
+        assert_includes(options.npm_serve_command, "--argoVersion=0.1.2")
+      end
+
+      def test_public_url_is_included_if_one_is_given
+        tunnel_url = "test.com"
+        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin,
+        public_url: tunnel_url)
+
+        assert_includes(options.yarn_serve_command, "--publicUrl=#{tunnel_url}")
+        assert_includes(options.npm_serve_command, "--publicUrl=#{tunnel_url}")
+      end
+
+      def test_public_url_is_not_included_if_one_not_given
+        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin)
+
+        refute_includes(options.yarn_serve_command, "--publicUrl=test.com")
+        refute_includes(options.npm_serve_command, "--publicUrl=test.com")
+      end
+
+      private
+
+      def argo_renderer_package(package_name:, version: "0.1.2")
+        Features::ArgoRendererPackage.new(
+          package_name: package_name,
+          version: version
+        )
+      end
+
+      def argo_admin
+        argo_renderer_package(package_name: "@shopify/argo-admin")
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/choose_next_available_port_test.rb
+++ b/test/project_types/extension/tasks/choose_next_available_port_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Tasks
+    class ChooseNextAvailablePortTest < MiniTest::Test
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def test_given_port_is_returned_when_available
+        socket = mock.tap { |s| s.expects(:close).once }
+        Socket.expects(:tcp).with("example.com", 12345, connect_timeout: 1).yields(socket).returns(true).once
+
+        port = Tasks::ChooseNextAvailablePort.new(from: 12345, host: "example.com").call
+        assert_predicate(port, :success?)
+        assert_equal(12345, port.value)
+      end
+
+      def test_returns_next_available_port_if_given_port_is_taken
+        socket = mock.tap { |s| s.expects(:close).twice }
+        Socket.expects(:tcp).with("example.com", 12345, connect_timeout: 1).yields(socket).returns(false).once
+        Socket.expects(:tcp).with("example.com", 12346, connect_timeout: 1).yields(socket).returns(true).once
+
+        port = Tasks::ChooseNextAvailablePort.new(from: 12345, host: "example.com").call
+        assert_predicate(port, :success?)
+        assert_equal(12346, port.value)
+      end
+
+      def test_aborts_after_max_tries_exceeded
+        socket = mock.tap { |s| s.expects(:close).twice }
+        Socket.expects(:tcp).with("example.com", 12345, connect_timeout: 1).yields(socket).returns(false)
+        Socket.expects(:tcp).with("example.com", 12346, connect_timeout: 1).yields(socket).returns(false)
+
+        port = Tasks::ChooseNextAvailablePort.new(from: 12345, host: "example.com", to: 12347).call
+        assert_predicate(port, :failure?)
+        port.error.tap do |error|
+          assert_kind_of(ArgumentError, error)
+          assert_equal("Ports between 12345 and 12347 are unavailable", error.message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ We're not going to release this change as is as it breaks backwards compatibility. Instead, this branch is going to be merged into `project/extension-serve` and followed up with PR that will introduce guards that probe whether the currently installed version of Argo Admin CLI already supports the new API, a.k.a provides support for `--port` and `--publicURL`.

---

### WHY are these changes introduced?

Closes: https://github.com/Shopify/shopify-app-cli/issues/1174

### WHAT is this pull request doing?

* Moving argo serve options to its own class, as this logic continues to grow. This should make options more scalable and configurable.
* Adding a `tunnel` flag to `serve` command, passing down the flag to `argo_serve`
* If tunnel is true, a tunnel is created on either the argo default port, or the next available port if the default port is taken
* The tunnel URL is passed down to the `argo_admin_cli` via a `publicUrl` argument

## Tophat 🎩 

* `cd` into an argo extension project
* Ensure the version of `argo-admin-cli` the extension is using is `0.10.1-alpha.2`
```
  "devDependencies": {
    "@shopify/argo-admin-cli": "0.10.1-alpha.2"
  },
```
* run `shopify serve`
* `publicUrl` should appear as an argument passed to `argo-admin-cli`

<img width="1895" alt="Screen Shot 2021-04-28 at 10 37 58 AM" src="https://user-images.githubusercontent.com/989784/116432950-a7040880-a80e-11eb-984f-f42a2d40e8a6.png">

Running the command with `shopify serve --no-tunnel` should serve the command with no `--publicUrl` option.

As part of this change, we're also passing in the port to `argo-admin-cli`, if you want to create a new application with the new template that does not have the `--port` hardcoded into it, replace [this line](https://github.com/Shopify/shopify-app-cli/blob/master/lib/shopify-cli/git.rb#L51) in `Shopify::Git` with this line:

`clone_progress("clone", "-b", "feature/remove-hardcoded-port", "--single-branch", repository, dest, ctx: ctx)`

Otherwise, you will see 2 ports as part of the flags being passed. The first port is the hardcoded port, the second port is the port Shopify CLI is passing.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
