### PR TITLE
[scripts] Prompt user during push if they want to connect to an existing script

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -24,6 +24,10 @@ module Script
     autoload :ScriptForm, Project.project_filepath("forms/script_form")
   end
 
+  module Tasks
+    autoload :EnsureEnv, Project.project_filepath("tasks/ensure_env")
+  end
+
   module Layers
     module Application
       autoload :BuildScript, Project.project_filepath("layers/application/build_script")

--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -8,7 +8,7 @@ module Script
       end
 
       def call(_args, _name)
-        ShopifyCli::Tasks::EnsureEnv.call(@ctx, required: [:api_key, :secret, :shop])
+        Tasks::EnsureEnv.call(@ctx)
 
         api_key = Layers::Infrastructure::ScriptProjectRepository.new(ctx: @ctx).get.api_key
         return @ctx.puts(self.class.help) unless api_key

--- a/lib/project_types/script/graphql/get_app_scripts.graphql
+++ b/lib/project_types/script/graphql/get_app_scripts.graphql
@@ -1,0 +1,6 @@
+query GetAppScripts($appKey: String!, $extensionPointName: ExtensionPointName!) {
+  appScripts(appKeys: [$appKey], extensionPointName: $extensionPointName) {
+    uuid
+    title
+  }
+}

--- a/lib/project_types/script/layers/domain/script_project.rb
+++ b/lib/project_types/script/layers/domain/script_project.rb
@@ -6,6 +6,8 @@ module Script
       class ScriptProject
         include SmartProperties
 
+        UUID_ENV_KEY = "UUID"
+
         property! :id, accepts: String
         property :env, accepts: ShopifyCli::Resources::EnvFile
 
@@ -29,8 +31,22 @@ module Script
           env&.api_key
         end
 
+        def api_secret
+          env&.secret
+        end
+
         def uuid
-          env&.extra&.[]("UUID")
+          uuid_defined? && !raw_uuid.empty? ? raw_uuid : nil
+        end
+
+        def uuid_defined?
+          !raw_uuid.nil?
+        end
+
+        private
+
+        def raw_uuid
+          env&.extra&.[](UUID_ENV_KEY)
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -28,7 +28,6 @@ module Script
           raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
 
           script_content = ctx.binread(build_file_path)
-
           Domain::PushPackage.new(
             id: build_file_path,
             uuid: script_project.uuid,

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -76,6 +76,25 @@ module Script
           )
         end
 
+        def create_env(api_key:, secret:, uuid:)
+          ShopifyCli::Resources::EnvFile.new(
+            api_key: api_key,
+            secret: secret,
+            extra: {
+              Domain::ScriptProject::UUID_ENV_KEY => uuid,
+            }
+          ).write(ctx)
+
+          Domain::ScriptProject.new(
+            id: ctx.root,
+            env: project.env,
+            script_name: script_name,
+            extension_point_type: extension_point_type,
+            language: language,
+            config_ui: ConfigUiRepository.new(ctx: ctx).get(config_ui_file),
+          )
+        end
+
         private
 
         def capture_io(&block)
@@ -109,7 +128,7 @@ module Script
         end
 
         def project
-          ShopifyCli::Project.current
+          @project ||= ShopifyCli::Project.current(force_reload: true)
         end
 
         def default_config_ui_content(title)

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -58,6 +58,12 @@ module Script
           end
         end
 
+        def get_app_scripts(api_key:, extension_point_type:)
+          query_name = "get_app_scripts"
+          variables = { appKey: api_key, extensionPointName: extension_point_type.upcase }
+          script_service_request(query_name: query_name, api_key: api_key, variables: variables)["data"]["appScripts"]
+        end
+
         private
 
         class ScriptServiceAPI < ShopifyCli::API

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -193,10 +193,11 @@ module Script
           enabling: "Enabling",
           enabled: "Enabled",
           ensure_env: {
-            organization_select: "To which partner organization does this project belong?",
-            app_select: "To which app does this project belong?",
-            ask_connect_to_existing_script: "Do you want to connect to an existing Script?",
-            ask_which_script_to_connect_to: "Which Script do you want to connect to?",
+            organization_select: "Which partner organization do you want to use?",
+            app_select: "Which app do you want to push this script to?",
+            ask_connect_to_existing_script: "This app has some scripts. Do you want to replace any of the "\
+              "existing scripts with the current script?",
+            ask_which_script_to_connect_to: "Which script do you want to replace?",
           },
         },
       },

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -192,6 +192,12 @@ module Script
           disabled: "Disabled",
           enabling: "Enabling",
           enabled: "Enabled",
+          ensure_env: {
+            organization_select: "To which partner organization does this project belong?",
+            app_select: "To which app does this project belong?",
+            ask_connect_to_existing_script: "Do you want to connect to an existing Script?",
+            ask_which_script_to_connect_to: "Which Script do you want to connect to?",
+          },
         },
       },
     }.freeze

--- a/lib/project_types/script/tasks/ensure_env.rb
+++ b/lib/project_types/script/tasks/ensure_env.rb
@@ -1,0 +1,77 @@
+require "shopify_cli"
+
+module Script
+  module Tasks
+    class EnsureEnv < ShopifyCli::Task
+      attr_accessor :ctx
+
+      def call(ctx)
+        self.ctx = ctx
+
+        script_project_repo = Layers::Infrastructure::ScriptProjectRepository.new(ctx: ctx)
+        script_project = script_project_repo.get
+
+        return if script_project.api_key && script_project.api_secret && script_project.uuid_defined?
+
+        org = ask_org
+        app = ask_app(org["apps"])
+        uuid = ask_script_uuid(app, script_project.extension_point_type)
+
+        script_project_repo.create_env(
+          api_key: app["apiKey"],
+          secret: app["apiSecretKeys"].first["secret"],
+          uuid: uuid
+        )
+      end
+
+      private
+
+      def ask_org
+        if ShopifyCli::Shopifolk.check && wants_to_run_against_shopify_org?
+          ShopifyCli::Shopifolk.act_as_shopify_organization
+        end
+
+        orgs = ShopifyCli::PartnersAPI::Organizations.fetch_with_app(ctx)
+        if orgs.count == 1
+          orgs.first
+        elsif orgs.count > 0
+          CLI::UI::Prompt.ask(ctx.message("script.application.ensure_env.organization_select")) do |handler|
+            orgs.each do |org|
+              handler.option("#{org["businessName"]} (#{org["id"]})") { org }
+            end
+          end
+        else
+          raise Errors::NoExistingOrganizationsError
+        end
+      end
+
+      def ask_app(apps)
+        if apps.count == 1
+          apps.first
+        elsif apps.count > 0
+          CLI::UI::Prompt.ask(ctx.message("script.application.ensure_env.app_select")) do |handler|
+            apps.each do |app|
+              handler.option(app["title"]) { app }
+            end
+          end
+        else
+          raise Errors::NoExistingAppsError
+        end
+      end
+
+      def ask_script_uuid(app, extension_point_type)
+        script_service = Layers::Infrastructure::ScriptService.new(ctx: ctx)
+        scripts = script_service.get_app_scripts(api_key: app["apiKey"], extension_point_type: extension_point_type)
+
+        return nil unless scripts.count > 0 &&
+          CLI::UI::Prompt.confirm(ctx.message("script.application.ensure_env.ask_connect_to_existing_script"))
+
+        CLI::UI::Prompt.ask(ctx.message("script.application.ensure_env.ask_which_script_to_connect_to")) do |handler|
+          scripts.each do |script|
+            handler.option("#{script["title"]} (#{script["uuid"]})") { script["uuid"] }
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -24,10 +24,7 @@ module Script
       end
 
       def test_calls_push_script
-        ShopifyCli::Tasks::EnsureEnv
-          .any_instance.expects(:call)
-          .with(@context, required: [:api_key, :secret, :shop])
-
+        Tasks::EnsureEnv.expects(:call).with(@context)
         Layers::Application::PushScript.expects(:call).with(ctx: @context, force: @force)
 
         @context
@@ -44,12 +41,10 @@ module Script
       end
 
       def test_push_propagates_error_when_ensure_env_fails
-        @env = nil
-
         err_msg = "error message"
-        ShopifyCli::Tasks::EnsureEnv
-          .any_instance.expects(:call)
-          .with(@context, required: [:api_key, :secret, :shop])
+        Tasks::EnsureEnv
+          .expects(:call)
+          .with(@context)
           .raises(StandardError.new(err_msg))
 
         e = assert_raises(StandardError) { perform_command }

--- a/test/project_types/script/tasks/ensure_env_test.rb
+++ b/test/project_types/script/tasks/ensure_env_test.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+describe Script::Tasks::EnsureEnv do
+  include TestHelpers::FakeFS
+
+  describe ".call" do
+    let(:context) { TestHelpers::FakeContext.new(root: Dir.mktmpdir) }
+    let(:language) { "assemblyscript" }
+    let(:extension_point_type) { "discount" }
+    let(:script_name) { "name" }
+    let(:is_shopifolk) { false }
+    let(:script_project_repository) { TestHelpers::FakeScriptProjectRepository.new }
+
+    subject do
+      Script::Tasks::EnsureEnv.call(context)
+    end
+
+    before do
+      context.output_captured = true
+      ShopifyCli::Shopifolk.stubs(:check).returns(is_shopifolk)
+      Script::Layers::Infrastructure::ScriptProjectRepository.stubs(:new).returns(script_project_repository)
+      script_project_repository.create(
+        language: language,
+        extension_point_type: extension_point_type,
+        script_name: script_name,
+        no_config_ui: false,
+        env: env
+      )
+    end
+
+    describe "when env already has all required fields" do
+      let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: "api_key", secret: "shh", extra: { "UUID" => "uuid" }) }
+
+      it "does nothing" do
+        CLI::UI::Prompt.expects(:ask).never
+        CLI::UI::Prompt.expects(:confirm).never
+        ShopifyCli::PartnersAPI.expects(:query).never
+        Script::Layers::Infrastructure::ScriptService.any_instance.expects(:get_app_scripts).never
+
+        assert_nil subject
+      end
+    end
+
+    describe "when env is not yet valid" do
+      def new_app(title, api_key, secret)
+        {
+          "title" => title,
+          "apiKey" => api_key,
+          "apiSecretKeys" => [{ "secret" => secret }],
+        }
+      end
+
+      def new_org(id, name)
+        {
+          "id" => id,
+          "businessName" => name,
+        }
+      end
+
+      def expect_new_env
+        assert_equal selected_api_key, subject.env.api_key
+        assert_equal selected_secret, subject.env.secret
+
+        if selected_uuid.nil?
+          assert_nil subject.env.extra["UUID"]
+        else
+          assert_equal selected_uuid, subject.env.extra["UUID"]
+        end
+      end
+
+      def self.it_prompts_user_and_update_env
+        let(:orgs) { [new_org(1, "business1")] }
+        let(:apps) { [new_app("app1", selected_api_key, selected_secret)] }
+        let(:existing_scripts) { [] }
+        let(:orgs_with_apps) do
+          orgs.map do |org|
+            org.merge({ "apps" => apps })
+          end
+        end
+        let(:selected_org) { orgs_with_apps.first }
+        let(:selected_api_key) { "default_api_key" }
+        let(:selected_secret) { "default_secret" }
+        let(:selected_uuid) { nil }
+
+        before do
+          ShopifyCli::PartnersAPI::Organizations
+            .stubs(:fetch_with_app)
+            .returns(orgs_with_apps)
+          Script::Layers::Infrastructure::ScriptService
+            .any_instance
+            .stubs(:get_app_scripts)
+            .with(api_key: selected_api_key, extension_point_type: extension_point_type)
+            .returns(existing_scripts)
+        end
+
+        describe("when asking org") do
+          describe("when number of orgs == 0") do
+            let(:orgs) { [] }
+
+            it("raises NoExistingOrganizationsError") do
+              assert_raises(Script::Errors::NoExistingOrganizationsError) { subject }
+            end
+          end
+
+          describe("when number of orgs == 1") do
+            let(:orgs) { [new_org(1, "business1")] }
+            let(:selected_org) { orgs_with_apps.first }
+
+            it("selects the org by default") do
+              assert_equal selected_api_key, subject.env.api_key
+              assert_equal selected_secret, subject.env.secret
+              assert_nil subject.env.extra["UUID"]
+            end
+          end
+
+          describe("when number of orgs > 1") do
+            let(:orgs) { [new_org(1, "business1"), new_org(2, "business2")] }
+            let(:selected_org) { orgs_with_apps.last }
+
+            it("prompts to select an org") do
+              CLI::UI::Prompt
+                .expects(:ask)
+                .with(context.message("script.application.ensure_env.organization_select"))
+                .returns(selected_org)
+
+              expect_new_env
+            end
+          end
+        end
+
+        describe("when asking app connection") do
+          describe("when number of apps == 0") do
+            let(:apps) { [] }
+
+            it("raises NoExistingAppsError") do
+              assert_raises(Script::Errors::NoExistingAppsError) { subject }
+            end
+          end
+
+          describe("when number of apps == 1") do
+            let(:apps) { [new_app("app1", selected_api_key, selected_secret)] }
+            let(:selected_api_key) { "selected_api_key" }
+            let(:selected_secret) { "selected_secret" }
+
+            it("selects the app by default") do
+              expect_new_env
+            end
+          end
+
+          describe("when number of apps > 1") do
+            let(:apps) { [new_app("app1", "1", "1"), new_app("app2", selected_api_key, selected_secret)] }
+            let(:selected_api_key) { "selected_api_key" }
+            let(:selected_secret) { "selected_secret" }
+
+            it("prompts to select an app") do
+              CLI::UI::Prompt
+                .expects(:ask)
+                .with(context.message("script.application.ensure_env.app_select"))
+                .returns(apps.last)
+
+              expect_new_env
+            end
+          end
+        end
+
+        describe("when asking script connection") do
+          describe("when number of scripts == 0") do
+            let(:selected_uuid) { nil }
+
+            it("should set uuid to nil") do
+              expect_new_env
+            end
+          end
+
+          describe("when number of scripts > 0") do
+            let(:new_script_uuid) { "new_script_uuid" }
+            let(:existing_scripts) { [{ "title" => "script_title", "uuid" => new_script_uuid }] }
+
+            describe("when user wants to connect to script") do
+              let(:selected_uuid) { new_script_uuid }
+
+              it("should set uuid to the uuid of that script") do
+                CLI::UI::Prompt
+                  .expects(:confirm)
+                  .with(context.message("script.application.ensure_env.ask_connect_to_existing_script"))
+                  .returns(true)
+
+                CLI::UI::Prompt
+                  .expects(:ask)
+                  .with(context.message("script.application.ensure_env.ask_which_script_to_connect_to"))
+                  .returns(selected_uuid)
+
+                expect_new_env
+              end
+            end
+
+            describe("when user does not want to connect to script") do
+              let(:selected_uuid) { nil }
+
+              it("should set uuid to nil") do
+                CLI::UI::Prompt
+                  .expects(:confirm)
+                  .with(context.message("script.application.ensure_env.ask_connect_to_existing_script"))
+                  .returns(false)
+
+                CLI::UI::Prompt
+                  .expects(:ask)
+                  .with(context.message("script.application.ensure_env.ask_which_script_to_connect_to"))
+                  .never
+
+                expect_new_env
+              end
+            end
+          end
+        end
+      end
+
+      describe "when env is empty" do
+        let(:env) { nil }
+
+        it_prompts_user_and_update_env
+      end
+
+      describe "when missing uuid" do
+        let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: "api_key", secret: "shh") }
+
+        it_prompts_user_and_update_env
+      end
+    end
+  end
+end

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -35,6 +35,11 @@ module TestHelpers
       @project
     end
 
+    def create_env(api_key:, secret:, uuid:)
+      @project.env = ShopifyCli::Resources::EnvFile.new(api_key: api_key, secret: secret, extra: { "UUID" => uuid })
+      @project
+    end
+
     class FakeConfigUiRepository
       def initialize
         @cache = {}


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/2951
Closes https://github.com/Shopify/script-service/issues/2422

We want to be able to connect to an existing script that has been pushed to Shopify. 

### WHAT is this pull request doing?

- Adds a custom task to ensure the `.env` file filled with all required keys
    - This task only prompts for the fields needed (`org` and `app`) instead of all fields (`shop`) like we used to prompt for.
- Adds a method to `ScriptService` infra service to fetch all scripts on a given app and extension point
- When prompting for `.env` values during push, all existing scripts for an api_key and extension point will be fetched. The user will be asked if they want to connect to one of these existing scripts, instead of creating a new one.

### 🎩 
![image](https://user-images.githubusercontent.com/28009669/117050989-06b55480-ace4-11eb-947f-afcd91524931.png)
![image](https://user-images.githubusercontent.com/28009669/117051004-0cab3580-ace4-11eb-8cd5-e124a0066e8f.png)