### PR TITLE
add running_on?(port) helper to ShopifyCli::Tunnel

### DIFF
--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -59,6 +59,16 @@ module Extension
         return runtime_configuration unless specification_handler.establish_tunnel?(@ctx)
         return runtime_configuration unless runtime_configuration.tunnel_requested?
 
+        return start_tunnel(runtime_configuration) if can_start_tunnel?(runtime_configuration)
+        @ctx.abort(@ctx.message("serve.tunnel_already_running"))
+      end
+
+      def can_start_tunnel?(runtime_configuration)
+        return true if ShopifyCli::Tunnel.urls.empty?
+        ShopifyCli::Tunnel.running_on?(runtime_configuration.port)
+      end
+
+      def start_tunnel(runtime_configuration)
         tunnel_url = ShopifyCli::Tunnel.start(@ctx, port: runtime_configuration.port)
         runtime_configuration.tap { |c| c.tunnel_url = tunnel_url }
       end

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -53,7 +53,6 @@ module Extension
 
       def renderer_package(context)
         js_system = ShopifyCli::JsSystem.new(ctx: context)
-
         Tasks::FindNpmPackages
           .exactly_one_of(*PACKAGE_NAMES, js_system: js_system)
           .then { |package| Features::ArgoRendererPackage.from_npm_package(package) }

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -59,6 +59,7 @@ module Extension
         no_available_ports_found: "No available ports found to run extension.",
         serve_failure_message: "Failed to run extension code.",
         serve_missing_information: "Missing shop or api_key.",
+        tunnel_already_running: "A tunnel running on another port has been detected. Close the tunnel and try again.",
       },
       tunnel: {
         missing_token: "{{x}} {{red:auth requires a token argument}}. "\

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -141,6 +141,24 @@ module ShopifyCli
       end
     end
 
+    def test_tunnel_running_on_returns_false_if_port_provided_is_available
+      mock_ngrok_tunnels_http_call(response_body: JSON.dump(fake_ngrok_api_response))
+      port_to_check = 12345
+      refute Tunnel.running_on?(port_to_check)
+    end
+
+    def test_tunnel_running_on_returns_true_if_tunnel_running_on_provided_port
+      mock_ngrok_tunnels_http_call(response_body: JSON.dump(fake_ngrok_api_response))
+      port_to_check = 39351
+      assert Tunnel.running_on?(port_to_check)
+    end
+
+    def test_tunnel_running_on_returns_false_if_tunnel_urls_empty
+      mock_ngrok_tunnels_http_call(response_body: JSON.dump({}))
+      port_to_check = 39351
+      refute Tunnel.running_on?(port_to_check)
+    end
+
     private
 
     def with_log(fixture: "ngrok", time: Time.now.strftime("%s"))


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/shopify-app-cli/pull/1191

`Extensions::Commands::Serve` needs to be able to start a tunnel from the serve command, and pass the URL the tunnel is running on to the underlying extension CLI.

~In order for us to be able to do this, we need to make sure there isn't a tunnel already running on the same port.~
If there is another tunnel already running, but on a different port, we should abort and let the user know, so the user can decide how they want to handle (stop the other tunnel if they choose).

### WHAT is this pull request doing?

This PR introduces a helper for `ShopifyCli::Tunnel` to check if there is already a tunnel running on a specific port.

Usage: `ShopifyCli::Tunnel.running_on?(8000)`. This returns a boolean value whether a tunnel is running on the given port.

PR also incorporates the new helper into `Extension::Commands:Serve` to check if a tunnel is already running, before we start a new tunnel.

## Tophat instructions 🎩 

### No tunnels running

1. Run `killall -9 ngrok` to ensure there are no tunnels running (`shopify tunnel stop` does not kill the tunnels)
2. `cd` into an extension project
3. Run `shopify serve`
4. You should see a webpack server start on default port `39351`

<img width="1896" alt="serve - no tunnels running" src="https://user-images.githubusercontent.com/989784/118296564-bd62c300-b4a2-11eb-8005-8478364cf075.png">

### Tunnel already running on same port

1. Stop the webpack server with `cmd/ctrl + c`
2. Restart the webpack server with `shopify serve`
3. You should see the webpack server start on the same port as before

<img width="1887" alt="serve - tunnel running on same port" src="https://user-images.githubusercontent.com/989784/118296957-29452b80-b4a3-11eb-81c2-3201149c165c.png">

### Tunnel running on a different port

1. Kill all ngrok tunnels `killall -9 ngrok`
2. Start a tunnel on a different port `shopify tunnel --port=8080`
3. Attempt to run `shopify serve`
4. Notice an error message letting you know a tunnel is running on a different port

<img width="1894" alt="serve -- tunnel running on different port" src="https://user-images.githubusercontent.com/989784/118297129-5db8e780-b4a3-11eb-9400-2dd0da088125.png">


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrmenting this when releasing).
