### PR TITLE
Release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ------
 
+Version 1.9.1
+-------------
 * [1201](https://github.com/Shopify/shopify-app-cli/pull/1201) Determine Argo Renderer Dynamically. This fixes `shopify serve` and `shopify push` for extensions.
 
 Version 1.9.0

--- a/lib/shopify-cli/version.rb
+++ b/lib/shopify-cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCli
-  VERSION = "1.9.0"
+  VERSION = "1.9.1"
 end


### PR DESCRIPTION

### WHY are these changes introduced?

App Extension development is broken in 1.9.0

### WHAT is this pull request doing?

Releasing 1.9.1 which inclues
* [1201](https://github.com/Shopify/shopify-app-cli/pull/1201) Determine Argo Renderer Dynamically. This fixes `shopify serve` and `shopify push` for extensions.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
