### PR TITLE
Add PHP connect command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 * [1197](https://github.com/Shopify/shopify-app-cli/pull/1197): Add `create` command for PHP app projects.
 * [1241](https://github.com/Shopify/shopify-app-cli/pull/1241): Add `serve` command for PHP app projects.
 * [1243](https://github.com/Shopify/shopify-app-cli/pull/1243): Add `tunnel` command for PHP app projects.
+* [1245](https://github.com/Shopify/shopify-app-cli/pull/1245): Add `connect` command for PHP app projects.
 
 Version 1.9.0
 -------------

--- a/lib/project_types/php/cli.rb
+++ b/lib/project_types/php/cli.rb
@@ -3,7 +3,7 @@ module PHP
   class Project < ShopifyCli::ProjectType
     title("PHP App")
     creator("PHP::Commands::Create")
-    # connector("PHP::Commands::Connect")
+    connector("PHP::Commands::Connect")
 
     register_command("PHP::Commands::Serve", "serve")
     register_command("PHP::Commands::Tunnel", "tunnel")
@@ -17,6 +17,7 @@ module PHP
     autoload :Create, Project.project_filepath("commands/create")
     autoload :Serve, Project.project_filepath("commands/serve")
     autoload :Tunnel, Project.project_filepath("commands/tunnel")
+    autoload :Connect, Project.project_filepath("commands/connect")
   end
 
   # define/autoload project specific Tasks

--- a/lib/project_types/php/commands/connect.rb
+++ b/lib/project_types/php/commands/connect.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PHP
+  module Commands
+    class Connect < ShopifyCli::SubCommand
+      def call(*)
+        if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
+          @ctx.puts(@ctx.message("php.connect.production_warning"))
+        end
+
+        app = ShopifyCli::Commands::Connect.new.default_connect(:php)
+        @ctx.done(@ctx.message("php.connect.connected", app))
+      end
+    end
+  end
+end

--- a/lib/project_types/php/messages/messages.rb
+++ b/lib/project_types/php/messages/messages.rb
@@ -4,6 +4,13 @@ module PHP
   module Messages
     MESSAGES = {
       php: {
+        connect: {
+          connected: "Project now connected to {{green:%s}}",
+          production_warning: <<~MESSAGE,
+            {{yellow:! Warning: if you have connected to an {{bold:app in production}}, running {{command:serve}} may update the app URL and cause an outage.
+            MESSAGE
+        },
+
         create: {
           help: <<~HELP,
             {{command:%s create php}}: Creates an embedded PHP app.

--- a/test/project_types/php/commands/connect_test.rb
+++ b/test/project_types/php/commands/connect_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require "project_types/php/test_helper"
+
+module PHP
+  module Commands
+    class ConnectTest < Minitest::Test
+      include TestHelpers::Partners
+      include TestHelpers::FakeUI
+      include TestHelpers::FakeFS
+
+      def setup
+        super
+        ShopifyCli::Core::Monorail.stubs(:enabled?).returns(false)
+      end
+
+      def test_can_connect
+        ShopifyCli::Project.stubs(:has_current?).returns(false)
+        ShopifyCli::Commands::Connect.any_instance.expects(:default_connect).with(:php).returns("php-app")
+        ShopifyCli::Context.any_instance.expects(:message).with("php.connect.connected", "php-app")
+
+        run_cmd("connect php")
+      end
+
+      def test_warns_if_in_production
+        mock_project = mock
+        mock_project.expects(:env).returns({ "DUMMY_ENV_VAR" => "Dummy Value" })
+
+        ShopifyCli::Project.expects(:current_project_type).returns(:php)
+        ShopifyCli::Project.stubs(:has_current?).returns(true)
+        ShopifyCli::Project.stubs(:current).returns(mock_project)
+
+        ShopifyCli::Commands::Connect.any_instance.expects(:default_connect).with(:php).returns("php-app")
+        ShopifyCli::Context.any_instance.expects(:message).with("php.connect.production_warning")
+        ShopifyCli::Context.any_instance.expects(:message).with("php.connect.connected", "php-app")
+
+        run_cmd("connect php")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?

Adding a `Connector` for the PHP project type, which just runs the default connect command.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrmenting this when releasing).
