### PR TITLE
Feature/extension serve checks

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -69,6 +69,7 @@ module Extension
     autoload :ArgoSetupSteps, Project.project_filepath("features/argo_setup_steps")
     autoload :ArgoDependencies, Project.project_filepath("features/argo_dependencies")
     autoload :ArgoConfig, Project.project_filepath("features/argo_config")
+    autoload :ArgoCliCompatibility, Project.project_filepath("features/argo_cli_compatibility")
     autoload :Argo, Project.project_filepath("features/argo")
   end
 

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -53,6 +53,7 @@ module Extension
 
       def renderer_package(context)
         js_system = ShopifyCli::JsSystem.new(ctx: context)
+
         Tasks::FindNpmPackages
           .exactly_one_of(*PACKAGE_NAMES, js_system: js_system)
           .then { |package| Features::ArgoRendererPackage.from_npm_package(package) }

--- a/lib/project_types/extension/features/argo_cli_compatibility.rb
+++ b/lib/project_types/extension/features/argo_cli_compatibility.rb
@@ -1,0 +1,42 @@
+module Extension
+  module Features
+    class ArgoCliCompatibility
+      include SmartProperties
+
+      ARGO_ADMIN_CLI = "@shopify/argo-admin-cli"
+      ARGO_RUN = "@shopify/argo-run"
+      VERSION_0_11_0 = "0.11.0"
+      VERSION_0_9_3 = "0.9.3"
+
+      CLI_PACKAGE_NAMES = [
+        ARGO_ADMIN_CLI,
+        ARGO_RUN,
+      ].freeze
+
+      property! :renderer_package, accepts: Features::ArgoRendererPackage
+      property! :installed_cli_package, accepts: Models::NpmPackage
+
+      def accepts_port?
+        renderer_package.admin? && supported_since?(VERSION_0_11_0)
+      end
+
+      def accepts_tunnel_url?
+        renderer_package.admin? && supported_since?(VERSION_0_11_0)
+      end
+
+      def accepts_uuid?
+        renderer_package.admin? && supported_since?(VERSION_0_11_0)
+      end
+
+      def accepts_argo_version?
+        renderer_package.admin? && supported_since?(VERSION_0_9_3)
+      end
+
+      private
+
+      def supported_since?(version)
+        installed_cli_package >= Models::NpmPackage.new(name: installed_cli_package.name, version: version)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/argo_renderer_package.rb
+++ b/lib/project_types/extension/features/argo_renderer_package.rb
@@ -12,7 +12,6 @@ module Extension
         ARGO_ADMIN,
         ARGO_POST_PURCHASE,
       ].freeze
-      MINIMUM_ARGO_VERSION = "0.9.3".freeze
 
       property! :package_name, accepts: PACKAGE_NAMES
       property! :version, accepts: String
@@ -29,15 +28,6 @@ module Extension
 
       def admin?
         package_name == ARGO_ADMIN
-      end
-
-      ##
-      # Temporarily returns false in all cases as the argo webpack server is
-      # unable to handle the UUID flag.
-      def supports_uuid_flag?
-        false
-        # return false if checkout?
-        # Gem::Version.new(version) > Gem::Version.new(MINIMUM_ARGO_VERSION)
       end
     end
   end

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -4,6 +4,7 @@ module Extension
       include SmartProperties
 
       property! :specification_handler, accepts: Extension::Models::SpecificationHandlers::Default
+      property! :cli_compatibility, accepts: Features::ArgoCliCompatibility
       property! :context, accepts: ShopifyCli::Context
       property! :port, accepts: Integer, default: 39351
       property  :tunnel_url, accepts: String, default: ""
@@ -12,12 +13,16 @@ module Extension
         validate_env!
 
         CLI::UI::Frame.open(context.message("serve.frame_title")) do
-          success = ShopifyCli::JsSystem.call(context, yarn: yarn_serve_command, npm: npm_serve_command)
+          success = call_js_system(yarn_command: yarn_serve_command, npm_command: npm_serve_command)
           context.abort(context.message("serve.serve_failure_message")) unless success
         end
       end
 
       private
+
+      def call_js_system(yarn_command:, npm_command:)
+        ShopifyCli::JsSystem.call(context, yarn: yarn_command, npm: npm_command)
+      end
 
       def specification
         specification_handler.specification
@@ -32,8 +37,8 @@ module Extension
       end
 
       def serve_options
-        @options ||= Features::ArgoServeOptions.new(port: port, context: context, required_fields: required_fields,
-          renderer_package: renderer_package, public_url: tunnel_url)
+        @options ||= Features::ArgoServeOptions.new(cli_compatibility: cli_compatibility, port: port, context: context,
+          required_fields: required_fields, renderer_package: renderer_package, public_url: tunnel_url)
       end
 
       def yarn_serve_command

--- a/lib/project_types/extension/features/argo_serve_options.rb
+++ b/lib/project_types/extension/features/argo_serve_options.rb
@@ -2,6 +2,8 @@ module Extension
   module Features
     class ArgoServeOptions
       include SmartProperties
+
+      property! :cli_compatibility, accepts: Features::ArgoCliCompatibility
       property! :context, accepts: ShopifyCli::Context
       property  :port, accepts: Integer, default: 39351
       property  :public_url, accepts: String, default: ""
@@ -23,13 +25,14 @@ module Extension
 
       def options
         project = ExtensionProject.current
+
         @serve_options ||= [].tap do |options|
-          options << "--port=#{port}"
+          options << "--port=#{port}" if cli_compatibility.accepts_port?
           options << "--shop=#{project.env.shop}" if required_fields.include?(:shop)
           options << "--apiKey=#{project.env.api_key}" if required_fields.include?(:api_key)
-          options << "--argoVersion=#{renderer_package.version}" if renderer_package.admin?
-          options << "--uuid=#{project.registration_uuid}" if renderer_package.supports_uuid_flag?
-          options << "--publicUrl=#{public_url}" unless public_url.empty?
+          options << "--argoVersion=#{renderer_package.version}" if cli_compatibility.accepts_argo_version?
+          options << "--uuid=#{project.registration_uuid}" if cli_compatibility.accepts_uuid?
+          options << "--publicUrl=#{public_url}" if cli_compatibility.accepts_tunnel_url?
         end
       end
     end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -116,6 +116,7 @@ module Extension
       },
       errors: {
         unknown_type: "Unknown extension type %s",
+        package_not_found: "`%s` package not found.",
       },
     }
 

--- a/lib/project_types/extension/models/specification.rb
+++ b/lib/project_types/extension/models/specification.rb
@@ -12,6 +12,7 @@ module Extension
           property! :git_template, converts: :to_str
           property! :required_fields, accepts: Array, default: -> { [] }
           property! :required_shop_beta_flags, accepts: Array, default: -> { [] }
+          property! :cli_package_name, accepts: String, converts: :to_str, default: ""
         end
 
         def self.build(feature_set_attributes)

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -42,21 +42,36 @@ module Extension
           []
         end
 
-        def choose_port?
-          false
+        def choose_port?(context)
+          cli_compatibility(context).accepts_port?
         end
 
-        def establish_tunnel?
-          false
+        def establish_tunnel?(context)
+          cli_compatibility(context).accepts_tunnel_url?
         end
 
         def serve(context:, port:, tunnel_url:)
-          Features::ArgoServe.new(specification_handler: self, context: context, port: port,
-tunnel_url: tunnel_url).call
+          Features::ArgoServe.new(specification_handler: self, cli_compatibility: cli_compatibility(context),
+          context: context, port: port, tunnel_url: tunnel_url).call
         end
 
         def renderer_package(context)
           argo.renderer_package(context)
+        end
+
+        def cli_compatibility(context)
+          @cli_compatibility ||= Features::ArgoCliCompatibility.new(renderer_package: renderer_package(context),
+          installed_cli_package: installed_cli_package(context))
+        end
+
+        def cli_package_name
+          specification.features.argo ? specification.features.argo.cli_package_name : ""
+        end
+
+        def installed_cli_package(context)
+          js_system = ShopifyCli::JsSystem.new(ctx: context)
+          Tasks::FindNpmPackages.exactly_one_of(cli_package_name, js_system: js_system)
+            .unwrap { |_e| context.abort(context.message("errors.package_not_found", cli_package_name)) }
         end
 
         protected
@@ -64,7 +79,7 @@ tunnel_url: tunnel_url).call
         def argo
           Features::Argo.new(
             git_template: specification.features.argo.git_template,
-            renderer_package_name: specification.features.argo.renderer_package_name,
+            renderer_package_name: specification.features.argo.renderer_package_name
           )
         end
 

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -42,10 +42,12 @@ module Extension
             renderer_package_name: "@shopify/argo-admin",
             required_fields: [:shop, :api_key],
             required_shop_beta_flags: [:argo_admin_beta],
+            cli_package_name: "@shopify/argo-admin-cli",
           },
           checkout: {
             git_template: "https://github.com/Shopify/argo-checkout-template.git",
             renderer_package_name: "@shopify/argo-checkout",
+            cli_package_name: "@shopify/argo-run",
           },
         }
       end

--- a/lib/project_types/extension/tasks/find_npm_packages.rb
+++ b/lib/project_types/extension/tasks/find_npm_packages.rb
@@ -4,6 +4,7 @@ module Extension
       include ShopifyCli::MethodObject
 
       property! :js_system, accepts: ShopifyCli::JsSystem
+      property! :production_only, accepts: [true, false], default: false, reader: :production_only?
 
       def self.at_least_one_of(*package_names, **config)
         new(**config).at_least_one_of(*package_names)
@@ -82,11 +83,11 @@ module Extension
       end
 
       def yarn_list
-        %w[list --production]
+        production_only? ? %w[list --production] : %w[list]
       end
 
       def npm_list
-        %w[list --prod --depth=1]
+        production_only? ? %w[list --prod --depth=1] : %w[list --depth=1]
       end
 
       def search_packages(packages, package_list)

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -16,23 +16,59 @@ module Extension
 
       def test_defers_serving_to_the_specification_handler
         serve = ::Extension::Commands::Serve.new(@context)
+        stub_specification_handler_options(serve)
         serve.specification_handler.expects(:serve)
         serve.call([], "serve")
       end
 
-      def test_error_raised_if_no_available_ports_found
+      def test_error_raised_if_specification_handler_supports_choosing_port_but_no_ports_available
         serve = ::Extension::Commands::Serve.new(@context)
 
         Tasks::ChooseNextAvailablePort.expects(:call)
           .with(from: ::Extension::Commands::Serve::DEFAULT_PORT)
           .returns(ShopifyCli::Result.failure(ArgumentError))
           .once
+        serve.specification_handler.expects(:choose_port?).returns(true).once
 
         error = assert_raises ShopifyCli::Abort do
           serve.call([], "serve")
         end
 
         assert_includes error.message, @context.message("serve.no_available_ports_found")
+      end
+
+      def test_port_not_chosen_if_specification_handler_does_not_support_chosen_port
+        serve = ::Extension::Commands::Serve.new(@context)
+        stub_specification_handler_options(serve)
+        Tasks::ChooseNextAvailablePort.expects(:call).never
+        serve.specification_handler.expects(:serve).once
+        serve.call([], "serve")
+      end
+
+      def test_new_tunnel_started_if_specification_handler_supports_establish_tunnel
+        serve = ::Extension::Commands::Serve.new(@context)
+        stub_specification_handler_options(serve, choose_port: true, establish_tunnel: true)
+        ShopifyCli::Tunnel.expects(:start)
+          .with(@context, port: Extension::Commands::Serve::DEFAULT_PORT)
+          .returns("ngrok.example.com")
+          .once
+        serve.specification_handler.expects(:serve).once
+        serve.call([], "serve")
+      end
+
+      def test_tunnel_not_started_if_specification_handler_does_not_support_establish_tunnel
+        serve = ::Extension::Commands::Serve.new(@context)
+        stub_specification_handler_options(serve)
+        ShopifyCli::Tunnel.expects(:start).never
+        serve.specification_handler.expects(:serve).once
+        serve.call([], "serve")
+      end
+
+      private
+
+      def stub_specification_handler_options(serve, choose_port: false, establish_tunnel: false)
+        serve.specification_handler.expects(:choose_port?).returns(choose_port).once
+        serve.specification_handler.expects(:establish_tunnel?).returns(establish_tunnel).once
       end
     end
   end

--- a/test/project_types/extension/features/argo_cli_compatibility_test.rb
+++ b/test/project_types/extension/features/argo_cli_compatibility_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Features
+    class ArgoCliCompatibilityTest < MiniTest::Test
+      include ExtensionTestHelpers::TempProjectSetup
+
+      Package = Struct.new(:name, :version)
+
+      def test_accepts_port_is_true_for_supported_versions
+        argo_admin = Features::ArgoRendererPackage.new(package_name: "@shopify/argo-admin",
+          version: "0.0.1-doesnt-matter")
+
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0")
+
+        argo_cli_compatibility = Features::ArgoCliCompatibility.new(renderer_package: argo_admin,
+        installed_cli_package: installed_cli_package)
+
+        assert_predicate(argo_cli_compatibility, :accepts_port?)
+      end
+
+      def test_accepts_port_is_false_for_unsupported_versions
+        argo_admin = Features::ArgoRendererPackage.new(package_name: "@shopify/argo-admin",
+          version: "0.0.1-doesnt-matter")
+
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.9.0")
+
+        argo_cli_compatibility = Features::ArgoCliCompatibility.new(renderer_package: argo_admin,
+        installed_cli_package: installed_cli_package)
+
+        refute_predicate(argo_cli_compatibility, :accepts_port?)
+      end
+
+      def test_accepts_tunnel_url_is_true_for_supported_versions
+        argo_admin = Features::ArgoRendererPackage.new(package_name: "@shopify/argo-admin",
+          version: "0.0.1-doesnt-matter")
+
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0")
+
+        argo_cli_compatibility = Features::ArgoCliCompatibility.new(renderer_package: argo_admin,
+          installed_cli_package: installed_cli_package)
+
+        assert_predicate(argo_cli_compatibility, :accepts_tunnel_url?)
+      end
+
+      def test_accepts_tunnel_url_is_fales_for_unsupported_versions
+        argo_admin = Features::ArgoRendererPackage.new(package_name: "@shopify/argo-admin",
+          version: "0.0.1-doesnt-matter")
+
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.9.0")
+
+        argo_cli_compatibility = Features::ArgoCliCompatibility.new(renderer_package: argo_admin,
+          installed_cli_package: installed_cli_package)
+
+        refute_predicate(argo_cli_compatibility, :accepts_tunnel_url?)
+      end
+
+      def test_accepts_uuid_is_true_for_supported_versions
+        argo_admin = Features::ArgoRendererPackage.new(package_name: "@shopify/argo-admin",
+          version: "0.0.1-doesnt-matter")
+
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0")
+
+        argo_cli_compatibility = Features::ArgoCliCompatibility.new(renderer_package: argo_admin,
+          installed_cli_package: installed_cli_package)
+
+        assert_predicate(argo_cli_compatibility, :accepts_uuid?)
+      end
+
+      def test_accepts_uuid_is_false_for_unsupported_versions
+        argo_admin = Features::ArgoRendererPackage.new(package_name: "@shopify/argo-admin",
+          version: "0.0.1-doesnt-matter")
+
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.9.0")
+
+        argo_cli_compatibility = Features::ArgoCliCompatibility.new(renderer_package: argo_admin,
+          installed_cli_package: installed_cli_package)
+
+        refute_predicate(argo_cli_compatibility, :accepts_uuid?)
+      end
+
+      def test_accepts_argo_version_returns_true_for_admin_renderer
+        argo_checkout = Features::ArgoRendererPackage.new(package_name: "@shopify/argo-admin",
+          version: "0.0.1-doesnt-matter")
+
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-run", version: "0.11.0")
+
+        argo_cli_compatibility = Features::ArgoCliCompatibility.new(renderer_package: argo_checkout,
+          installed_cli_package: installed_cli_package)
+
+        assert_predicate(argo_cli_compatibility, :accepts_argo_version?)
+      end
+
+      def test_accepts_argo_version_returns_false_for_non_admin_renderer
+        argo_checkout = Features::ArgoRendererPackage.new(package_name: "@shopify/argo-checkout",
+          version: "0.0.1-doesnt-matter")
+
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-run", version: "0.0.1")
+
+        argo_cli_compatibility = Features::ArgoCliCompatibility.new(renderer_package: argo_checkout,
+          installed_cli_package: installed_cli_package)
+
+        refute_predicate(argo_cli_compatibility, :accepts_argo_version?)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_renderer_package_test.rb
+++ b/test/project_types/extension/features/argo_renderer_package_test.rb
@@ -22,21 +22,6 @@ module Extension
         assert_predicate(argo_renderer_package, :admin?)
       end
 
-      def test_argo_minimum_version_supports_uuid_flag
-        skip("Passing the a UUID to the Argo Webpack server is currently not supported")
-
-        uuid_supported = Features::ArgoRendererPackage.new(
-          package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
-          version: "0.9.4"
-        )
-        uuid_unsupported = Features::ArgoRendererPackage.new(
-          package_name: Features::ArgoRendererPackage::ARGO_ADMIN,
-          version: "0.1.2"
-        )
-        assert_predicate(uuid_supported, :supports_uuid_flag?)
-        refute_predicate(uuid_unsupported, :supports_uuid_flag?)
-      end
-
       def test_instantiation_from_npm_package
         npm_package = Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.9.3")
         argo_renderer_package = ArgoRendererPackage.from_npm_package(npm_package)

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -10,136 +10,43 @@ module Extension
       include ExtensionTestHelpers::TempProjectSetup
 
       ARGO_ADMIN_TEMPLATE = "https://github.com/Shopify/argo-admin.git"
-      ARGO_CHECKOUT_TEMPLATE = "https://github.com/Shopify/argo-checkout.git"
 
-      def setup
-        super
-        @api_key = "123abc"
-        @registration_uuid = "dev-123"
-        @argo_version = "0.9.4"
-      end
+      def test_argo_serve_defers_to_js_system
+        installed_cli_package = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0")
+        npm_package = Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.0.1")
+        renderer_package = Features::ArgoRendererPackage.from_npm_package(npm_package)
+        cli_compatibility = Features::ArgoCliCompatibility.new(installed_cli_package: installed_cli_package,
+          renderer_package: renderer_package)
+        argo_serve = Features::ArgoServe.new(context: @context, cli_compatibility: cli_compatibility,
+          specification_handler: specification_handler)
 
-      def test_extensions_that_require_version_have_argo_version_command_line_argument
-        stub_argo_enabled_shop
-        dummy_handler = build_dummy_specification_handler(
-          renderer_package_version: @argo_version,
-          specification: admin_specification
-        )
-
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with do |args|
-            assert_includes args.fetch(:yarn), "--argoVersion=#{@argo_version}"
-            assert_includes args.fetch(:npm), "--argoVersion=#{@argo_version}"
-          end
-          .returns(true)
-          .once
-        ArgoServe.new(specification_handler: dummy_handler, context: @context).call
-      end
-
-      def test_extension_versions_that_do_not_require_argo_version_do_not_have_argo_version_command_line_arg
-        stub_argo_enabled_shop
-        dummy_handler = build_dummy_specification_handler(
-          renderer_package_version: @argo_version,
-          specification: checkout_specification
-        )
-
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with do |args|
-            refute_includes(args.fetch(:yarn), "--argoVersion=#{@argo_version}")
-            refute_includes(args.fetch(:npm), "--argoVersion=#{@argo_version}")
-          end
-          .returns(true)
-          .once
-        ArgoServe.new(specification_handler: dummy_handler, context: @context).call
-      end
-
-      def test_extension_versions_that_support_uuid_have_uuid_command_line_argument
-        skip("Passing the a UUID to the Argo Webpack server is currently not supported")
-
-        stub_argo_enabled_shop
-        dummy_handler = build_dummy_specification_handler(
-          renderer_package_version: @argo_version,
-          specification: admin_specification
-        )
-
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with do |args|
-            assert_includes args.fetch(:yarn), "--uuid=#{@registration_uuid}"
-            assert_includes args.fetch(:npm), "--uuid=#{@registration_uuid}"
-          end
-          .returns(true)
-          .once
-        ArgoServe.new(specification_handler: dummy_handler, context: @context).call
-      end
-
-      def test_extension_versions_that_do_not_support_uuid_do_not_have_uuid_command_line_argument
-        stub_argo_enabled_shop
-        unsupported_argo = "0.9.2"
-        dummy_handler = build_dummy_specification_handler(
-          renderer_package_version: unsupported_argo,
-          specification: admin_specification
-        )
-
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with do |args|
-            refute_includes(args.fetch(:yarn), "--uuid=#{@registration_uuid}")
-            refute_includes(args.fetch(:npm), "--uuid=#{@registration_uuid}")
-          end
-          .returns(true)
-          .once
-        ArgoServe.new(specification_handler: dummy_handler, context: @context).call
+        Tasks::FindNpmPackages.expects(:exactly_one_of).returns(ShopifyCli::Result.success(npm_package))
+        argo_serve.expects(:validate_env!).once
+        argo_serve.expects(:call_js_system).returns(true).once
+        argo_serve.call
       end
 
       private
 
-      def mock_specification(surface:, git_template:, renderer_package_name:, required_fields: [], betas: [])
-        {
-          identifier: "test",
-          features: {
-            argo: {
-              surface: surface,
-              git_template: git_template,
-              renderer_package_name: renderer_package_name,
-              required_fields: required_fields,
-              required_shop_beta_flags: betas,
+      def specification
+        Extension::Models::Specification.new(
+          {
+            identifier: "test",
+            features: {
+              argo: {
+                surface: "admin",
+                git_template: ARGO_ADMIN_TEMPLATE,
+                renderer_package_name: "@shopify/argo-admin",
+                required_fields: [],
+                required_shop_beta_flags: [],
+              },
             },
-          },
-        }
-      end
-
-      def checkout_specification
-        mock_specification(surface: "checkout", git_template: ARGO_CHECKOUT_TEMPLATE,
-renderer_package_name: "@shopify/argo-checkout")
-      end
-
-      def admin_specification
-        mock_specification(surface: "admin", git_template: ARGO_ADMIN_TEMPLATE,
-renderer_package_name: "@shopify/argo-admin")
-      end
-
-      def stub_argo_enabled_shop(api_key: @api_key, registration_uuid: @registration_uuid, argo_version: @argo_version)
-        _ = argo_version
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
-        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        setup_temp_project(api_key: api_key, registration_uuid: registration_uuid)
-      end
-
-      def build_dummy_specification_handler(renderer_package_version:, specification:)
-        dummy_specification = Extension::Models::Specification.new(specification)
-        dummy_handler = Extension::Models::SpecificationHandlers::Default.new(dummy_specification)
-        dummy_handler.stubs(:renderer_package).returns(
-          Extension::Features::ArgoRendererPackage.new(
-            package_name: dummy_specification.features.argo.renderer_package_name,
-            version: renderer_package_version
-          )
+          }
         )
-        dummy_handler
+      end
+
+      def specification_handler
+        Extension::Models::SpecificationHandlers::Default.new(specification)
       end
     end
   end

--- a/test/project_types/extension/tasks/argo_serve_options_test.rb
+++ b/test/project_types/extension/tasks/argo_serve_options_test.rb
@@ -5,66 +5,68 @@ require "project_types/extension/extension_test_helpers"
 module Extension
   module Tasks
     class ArgoServeOptionsTest < MiniTest::Test
-      include ExtensionTestHelpers::TempProjectSetup
+      include ExtensionTestHelpers::TestExtensionSetup
       include TestHelpers::FakeUI
 
       DEFAULT_PORT = 39351
 
-      def test_serve_options_include_port_when_no_port_given
-        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin)
+      def test_serve_options_include_port_if_port_supported
+        cli_compatibility = setup_cli_compatibility(renderer_package: argo_admin, version: "0.11.0")
+        options = Features::ArgoServeOptions.new(cli_compatibility: cli_compatibility, context: @context,
+renderer_package: argo_admin)
 
         assert_includes(options.yarn_serve_command, "--port=#{DEFAULT_PORT}")
         assert_includes(options.npm_serve_command, "--port=#{DEFAULT_PORT}")
       end
 
-      def test_serve_options_use_custom_port_if_one_is_given
-        custom_port = 12345
-        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin, port: custom_port)
-
-        assert_includes(options.yarn_serve_command, "--port=#{custom_port}")
-        assert_includes(options.npm_serve_command, "--port=#{custom_port}")
-      end
-
-      def test_default_serve_options_include_api_key_when_required
+      def test_serve_options_include_api_key_when_required
         required_fields = [:api_key]
-        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin,
-          required_fields: required_fields)
+        cli_compatibility = setup_cli_compatibility(renderer_package: argo_admin, version: "0.1.2-doesnt-matter")
+        options = Features::ArgoServeOptions.new(cli_compatibility: cli_compatibility, context: @context,
+          renderer_package: argo_admin, required_fields: required_fields)
 
         assert_includes(options.yarn_serve_command, "--apiKey=apikey")
         assert_includes(options.npm_serve_command, "--apiKey=apikey")
       end
 
-      def test_default_serve_options_include_shop_when_required
+      def test_serve_options_include_shop_when_required
         required_fields = [:shop]
-
-        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin,
-          required_fields: required_fields)
+        cli_compatibility = setup_cli_compatibility(renderer_package: argo_admin, version: "0.1.2-doesnt-matter")
+        options = Features::ArgoServeOptions.new(cli_compatibility: cli_compatibility, context: @context,
+          renderer_package: argo_admin, required_fields: required_fields)
 
         assert_includes(options.yarn_serve_command, "--shop=my-test-shop.myshopify.com")
         assert_includes(options.npm_serve_command, "--shop=my-test-shop.myshopify.com")
       end
 
-      def test_serve_options_include_argo_version_if_renderer_package_is_admin
-        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin)
+      def test_serve_options_include_argo_version_if_argo_version_supported
+        cli_compatibility = setup_cli_compatibility(renderer_package: argo_admin, version: "0.9.3")
+        options = Features::ArgoServeOptions.new(cli_compatibility: cli_compatibility, context: @context,
+renderer_package: argo_admin)
 
         assert_includes(options.yarn_serve_command, "--argoVersion=0.1.2")
         assert_includes(options.npm_serve_command, "--argoVersion=0.1.2")
       end
 
-      def test_public_url_is_included_if_one_is_given
+      def test_public_url_is_included_if_public_url_supported
+        cli_compatibility = setup_cli_compatibility(renderer_package: argo_admin, version: "0.11.0")
         tunnel_url = "test.com"
-        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin,
-        public_url: tunnel_url)
+        options = Features::ArgoServeOptions.new(cli_compatibility: cli_compatibility, context: @context,
+          renderer_package: argo_admin, public_url: tunnel_url)
 
         assert_includes(options.yarn_serve_command, "--publicUrl=#{tunnel_url}")
         assert_includes(options.npm_serve_command, "--publicUrl=#{tunnel_url}")
       end
 
-      def test_public_url_is_not_included_if_one_not_given
-        options = Features::ArgoServeOptions.new(context: @context, renderer_package: argo_admin)
+      def test_serve_options_include_uuid_if_uuid_supported
+        cli_compatibility = setup_cli_compatibility(renderer_package: argo_admin, version: "0.11.0")
+        registration_uuid = "dev-12345"
+        ExtensionProject.any_instance.expects(:registration_uuid).returns(registration_uuid)
+        options = Features::ArgoServeOptions.new(cli_compatibility: cli_compatibility, context: @context,
+renderer_package: argo_admin)
 
-        refute_includes(options.yarn_serve_command, "--publicUrl=test.com")
-        refute_includes(options.npm_serve_command, "--publicUrl=test.com")
+        assert_includes(options.yarn_serve_command, "--uuid=#{registration_uuid}")
+        assert_includes(options.npm_serve_command, "--uuid=#{registration_uuid}")
       end
 
       private
@@ -78,6 +80,13 @@ module Extension
 
       def argo_admin
         argo_renderer_package(package_name: "@shopify/argo-admin")
+      end
+
+      def setup_cli_compatibility(renderer_package:, version:, cli_package_name: "@shopify/argo-admin-cli")
+        installed_cli_package = Models::NpmPackage.new(name: cli_package_name, version: version)
+
+        Features::ArgoCliCompatibility.new(renderer_package: renderer_package,
+          installed_cli_package: installed_cli_package)
       end
     end
   end

--- a/test/project_types/extension/tasks/find_npm_packages_test.rb
+++ b/test/project_types/extension/tasks/find_npm_packages_test.rb
@@ -106,14 +106,25 @@ module Extension
         end
       end
 
-      def test_js_system_is_invoked_with_the_correct_arguments
-        js_system = stub_js_system do |stub|
-          stub.with do |config|
+      def test_includes_development_dependencies_by_default
+        js_system = stub_js_system do |expect_js_system_call|
+          expect_js_system_call.with do |config|
+            assert_equal ["list"], config.fetch(:yarn)
+            assert_equal ["list", "--depth=1"], config.fetch(:npm)
+          end
+        end
+        result = FindNpmPackages.call(js_system: js_system)
+        assert_predicate(result, :success?)
+      end
+
+      def test_supports_filtering_by_production_dependencies
+        js_system = stub_js_system do |expect_js_system_call|
+          expect_js_system_call.with do |config|
             assert_equal ["list", "--production"], config.fetch(:yarn)
             assert_equal ["list", "--prod", "--depth=1"], config.fetch(:npm)
           end
         end
-        result = FindNpmPackages.call(js_system: js_system)
+        result = FindNpmPackages.call(js_system: js_system, production_only: true)
         assert_predicate(result, :success?)
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Check that `argo-admin-cli` version is compatible with `--port` and `--publicUrl` flags being passed in.

### WHAT is this pull request doing?

Incorporates `Tasks::FindNpmPackages` to find `argo-admin-cli` version to check for backwards compatibility.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
