### PR TITLE
[scripts] upcase uuid key in .env

### DIFF
--- a/lib/project_types/script/layers/domain/script_project.rb
+++ b/lib/project_types/script/layers/domain/script_project.rb
@@ -30,7 +30,7 @@ module Script
         end
 
         def uuid
-          env&.extra&.[]("uuid")
+          env&.extra&.[]("UUID")
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -61,7 +61,7 @@ module Script
         def update_env(**args)
           capture_io do
             args.slice(*MUTABLE_ENV_VALUES).each do |key, value|
-              project.env.extra[key.to_s] = value
+              project.env.extra[key.to_s.upcase] = value
               project.env.update(ctx, :extra, project.env.extra)
             end
           end

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -154,7 +154,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       describe "when env has values" do
         let(:uuid) { "uuid" }
         let(:api_key) { "api_key" }
-        let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: api_key, secret: "foo", extra: { "uuid" => uuid }) }
+        let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: api_key, secret: "foo", extra: { "UUID" => uuid }) }
 
         it "should provide access to the env values" do
           ShopifyCli::Project.any_instance.expects(:env).returns(env).at_least_once
@@ -302,9 +302,9 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         ShopifyCli::Project.clear
         updated_env = ShopifyCli::Project.current.env.to_h
 
-        assert_equal hash_except(previous_env, "uuid"), hash_except(updated_env, "uuid")
-        refute_equal previous_env["uuid"], updated_env["uuid"]
-        assert_equal updated_uuid, updated_env["uuid"]
+        assert_equal hash_except(previous_env, "UUID"), hash_except(updated_env, "UUID")
+        refute_equal previous_env["UUID"], updated_env["UUID"]
+        assert_equal updated_uuid, updated_env["UUID"]
         assert_equal updated_uuid, subject.uuid
       end
     end

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -15,7 +15,7 @@ module TestHelpers
 
       @project = Script::Layers::Domain::ScriptProject.new(
         id: "/#{script_name}",
-        env: env || ShopifyCli::Resources::EnvFile.new(api_key: "1234", secret: "shh"),
+        env: env || ShopifyCli::Resources::EnvFile.new(api_key: "1234", secret: "shh", extra: {}),
         script_name: script_name,
         extension_point_type: extension_point_type,
         language: language,
@@ -29,7 +29,7 @@ module TestHelpers
 
     def update_env(**args)
       args.slice(*Script::Layers::Infrastructure::ScriptProjectRepository::MUTABLE_ENV_VALUES).each do |key, value|
-        @project.env.extra[key.to_s] = value
+        @project.env.extra[key.to_s.upcase] = value
       end
 
       @project


### PR DESCRIPTION
### WHY are these changes introduced?

The UUID is currently stored as downcase in the env, but other keys are stored as UPCASE.

### WHAT is this pull request doing?

Stores the uuid in the `.env` file like `UUID=fi8db-...` instead of `uuid=fi8db-...` to be consistent. 
