### PR TITLE
[scripts] use sample script config-ui.yml file

### DIFF
--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -79,19 +79,6 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
         it "should create a new script project" do
           it_should_create_a_new_script_project
-        end
-
-        it "should create a config_ui_file" do
-          capture_io { subject }
-
-          config_ui = config_ui_repository.get(expected_config_ui_filename)
-
-          refute_nil config_ui
-          assert_equal expected_config_ui_filename, config_ui.filename
-          assert_equal expected_config_ui_content, config_ui.content
-          assert_equal config_ui.filename, subject.config_ui.filename
-          assert_equal config_ui.content, subject.config_ui.content
-
           assert_equal expected_config_ui_filename, ShopifyCli::Project.current.config["config_ui_file"]
         end
       end
@@ -102,13 +89,6 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
         it "should create a new script project" do
           it_should_create_a_new_script_project
-        end
-
-        it "should not create a config_ui_file" do
-          capture_io { subject }
-
-          assert_nil subject.config_ui
-
           assert_nil ShopifyCli::Project.current.config["config_ui_file"]
         end
       end
@@ -139,7 +119,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     before do
       ShopifyCli::Project.stubs(:has_current?).returns(true)
       ShopifyCli::Project.stubs(:current).returns(current_project)
-      config_ui_repository.create(config_ui_file, config_ui_content)
+      ctx.write(config_ui_file, config_ui_content)
     end
 
     describe "when project config is valid" do
@@ -312,22 +292,6 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
   describe "ConfigUiRepository" do
     let(:instance) { Script::Layers::Infrastructure::ScriptProjectRepository::ConfigUiRepository.new(ctx: ctx) }
-
-    describe "#create" do
-      let(:filename) { "filename" }
-      let(:content) { "content" }
-
-      subject { instance.create(filename, content) }
-
-      it "should write the content to the filename" do
-        subject
-        assert_equal content, File.read(filename)
-      end
-
-      it "should return a ConfigUi entity" do
-        assert subject.is_a?(Script::Layers::Domain::ConfigUi)
-      end
-    end
 
     describe "#get" do
       subject { instance.get(filename) }


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/2696

This shouldn't be merged until the EP packages have been deployed.

EPs should define the `config-ui.yml` file for their sample script. Since only `shipping_methods` and `payment_methods` are currently supported and defined their own config-ui, we no longer need to generate a file in the CLI. 

### WHAT is this pull request doing?

Removes the `ConfigUiRepository#create` method as that will be done during bootstrap