### PR TITLE
Add php create command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [1197](https://github.com/Shopify/shopify-app-cli/pull/1197): Add `create` command for PHP app projects.
 
 Version 1.9.0
 -------------

--- a/lib/project_types/php/cli.rb
+++ b/lib/project_types/php/cli.rb
@@ -22,6 +22,6 @@ module PHP
 
   # define/autoload project specific Forms
   module Forms
-    # autoload :Create, Project.project_filepath("forms/create")
+    autoload :Create, Project.project_filepath("forms/create")
   end
 end

--- a/lib/project_types/php/commands/create.rb
+++ b/lib/project_types/php/commands/create.rb
@@ -1,16 +1,96 @@
 # frozen_string_literal: true
+require "semantic/semantic"
+
 module PHP
   module Commands
     class Create < ShopifyCli::SubCommand
       options do |parser, flags|
+        parser.on("--name=NAME") { |name| flags[:title] = name }
+        parser.on("--organization-id=ID") { |organization_id| flags[:organization_id] = organization_id }
+        parser.on("--shop-domain=MYSHOPIFYDOMAIN") { |shop_domain| flags[:shop_domain] = shop_domain }
+        parser.on("--type=APPTYPE") { |type| flags[:type] = type }
+        parser.on("--verbose") { flags[:verbose] = true }
       end
 
-      def call(_args, _name)
-        raise NotImplementedError
+      def call(args, _name)
+        form = Forms::Create.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) if form.nil?
+
+        check_php
+        check_composer
+        build(form.name)
+
+        ShopifyCli::Project.write(
+          @ctx,
+          project_type: "php",
+          organization_id: form.organization_id,
+        )
+
+        api_client = ShopifyCli::Tasks::CreateApiClient.call(
+          @ctx,
+          org_id: form.organization_id,
+          title: form.title,
+          type: form.type,
+        )
+
+        ShopifyCli::Resources::EnvFile.new(
+          api_key: api_client["apiKey"],
+          secret: api_client["apiSecretKeys"].first["secret"],
+          shop: form.shop_domain,
+          scopes: "write_products,write_customers,write_draft_orders",
+        ).write(@ctx)
+
+        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client["id"], local_debug?)
+
+        @ctx.puts(@ctx.message("apps.create.info.created", form.title, partners_url))
+        @ctx.puts(@ctx.message("apps.create.info.serve", form.name, ShopifyCli::TOOL_NAME))
+        unless ShopifyCli::Shopifolk.acting_as_shopify_organization?
+          @ctx.puts(@ctx.message("apps.create.info.install", partners_url, form.title))
+        end
       end
 
       def self.help
-        ShopifyCli::Context.message("php.create.help", ShopifyCli::TOOL_NAME)
+        ShopifyCli::Context.message("php.create.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+      end
+
+      private
+
+      def check_php
+        cmd_path = @ctx.which("php")
+        @ctx.abort(@ctx.message("php.create.error.php_required")) if cmd_path.nil?
+
+        version, stat = @ctx.capture2e("php", "-r", "echo phpversion();")
+        @ctx.abort(@ctx.message("php.create.error.php_version_failure")) unless stat.success?
+
+        if ::Semantic::Version.new(version) < ::Semantic::Version.new('8.0.0')
+          @ctx.abort(@ctx.message("php.create.error.php_version_too_low", '8.0'))
+        end
+
+        @ctx.done(@ctx.message("php.create.php_version", version))
+      end
+
+      def check_composer
+        cmd_path = @ctx.which("composer")
+        @ctx.abort(@ctx.message("php.create.error.composer_required")) if cmd_path.nil?
+      end
+
+      def build(name)
+        ShopifyCli::Git.clone("https://github.com/Shopify/shopify-app-php.git", name)
+
+        @ctx.root = File.join(@ctx.root, name)
+
+        ShopifyCli::PHPDeps.install(@ctx, !options.flags[:verbose].nil?)
+
+        begin
+          @ctx.rm_r(".git")
+          @ctx.rm_r(".github")
+        rescue Errno::ENOENT => e
+          @ctx.debug(e)
+        end
+      end
+
+      def local_debug?
+        @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
       end
     end
   end

--- a/lib/project_types/php/forms/create.rb
+++ b/lib/project_types/php/forms/create.rb
@@ -1,0 +1,45 @@
+require "uri"
+
+module PHP
+  module Forms
+    class Create < ShopifyCli::Form
+      attr_accessor :name
+      flag_arguments :title, :organization_id, :shop_domain, :type
+
+      def ask
+        self.title ||= CLI::UI::Prompt.ask(ctx.message("php.forms.create.app_name"))
+        self.name = format_name
+        self.type = ask_type
+        res = ShopifyCli::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
+        self.organization_id = res[:organization_id]
+        self.shop_domain = res[:shop_domain]
+      end
+
+      private
+
+      def format_name
+        name = title.downcase.split(" ").join("_")
+
+        if name.include?("shopify")
+          ctx.abort(ctx.message("php.forms.create.error.invalid_app_name"))
+        end
+        name
+      end
+
+      def ask_type
+        if type.nil?
+          return CLI::UI::Prompt.ask(ctx.message("php.forms.create.app_type.select")) do |handler|
+            handler.option(ctx.message("php.forms.create.app_type.select_public")) { "public" }
+            handler.option(ctx.message("php.forms.create.app_type.select_custom")) { "custom" }
+          end
+        end
+
+        unless ShopifyCli::Tasks::CreateApiClient::VALID_APP_TYPES.include?(type)
+          ctx.abort(ctx.message("php.forms.create.error.invalid_app_type", type))
+        end
+        ctx.puts(ctx.message("php.forms.create.app_type.selected", type))
+        type
+      end
+    end
+  end
+end

--- a/lib/project_types/php/messages/messages.rb
+++ b/lib/project_types/php/messages/messages.rb
@@ -6,8 +6,49 @@ module PHP
       php: {
         create: {
           help: <<~HELP,
-            {{command:%s create php}}: Not implemented yet
+          {{command:%s create php}}: Creates an embedded PHP app.
+            Usage: {{command:%s create php}}
+            Options:
+              {{command:--name=NAME}} App name. Any string.
+              {{command:--organization-id=ID}} Partner organization ID. Must be an existing organization.
+              {{command:--shop-domain=MYSHOPIFYDOMAIN}} Development store URL. Must be an existing development store.
+              {{command:--type=APPTYPE}} Whether this app is public or custom.
+              {{command:--verbose}} Output verbose information when installing dependencies.
           HELP
+
+          error: {
+            php_required: <<~VERSION,
+            PHP is required to create an app project. For installation instructions, visit:
+              {{underline:https://www.php.net/manual/en/install.php}}
+            VERSION
+            php_version_failure: <<~VERSION,
+            Failed to get the current PHP version. Please make sure it is installed as per the instructions at:
+              {{underline:https://www.php.net/manual/en/install.php.}}
+            VERSION
+            php_version_too_low: "Your PHP version is too low. Please use version %s or higher.",
+            composer_required: <<~COMPOSER,
+            Composer is required to create an app project. Download at:
+              {{underline:https://getcomposer.org/download/}}
+            COMPOSER
+          },
+
+          php_version: "PHP %s",
+        },
+
+        forms: {
+          create: {
+            error: {
+              invalid_app_name: "App name cannot contain 'Shopify'",
+              invalid_app_type: "Invalid app type %s",
+            },
+            app_name: "App name",
+            app_type: {
+              select: "What type of app are you building?",
+              select_public: "Public: An app built for a wide merchant audience.",
+              select_custom: "Custom: An app custom built for a single client.",
+              selected: "App type {{green:%s}}",
+            },
+          },
         },
       },
     }.freeze

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -180,6 +180,19 @@ module ShopifyCli
           },
         },
 
+        php_deps: {
+          error: {
+              missing_package: "Expected to have a file at: %s",
+              invalid_package: "{{info:%s}} was not valid JSON. Fix this then try again",
+              install_spinner_error: "Unable to install all %d dependencies",
+              install_error: "An error occurred while installing dependencies",
+          },
+
+          installing: "Installing Composer dependencies...",
+          installed: "Dependencies installed",
+          installed_count: "%d dependencies installed",
+        },
+
         api: {
           error: {
             internal_server_error: "{{red:{{x}} An unexpected error occurred on Shopify.}}",

--- a/lib/shopify-cli/php_deps.rb
+++ b/lib/shopify-cli/php_deps.rb
@@ -1,0 +1,99 @@
+require "shopify_cli"
+
+module ShopifyCli
+  ##
+  # ShopifyCli::PHPDeps ensures that all PHP dependencies are installed for projects.
+  #
+  class PHPDeps
+    include SmartProperties
+
+    property! :ctx, accepts: ShopifyCli::Context
+
+    ##
+    # Proxy to instance method ShopifyCli::PHPDeps.new.install.
+    #
+    # #### Parameters
+    # - `ctx`: running context from your command
+    # - `verbose`: whether to run the installation tools in verbose mode
+    #
+    # #### Example
+    #
+    #   ShopifyCli::PHPDeps.install(ctx)
+    #
+    def self.install(ctx, verbose = false)
+      new(ctx: ctx).install(verbose)
+    end
+
+    ##
+    # Installs all of a project's PHP dependencies using Composer.
+    #
+    # #### Parameters
+    # - `verbose`: whether to run the installation tools in verbose mode
+    #
+    # #### Example
+    #
+    #   # context is the running context for the command
+    #   ShopifyCli::PHPDeps.new(context).install(true)
+    #
+    def install(verbose = false)
+      title = ctx.message("core.php_deps.installing")
+      success = ctx.message("core.php_deps.installed")
+      failure = ctx.message("core.php_deps.error.install_error")
+
+      CLI::UI::Frame.open(title, success_text: success, failure_text: failure) do
+        composer(verbose)
+      end
+    end
+
+    private
+
+    def composer(verbose = false)
+      cmd = %w(composer install)
+      cmd << "--quiet" unless verbose
+
+      run_install_command(cmd)
+    end
+
+    def run_install_command(cmd)
+      deps = parse_dependencies
+      errors = nil
+
+      spinner_title = ctx.message("core.php_deps.installing")
+      success = CLI::UI::Spinner.spin(spinner_title, auto_debrief: false) do |spinner|
+        _out, errors, status = CLI::Kit::System.capture3(*cmd, env: @ctx.env, chdir: ctx.root)
+        update_spinner_title_and_status(spinner, status, deps)
+      end
+
+      errors.lines.each { |e| ctx.puts e } unless success || errors.nil?
+      success
+    end
+
+    def update_spinner_title_and_status(spinner, status, deps)
+      if status.success?
+        spinner.update_title(ctx.message("core.php_deps.installed_count", deps.size))
+      else
+        spinner.update_title(ctx.message("core.php_deps.error.install_spinner_error", deps.size))
+        CLI::UI::Spinner::TASK_FAILED
+      end
+    end
+
+    def parse_dependencies
+      composer_json = File.join(ctx.root, "composer.json")
+      pkg = begin
+        JSON.parse(File.read(composer_json))
+      rescue Errno::ENOENT, Errno::ENOTDIR
+        ctx.abort(ctx.message("core.php_deps.error.missing_package", composer_json))
+      end
+
+      %w(require require-dev).map do |key|
+        pkg.fetch(key, []).keys
+      end.flatten
+    rescue JSON::ParserError
+      ctx.puts(
+        ctx.message("core.php_deps.error.invalid_package", File.read(File.join(path, "composer.json"))),
+        error: true
+      )
+      raise ShopifyCli::AbortSilent
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -108,6 +108,7 @@ module ShopifyCli
   autoload :Heroku, "shopify-cli/heroku"
   autoload :JsDeps, "shopify-cli/js_deps"
   autoload :JsSystem, "shopify-cli/js_system"
+  autoload :PHPDeps, "shopify-cli/php_deps"
   autoload :MethodObject, "shopify-cli/method_object"
   autoload :LazyDelegator, "shopify-cli/lazy_delegator"
   autoload :Log, "shopify-cli/log"

--- a/test/project_types/php/commands/create_test.rb
+++ b/test/project_types/php/commands/create_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+require "project_types/php/test_helper"
+require "semantic/semantic"
+
+module PHP
+  module Commands
+    class CreateTest < MiniTest::Test
+      include TestHelpers::Partners
+      include TestHelpers::FakeUI
+
+      ENV_FILE = <<~CONTENT
+        SHOPIFY_API_KEY=newapikey
+        SHOPIFY_API_SECRET=secret
+        SHOP=testshop.myshopify.com
+        SCOPES=write_products,write_customers,write_draft_orders
+      CONTENT
+
+      SHOPIFYCLI_FILE = <<~APPTYPE
+        ---
+        project_type: php
+        organization_id: 42
+      APPTYPE
+
+      def test_prints_help_with_no_name_argument
+        io = capture_io { run_cmd("create php --help") }
+        assert_match(CLI::UI.fmt(PHP::Commands::Create.help), io.join)
+      end
+
+      def test_check_php_installed
+        @context.expects(:which).with("php").returns(nil)
+        assert_raises ShopifyCli::Abort, "php.create.error.php_required" do
+          perform_command
+        end
+      end
+
+      def test_check_get_php_version
+        @context.expects(:which).with("php").returns("/usr/bin/php")
+        @context.expects(:capture2e).with("php", "-r", "echo phpversion();").returns([nil, mock(success?: false)])
+        assert_raises ShopifyCli::Abort, "php.create.error.php_version_failure" do
+          perform_command
+        end
+      end
+
+      def test_check_composer_installed
+        @context.expects(:which).with("php").returns("/usr/bin/php")
+        @context.expects(:which).with("composer").returns(nil)
+        assert_raises ShopifyCli::Abort, "php.create.error.composer_required" do
+          perform_command
+        end
+      end
+
+      def test_can_create_new_app
+        create_test_app_directory_structure
+
+        @context.stubs(:uname).returns("Mac")
+        expect_php_composer_check_commands
+        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-php.git", "test-app")
+        ShopifyCli::PHPDeps.expects(:install)
+
+        stub_partner_req(
+          "create_app",
+          variables: {
+            org: 42,
+            title: "test-app",
+            type: "public",
+            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            redir: ["http://127.0.0.1:3456"],
+          },
+          resp: {
+            'data': {
+              'appCreate': {
+                'app': {
+                  'apiKey': "newapikey",
+                  'apiSecretKeys': [{ 'secret': "secret" }],
+                },
+              },
+            },
+          }
+        )
+
+        perform_command
+
+        assert_equal SHOPIFYCLI_FILE, File.read("test-app/.shopify-cli.yml")
+        assert_equal ENV_FILE, File.read("test-app/.env")
+        refute File.exist?("test-app/.git")
+        refute File.exist?("test-app/.github")
+
+        FileUtils.rm_r("test-app")
+      end
+
+      private
+
+      def perform_command
+        run_cmd("create php \
+          --name=test-app \
+          --type=public \
+          --organization-id=42 \
+          --shop-domain=testshop.myshopify.com")
+      end
+
+      def expect_php_composer_check_commands
+        @context.expects(:which).with("php").returns("/usr/bin/php")
+        @context.expects(:capture2e).with("php", "-r", "echo phpversion();").returns(["8.0.0", mock(success?: true)])
+        @context.expects(:which).with("composer").returns("/usr/bin/composer")
+      end
+
+      def create_test_app_directory_structure
+        FileUtils.mkdir_p("test-app")
+        FileUtils.touch("test-app/.git")
+        FileUtils.touch("test-app/.github")
+      end
+    end
+  end
+end

--- a/test/project_types/php/forms/create_test.rb
+++ b/test/project_types/php/forms/create_test.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+require "project_types/php/test_helper"
+
+module PHP
+  module Forms
+    class CreateTest < MiniTest::Test
+      include TestHelpers::Partners
+
+      def setup
+        super
+        ShopifyCli::Shopifolk.stubs(:check)
+        stub_shopify_org_confirmation
+      end
+
+      def test_returns_all_defined_attributes_if_valid
+        form = ask
+        assert_equal("test_app", form.name)
+        assert_equal("Test App", form.title)
+        assert_equal(42, form.organization_id)
+        assert_equal("shop.myshopify.com", form.shop_domain)
+      end
+
+      def test_title_can_be_provided_by_flag
+        form = ask(title: "My New App")
+        assert_equal("my_new_app", form.name)
+        assert_equal("My New App", form.title)
+      end
+
+      def test_aborts_if_title_includes_shopify
+        io = capture_io do
+          form = ask(title: "Shopify")
+          assert_nil(form)
+        end
+        assert_match(@context.message("php.forms.create.error.invalid_app_name"), io.join)
+      end
+
+      def test_type_can_be_provided_by_flag
+        form = ask(type: "public")
+        assert_equal("public", form.type)
+      end
+
+      def test_type_is_validated
+        io = capture_io do
+          form = ask(type: "not_a_type")
+          assert_nil(form)
+        end
+        assert_match(@context.message("php.forms.create.error.invalid_app_type", "not_a_type"), io.join)
+      end
+
+      def test_type_is_prompted
+        CLI::UI::Prompt.expects(:ask).with(@context.message("php.forms.create.app_type.select")).returns("public")
+        ask(type: nil)
+      end
+
+      def test_user_will_be_prompted_if_more_than_one_organization
+        stub_partner_req(
+          "all_organizations",
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    'id': 421,
+                    'businessName': "one",
+                    'stores': { 'nodes': [{ 'shopDomain': "store.myshopify.com" }] },
+                  },
+                  {
+                    'id': 431,
+                    'businessName': "two",
+                    'stores': {
+                      'nodes': [
+                        { 'shopDomain': "other.myshopify.com", 'transferDisabled': true },
+                        { 'shopDomain': "yet-another.myshopify.com" },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        )
+        CLI::UI::Prompt.expects(:ask).returns(431)
+        form = ask(org_id: nil, shop: nil)
+        assert_equal(431, form.organization_id)
+        assert_equal("other.myshopify.com", form.shop_domain)
+      end
+
+      def test_will_auto_pick_with_only_one_org
+        stub_partner_req(
+          "all_organizations",
+          resp: {
+            data: {
+              organizations: {
+                nodes: [{
+                  'id': 421,
+                  'businessName': "hoopy froods",
+                  'stores': { 'nodes': [{ 'shopDomain': "next.myshopify.com", 'transferDisabled': true }] },
+                }],
+              },
+            },
+          },
+        )
+        io = capture_io do
+          form = ask(org_id: nil, shop: nil)
+          assert_equal(421, form.organization_id)
+          assert_equal("next.myshopify.com", form.shop_domain)
+        end
+        assert_match(
+          CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.organization", "hoopy froods", 421)),
+          io.join,
+        )
+      end
+
+      def test_organization_will_be_fetched_if_id_is_provided_but_not_shop
+        stub_partner_req(
+          "find_organization",
+          variables: { id: 123 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 123,
+                    stores: { nodes: [{ shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true }] },
+                  },
+                ],
+              },
+            },
+          }
+        )
+        form = ask(org_id: 123, shop: nil)
+        assert_equal(123, form.organization_id)
+        assert_equal("shopdomain.myshopify.com", form.shop_domain)
+      end
+
+      def test_it_will_fail_if_no_orgs_are_available
+        stub_partner_req(
+          "all_organizations",
+          resp: { data: { organizations: { nodes: [] } } },
+        )
+
+        io = capture_io do
+          form = ask(org_id: nil, shop: nil)
+          assert_nil(form)
+        end
+        assert_match(@context.message("core.tasks.select_org_and_shop.error.partners_notice"), io.join)
+        assert_match(@context.message("core.tasks.select_org_and_shop.error.no_organizations"), io.join)
+      end
+
+      def test_returns_no_shop_if_none_are_available
+        stub_partner_req(
+          "find_organization",
+          variables: { id: 123 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [{ id: 123, stores: { nodes: [] } }],
+              },
+            },
+          }
+        )
+
+        io = capture_io do
+          form = ask(org_id: 123, shop: nil)
+          assert_nil form.shop_domain
+        end
+        log = io.join
+        assert_match(CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.error.no_development_stores")), log)
+        assert_match(CLI::UI.fmt(@context.message("core.tasks.select_org_and_shop.create_store", 123)), log)
+      end
+
+      def test_autopicks_only_shop
+        stub_partner_req(
+          "find_organization",
+          variables: { id: 123 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 123,
+                    stores: { nodes: [{ shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true }] },
+                  },
+                ],
+              },
+            },
+          }
+        )
+        io = capture_io do
+          form = ask(org_id: 123, shop: nil)
+          assert_equal("shopdomain.myshopify.com", form.shop_domain)
+        end
+        assert_match(CLI::UI.fmt(
+          @context.message("core.tasks.select_org_and_shop.development_store", "shopdomain.myshopify.com")
+        ), io.join)
+      end
+
+      def test_prompts_user_to_pick_from_shops
+        stub_partner_req(
+          "find_organization",
+          variables: { id: 123 },
+          resp: {
+            data: {
+              organizations: {
+                nodes: [
+                  {
+                    id: 123,
+                    stores: { nodes: [
+                      { shopDomain: "shopdomain.myshopify.com", 'transferDisabled': true },
+                      { shopDomain: "shop.myshopify.com", 'convertableToPartnerTest': true },
+                      { shopDomain: "other.myshopify.com" },
+                    ] },
+                  },
+                ],
+              },
+            },
+          }
+        )
+
+        CLI::UI::Prompt.expects(:ask)
+          .with(
+            @context.message("core.tasks.select_org_and_shop.development_store_select"),
+            options: %w(shopdomain.myshopify.com shop.myshopify.com)
+          )
+          .returns("selected")
+        form = ask(org_id: 123, shop: nil)
+        assert_equal("selected", form.shop_domain)
+      end
+
+      private
+
+      def ask(title: "Test App", org_id: 42, shop: "shop.myshopify.com", type: "custom")
+        Create.ask(
+          @context,
+          [],
+          title: title,
+          type: type,
+          organization_id: org_id,
+          shop_domain: shop,
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/php/test_helper.rb
+++ b/test/project_types/php/test_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+require "test_helper"
+
+ShopifyCli::ProjectType.load_type(:php)


### PR DESCRIPTION
### WHY are these changes introduced?

The first step in creating a new PHP app is actually cloning the repo. This PR adds the `create` command which is essentially the same as the node / rails ones, which clones the example repo and installs the composer dependencies so the app can run.

### WHAT is this pull request doing?

Adding a `create` command, that looks more or less like so:

![create_php_app](https://user-images.githubusercontent.com/64600052/116719909-989e2400-a9a9-11eb-8dca-7103338ad443.gif)

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
