### PR TITLE
Feature: Add ArgoAdmin specification handler

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -40,6 +40,7 @@ module Extension
     autoload :ConfigureFeatures, Project.project_filepath("tasks/configure_features")
     autoload :ChooseNextAvailablePort, Project.project_filepath("tasks/choose_next_available_port")
     autoload :FindNpmPackages, Project.project_filepath("tasks/find_npm_packages")
+    autoload :Serve, Project.project_filepath("tasks/serve")
 
     module Converters
       autoload :RegistrationConverter, Project.project_filepath("tasks/converters/registration_converter")
@@ -76,6 +77,7 @@ module Extension
   module Models
     module SpecificationHandlers
       autoload :Default, Project.project_filepath("models/specification_handlers/default")
+      autoload :ArgoAdmin, Project.project_filepath("models/specification_handlers/argo_admin")
     end
 
     autoload :App, Project.project_filepath("models/app")

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -77,7 +77,7 @@ module Extension
   module Models
     module SpecificationHandlers
       autoload :Default, Project.project_filepath("models/specification_handlers/default")
-      autoload :ArgoAdmin, Project.project_filepath("models/specification_handlers/argo_admin")
+      autoload :Argo, Project.project_filepath("models/specification_handlers/argo")
     end
 
     autoload :App, Project.project_filepath("models/app")

--- a/lib/project_types/extension/models/specification.rb
+++ b/lib/project_types/extension/models/specification.rb
@@ -12,7 +12,13 @@ module Extension
           property! :git_template, converts: :to_str
           property! :required_fields, accepts: Array, default: -> { [] }
           property! :required_shop_beta_flags, accepts: Array, default: -> { [] }
-          property! :cli_package_name, accepts: String, converts: :to_str, default: ""
+
+          def handler
+            case surface
+            when "admin"
+              SpecificationHandlers::ArgoAdmin
+            end
+          end
         end
 
         def self.build(feature_set_attributes)
@@ -34,6 +40,15 @@ module Extension
 
       def graphql_identifier
         super || identifier
+      end
+
+      def surface
+        return nil unless feature?(:argo)
+        features.argo.surface
+      end
+
+      def feature?(name)
+        features.key?(name.to_sym)
       end
     end
   end

--- a/lib/project_types/extension/models/specification.rb
+++ b/lib/project_types/extension/models/specification.rb
@@ -12,13 +12,6 @@ module Extension
           property! :git_template, converts: :to_str
           property! :required_fields, accepts: Array, default: -> { [] }
           property! :required_shop_beta_flags, accepts: Array, default: -> { [] }
-
-          def handler
-            case surface
-            when "admin"
-              SpecificationHandlers::ArgoAdmin
-            end
-          end
         end
 
         def self.build(feature_set_attributes)

--- a/lib/project_types/extension/models/specification.rb
+++ b/lib/project_types/extension/models/specification.rb
@@ -41,15 +41,6 @@ module Extension
       def graphql_identifier
         super || identifier
       end
-
-      def surface
-        return nil unless feature?(:argo)
-        features.argo.surface
-      end
-
-      def feature?(name)
-        features.key?(name.to_sym)
-      end
     end
   end
 end

--- a/lib/project_types/extension/models/specification_handlers/argo.rb
+++ b/lib/project_types/extension/models/specification_handlers/argo.rb
@@ -6,6 +6,16 @@ module Extension
       class Argo < Default
         CLI_PACKAGE_NAME = "@shopify/argo-admin-cli"
 
+        def serve(context:, port:, tunnel_url:)
+          Features::ArgoServe.new(
+            specification_handler: self,
+            cli_compatibility: cli_compatibility(context),
+            context: context,
+            port: port,
+            tunnel_url: tunnel_url
+          ).call
+        end
+
         def choose_port?(context)
           cli_compatibility(context).accepts_port?
         end
@@ -14,14 +24,13 @@ module Extension
           cli_compatibility(context).accepts_tunnel_url?
         end
 
-        def serve(context:, port:, tunnel_url:)
-          Features::ArgoServe.new(specification_handler: self, cli_compatibility: cli_compatibility(context),
-          context: context, port: port, tunnel_url: tunnel_url).call
-        end
+        private
 
         def cli_compatibility(context)
-          @cli_compatibility ||= Features::ArgoCliCompatibility.new(renderer_package: renderer_package(context),
-          installed_cli_package: installed_cli_package(context))
+          @cli_compatibility ||= Features::ArgoCliCompatibility.new(
+            renderer_package: renderer_package(context),
+            installed_cli_package: installed_cli_package(context)
+          )
         end
 
         def installed_cli_package(context)

--- a/lib/project_types/extension/models/specification_handlers/argo.rb
+++ b/lib/project_types/extension/models/specification_handlers/argo.rb
@@ -3,7 +3,7 @@
 module Extension
   module Models
     module SpecificationHandlers
-      class ArgoAdmin < Default
+      class Argo < Default
         CLI_PACKAGE_NAME = "@shopify/argo-admin-cli"
 
         def choose_port?(context)

--- a/lib/project_types/extension/models/specification_handlers/argo_admin.rb
+++ b/lib/project_types/extension/models/specification_handlers/argo_admin.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
-require "base64"
 
 module Extension
   module Models
     module SpecificationHandlers
-      class CheckoutPostPurchase < Default
-        PERMITTED_CONFIG_KEYS = [:metafields]
-        CLI_PACKAGE_NAME = "@shopify/argo-run"
+      class ArgoAdmin < Default
+        CLI_PACKAGE_NAME = "@shopify/argo-admin-cli"
 
-        def config(context)
-          {
-            **Features::ArgoConfig.parse_yaml(context, PERMITTED_CONFIG_KEYS),
-            **argo.config(context),
-          }
+        def choose_port?(context)
+          cli_compatibility(context).accepts_port?
+        end
+
+        def establish_tunnel?(context)
+          cli_compatibility(context).accepts_tunnel_url?
         end
 
         def serve(context:, port:, tunnel_url:)

--- a/lib/project_types/extension/models/specification_handlers/checkout_post_purchase.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_post_purchase.rb
@@ -4,7 +4,7 @@ require "base64"
 module Extension
   module Models
     module SpecificationHandlers
-      class CheckoutPostPurchase < Default
+      class CheckoutPostPurchase < Argo
         PERMITTED_CONFIG_KEYS = [:metafields]
         CLI_PACKAGE_NAME = "@shopify/argo-run"
 
@@ -13,22 +13,6 @@ module Extension
             **Features::ArgoConfig.parse_yaml(context, PERMITTED_CONFIG_KEYS),
             **argo.config(context),
           }
-        end
-
-        def serve(context:, port:, tunnel_url:)
-          Features::ArgoServe.new(specification_handler: self, cli_compatibility: cli_compatibility(context),
-          context: context, port: port, tunnel_url: tunnel_url).call
-        end
-
-        def cli_compatibility(context)
-          @cli_compatibility ||= Features::ArgoCliCompatibility.new(renderer_package: renderer_package(context),
-          installed_cli_package: installed_cli_package(context))
-        end
-
-        def installed_cli_package(context)
-          js_system = ShopifyCli::JsSystem.new(ctx: context)
-          Tasks::FindNpmPackages.exactly_one_of(CLI_PACKAGE_NAME, js_system: js_system)
-            .unwrap { |_e| context.abort(context.message("errors.package_not_found", CLI_PACKAGE_NAME)) }
         end
       end
     end

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -42,36 +42,20 @@ module Extension
           []
         end
 
-        def choose_port?(context)
-          cli_compatibility(context).accepts_port?
+        def choose_port?(_context)
+          false
         end
 
-        def establish_tunnel?(context)
-          cli_compatibility(context).accepts_tunnel_url?
+        def establish_tunnel?(_context)
+          false
         end
 
-        def serve(context:, port:, tunnel_url:)
-          Features::ArgoServe.new(specification_handler: self, cli_compatibility: cli_compatibility(context),
-          context: context, port: port, tunnel_url: tunnel_url).call
+        def serve(context:, **_args)
+          Tasks::Serve.new(context: context).call
         end
 
         def renderer_package(context)
           argo.renderer_package(context)
-        end
-
-        def cli_compatibility(context)
-          @cli_compatibility ||= Features::ArgoCliCompatibility.new(renderer_package: renderer_package(context),
-          installed_cli_package: installed_cli_package(context))
-        end
-
-        def cli_package_name
-          specification.features.argo ? specification.features.argo.cli_package_name : ""
-        end
-
-        def installed_cli_package(context)
-          js_system = ShopifyCli::JsSystem.new(ctx: context)
-          Tasks::FindNpmPackages.exactly_one_of(cli_package_name, js_system: js_system)
-            .unwrap { |_e| context.abort(context.message("errors.package_not_found", cli_package_name)) }
         end
 
         protected

--- a/lib/project_types/extension/models/specifications.rb
+++ b/lib/project_types/extension/models/specifications.rb
@@ -87,9 +87,8 @@ module Extension
 
       def resolve_argo_specific_handler(specification, error)
         raise error unless error.is_a?(NameError)
-        handler = specification.features&.argo&.handler
-        raise NameError, "No specific handler for Argo target surface" if handler.nil?
-        handler
+        return SpecificationHandlers::Argo if !!specification.features&.argo
+        raise NameError, "No specific handler for Argo target surface"
       end
 
       def resolve_default_handler(error)

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -42,12 +42,10 @@ module Extension
             renderer_package_name: "@shopify/argo-admin",
             required_fields: [:shop, :api_key],
             required_shop_beta_flags: [:argo_admin_beta],
-            cli_package_name: "@shopify/argo-admin-cli",
           },
           checkout: {
             git_template: "https://github.com/Shopify/argo-checkout-template.git",
             renderer_package_name: "@shopify/argo-checkout",
-            cli_package_name: "@shopify/argo-run",
           },
         }
       end

--- a/lib/project_types/extension/tasks/serve.rb
+++ b/lib/project_types/extension/tasks/serve.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "shopify_cli"
+
+module Extension
+  module Tasks
+    class Serve < ShopifyCli::Task
+      include SmartProperties
+
+      property! :context, accepts: ShopifyCli::Context
+
+      YARN_SERVE_COMMAND = %w(server)
+      NPM_SERVE_COMMAND = %w(run-script server)
+
+      def call
+        CLI::UI::Frame.open(context.message("serve.frame_title")) do
+          success = ShopifyCli::JsSystem.call(context, yarn: YARN_SERVE_COMMAND, npm: NPM_SERVE_COMMAND)
+          context.abort(context.message("serve.serve_failure_message")) unless success
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -47,6 +47,8 @@ module Extension
       def test_new_tunnel_started_if_specification_handler_supports_establish_tunnel
         serve = ::Extension::Commands::Serve.new(@context)
         stub_specification_handler_options(serve, choose_port: true, establish_tunnel: true)
+        Tasks::ChooseNextAvailablePort.expects(:call)
+          .returns(ShopifyCli::Result.success(Extension::Commands::Serve::DEFAULT_PORT))
         ShopifyCli::Tunnel.expects(:start)
           .with(@context, port: Extension::Commands::Serve::DEFAULT_PORT)
           .returns("ngrok.example.com")

--- a/test/project_types/extension/models/specifications_test.rb
+++ b/test/project_types/extension/models/specifications_test.rb
@@ -24,7 +24,7 @@ module Extension
 
       def test_returns_argo_admin_specific_specification_handler
         specifications = DummySpecifications.build(surface: "admin")
-        assert_kind_of(SpecificationHandlers::ArgoAdmin, specifications["TEST_EXTENSION"])
+        assert_kind_of(SpecificationHandlers::Argo, specifications["TEST_EXTENSION"])
       end
 
       def test_supports_retrieving_an_individual_specification_handler

--- a/test/project_types/extension/models/specifications_test.rb
+++ b/test/project_types/extension/models/specifications_test.rb
@@ -17,9 +17,14 @@ module Extension
         assert_nothing_raised { Specifications.new(fetch_specifications: -> { [] }) }
       end
 
-      def test_supports_retrieving_all_specification_handlers
-        specifications = DummySpecifications.build
+      def test_returns_default_specification_handler_as_fallback
+        specifications = DummySpecifications.build(surface: "checkout")
         assert_kind_of(SpecificationHandlers::Default, specifications["TEST_EXTENSION"])
+      end
+
+      def test_returns_argo_admin_specific_specification_handler
+        specifications = DummySpecifications.build(surface: "admin")
+        assert_kind_of(SpecificationHandlers::ArgoAdmin, specifications["TEST_EXTENSION"])
       end
 
       def test_supports_retrieving_an_individual_specification_handler


### PR DESCRIPTION
### WHY are these changes introduced?

`SpecificationHandler::Default` was beginning to have a lot of Argo Admin specific knowledge, so we're introducing an Argo Admin handler.

### WHAT is this pull request doing?

* Adds `ArgoAdminSpecificationHandler`
* Adds logic to select a SpecificationHandler if `handler` is provided
* Moves argo-specific knowledge to `SpecificationHandler::ArgoAdmin`
* Introduces a generic Serve command (so `ArgoServe` is only used for Argo extensions) under `Tasks::Serve` (open to renaming)

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrmenting this when releasing).
