### PR TITLE
Add php open command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 * [1241](https://github.com/Shopify/shopify-app-cli/pull/1241): Add `serve` command for PHP app projects.
 * [1243](https://github.com/Shopify/shopify-app-cli/pull/1243): Add `tunnel` command for PHP app projects.
 * [1245](https://github.com/Shopify/shopify-app-cli/pull/1245): Add `connect` command for PHP app projects.
+* [1247](https://github.com/Shopify/shopify-app-cli/pull/1247): Add `open` command for PHP app projects.
 
 Version 1.9.0
 -------------

--- a/lib/project_types/php/cli.rb
+++ b/lib/project_types/php/cli.rb
@@ -7,6 +7,7 @@ module PHP
 
     register_command("PHP::Commands::Serve", "serve")
     register_command("PHP::Commands::Tunnel", "tunnel")
+    register_command("PHP::Commands::Open", "open")
 
     require Project.project_filepath("messages/messages")
     register_messages(PHP::Messages::MESSAGES)
@@ -18,6 +19,7 @@ module PHP
     autoload :Serve, Project.project_filepath("commands/serve")
     autoload :Tunnel, Project.project_filepath("commands/tunnel")
     autoload :Connect, Project.project_filepath("commands/connect")
+    autoload :Open, Project.project_filepath("commands/open")
   end
 
   # define/autoload project specific Tasks

--- a/lib/project_types/php/commands/open.rb
+++ b/lib/project_types/php/commands/open.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PHP
+  module Commands
+    class Open < ShopifyCli::Command
+      def call(*)
+        project = ShopifyCli::Project.current
+        @ctx.open_url!("#{project.env.host}/login?shop=#{project.env.shop}")
+      end
+
+      def self.help
+        ShopifyCli::Context.message("php.open.help", ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/php/messages/messages.rb
+++ b/lib/project_types/php/messages/messages.rb
@@ -49,6 +49,13 @@ module PHP
           app_set_up: "App is now set up",
         },
 
+        open: {
+          help: <<~HELP,
+            Open your local development app in the default browser.
+              Usage: {{command:%s open}}
+            HELP
+        },
+
         serve: {
           help: <<~HELP,
             Start a local development PHP server for your project, as well as a public ngrok tunnel to your localhost.

--- a/test/project_types/php/commands/open_test.rb
+++ b/test/project_types/php/commands/open_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require "project_types/php/test_helper"
+require 'benchmark'
+module PHP
+  module Commands
+    class OpenTest < MiniTest::Test
+      def setup
+        super
+        project_context("app_types", "php")
+        @context.stubs(:system)
+      end
+
+      def test_run
+        ShopifyCli::Context.any_instance.expects(:open_url!)
+          .with("https://example.com/login?shop=my-test-shop.myshopify.com")
+        run_cmd("open")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHAT is this pull request doing?

Adding the `open` command for PHP apps, which just prints out the URL to access the local app while it's running with `serve`.

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrmenting this when releasing).
