### PR TITLE
Add PHP serve command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ------
 * [1197](https://github.com/Shopify/shopify-app-cli/pull/1197): Add `create` command for PHP app projects.
+* [1241](https://github.com/Shopify/shopify-app-cli/pull/1241): Add `serve` command for PHP app projects.
 
 Version 1.9.0
 -------------

--- a/lib/project_types/php/cli.rb
+++ b/lib/project_types/php/cli.rb
@@ -5,7 +5,7 @@ module PHP
     creator("PHP::Commands::Create")
     # connector("PHP::Commands::Connect")
 
-    # register_command("Node::Commands::Deploy", "deploy")
+    register_command("PHP::Commands::Serve", "serve")
 
     require Project.project_filepath("messages/messages")
     register_messages(PHP::Messages::MESSAGES)
@@ -14,6 +14,7 @@ module PHP
   # define/autoload project specific Commands
   module Commands
     autoload :Create, Project.project_filepath("commands/create")
+    autoload :Serve, Project.project_filepath("commands/serve")
   end
 
   # define/autoload project specific Tasks

--- a/lib/project_types/php/commands/serve.rb
+++ b/lib/project_types/php/commands/serve.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+module PHP
+  module Commands
+    class Serve < ShopifyCli::Command
+      PORT = 3000
+
+      prerequisite_task :ensure_env, :ensure_dev_store
+
+      options do |parser, flags|
+        parser.on("--host=HOST") do |h|
+          flags[:host] = h.gsub('"', "")
+        end
+      end
+
+      def call(*)
+        project = ShopifyCli::Project.current
+        url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx, port: PORT)
+        @ctx.abort(@ctx.message("php.serve.error.host_must_be_https")) if url.match(/^https/i).nil?
+        project.env.update(@ctx, :host, url)
+        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+          @ctx,
+          url: url,
+          callback_url: "/auth/callback",
+        )
+
+        if project.env.shop
+          project_url = "#{project.env.host}/login?shop=#{project.env.shop}"
+          @ctx.puts("\n" + @ctx.message("php.serve.open_info", project_url) + "\n")
+        end
+
+        CLI::UI::Frame.open(@ctx.message("php.serve.running_server")) do
+          if ShopifyCli::ProcessSupervision.running?(:npm_watch)
+            ShopifyCli::ProcessSupervision.stop(:npm_watch)
+          end
+          ShopifyCli::ProcessSupervision.start(:npm_watch, "npm run watch", force_spawn: true)
+
+          env = project.env.to_h
+          @ctx.system("php", "artisan", "serve", "--port", PORT.to_s, env: env)
+        end
+      end
+
+      def self.help
+        ShopifyCli::Context.message("php.serve.help", ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message("php.serve.extended_help")
+      end
+    end
+  end
+end

--- a/lib/project_types/php/messages/messages.rb
+++ b/lib/project_types/php/messages/messages.rb
@@ -42,6 +42,27 @@ module PHP
           app_set_up: "App is now set up",
         },
 
+        serve: {
+          help: <<~HELP,
+            Start a local development PHP server for your project, as well as a public ngrok tunnel to your localhost.
+              Usage: {{command:%s serve}}
+            HELP
+          extended_help: <<~HELP,
+            {{bold:Options:}}
+              {{cyan:--host=HOST}}: Bypass running tunnel and use custom host. HOST must be HTTPS url.
+            HELP
+
+          error: {
+            host_must_be_https: "HOST must be a HTTPS url.",
+          },
+
+          open_info: <<~MESSAGE,
+            {{*}} To install and start using your app, open this URL in your browser:
+            {{green:%s}}
+          MESSAGE
+          running_server: "Running server…",
+        },
+
         forms: {
           create: {
             error: {

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -188,7 +188,7 @@ module ShopifyCli
             install_error: "An error occurred while installing dependencies",
           },
 
-          installing: "Installing Composer dependencies...",
+          installing: "Installing Composer dependencies…",
           installed: "Dependencies installed",
           installed_count: "%d dependencies installed",
         },

--- a/lib/shopify-cli/process_supervision.rb
+++ b/lib/shopify-cli/process_supervision.rb
@@ -50,19 +50,21 @@ module ShopifyCli
       #
       # * `identifier` - a string or symbol to identify the new process by.
       # * `args` - a command to run, either a string or array of strings
+      # * `force_spawn` - whether we want the child process to be a spawn and not a fork, so it is terminated along with
+      #                   the parent
       #
       # #### Returns
       #
       # * `process` - ProcessSupervision instance if the process is running, this
       #   will be nil if the process did not start.
       #
-      def start(identifier, args)
+      def start(identifier, args, force_spawn: false)
         return for_ident(identifier) if running?(identifier)
 
         # Windows doesn't support forking process without extra gems, so we resort to spawning a new child process -
         # that means that it dies along with the original process if it is interrupted. On UNIX, we fork the process so
         # that it doesn't have to be restarted on every run.
-        if Context.new.windows?
+        if Context.new.windows? || force_spawn
           pid_file = new(identifier)
 
           # Make sure the file exists and is empty, otherwise Windows fails

--- a/test/fixtures/app_types/php/.env
+++ b/test/fixtures/app_types/php/.env
@@ -1,0 +1,6 @@
+SHOPIFY_API_KEY=mykey
+SHOPIFY_API_SECRET=mysecretkey
+SHOP=my-test-shop.myshopify.com
+SCOPES=read_products
+HOST=https://example.com
+DB_DATABASE=storage/db.sqlite

--- a/test/fixtures/app_types/php/.shopify-cli.yml
+++ b/test/fixtures/app_types/php/.shopify-cli.yml
@@ -1,0 +1,2 @@
+---
+project_type: php

--- a/test/project_types/php/commands/serve_test.rb
+++ b/test/project_types/php/commands/serve_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+require "project_types/php/test_helper"
+
+module PHP
+  module Commands
+    class ServeTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        project_context("app_types", "php")
+        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
+        @context.stubs(:system)
+      end
+
+      def test_server_command
+        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
+        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCli::Resources::EnvFile.any_instance.expects(:update)
+        ShopifyCli::ProcessSupervision.expects(:running?).with(:npm_watch).returns(false)
+        ShopifyCli::ProcessSupervision.expects(:stop).never
+        ShopifyCli::ProcessSupervision.expects(:start).with(:npm_watch, "npm run watch", force_spawn: true)
+
+        @context.expects(:system).with(
+          "php",
+          "artisan",
+          "serve",
+          "--port",
+          "3000",
+          env: {
+            "SHOPIFY_API_KEY" => "mykey",
+            "SHOPIFY_API_SECRET" => "mysecretkey",
+            "SHOP" => "my-test-shop.myshopify.com",
+            "SCOPES" => "read_products",
+            "HOST" => "https://example.com",
+            "DB_DATABASE" => "storage/db.sqlite",
+          }
+        )
+
+        @context.expects(:puts).with(
+          "\n" +
+          @context.message("php.serve.open_info", "https://example.com/login?shop=my-test-shop.myshopify.com") +
+          "\n"
+        )
+
+        run_cmd("serve")
+      end
+
+      def test_restarts_npm_watch_if_running
+        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
+        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCli::Resources::EnvFile.any_instance.expects(:update)
+        ShopifyCli::ProcessSupervision.expects(:running?).with(:npm_watch).returns(true)
+        ShopifyCli::ProcessSupervision.expects(:stop).with(:npm_watch)
+        ShopifyCli::ProcessSupervision.expects(:start).with(:npm_watch, "npm run watch", force_spawn: true)
+
+        @context.expects(:system).with(
+          "php",
+          "artisan",
+          "serve",
+          "--port",
+          "3000",
+          env: {
+            "SHOPIFY_API_KEY" => "mykey",
+            "SHOPIFY_API_SECRET" => "mysecretkey",
+            "SHOP" => "my-test-shop.myshopify.com",
+            "SCOPES" => "read_products",
+            "HOST" => "https://example.com",
+            "DB_DATABASE" => "storage/db.sqlite",
+          }
+        )
+
+        @context.expects(:puts).with(
+          "\n" +
+          @context.message("php.serve.open_info", "https://example.com/login?shop=my-test-shop.myshopify.com") +
+          "\n"
+        )
+
+        run_cmd("serve")
+      end
+
+      def test_server_command_with_invalid_host_url
+        ShopifyCli::Tunnel.stubs(:start).returns("garbage://example.com")
+        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call).never
+        ShopifyCli::Resources::EnvFile.any_instance.expects(:update).never
+        ShopifyCli::ProcessSupervision.expects(:stop).never
+        ShopifyCli::ProcessSupervision.expects(:start).never
+
+        @context.expects(:system).with(
+          "php",
+          "artisan",
+          "serve",
+          "--port",
+          "3000",
+          env: {
+            "SHOPIFY_API_KEY" => "mykey",
+            "SHOPIFY_API_SECRET" => "mysecretkey",
+            "SHOP" => "my-test-shop.myshopify.com",
+            "SCOPES" => "read_products",
+            "HOST" => "https://example.com",
+            "DB_DATABASE" => "storage/db.sqlite",
+          }
+        ).never
+
+        assert_raises ShopifyCli::Abort do
+          run_cmd("serve")
+        end
+      end
+
+      def test_update_env_with_host
+        ShopifyCli::Tunnel.expects(:start).never
+        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
+          @context, :host, "https://example-foo.com"
+        )
+        run_cmd('serve --host="https://example-foo.com"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Once PHP apps are created, we need to be able to serve them. This command needs to run both `npm run watch` and `php artisan serve`, once the ngrok tunnel is set up.

### WHAT is this pull request doing?

Adding a `serve` command for PHP projects which does all of the above.

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrmenting this when releasing).
