### PR TITLE
Change Post Purchase Render Package

### DIFF
--- a/lib/project_types/extension/features/argo_renderer_package.rb
+++ b/lib/project_types/extension/features/argo_renderer_package.rb
@@ -4,11 +4,13 @@ module Extension
       include SmartProperties
 
       ARGO_CHECKOUT = "@shopify/argo-checkout"
+      ARGO_POST_PURCHASE = "@shopify/argo-post-purchase"
       ARGO_ADMIN = "@shopify/argo-admin"
 
       PACKAGE_NAMES = [
         ARGO_CHECKOUT,
         ARGO_ADMIN,
+        ARGO_POST_PURCHASE,
       ].freeze
       MINIMUM_ARGO_VERSION = "0.9.3".freeze
 
@@ -21,6 +23,10 @@ module Extension
 
       def admin?
         package_name == ARGO_ADMIN
+      end
+
+      def post_purchase?
+        package_name == ARGO_POST_PURCHASE
       end
 
       def supports_uuid_flag?

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -45,7 +45,7 @@ module Extension
           },
           checkout: {
             git_template: "https://github.com/Shopify/argo-checkout-template.git",
-            renderer_package_name: "@shopify/argo-checkout",
+            renderer_package_name: "@shopify/argo-post-purchase",
           },
         }
       end

--- a/test/project_types/extension/features/argo_renderer_package_test.rb
+++ b/test/project_types/extension/features/argo_renderer_package_test.rb
@@ -22,6 +22,14 @@ module Extension
         assert_predicate(argo_renderer_package, :admin?)
       end
 
+      def test_admin_is_returned_for_admin_package
+        argo_renderer_package = Features::ArgoRendererPackage.new(
+          package_name: Features::ArgoRendererPackage::ARGO_POST_PURCHASE,
+          version: "1.2.3"
+        )
+        assert_predicate(argo_renderer_package, :post_purchase?)
+      end
+
       def test_argo_minimum_version_supports_uuid_flag
         uuid_supported = Features::ArgoRendererPackage.new(
           package_name: Features::ArgoRendererPackage::ARGO_ADMIN,

--- a/test/project_types/extension/tasks/configure_features_test.rb
+++ b/test/project_types/extension/tasks/configure_features_test.rb
@@ -60,10 +60,10 @@ module Extension
         )
       end
 
-      def test_correct_renderer_package_name_for_checkout_extensions
+      def test_correct_renderer_package_name_for_checkout_post_purchase_extensions
         set_of_attributes = build_set_of_specification_attributes(surface: "checkout")
         result = ConfigureFeatures.call(set_of_attributes)
-        assert_equal "@shopify/argo-checkout", result.value.dig(0, :features, :argo, :renderer_package_name)
+        assert_equal "@shopify/argo-post-purchase", result.value.dig(0, :features, :argo, :renderer_package_name)
       end
 
       private


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/argo-private/issues/1503.

### WHAT is this pull request doing?

Changes the renderer package for post purchase extensions from `@Shopify/argo-checkout` to `@Shopify/argo-post-purchase`.


### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
