### PR TITLE
Update ScriptRepushError message

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -79,10 +79,10 @@ module Script
         end
 
         class ScriptRepushError < ScriptProjectError
-          attr_reader :api_key
-          def initialize(api_key)
+          attr_reader :uuid
+          def initialize(uuid)
             super()
-            @api_key = api_key
+            @uuid = uuid
           end
         end
 

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -40,7 +40,7 @@ module Script
           return resp_hash["data"]["appScriptUpdateOrCreate"]["appScript"]["uuid"] if user_errors.empty?
 
           if user_errors.any? { |e| e["tag"] == "already_exists_error" }
-            raise Errors::ScriptRepushError, api_key
+            raise Errors::ScriptRepushError, uuid
           elsif (e = user_errors.any? { |err| err["tag"] == "config_ui_syntax_error" })
             raise Errors::ConfigUiSyntaxError, config_ui&.filename
           elsif (e = user_errors.find { |err| err["tag"] == "config_ui_missing_keys_error" })

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -113,7 +113,7 @@ module Script
           graphql_error_cause: "An error was returned: %s.",
           graphql_error_help: "\nReview the error and try again.",
 
-          script_repush_cause: "A script with the same extension point already exists on app (API key: %s).",
+          script_repush_cause: "A script with this UUID already exists (UUID: %s).",
           script_repush_help: "Use {{cyan:--force}} to replace the existing script.",
 
           shop_auth_cause: "Unable to authenticate with the store.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -214,7 +214,7 @@ module Script
           }
         when Layers::Infrastructure::Errors::ScriptRepushError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.script_repush_cause", e.api_key),
+            cause_of_error: ShopifyCli::Context.message("script.error.script_repush_cause", e.uuid),
             help_suggestion: ShopifyCli::Context.message("script.error.script_repush_help"),
           }
         when Layers::Infrastructure::Errors::ShopAuthenticationError

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -290,7 +290,7 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when ScriptRepushError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::ScriptRepushError.new("api_key") }
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptRepushError.new("uuid") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end


### PR DESCRIPTION
### WHY are these changes introduced?

This PR updates the `ScriptRepushError` message to be more reflective of the multi-script changes.

Closes https://github.com/Shopify/script-service/issues/3053

### WHAT is this pull request doing?

This PR updates the text content shown to the user as well as the `ScriptRepushError` to take in a UUID instead of app key.

![image](https://user-images.githubusercontent.com/1742857/117887430-ac396c80-b27e-11eb-9f27-575cd840ad25.png)

### Update checklist
- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrmenting this when releasing).
