### PR TITLE
Bundler 2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,4 +76,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
### WHY are these changes introduced?

Trying to fix issues with our deployment pipeline

### WHAT is this pull request doing?

Update bundler to 2.1.4 which is the default for Ruby 2.7

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrmenting this when releasing).
