### PR TITLE
Models::NpmPackage

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -84,6 +84,7 @@ module Extension
     autoload :Specification, Project.project_filepath("models/specification")
     autoload :Specifications, Project.project_filepath("models/specifications")
     autoload :LazySpecificationHandler, Project.project_filepath("models/lazy_specification_handler")
+    autoload :NpmPackage, Project.project_filepath("models/npm_package")
   end
 
   autoload :ExtensionProjectKeys, Project.project_filepath("extension_project_keys")

--- a/lib/project_types/extension/models/npm_package.rb
+++ b/lib/project_types/extension/models/npm_package.rb
@@ -1,0 +1,12 @@
+module Extension
+  module Models
+    NpmPackage = Struct.new(:name, :version, keyword_init: true) do
+      include Comparable
+
+      def <=>(other)
+        return nil unless name == other.name
+        Gem::Version.new(version) <=> Gem::Version.new(other.version)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/find_npm_packages.rb
+++ b/lib/project_types/extension/tasks/find_npm_packages.rb
@@ -3,8 +3,6 @@ module Extension
     class FindNpmPackages
       include ShopifyCli::MethodObject
 
-      Package = Struct.new(:name, :version)
-
       property! :js_system, accepts: ShopifyCli::JsSystem
 
       def self.at_least_one_of(*package_names, **config)
@@ -68,7 +66,7 @@ module Extension
       def search_packages(packages, package_list)
         pattern = /(#{packages.join("|")})@(\d.*)$/
         package_list.scan(pattern).map do |(name, version)|
-          Package.new(name, version.strip)
+          Models::NpmPackage.new(name: name, version: version.strip)
         end
       end
     end

--- a/test/project_types/extension/models/npm_package_test.rb
+++ b/test/project_types/extension/models/npm_package_test.rb
@@ -1,0 +1,64 @@
+
+require "test_helper"
+
+module Extension
+  module Models
+    class NpmPackageTest < MiniTest::Test
+      def setup
+        ShopifyCli::ProjectType.load_type(:extension)
+        super
+      end
+
+      def test_has_name
+        package = NpmPackage.new(**valid_attributes_with(name: "some-package-name"))
+        assert_equal "some-package-name", package.name
+      end
+
+      def test_has_version
+        package = NpmPackage.new(**valid_attributes_with(version: "0.0.1"))
+        assert_equal "0.0.1", package.version
+      end
+
+      def test_packages_with_different_names_are_not_comparable
+        package_a = NpmPackage.new(**valid_attributes_with(name: "a"))
+        package_b = NpmPackage.new(**valid_attributes_with(name: "b"))
+        assert_nil package_a <=> package_b
+      end
+
+      def test_packages_with_the_same_attributes_are_considered_equal
+        package_a = NpmPackage.new(**valid_attributes)
+        package_b = NpmPackage.new(**valid_attributes)
+        assert_equal 0, package_a <=> package_b
+      end
+
+      def test_packages_can_be_ordered_by_their_version
+        versions = [
+          ["0.0.1", :<, "0.0.2"],
+          ["0.0.1", :<, "0.0.1.1"],
+          ["0.0.1", :<, "0.1"],
+        ]
+
+        versions.each do |(a, operator, b)|
+          package_a = NpmPackage.new(**valid_attributes_with(version: a))
+          package_b = NpmPackage.new(**valid_attributes_with(version: b))
+          assert package_a.send(operator, package_b)
+        end
+      end
+
+      private
+
+      def valid_attributes_with(**overrides)
+        unknown_attributes = overrides.keys - valid_attributes.keys
+        raise ArgumentError, "Unknown attributes: #{unknown_attributes}" if unknown_attributes.any?
+        valid_attributes.merge(overrides)
+      end
+
+      def valid_attributes
+        {
+          name: "@shopify/argo-test",
+          version: "1.2.3",
+        }
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/find_npm_packages_test.rb
+++ b/test/project_types/extension/tasks/find_npm_packages_test.rb
@@ -81,10 +81,10 @@ module Extension
       end
 
       def test_js_system_is_invoked_with_the_correct_arguments
-        js_system = stub_js_system do |js_system|
-          js_system.with do |**args|
-            assert_equal ["list", "--production"], args.fetch(:yarn)
-            assert_equal ["list", "--prod", "--depth=1"], args.fetch(:npm)
+        js_system = stub_js_system do |stub|
+          stub.with do |config|
+            assert_equal ["list", "--production"], config.fetch(:yarn)
+            assert_equal ["list", "--prod", "--depth=1"], config.fetch(:npm)
           end
         end
         result = FindNpmPackages.call(js_system: js_system)


### PR DESCRIPTION
### WHY are these changes introduced?

To simplify comparing NPM Packages.

### WHAT is this pull request doing?

Extracts `Extension::Tasks::FindNpmPackages::Package` into `Extension::Models::NpmPackage` and implements the [`Comparable`](https://docs.ruby-lang.org/en/2.5.0/Comparable.html) interface.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
