### PR TITLE
Prioritizes returning an https url over http with 'shopify tunnel status'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ------
 
+* [#1221](https://github.com/Shopify/shopify-app-cli/pull/1221): Prioritizes returning an HTTPS URL over HTTP from `shopify tunnel status`.
+
 Version 1.10.0
 -------------
 * Updating internal features in development

--- a/lib/project_types/extension/commands/tunnel.rb
+++ b/lib/project_types/extension/commands/tunnel.rb
@@ -37,7 +37,9 @@ module Extension
       private
 
       def status
-        tunnel_url = ShopifyCli::Tunnel.urls.first
+        tunnel_urls = ShopifyCli::Tunnel.urls
+        tunnel_url = tunnel_urls.find { |url| url.start_with?("https://") }
+        tunnel_url = tunnel_urls.first if tunnel_url.nil?
 
         if tunnel_url.nil?
           @ctx.puts(@ctx.message("tunnel.no_tunnel_running"))

--- a/test/project_types/extension/commands/tunnel_test.rb
+++ b/test/project_types/extension/commands/tunnel_test.rb
@@ -67,7 +67,7 @@ module Extension
         capture_io { run_tunnel(Tunnel::STOP_SUBCOMMAND) }
       end
 
-      def test_status_outputs_no_tunnel_running_if_tunnel_url_returns_empty
+      def test_status_outputs_no_tunnel_running_if_tunnel_urls_returns_empty
         ShopifyCli::Tunnel.expects(:urls).returns([]).once
 
         io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
@@ -75,13 +75,23 @@ module Extension
         assert_message_output(io: io, expected_content: @context.message("tunnel.no_tunnel_running"))
       end
 
-      def test_status_outputs_the_running_tunnel_url_if_returned_by_tunnel_url
-        fake_url = "http://12345.ngrok.io"
-        ShopifyCli::Tunnel.expects(:urls).returns([fake_url]).once
+      def test_status_outputs_the_https_url_of_the_running_tunnel_url_if_returned_by_tunnel_urls
+        fake_http_url = "http://12345.ngrok.io"
+        fake_https_url = "https://12345.ngrok.io"
+        ShopifyCli::Tunnel.expects(:urls).returns([fake_http_url, fake_https_url]).once
 
         io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
 
-        assert_message_output(io: io, expected_content: @context.message("tunnel.tunnel_running_at", fake_url))
+        assert_message_output(io: io, expected_content: @context.message("tunnel.tunnel_running_at", fake_https_url))
+      end
+
+      def test_status_outputs_the_http_url_of_the_running_tunnel_url_if_no_https_url_is_returned_by_tunnel_urls
+        fake_http_url = "http://12345.ngrok.io"
+        ShopifyCli::Tunnel.expects(:urls).returns([fake_http_url]).once
+
+        io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
+
+        assert_message_output(io: io, expected_content: @context.message("tunnel.tunnel_running_at", fake_http_url))
       end
 
       private


### PR DESCRIPTION
### WHY are these changes introduced?

While using `shopify tunnel` for the first time to test out a local shopify extension over HTTPS via an ngrok tunnel, I noticed an interesting difference in the output of the following commands:

* `shopify tunnel start` outputs an HTTPS URL
* `shopify tunnel status` outputs an HTTP URL

IMO, to offer a more secure user experience by default, we should always be outputting an HTTPS URL instead of HTTP whenever possible.

### WHAT is this pull request doing?

Before, the `shopify tunnel status` command would get all URLs for the ngrok tunnel and just return the first one. As of writing, ngrok returns the HTTP URL before the HTTPS one, so the HTTP URL would return first.

Now, I am using `Enumerable#find` to return the very first HTTPS URL. If none exists, then I fallback to existing behaviour (return the first available URL and output the same message as before).

**NOTE:** I have made an educated guess that this kind of change warrants a PATCH version bump. Therefore, I've incremented the version from 1.10.0 to 1.10.1. Feel free to instruct me to change my approach if necessary.

### Testing

This was done from an extension I just created with `shopify create extension`, using the latest version of Shopify CLI downloaded from Homebrew:

```
➜  evan_test_localhost shopify tunnel status
Tunnel running at: http://56dfc99e384a.ngrok.io
➜  evan_test_localhost ~/src/path/to/local/shopify-app-cli/bin/shopify tunnel status
⭑ You are running a development version of the CLI at:
  /{SNIP}/shopify-app-cli/bin/shopify

Tunnel running at: https://56dfc99e384a.ngrok.io
```

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
