### PR TITLE
[scripts] Update filename of generated wasm

### DIFF
--- a/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_project_creator.rb
@@ -12,7 +12,7 @@ module Script
 
         BOOTSTRAP = "npx --no-install shopify-scripts-toolchain-as bootstrap --from %{extension_point} --dest %{base}"
         BUILD = "shopify-scripts-toolchain-as build --src src/shopify_main.ts " \
-        "--binary build/%{script_name}.wasm --metadata build/metadata.json"
+        "--binary build/script.wasm --metadata build/metadata.json"
         MIN_NODE_VERSION = "14.5.0"
         ASC_ARGS = "-- --lib node_modules --optimize --use Date="
 
@@ -81,13 +81,12 @@ module Script
 
         def build_command
           type = extension_point.dasherize_type
-          base_command = format(BUILD, script_name: script_name)
           domain = extension_point.domain
 
           if domain.nil?
-            "#{base_command} #{ASC_ARGS}"
+            "#{BUILD} #{ASC_ARGS}"
           else
-            "#{base_command} --domain #{domain} --ep #{type} #{ASC_ARGS}"
+            "#{BUILD} --domain #{domain} --ep #{type} #{ASC_ARGS}"
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/assemblyscript_task_runner.rb
@@ -79,11 +79,19 @@ module Script
         end
 
         def bytecode
-          filename = format(BYTECODE_FILE, name: script_name)
-          raise Errors::WebAssemblyBinaryNotFoundError unless ctx.file_exist?(filename)
+          legacy_filename = format(BYTECODE_FILE, name: script_name)
+          filename = format(BYTECODE_FILE, name: "script")
 
-          contents = ctx.binread(filename)
-          ctx.rm(filename)
+          bytecode_file = if ctx.file_exist?(filename)
+            filename
+          elsif ctx.file_exist?(legacy_filename)
+            legacy_filename
+          else
+            raise Errors::WebAssemblyBinaryNotFoundError
+          end
+
+          contents = ctx.binread(bytecode_file)
+          ctx.rm(bytecode_file)
 
           contents
         end

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -8,7 +8,7 @@ module Script
         property! :ctx, accepts: ShopifyCli::Context
 
         def create_push_package(script_project:, script_content:, compiled_type:, metadata:)
-          build_file_path = file_path(script_project.id, script_project.script_name, compiled_type)
+          build_file_path = file_path(script_project.id, compiled_type)
           write_to_path(build_file_path, script_content)
 
           Domain::PushPackage.new(
@@ -24,7 +24,7 @@ module Script
         end
 
         def get_push_package(script_project:, compiled_type:, metadata:)
-          build_file_path = file_path(script_project.id, script_project.script_name, compiled_type)
+          build_file_path = file_path(script_project.id, compiled_type)
           raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
 
           script_content = ctx.binread(build_file_path)
@@ -47,8 +47,8 @@ module Script
           ctx.binwrite(path, content)
         end
 
-        def file_path(path_to_script, script_name, compiled_type)
-          "#{path_to_script}/build/#{script_name}.#{compiled_type}"
+        def file_path(path_to_script, compiled_type)
+          "#{path_to_script}/build/script.#{compiled_type}"
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/rust_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/rust_task_runner.rb
@@ -3,15 +3,14 @@ module Script
   module Layers
     module Infrastructure
       class RustTaskRunner
-        attr_reader :ctx, :script_name
+        attr_reader :ctx
 
         BUILD_TARGET = "wasm32-unknown-unknown"
         METADATA_FILE = "build/metadata.json"
         CARGO_BUILD_CMD = "cargo build --target=#{BUILD_TARGET} --release"
 
-        def initialize(ctx, script_name)
+        def initialize(ctx, _)
           @ctx = ctx
-          @script_name = script_name
         end
 
         def dependencies_installed?
@@ -47,7 +46,7 @@ module Script
         end
 
         def bytecode
-          binary_name = "#{script_name}.wasm"
+          binary_name = "script.wasm"
           binary_path = "target/#{BUILD_TARGET}/release/#{binary_name}"
           raise Errors::WebAssemblyBinaryNotFoundError unless ctx.file_exist?(binary_path)
 

--- a/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_project_creator_test.rb
@@ -40,7 +40,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
         build = payload.dig("scripts", "build")
         expected = [
           "shopify-scripts-toolchain-as build --src src/shopify_main.ts",
-          "--binary build/myscript.wasm --metadata build/metadata.json",
+          "--binary build/script.wasm --metadata build/metadata.json",
           "-- --lib node_modules --optimize --use Date=",
         ].join(" ")
         expected == build
@@ -189,7 +189,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptProjectCreator do
         payload = JSON.parse(contents)
         build = payload.dig("scripts", "build")
         expected = [
-          "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/myscript.wasm",
+          "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/script.wasm",
           "--metadata build/metadata.json --domain checkout --ep discount",
           "-- --lib node_modules --optimize --use Date=",
         ].join(" ")

--- a/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/assemblyscript_task_runner_test.rb
@@ -48,13 +48,7 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
     end
 
     it "should raise an error if the generated web assembly is not found" do
-      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
-      ctx
-        .expects(:file_exist?)
-        .with("build/foo.wasm")
-        .once
-        .returns(false)
-
+      ctx.write("package.json", JSON.generate(package_json))
       ctx
         .expects(:capture2e)
         .with("npm run build")
@@ -64,26 +58,37 @@ describe Script::Layers::Infrastructure::AssemblyScriptTaskRunner do
       assert_raises(Script::Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError) { subject }
     end
 
-    it "should trigger the compilation process" do
-      wasm = "some compiled code"
-      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
-      ctx.expects(:binread).with("build/foo.wasm").once.returns(wasm)
+    describe "success" do
+      def self.it_triggers_compilation_process
+        it("triggers the compilation process") do
+          wasm = "some compiled code"
+          ctx.write("package.json", JSON.generate(package_json))
+          ctx.mkdir_p(File.dirname(wasmfile))
+          ctx.write(wasmfile, wasm)
 
-      ctx
-        .expects(:capture2e)
-        .with("npm run build")
-        .once
-        .returns(["output", mock(success?: true)])
+          ctx
+            .expects(:capture2e)
+            .with("npm run build")
+            .once
+            .returns(["output", mock(success?: true)])
 
-      ctx
-        .expects(:file_exist?)
-        .with("build/foo.wasm")
-        .once
-        .returns(true)
+          assert ctx.file_exist?(wasmfile)
+          assert_equal wasm, subject
+          refute ctx.file_exist?(wasmfile)
+        end
+      end
 
-      ctx.expects("rm").with("build/foo.wasm").once
+      describe "legacy naming" do
+        let(:wasmfile) { "build/#{script_name}.wasm" }
 
-      assert_equal wasm, subject
+        it_triggers_compilation_process
+      end
+
+      describe "new naming" do
+        let(:wasmfile) { "build/script.wasm" }
+
+        it_triggers_compilation_process
+      end
     end
 
     it "should raise error without command output on failure" do

--- a/test/project_types/script/layers/infrastructure/rust_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/rust_task_runner_test.rb
@@ -44,7 +44,7 @@ describe Script::Layers::Infrastructure::RustTaskRunner do
       ctx
         .expects(:file_exist?)
         .once
-        .with("target/wasm32-unknown-unknown/release/#{script_name}.wasm")
+        .with("target/wasm32-unknown-unknown/release/script.wasm")
         .returns(false)
 
       assert_raises(Script::Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError) { subject }
@@ -60,13 +60,13 @@ describe Script::Layers::Infrastructure::RustTaskRunner do
       ctx
         .expects(:file_exist?)
         .once
-        .with("target/wasm32-unknown-unknown/release/#{script_name}.wasm")
+        .with("target/wasm32-unknown-unknown/release/script.wasm")
         .returns(true)
 
       ctx
         .expects(:binread)
         .once
-        .with("target/wasm32-unknown-unknown/release/#{script_name}.wasm")
+        .with("target/wasm32-unknown-unknown/release/script.wasm")
         .returns("blob")
 
       assert_equal "blob", subject


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/3054

The filename of the generated WASM depends on the title of the script. In AS, this filename is hardcoded in the npm `build` script. So if a user changes the title of a script, everything blows up.

### WHAT is this pull request doing?

- Renames the wasm file to `script.wasm` instead of `<script-title>.wasm`
- Supports legacy naming so existing scripts that have the existing title hardcoded into npm `build` command will still function properly

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrmenting this when releasing).
