### PR TITLE
[scripts] Show more execution context during a system call failure

### DIFF
--- a/lib/project_types/script/layers/domain/errors.rb
+++ b/lib/project_types/script/layers/domain/errors.rb
@@ -39,7 +39,14 @@ module Script
           end
         end
 
-        class ServiceFailureError < ScriptProjectError; end
+        class SystemCallFailureError < ScriptProjectError
+          attr_reader :out, :cmd
+          def initialize(out:, cmd:)
+            super()
+            @out = out
+            @cmd = cmd
+          end
+        end
 
         class MetadataNotFoundError < ScriptProjectError; end
 

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -65,7 +65,7 @@ module Script
           check_compilation_dependencies!
 
           out, status = ctx.capture2e(SCRIPT_SDK_BUILD)
-          raise Domain::Errors::ServiceFailureError, out unless status.success?
+          raise Domain::Errors::SystemCallFailureError.new(out: out, cmd: SCRIPT_SDK_BUILD) unless status.success?
         end
 
         def check_compilation_dependencies!

--- a/lib/project_types/script/layers/infrastructure/rust_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/rust_project_creator.rb
@@ -27,28 +27,29 @@ module Script
 
         private
 
+        def run_cmd(cmd)
+          out, status = ctx.capture2e(cmd)
+          raise Domain::Errors::SystemCallFailureError.new(out: out, cmd: cmd) unless status.success?
+          out
+        end
+
         def git_init
-          out, status = ctx.capture2e("git init")
-          raise Domain::Errors::ServiceFailureError, out unless status.success?
+          run_cmd("git init")
         end
 
         def setup_remote
           repo = extension_point.sdks.rust.package
-          out, status = ctx.capture2e("git remote add -f origin #{repo}")
-          raise Domain::Errors::ServiceFailureError, out unless status.success?
+          run_cmd("git remote add -f origin #{repo}")
         end
 
         def setup_sparse_checkout
           type = extension_point.type
-          out, status = ctx.capture2e("git config core.sparsecheckout true")
-          raise Domain::Errors::ServiceFailureError, out unless status.success?
-          out, status = ctx.capture2e("echo #{type}/#{SAMPLE_PATH} >> .git/info/sparse-checkout")
-          raise Domain::Errors::ServiceFailureError, out unless status.success?
+          run_cmd("git config core.sparsecheckout true")
+          run_cmd("echo #{type}/#{SAMPLE_PATH} >> .git/info/sparse-checkout")
         end
 
         def pull
-          out, status = ctx.capture2e("git pull origin #{ORIGIN_BRANCH}")
-          raise Domain::Errors::ServiceFailureError, out unless status.success?
+          run_cmd("git pull origin #{ORIGIN_BRANCH}")
         end
 
         def clean

--- a/lib/project_types/script/layers/infrastructure/rust_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/rust_task_runner.rb
@@ -7,6 +7,7 @@ module Script
 
         BUILD_TARGET = "wasm32-unknown-unknown"
         METADATA_FILE = "build/metadata.json"
+        CARGO_BUILD_CMD = "cargo build --target=#{BUILD_TARGET} --release"
 
         def initialize(ctx, script_name)
           @ctx = ctx
@@ -42,8 +43,8 @@ module Script
         private
 
         def compile
-          out, status = ctx.capture2e("cargo build --target=#{BUILD_TARGET} --release")
-          raise Domain::Errors::ServiceFailureError, out unless status.success?
+          out, status = ctx.capture2e(CARGO_BUILD_CMD)
+          raise Domain::Errors::SystemCallFailureError.new(out: out, cmd: CARGO_BUILD_CMD) unless status.success?
         end
 
         def bytecode

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -78,8 +78,8 @@ module Script
 
           script_not_found_cause: "Couldn't find script %s for extension point %s",
 
-          service_failure_cause: "Internal service error.",
-          service_failure_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",
+          system_call_failure_cause: "An error was returned while running {{command:%{cmd}}}.",
+          system_call_failure_help: "Review the following error and try again.\n{{red:%{out}}}",
 
           metadata_validation_cause: "Invalid script extension metadata.",
           metadata_validation_help: "Ensure the 'shopify/scripts-toolchain-as' package is up to date.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -110,10 +110,11 @@ module Script
               e.extension_point_type
             ),
           }
-        when Layers::Domain::Errors::ServiceFailureError
+        when Layers::Domain::Errors::SystemCallFailureError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.service_failure_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.service_failure_help"),
+            cause_of_error: ShopifyCli::Context
+              .message("script.error.system_call_failure_cause", cmd: e.cmd),
+            help_suggestion: ShopifyCli::Context.message("script.error.system_call_failure_help", out: e.out.chomp),
           }
         when Layers::Domain::Errors::MetadataValidationError
           {

--- a/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
@@ -24,6 +24,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
       },
     }
   end
+  let(:fake_capture2e_response) { [nil, OpenStruct.new(success?: true)] }
 
   before do
     context.mkdir_p(script_name)
@@ -32,19 +33,8 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
   describe ".setup_dependencies" do
     subject { project_creator.setup_dependencies }
 
-    it "should write to npmrc" do
-      context
-        .expects(:system)
-        .with("npm", "--userconfig", "./.npmrc", "config", "set", "@shopify:registry", "https://registry.npmjs.com")
-      context
-        .expects(:system)
-        .with("npm", "--userconfig", "./.npmrc", "config", "set", "engine-strict", "true")
-      subject
-    end
-
     it "should write to package.json" do
-      context.expects(:system).twice
-      context.expects(:capture2e).once.returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)])
+      context.expects(:capture2e).returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)]).times(3)
       context.expects(:write).with do |_file, contents|
         payload = JSON.parse(contents)
         build = payload.dig("scripts", "build")
@@ -60,8 +50,14 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
     end
 
     it "should fetch the latest extension point version if the package is not versioned" do
-      context.expects(:system).twice
-
+      context
+        .expects(:capture2e)
+        .with("npm --userconfig ./.npmrc config set @shopify:registry https://registry.npmjs.com")
+        .returns(fake_capture2e_response)
+      context
+        .expects(:capture2e)
+        .with("npm --userconfig ./.npmrc config set engine-strict true")
+        .returns(fake_capture2e_response)
       context
         .expects(:capture2e)
         .with("npm show @shopify/extension-point-as-fake version --json")
@@ -81,7 +77,14 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
     end
 
     it "should set the specified package version when the package is versioned" do
-      context.expects(:system).twice
+      context
+        .expects(:capture2e)
+        .with("npm --userconfig ./.npmrc config set @shopify:registry https://registry.npmjs.com")
+        .returns(fake_capture2e_response)
+      context
+        .expects(:capture2e)
+        .then.with("npm --userconfig ./.npmrc config set engine-strict true")
+        .returns(fake_capture2e_response)
 
       context
         .expects(:capture2e)
@@ -102,7 +105,14 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
     end
 
     it "should raise if the latest extension point version can't be fetched" do
-      context.expects(:system).twice
+      context
+        .expects(:capture2e)
+        .with("npm --userconfig ./.npmrc config set @shopify:registry https://registry.npmjs.com")
+        .returns(fake_capture2e_response)
+      context
+        .expects(:capture2e)
+        .then.with("npm --userconfig ./.npmrc config set engine-strict true")
+        .returns(fake_capture2e_response)
 
       context
         .expects(:capture2e)
@@ -117,7 +127,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
       sdk.expects(:package).twice.returns("@shopify/extension-point-as-fake")
       extension_point.expects(:sdks).times(5).returns(stub(all: [sdk], assemblyscript: sdk))
 
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError) { subject }
     end
   end
 
@@ -141,7 +151,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
         )
         .returns(["", OpenStruct.new(success?: false)])
 
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError) { subject }
     end
   end
 
@@ -174,8 +184,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
     end
 
     it "should create the build command in the package.json with the appropriate domain arguments" do
-      context.expects(:system).twice
-      context.expects(:capture2e).once.returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)])
+      context.expects(:capture2e).once.returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)]).times(3)
       context.expects(:write).with do |_file, contents|
         payload = JSON.parse(contents)
         build = payload.dig("scripts", "build")

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -94,7 +94,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
         .stubs(:capture2e)
         .returns([output, mock(success?: false)])
 
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError, output) do
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError, output) do
         subject
       end
     end

--- a/test/project_types/script/layers/infrastructure/rust_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/rust_project_creator_test.rb
@@ -78,7 +78,7 @@ describe Script::Layers::Infrastructure::RustProjectCreator do
         .with("git init").once
         .returns(system_output(msg: "Couldn't initialize git repository", success: false))
 
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError) { subject }
     end
 
     it "should raise a service failure error if the git remote cannot be configured" do
@@ -89,7 +89,7 @@ describe Script::Layers::Infrastructure::RustProjectCreator do
         .with("git remote add -f origin #{extension_point.sdks.rust.package}").once
         .returns(system_output(msg: "Couldn't set remote origin", success: false))
 
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError) { subject }
     end
 
     it "should raise a service failure error if sparse checkout cannot be configured" do
@@ -100,7 +100,7 @@ describe Script::Layers::Infrastructure::RustProjectCreator do
         .with("git config core.sparsecheckout true").once
         .returns(system_output(msg: "Couldn't set sparse checkout", success: false))
 
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError) { subject }
     end
 
     it "should raise a service failure error if the sparse checkout config cannot be written" do
@@ -110,7 +110,7 @@ describe Script::Layers::Infrastructure::RustProjectCreator do
         .with("echo #{extension_point.type}/default >> .git/info/sparse-checkout").once
         .returns(system_output(msg: "Couldn't write to the sparse checkout config", success: false))
 
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError) { subject }
     end
 
     it "raises if there is an error pulling from the remote's origin" do
@@ -120,7 +120,7 @@ describe Script::Layers::Infrastructure::RustProjectCreator do
         .with("git pull origin main")
         .once
         .returns(system_output(msg: "Fatal", success: false))
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError) { subject }
     end
   end
 end

--- a/test/project_types/script/layers/infrastructure/rust_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/rust_task_runner_test.rb
@@ -31,7 +31,7 @@ describe Script::Layers::Infrastructure::RustTaskRunner do
         .with("cargo build --target=wasm32-unknown-unknown --release")
         .returns(system_output(msg: "", success: false))
 
-      assert_raises(Script::Layers::Domain::Errors::ServiceFailureError) { subject }
+      assert_raises(Script::Layers::Domain::Errors::SystemCallFailureError) { subject }
     end
 
     it "should raise if the generated wasm binary doesn't exist" do


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up on the slack convo where there was an issue fetching a package from the shopify registry. TLDR, we aren't showing enough context to be able to adequately debug problems. 

### WHAT is this pull request doing?

- Renames `ServiceFailureError` to `SystemCallFailureError` since this class is only raised during `ctx.system`/`ctx.capture2e` failures
- On error, provide the name of the command that failed along with the error.

![image](https://user-images.githubusercontent.com/28009669/117719063-edf8e300-b1aa-11eb-8188-413e09665f37.png)


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
