### PR TITLE
[scripts] Deprecate payment_filter and shipping_filter eps to beta

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -11,6 +11,7 @@ unit_limit_per_order:
     sdk-version: "^9.0.0"
     toolchain-version: "^5.0.0"
 payment_filter:
+  deprecated: true
   assemblyscript:
     package: "@shopify/extension-point-as-payment-filter"
     sdk-version: "^9.0.0"
@@ -19,6 +20,7 @@ payment_filter:
     beta: true
     package: "https://github.com/Shopify/scripts-apis-rs"
 shipping_filter:
+  deprecated: true
   assemblyscript:
     package: "@shopify/extension-point-as-shipping-filter"
     sdk-version: "^9.0.0"


### PR DESCRIPTION
### WHY are these changes introduced?

We only want `payment_methods` and `shipping_methods` EPs to be displayed by default. 

### WHAT is this pull request doing?

- hides payment_filter and shipping_filter EPs by default

![image](https://user-images.githubusercontent.com/28009669/117058038-28b2d500-acec-11eb-98db-ec38e019faa3.png)


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
