### PR TITLE
add specification handler guards

### DIFF
--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -42,6 +42,14 @@ module Extension
           []
         end
 
+        def choose_port?
+          false
+        end
+
+        def establish_tunnel?
+          false
+        end
+
         def serve(context)
           Features::ArgoServe.new(specification_handler: self, context: context).call
         end


### PR DESCRIPTION
### WHY are these changes introduced?

Adding guards to the specification handler for choosing port or establishing tunnel functionality.
These return `false` by default for now, but the logic is to be filled in later.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
