### PR TITLE
[Extensions] Add CheckoutArgoExtension specification handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 * Improved handling of "account not found" scenario, plus improvements to related tests and UX messaging
 
 * [#1221](https://github.com/Shopify/shopify-app-cli/pull/1221): Prioritizes returning an HTTPS URL over HTTP from `shopify tunnel status`.
+- [#1229](https://github.com/Shopify/shopify-app-cli/pull/1229): Allows Checkout Extensions to specify configuration attributes in their extension.config.yml file.
 
 Version 1.10.0
 -------------

--- a/lib/project_types/extension/models/specification_handlers/checkout_argo_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_argo_extension.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module SpecificationHandlers
+      class CheckoutArgoExtension < Default
+        PERMITTED_CONFIG_KEYS = [:metafields, :extension_points]
+
+        def config(context)
+          {
+            **Features::ArgoConfig.parse_yaml(context, PERMITTED_CONFIG_KEYS),
+            **argo.config(context),
+          }
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/specification_handlers/checkout_argo_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_argo_extension_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Models
+    module SpecificationHandlers
+      class CheckoutArgoExtensionTest < MiniTest::Test
+        include ExtensionTestHelpers
+
+        def setup
+          super
+          YAML.stubs(:load_file).returns({})
+          ShopifyCli::ProjectType.load_type(:extension)
+          Features::Argo.any_instance.stubs(:config).returns({})
+          Features::ArgoConfig.stubs(:parse_yaml).returns({})
+
+          specifications = DummySpecifications.build(identifier: "checkout_argo_extension", surface: "checkout")
+
+          @identifier = "CHECKOUT_ARGO_EXTENSION"
+          @checkout_argo_extension = specifications[@identifier]
+        end
+
+        def test_create_uses_standard_argo_create_implementation
+          directory_name = "checkout_argo_extension"
+
+          Features::Argo.any_instance
+            .expects(:create)
+            .with(directory_name, @identifier, @context)
+            .once
+
+          @checkout_argo_extension.create(directory_name, @context)
+        end
+
+        def test_config_uses_standard_argo_config_implementation
+          Features::Argo.any_instance.expects(:config).with(@context).once.returns({})
+          @checkout_argo_extension.config(@context)
+        end
+
+        def test_config_merges_with_standard_argo_config_implementation
+          script_content = "alert(true)"
+          metafields = [{ key: "a-key", namespace: "a-namespace" }]
+          extension_points = ["Checkout::Feature::Render"]
+
+          initial_config = { script_content: script_content }
+          yaml_config = { "metafields": metafields, "extension_points": extension_points }
+
+          Features::Argo.any_instance.expects(:config).with(@context).once.returns(initial_config)
+          Features::ArgoConfig.stubs(:parse_yaml).returns(yaml_config)
+
+          config = @checkout_argo_extension.config(@context)
+          assert_equal(metafields, config[:metafields])
+          assert_equal(extension_points, config[:extension_points])
+          assert_equal(script_content, config[:script_content])
+        end
+
+        def test_config_passes_allowed_keys
+          Features::Argo.any_instance.stubs(:config).returns({})
+          Features::ArgoConfig
+            .expects(:parse_yaml)
+            .with(@context, [:metafields, :extension_points])
+            .once
+            .returns({})
+
+          @checkout_argo_extension.config(@context)
+        end
+
+        def test_graphql_identifier
+          assert_equal @identifier, @checkout_argo_extension.graphql_identifier
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/checkout-web/issues/5087

For Unite, we need to allow Checkout Argo Extensions to specify metafields in their config file so that we can fetch them on the backend to return the proper metafields. For this reason, this PR is adding a new specification handle for Checkout Argo Extensions such that we merge the attributes they provided in their config file with the normal argo extensions configuration attributes. 

### WHAT is this pull request doing?

Adding a specification handler for `CheckoutArgoExtension` such that we can persist configuration attributes from the `extension.config.yml` when the extension is pushed. We currently accept two attributes for this file, namely:

- Extension points:
  This will allow us to know which extension points an extension has chosen to extend
- Metafields:
  Allows partners to specify metafields namespace and key pairs that they need when running their extension.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).

### Tophating

- Make sure to run partners, identity and shopify Core and no interceptors are enabled.
- Create a `Checkout Extension` using `shopify create extension`
- Modify the config.yml file of the extension to include metafields (the extension points attribute should already be there)
- Push the extension with `shopify push` in the extension directory
- Check that the config file attributes were properly persisted on Core