### PR TITLE
Determine Argo Renderer Dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ------
 
+* [1201](https://github.com/Shopify/shopify-app-cli/pull/1201) Determine Argo Renderer Dynamically. This fixes `shopify serve` and `shopify push` for extensions.
+
 Version 1.9.0
 -------------
 * [1181](https://github.com/Shopify/shopify-app-cli/pull/1181): Remove the subcommand references of the `generate` command for node apps (fixes [1176](https://github.com/Shopify/shopify-app-cli/issues/1176))

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Extension
+  class PackageNotFound < RuntimeError; end
+
   class Project < ShopifyCli::ProjectType
     hidden_feature
     title("App Extension")

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -67,9 +67,9 @@ module Extension
           npm: npm_list,
           capture_response: true
         )
-        context.abort(
-          context.message("features.argo.dependencies.argo_missing_renderer_package_error", error)
-        ) unless status.success?
+        # context.abort(
+        #   context.message("features.argo.dependencies.argo_missing_renderer_package_error", error)
+        # ) unless status.success?
         result
       end
 

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -14,8 +14,8 @@ module Extension
       SCRIPT_PATH = %w(build main.js).freeze
 
       NPM_LIST_COMMAND = %w(list).freeze
-      YARN_LIST_COMMAND = %w(list --pattern).freeze
-      NPM_LIST_PARAMETERS = %w(--prod).freeze
+      YARN_LIST_COMMAND = %w(list).freeze
+      NPM_LIST_PARAMETERS = %w(--prod --depth=1).freeze
       YARN_LIST_PARAMETERS = %w(--production).freeze
       private_constant :NPM_LIST_COMMAND, :YARN_LIST_COMMAND, :NPM_LIST_PARAMETERS, :YARN_LIST_PARAMETERS
 
@@ -39,7 +39,7 @@ module Extension
         context.abort(context.message("features.argo.missing_file_error")) unless File.exist?(filepath)
         begin
           {
-            renderer_version: extract_argo_renderer_version(context),
+            renderer_version: renderer_package(context).version,
             serialized_script: Base64.strict_encode64(File.read(filepath).chomp),
           }
         rescue StandardError
@@ -48,45 +48,23 @@ module Extension
       end
 
       def renderer_package(context)
-        Features::ArgoRendererPackage.new(
-          package_name: renderer_package_name, version: extract_argo_renderer_version(context)
+        Features::ArgoRendererPackage.from_package_manager(run_list_command(context))
+      rescue Extension::PackageNotFound
+        context.abort(
+          context.message("features.argo.dependencies.argo_missing_renderer_package_error")
         )
       end
 
       private
 
-      def extract_argo_renderer_version(context)
-        result = run_list_command(context)
-        found_version = find_version_number(context, result)
-        context.abort(
-          context.message("features.argo.dependencies.argo_renderer_package_invalid_version_error")
-        ) if found_version.nil?
-        ::Semantic::Version.new(found_version).to_s
-      rescue ArgumentError
-        context.abort(
-          context.message("features.argo.dependencies.argo_renderer_package_invalid_version_error")
-        )
-      end
-
-      def find_version_number(context, result)
-        packages = result.to_json.split('\n')
-        found_package = packages.find do |package|
-          package.match(/#{renderer_package_name}@/)
-        end
-        if found_package.nil?
-          error = "'#{renderer_package_name}' not found."
-          context.abort(
-            context.message("features.argo.dependencies.argo_missing_renderer_package_error", error)
-          )
-        end
-        found_package.split("@")[2]&.strip
-      end
-
       def run_list_command(context)
-        js_system = ShopifyCli::JsSystem.new(ctx: context)
-        result, error, status = js_system.call(
-          yarn: YARN_LIST_COMMAND + [renderer_package_name] + YARN_LIST_PARAMETERS,
-          npm: NPM_LIST_COMMAND + [renderer_package_name] + NPM_LIST_PARAMETERS,
+        yarn_list = YARN_LIST_COMMAND + YARN_LIST_PARAMETERS
+        npm_list = NPM_LIST_COMMAND + NPM_LIST_PARAMETERS
+
+        result, error, status = ShopifyCli::JsSystem.call(
+          context,
+          yarn: yarn_list,
+          npm: npm_list,
           capture_response: true
         )
         context.abort(

--- a/lib/project_types/extension/features/argo_renderer_package.rb
+++ b/lib/project_types/extension/features/argo_renderer_package.rb
@@ -5,15 +5,26 @@ module Extension
 
       ARGO_CHECKOUT = "@shopify/argo-checkout"
       ARGO_ADMIN = "@shopify/argo-admin"
+      ARGO_POST_PURCHASE = "@shopify/argo-post-purchase"
 
       PACKAGE_NAMES = [
         ARGO_CHECKOUT,
         ARGO_ADMIN,
+        ARGO_POST_PURCHASE
       ].freeze
       MINIMUM_ARGO_VERSION = "0.9.3".freeze
 
       property! :package_name, accepts: PACKAGE_NAMES
       property! :version, accepts: String
+
+      class << self
+        def from_package_manager(package_manager_output)
+          pattern = /(?<name>#{PACKAGE_NAMES.join("|")})@(?<version>\d.*)$/
+          match = package_manager_output.match(pattern)
+          raise PackageNotFound, package_manager_output if match.nil?
+          return new(package_name: match[:name], version: match[:version].strip)
+        end
+      end
 
       def checkout?
         package_name == ARGO_CHECKOUT

--- a/lib/project_types/extension/features/argo_renderer_package.rb
+++ b/lib/project_types/extension/features/argo_renderer_package.rb
@@ -34,9 +34,13 @@ module Extension
         package_name == ARGO_ADMIN
       end
 
+      ##
+      # Temporarily returns false in all cases as the argo webpack server is
+      # unable to handle the UUID flag.
       def supports_uuid_flag?
-        return false if checkout?
-        Gem::Version.new(version) > Gem::Version.new(MINIMUM_ARGO_VERSION)
+        return false
+        # return false if checkout?
+        # Gem::Version.new(version) > Gem::Version.new(MINIMUM_ARGO_VERSION)
       end
     end
   end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -98,10 +98,7 @@ module Extension
               node_not_installed: "Node must be installed to create this extension.",
               version_too_low: "Your node version %s does not meet the minimum required version %s",
             },
-            argo_missing_renderer_package_error: "%s Install the missing package and try again.",
-            argo_renderer_package_invalid_version_error: <<~MESSAGE,
-              The renderer package version is not a valid SemVer Version (http://semver.org)
-            MESSAGE
+            argo_missing_renderer_package_error: "Extension template references invalid renderer package please contact Shopify for help.",
             yarn_install_error: "Something went wrong while running 'yarn install'. %s.",
             yarn_run_script_error: "Something went wrong while running script. %s.",
           },

--- a/lib/shopify-cli/js_system.rb
+++ b/lib/shopify-cli/js_system.rb
@@ -37,8 +37,8 @@ module ShopifyCli
       #
       #   ShopifyCli::JsSystem.call(ctx, yarn: ['install', '--silent'], npm: ['install', '--no-audit'])
       #
-      def call(ctx, yarn:, npm:)
-        JsSystem.new(ctx: ctx).call(yarn: yarn, npm: npm)
+      def call(ctx, yarn:, npm:, capture_response: false)
+        JsSystem.new(ctx: ctx).call(yarn: yarn, npm: npm, capture_response: capture_response)
       end
     end
 

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -5,6 +5,7 @@ require "project_types/extension/extension_test_helpers"
 module Extension
   module Commands
     class PushTest < MiniTest::Test
+      include TestHelpers::FakeUI
       include ExtensionTestHelpers::Messages
 
       def setup

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -5,107 +5,19 @@ require "project_types/extension/extension_test_helpers"
 module Extension
   module Commands
     class ServeTest < MiniTest::Test
-      include TestHelpers::Partners
       include TestHelpers::FakeUI
       include ExtensionTestHelpers::TempProjectSetup
 
-      YARN_SERVE_COMMAND = %w(server)
-      NPM_SERVE_COMMAND = %w(run-script server)
-
       def setup
         super
-        stub_argo_enabled_shop
-        api_key = "TEST"
-        registration_uuid = "dev-123"
-        setup_temp_project(api_key: api_key, registration_uuid: registration_uuid)
-        @argo_version = "0.9.4"
-        serve_args = [
-          "--shop=my-test-shop.myshopify.com",
-          "--apiKey=#{api_key}",
-          "--argoVersion=#{@argo_version}",
-          "--uuid=#{registration_uuid}",
-        ]
-        @yarn_serve_command = YARN_SERVE_COMMAND + serve_args
-        @npm_serve_command = NPM_SERVE_COMMAND + %w(--) + serve_args
+        ShopifyCli::ProjectType.load_type("extension")
+        setup_temp_project
       end
 
-      def test_implements_help
-        ShopifyCli::ProjectType.load_type(:extension)
-        ShopifyCli::Shopifolk.stubs(:check).returns(false)
-        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(false)
-
-        refute_empty(Serve.help)
-      end
-
-      def test_uses_js_system_to_run_npm_or_yarn_serve_commands
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
-          .returns(true)
-          .once
-
-        run_serve
-      end
-
-      def test_aborts_and_informs_the_user_when_serve_fails
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
-          .returns(false)
-          .once
-        @context.expects(:abort).with(@context.message("serve.serve_failure_message"))
-
-        run_serve
-      end
-
-      def test_uses_js_system_to_run_npm_or_yarn_serve_commands_with_shop_argument_for_first_party
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with(yarn: @yarn_serve_command, npm: @npm_serve_command)
-          .returns(true)
-          .once
-
-        run_serve
-      end
-
-      def test_raises_exception_if_shop_is_empty
-        ExtensionProject.stubs(:reload)
-
-        ExtensionProject.current.env.stubs(:shop).returns(" ")
-
-        exception = assert_raises ShopifyCli::Abort do
-          run_serve
-        end
-        assert_includes exception.message, @context.message("serve.serve_missing_information")
-      end
-
-      def test_raises_exception_if_api_key_is_empty
-        ExtensionProject.stubs(:reload)
-
-        ExtensionProject.current.env.stubs(:api_key).returns(" ")
-
-        exception = assert_raises ShopifyCli::Abort do
-          run_serve
-        end
-        assert_includes exception.message, @context.message("serve.serve_missing_information")
-      end
-
-      private
-
-      def run_serve(*args)
-        Serve.ctx = @context
-        Serve.call(args, "serve")
-      end
-
-      def stub_argo_enabled_shop
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
-        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        Extension::Features::Argo.any_instance.stubs(:extract_argo_renderer_version).returns(@argo_version)
+      def test_defers_serving_to_the_specification_handler
+        serve = ::Extension::Commands::Serve.new(@context)
+        serve.specification_handler.expects(:serve)
+        serve.call([], "serve")
       end
     end
   end

--- a/test/project_types/extension/extension_test_helpers/dummy_argo.rb
+++ b/test/project_types/extension/extension_test_helpers/dummy_argo.rb
@@ -2,8 +2,10 @@ module Extension
   module ExtensionTestHelpers
     class DummyArgo < Extension::Features::Argo
       GIT_TEMPLATE = "https://something"
-      RENDERER_PACKAGE = "@test-renderer-package"
+      RENDERER_PACKAGE = "@shopify/argo-admin"
       private_constant :GIT_TEMPLATE, :RENDERER_PACKAGE
+
+      property :fake_renderer_package, accepts: Features::ArgoRendererPackage
 
       def git_template
         GIT_TEMPLATE
@@ -11,6 +13,17 @@ module Extension
 
       def renderer_package_name
         RENDERER_PACKAGE
+      end
+
+      def renderer_version=(renderer_version)
+        self.fake_renderer_package = Features::ArgoRendererPackage.new(
+          package_name: renderer_package_name,
+          version: renderer_version
+        )
+      end
+
+      def renderer_package(context)
+        fake_renderer_package || super(context)
       end
     end
   end

--- a/test/project_types/extension/features/argo_renderer_package_test.rb
+++ b/test/project_types/extension/features/argo_renderer_package_test.rb
@@ -34,6 +34,83 @@ module Extension
         assert_predicate(uuid_supported, :supports_uuid_flag?)
         refute_predicate(uuid_unsupported, :supports_uuid_flag?)
       end
+
+      def test_instantiation_from_package_manager_output
+        argo_renderer_package = ArgoRendererPackage.from_package_manager(
+          package_manager_output,
+        )
+
+        assert_kind_of ArgoRendererPackage, argo_renderer_package
+        assert_equal "0.9.1", argo_renderer_package.version
+        assert_equal "@shopify/argo-post-purchase", argo_renderer_package.package_name
+      end
+
+      def test_instantiation_from_npm_output_using_depth_1_when_listing_packages
+        argo_renderer_package = ArgoRendererPackage.from_package_manager(
+          npm_output_with_depth_1,
+        )
+
+        assert_kind_of ArgoRendererPackage, argo_renderer_package
+        assert_equal "0.10.1", argo_renderer_package.version
+        assert_equal "@shopify/argo-admin", argo_renderer_package.package_name
+      end
+
+      def test_raises_an_error_when_no_renderer_package_was_found
+        assert_raises Extension::PackageNotFound do
+          argo_renderer_package = ArgoRendererPackage.from_package_manager(
+            malformed_package_manager_output_without_renderer,
+          )
+        end
+      end
+
+      def test_raises_an_error_when_no_exact_version_for_renderer_was_specified
+        assert_raises Extension::PackageNotFound do
+          argo_renderer_package = ArgoRendererPackage.from_package_manager(
+            malformed_package_manager_output_with_version_range,
+          )
+        end
+      end
+
+      private
+
+      def package_manager_output
+        <<~NPM
+        argo-checkout-template@0.1.0 /Users/t6d/src/local/cli-specification-experiment/2021-04-30_post_purchase_test
+        ├── @shopify/argo-post-purchase-react@0.9.3
+        ├── @shopify/argo-post-purchase@0.9.1
+        └── react@17.0.1
+        NPM
+      end
+
+      def malformed_package_manager_output_without_renderer
+        <<~NPM
+        argo-checkout-template@0.1.0 /Users/t6d/src/local/cli-specification-experiment/2021-04-30_post_purchase_test
+        ├── @shopify/argo-post-purchase-react@0.9.3
+        └── react@17.0.1
+        NPM
+      end
+
+      def malformed_package_manager_output_with_version_range
+        <<~NPM
+        argo-checkout-template@0.1.0 /Users/t6d/src/local/cli-specification-experiment/2021-04-30_post_purchase_test
+        ├── @shopify/argo-post-purchase-react@0.9.3
+        ├── @shopify/argo-post-purchase@^0.9.1
+        └── react@17.0.1
+        NPM
+      end
+
+      def npm_output_with_depth_1
+        <<~NPM
+        shopify-app-extension-template@0.1.0 /Users/trishta/src/extensions/test_dynamic_renderer_admin
+        ├─┬ @shopify/argo-admin-react@0.10.1
+        │ ├── @remote-ui/react@4.0.2
+        │ ├── @shopify/argo-admin@0.10.1
+        │ └── react@17.0.2 deduped
+        └─┬ react@17.0.2
+          ├── loose-envify@1.4.0
+          └── object-assign@4.1.1
+        NPM
+      end
     end
   end
 end

--- a/test/project_types/extension/features/argo_renderer_package_test.rb
+++ b/test/project_types/extension/features/argo_renderer_package_test.rb
@@ -23,6 +23,8 @@ module Extension
       end
 
       def test_argo_minimum_version_supports_uuid_flag
+        skip("Passing the a UUID to the Argo Webpack server is currently not supported")
+
         uuid_supported = Features::ArgoRendererPackage.new(
           package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
           version: "0.9.4"

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -56,6 +56,8 @@ module Extension
       end
 
       def test_extension_versions_that_support_uuid_have_uuid_command_line_argument
+        skip("Passing the a UUID to the Argo Webpack server is currently not supported")
+
         stub_argo_enabled_shop
         dummy_handler = build_dummy_specification_handler(
           renderer_package_version: @argo_version,

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -102,6 +102,8 @@ module Extension
       end
 
       def test_config_aborts_with_error_if_run_list_command_fails
+        skip("Temporarily bypassing exit code check due to issues with NPM 7.")
+
         Base64.stubs(:strict_encode64).returns(@encoded_script)
         with_stubbed_script(@context, Argo::SCRIPT_PATH) do
           stub_run_yarn_install_and_run_yarn_run_script_methods
@@ -116,6 +118,8 @@ module Extension
       end
 
       def test_config_aborts_with_error_if_found_version_is_invalid
+        skip("Temporarily bypassing exit code check due to issues with NPM 7.")
+
         Base64.stubs(:strict_encode64).returns(@encoded_script)
         invalid_version = "2.invalid.0"
         with_stubbed_script(@context, Argo::SCRIPT_PATH) do

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -26,7 +26,6 @@ module Extension
       def test_config_aborts_with_error_if_script_file_doesnt_exist
         File.stubs(:exist?).returns(false)
         stub_run_yarn_install_and_run_yarn_run_script_methods
-        @dummy_argo.stubs(:extract_argo_renderer_version).returns("0.0.1")
         error = assert_raises ShopifyCli::Abort do
           @dummy_argo.config(@context)
         end
@@ -36,28 +35,31 @@ module Extension
 
       def test_config_aborts_with_error_if_script_serialization_fails
         stub_run_yarn_install_and_run_yarn_run_script_methods
-        @dummy_argo.stubs(:extract_argo_renderer_version).returns("0.0.1")
         File.stubs(:exist?).returns(true)
         Base64.stubs(:strict_encode64).raises(IOError)
 
+        @dummy_argo.renderer_version = "0.0.1"
         error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
         assert_includes error.message, @context.message("features.argo.script_prepare_error")
       end
 
       def test_config_aborts_with_error_if_file_read_fails
         stub_run_yarn_install_and_run_yarn_run_script_methods
-        @dummy_argo.stubs(:extract_argo_renderer_version).returns("0.0.1")
         File.stubs(:exist?).returns(true)
         File.any_instance.stubs(:read).raises(IOError)
+
+        @dummy_argo.renderer_version = "0.0.1"
 
         error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
         assert_includes error.message, @context.message("features.argo.script_prepare_error")
       end
 
-      def test_config_encodes_script_into_context_if_it_exists
+      def test_config_encodes_script_into_config_if_it_exists
         with_stubbed_script(@context, Argo::SCRIPT_PATH) do
           stub_run_yarn_install_and_run_yarn_run_script_methods
-          @dummy_argo.stubs(:extract_argo_renderer_version).returns("0.0.1")
+
+          @dummy_argo.renderer_version = "0.0.1"
+
           config = @dummy_argo.config(@context)
 
           assert_includes config.keys, :serialized_script
@@ -68,7 +70,7 @@ module Extension
       def test_config_returns_argo_renderer_package_name_version_if_it_exists_using_yarn
         yarn_list_result = 'yarn list v1.22.5
         ├─ @fake-package@0.3.9
-        └─ @test-renderer-package@0.3.8
+        └─ @shopify/argo-admin@0.3.8
         ✨  Done in 0.40s.'
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
           stub_run_yarn_install_and_run_yarn_run_script_methods
@@ -84,7 +86,7 @@ module Extension
       def test_config_returns_argo_renderer_package_version_if_it_exists_using_npm
         npm_list_result = 'test-extension-template@0.1.0
         └─┬ @fake-package@0.4.3
-          └── @test-renderer-package@0.4.3
+          └── @shopify/argo-admin@0.4.3
           ✨  Done in 0.40s.
           '
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
@@ -119,15 +121,10 @@ module Extension
         with_stubbed_script(@context, Argo::SCRIPT_PATH) do
           stub_run_yarn_install_and_run_yarn_run_script_methods
           ShopifyCli::JsSystem.any_instance.stubs(:call).returns([@result, @no_error, mock(success?: true)])
-          Argo.any_instance.stubs(:find_version_number).returns(invalid_version)
+          ArgoRendererPackage.stubs(:from_package_manager).raises(Extension::PackageNotFound)
 
-          error_message = "The renderer package version is not a valid SemVer Version (http://semver.org)"
           error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
-          assert_includes error
-            .message, @context.message(
-              "features.argo.dependencies.argo_renderer_package_invalid_version_error",
-              error_message
-            )
+          assert_includes error.message, @context.message("features.argo.dependencies.argo_missing_renderer_package_error")
         end
       end
 
@@ -155,7 +152,7 @@ module Extension
           ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
           Argo.any_instance.expects(:run_yarn_install).returns(true).once
           Argo.any_instance.expects(:run_yarn_run_script).returns(true).once
-          Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
+          @dummy_argo.renderer_version = "0.0.1"
 
           @dummy_argo.config(@context)
         end
@@ -166,7 +163,7 @@ module Extension
           ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("npm")
           Argo.any_instance.expects(:run_yarn_install).never
           Argo.any_instance.expects(:run_yarn_run_script).never
-          Argo.any_instance.stubs(:extract_argo_renderer_version).returns("0.0.1")
+          @dummy_argo.renderer_version = "0.0.1"
 
           @dummy_argo.config(@context)
         end

--- a/test/shopify-cli/js_system_test.rb
+++ b/test/shopify-cli/js_system_test.rb
@@ -67,7 +67,7 @@ module ShopifyCli
     def test_call_on_class_proxies_to_the_instance_version_of_call
       yarn_command = "yarn"
       npm_command = "npm"
-      JsSystem.any_instance.expects(:call).with(yarn: yarn_command, npm: npm_command).once
+      JsSystem.any_instance.expects(:call).with(yarn: yarn_command, npm: npm_command, capture_response: false).once
 
       JsSystem.call(@context, yarn: yarn_command, npm: npm_command)
     end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/argo-private/issues/1503
Fixes https://github.com/Shopify/argo-private/issues/1504

### WHAT is this pull request doing?

Determines the renderer package dynamically instead of inferring it from the extension specification.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
