### PR TITLE
Add deploy command for PHP apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 * [1243](https://github.com/Shopify/shopify-app-cli/pull/1243): Add `tunnel` command for PHP app projects.
 * [1245](https://github.com/Shopify/shopify-app-cli/pull/1245): Add `connect` command for PHP app projects.
 * [1247](https://github.com/Shopify/shopify-app-cli/pull/1247): Add `open` command for PHP app projects.
+* [1249](https://github.com/Shopify/shopify-app-cli/pull/1249): Add `deploy heroku` command for PHP app projects.
 
 Version 1.9.0
 -------------

--- a/lib/project_types/php/cli.rb
+++ b/lib/project_types/php/cli.rb
@@ -8,6 +8,7 @@ module PHP
     register_command("PHP::Commands::Serve", "serve")
     register_command("PHP::Commands::Tunnel", "tunnel")
     register_command("PHP::Commands::Open", "open")
+    register_command("PHP::Commands::Deploy", "deploy")
 
     require Project.project_filepath("messages/messages")
     register_messages(PHP::Messages::MESSAGES)
@@ -20,6 +21,7 @@ module PHP
     autoload :Tunnel, Project.project_filepath("commands/tunnel")
     autoload :Connect, Project.project_filepath("commands/connect")
     autoload :Open, Project.project_filepath("commands/open")
+    autoload :Deploy, Project.project_filepath("commands/deploy")
   end
 
   # define/autoload project specific Tasks

--- a/lib/project_types/php/commands/deploy.rb
+++ b/lib/project_types/php/commands/deploy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "shopify_cli"
+
+module PHP
+  module Commands
+    class Deploy < ShopifyCli::Command
+      subcommand :Heroku, "heroku", Project.project_filepath("commands/deploy/heroku")
+
+      def call(*)
+        @ctx.puts(self.class.help)
+      end
+
+      def self.help
+        ShopifyCli::Context.message("php.deploy.help", ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message("php.deploy.extended_help", ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/php/commands/deploy/heroku.rb
+++ b/lib/project_types/php/commands/deploy/heroku.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+require "shopify_cli"
+
+module PHP
+  module Commands
+    class Deploy
+      class Heroku < ShopifyCli::SubCommand
+        def self.help
+          ShopifyCli::Context.message("php.deploy.heroku.help", ShopifyCli::TOOL_NAME)
+        end
+
+        def call(*)
+          spin_group = CLI::UI::SpinGroup.new
+          heroku_service = ShopifyCli::Heroku.new(@ctx)
+
+          spin_group.add(@ctx.message("php.deploy.heroku.downloading")) do |spinner|
+            heroku_service.download
+            spinner.update_title(@ctx.message("php.deploy.heroku.downloaded"))
+          end
+          spin_group.wait
+
+          install_message = @ctx.message(
+            @ctx.windows? ? "php.deploy.heroku.installing_windows" : "php.deploy.heroku.installing"
+          )
+          spin_group.add(install_message) do |spinner|
+            heroku_service.install
+            spinner.update_title(@ctx.message("php.deploy.heroku.installed"))
+          end
+          spin_group.wait
+
+          spin_group.add(@ctx.message("php.deploy.heroku.git.checking")) do |spinner|
+            ShopifyCli::Git.init(@ctx)
+            spinner.update_title(@ctx.message("php.deploy.heroku.git.initialized"))
+          end
+          spin_group.wait
+
+          if (account = heroku_service.whoami)
+            @ctx.puts(@ctx.message("php.deploy.heroku.authenticated_with_account", account))
+          else
+            CLI::UI::Frame.open(
+              @ctx.message("php.deploy.heroku.authenticating"),
+              success_text: @ctx.message("php.deploy.heroku.authenticated")
+            ) do
+              heroku_service.authenticate
+            end
+          end
+
+          if (app_name = heroku_service.app)
+            @ctx.puts(@ctx.message("php.deploy.heroku.app.selected", app_name))
+          else
+            app_type = CLI::UI::Prompt.ask(@ctx.message("php.deploy.heroku.app.no_apps_found")) do |handler|
+              handler.option(@ctx.message("php.deploy.heroku.app.create")) { :new }
+              handler.option(@ctx.message("php.deploy.heroku.app.select")) { :existing }
+            end
+
+            if app_type == :existing
+              app_name = CLI::UI::Prompt.ask(@ctx.message("php.deploy.heroku.app.name"))
+              CLI::UI::Frame.open(
+                @ctx.message("php.deploy.heroku.app.selecting", app_name),
+                success_text: @ctx.message("php.deploy.heroku.app.selected", app_name)
+              ) do
+                heroku_service.select_existing_app(app_name)
+              end
+            elsif app_type == :new
+              CLI::UI::Frame.open(
+                @ctx.message("php.deploy.heroku.app.creating"),
+                success_text: @ctx.message("php.deploy.heroku.app.created")
+              ) do
+                heroku_service.create_new_app
+                app_name = heroku_service.app
+              end
+            end
+          end
+
+          branches = ShopifyCli::Git.branches(@ctx)
+          if branches.length == 1
+            branch_to_deploy = branches[0]
+            @ctx.puts(@ctx.message("php.deploy.heroku.git.branch_selected", branch_to_deploy))
+          else
+            branch_to_deploy = CLI::UI::Prompt.ask(@ctx.message("php.deploy.heroku.git.what_branch")) do |handler|
+              branches.each do |branch|
+                handler.option(branch) { branch }
+              end
+            end
+          end
+
+          app_url = "https://#{app_name}.herokuapp.com"
+
+          CLI::UI::Frame.open(
+            @ctx.message("php.deploy.heroku.app.setting_configs"),
+            success_text: @ctx.message("php.deploy.heroku.app.configs_set")
+          ) do
+            allowed_configs = [/SHOPIFY_API_KEY/, /SHOPIFY_API_SECRET/, /SCOPES/, /HOST/]
+
+            ShopifyCli::Project.current.env.to_h.each do |config, value|
+              next unless allowed_configs.any? { |pattern| pattern.match?(config) }
+
+              value = app_url if config == "HOST"
+
+              current = heroku_service.get_config(config)
+              heroku_service.set_config(config, value) if current.nil? || current != value
+            end
+
+            current_key = heroku_service.get_config("APP_KEY")
+            if current_key.nil? || current_key.empty?
+              output, status = @ctx.capture2e("php", "artisan", "key:generate", "--show")
+
+              @ctx.abort(@ctx.message("php.deploy.heroku.error.generate_app_key")) unless status.success?
+
+              heroku_service.set_config("APP_KEY", output.strip) if status.success?
+            end
+
+            heroku_service.add_buildpacks(["heroku/php", "heroku/nodejs"])
+          end
+
+          CLI::UI::Frame.open(
+            @ctx.message("php.deploy.heroku.deploying"),
+            success_text: @ctx.message("php.deploy.heroku.deployed")
+          ) do
+            heroku_service.deploy(branch_to_deploy)
+          end
+
+          heroku_command = heroku_service.heroku_command
+          @ctx.puts(@ctx.message("php.deploy.heroku.post_deploy", app_url, heroku_command))
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/php/messages/messages.rb
+++ b/lib/project_types/php/messages/messages.rb
@@ -56,6 +56,64 @@ module PHP
             HELP
         },
 
+        deploy: {
+          help: <<~HELP,
+            Deploy the current PHP project to a hosting service. Heroku ({{underline:https://www.heroku.com}}) is currently the only option, but more will be added in the future.
+              Usage: {{command:%s deploy [ heroku ]}}
+            HELP
+
+          extended_help: <<~HELP,
+            {{bold:Subcommands:}}
+              {{cyan:heroku}}: Deploys the current PHP project to Heroku.
+                Usage: {{command:%s deploy heroku}}
+            HELP
+
+          heroku: {
+            help: <<~HELP,
+              Deploy the current PHP project to Heroku
+                Usage: {{command:%s deploy heroku}}
+              HELP
+
+            error: {
+              generate_app_key: "Failed to generate Laravel APP_KEY",
+            },
+
+            downloading: "Downloading Heroku CLI…",
+            downloaded: "Downloaded Heroku CLI",
+            installing: "Installing Heroku CLI…",
+            installing_windows: "Running Heroku CLI install wizard…",
+            installed: "Installed Heroku CLI",
+            authenticating: "Authenticating with Heroku…",
+            authenticated: "{{v}} Authenticated with Heroku",
+            authenticated_with_account: "{{v}} Authenticated with Heroku as `%s`",
+            deploying: "Deploying to Heroku…",
+            deployed: "Deployed to Heroku",
+            post_deploy: <<~DEPLOYED,
+              {{v}} Deployed to Heroku, you can access your app at {{green:%s}}
+
+                If you're deploying this app for the first time, make sure to set up your database and your app's environment at {{bold:App dashboard -> Settings -> Config Vars}}.
+              DEPLOYED
+            git: {
+              checking: "Checking git repo…",
+              initialized: "Git repo initialized",
+              what_branch: "What branch would you like to deploy?",
+              branch_selected: "{{v}} Git branch `%s` selected for deploy",
+            },
+            app: {
+              no_apps_found: "No existing Heroku app found. What would you like to do?",
+              name: "What is your Heroku app’s name?",
+              select: "Specify an existing Heroku app",
+              selecting: "Selecting Heroku app `%s`…",
+              selected: "{{v}} Heroku app `%s` selected",
+              create: "Create a new Heroku app",
+              creating: "Creating new Heroku app…",
+              created: "{{v}} New Heroku app created",
+              setting_configs: "Setting Shopify app configs…",
+              configs_set: "{{v}} Shopify app configs set",
+            },
+          },
+        },
+
         serve: {
           help: <<~HELP,
             Start a local development PHP server for your project, as well as a public ngrok tunnel to your localhost.

--- a/lib/shopify-cli/heroku.rb
+++ b/lib/shopify-cli/heroku.rb
@@ -67,19 +67,29 @@ module ShopifyCli
       nil
     end
 
-    private
-
-    def download_filename
-      URI.parse(DOWNLOAD_URLS[@ctx.os]).path.split("/").last
+    def get_config(config)
+      output, status = @ctx.capture2e(heroku_command, "config:get", config.to_s)
+      return output.strip if status.success?
+      nil
     end
 
-    def download_path
-      File.join(ShopifyCli.cache_dir, download_filename)
+    def set_config(config, value)
+      result = @ctx.system(heroku_command, "config:set", "#{config}=#{value}")
+
+      msg = @ctx.message("core.heroku.error.set_config", config, value)
+      @ctx.abort(msg) unless result.success?
     end
 
-    def git_remote
-      output, status = @ctx.capture2e("git", "remote", "get-url", "heroku")
-      status.success? ? output : nil
+    def add_buildpacks(buildpacks)
+      result = @ctx.system(heroku_command, "buildpacks:clear")
+      msg = @ctx.message("core.heroku.error.add_buildpacks")
+      @ctx.abort(msg) unless result.success?
+
+      buildpacks.each do |buildpack|
+        result = @ctx.system(heroku_command, "buildpacks:add", buildpack)
+        msg = @ctx.message("core.heroku.error.add_buildpacks")
+        @ctx.abort(msg) unless result.success?
+      end
     end
 
     def heroku_command
@@ -101,6 +111,21 @@ module ShopifyCli
       else
         "heroku"
       end
+    end
+
+    private
+
+    def download_filename
+      URI.parse(DOWNLOAD_URLS[@ctx.os]).path.split("/").last
+    end
+
+    def download_path
+      File.join(ShopifyCli.cache_dir, download_filename)
+    end
+
+    def git_remote
+      output, status = @ctx.capture2e("git", "remote", "get-url", "heroku")
+      status.success? ? output : nil
     end
 
     def installed?

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -111,6 +111,8 @@ module ShopifyCli
             download: "Heroku CLI could not be downloaded",
             install: "Could not install Heroku CLI",
             could_not_select_app: "Heroku app `%s` could not be selected",
+            set_config: "Failed to set config %s to %s in Heroku app",
+            add_buildpacks: "Failed to add buildpacks in Heroku app",
           },
         },
 

--- a/test/project_types/php/commands/deploy/heroku_test.rb
+++ b/test/project_types/php/commands/deploy/heroku_test.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+require "project_types/php/test_helper"
+
+module PHP
+  module Commands
+    module DeployTests
+      class HerokuTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include TestHelpers::Heroku
+
+        def setup
+          super
+          project_context("app_types", "php")
+
+          File.stubs(:exist?)
+          File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, "lib", "project_types", "php", "cli.rb")).returns(true)
+          File.expects(:exist?).with(File.join(FIXTURE_DIR, "app_types", "php", ".shopify-cli.yml")).returns(true)
+          ShopifyCli::Context.any_instance.stubs(:os).returns(:mac)
+          stub_successful_heroku_flow
+        end
+
+        def test_call_doesnt_download_heroku_cli_if_it_is_installed
+          expects_heroku_installed(status: true, twice: true)
+          expects_heroku_download(status: nil)
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_downloads_heroku_cli_if_it_is_not_installed
+          expects_heroku_installed(status: false)
+          expects_heroku_download(status: true)
+          expects_heroku_download_exists(status: true)
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_raises_if_heroku_cli_download_fails
+          expects_heroku_installed(status: false)
+          expects_heroku_download(status: false)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_raises_if_heroku_cli_download_is_missing
+          expects_heroku_installed(status: false)
+          expects_heroku_download_exists(status: false)
+          expects_heroku_download(status: true)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_doesnt_install_heroku_cli_if_it_is_already_installed
+          expects_heroku_installed(status: true, twice: true)
+          expects_tar_heroku(status: nil)
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_installs_heroku_cli_if_it_is_downloaded
+          expects_heroku_download(status: true)
+          expects_heroku_download_exists(status: true)
+          expects_heroku_installed(status: false, twice: true)
+          expects_tar_heroku(status: true)
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_raises_if_heroku_cli_install_fails
+          expects_heroku_download(status: true)
+          expects_heroku_download_exists(status: true)
+          expects_heroku_installed(status: false, twice: true)
+          expects_tar_heroku(status: false)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_raises_if_git_isnt_inited
+          expects_git_init_heroku(status: false, commits: false)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_raises_if_git_is_inited_but_there_are_no_commits
+          expects_git_init_heroku(status: true, commits: false)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_uses_existing_heroku_auth_if_available
+          expects_heroku_whoami(status: true)
+
+          @context.expects(:puts).with(@context.message("php.deploy.heroku.authenticated_with_account", "username"))
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_attempts_to_authenticate_with_heroku_if_not_already_authed
+          expects_heroku_whoami(status: false)
+          expects_heroku_login(status: true)
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_raises_if_heroku_auth_fails
+          expects_heroku_whoami(status: false)
+          expects_heroku_login(status: false)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_uses_existing_heroku_app_if_available
+          expects_git_remote_get_url_heroku(status: true, remote: "heroku")
+
+          @context.expects(:puts).with(@context.message("php.deploy.heroku.app.selected", "app-name"))
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_lets_you_choose_existing_heroku_app
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
+          expects_heroku_select_app(status: true)
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(@context.message("php.deploy.heroku.app.no_apps_found"))
+            .returns(:existing)
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(@context.message("php.deploy.heroku.app.name"))
+            .returns("app-name")
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_raises_if_choosing_existing_heroku_app_fails
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
+          expects_heroku_select_app(status: false)
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(@context.message("php.deploy.heroku.app.no_apps_found"))
+            .returns(:existing)
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(@context.message("php.deploy.heroku.app.name"))
+            .returns("app-name")
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_lets_you_create_new_heroku_app
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
+          expects_heroku_create(status: true)
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(@context.message("php.deploy.heroku.app.no_apps_found"))
+            .returns(:new)
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_raises_if_creating_new_heroku_app_fails
+          expects_git_remote_get_url_heroku(status: false, remote: "heroku")
+          expects_heroku_create(status: false)
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(@context.message("php.deploy.heroku.app.no_apps_found"))
+            .returns(:new)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_doesnt_prompt_if_only_one_branch_exists
+          expects_git_branch(status: true, multiple: false)
+
+          @context.expects(:puts).with(@context.message("php.deploy.heroku.git.branch_selected", "master"))
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_lets_you_specify_a_branch_if_multiple_exist
+          expects_git_branch(status: true, multiple: true)
+          expects_git_push_heroku(status: true, branch: "other_branch:master")
+
+          CLI::UI::Prompt.expects(:ask)
+            .with(@context.message("php.deploy.heroku.git.what_branch"))
+            .returns("other_branch")
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_raises_if_finding_branches_fails
+          expects_git_branch(status: false, multiple: false)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_successfully_deploys_to_heroku
+          expects_git_push_heroku(status: true, branch: "master:master")
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_raises_if_deploy_to_heroku_fails
+          expects_git_push_heroku(status: false, branch: "master:master")
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_raises_if_it_cannot_set_heroku_config
+          expects_heroku_set_config(status: false)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_raises_if_it_cannot_generate_php_key
+          expects_php_key_generate(status: false)
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_raises_if_it_cannot_clear_heroku_buildpacks
+          expects_heroku_add_buildpacks(
+            clear_status: false,
+            add_status: true,
+            buildpacks: ["heroku/php", "heroku/nodejs"],
+          )
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_raises_if_it_cannot_add_heroku_buildpacks
+          expects_heroku_add_buildpacks(
+            clear_status: true,
+            add_status: false,
+            buildpacks: ["heroku/php", "heroku/nodejs"],
+          )
+
+          assert_raises ShopifyCli::Abort do
+            run_cmd("deploy heroku")
+          end
+        end
+
+        def test_call_sets_all_shopify_config_vars
+          expects_heroku_get_config(status: true, config: "SHOPIFY_API_KEY", value: "mykey")
+          expects_heroku_get_config(status: true, config: "SHOPIFY_API_SECRET", value: "mysecretkey-old")
+          expects_heroku_get_config(status: true, config: "SCOPES", value: "read_products-old")
+          expects_heroku_get_config(status: true, config: "HOST", value: "https://example.com")
+          expects_heroku_get_config(status: true, config: "APP_KEY", value: "")
+
+          # SHOPIFY_API_KEY was unchanged, don't expect it
+          expects_heroku_set_config(status: true, config: "SHOPIFY_API_SECRET", value: "mysecretkey")
+          expects_heroku_set_config(status: true, config: "SCOPES", value: "read_products")
+          expects_heroku_set_config(status: true, config: "HOST", value: "https://app-name.herokuapp.com")
+          expects_heroku_set_config(status: true, config: "APP_KEY", value: "new_key")
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_generates_new_php_application_key
+          expects_php_key_generate(status: true)
+
+          run_cmd("deploy heroku")
+        end
+
+        def test_call_sets_heroku_buildpacks
+          expects_heroku_add_buildpacks(
+            clear_status: true,
+            add_status: true,
+            buildpacks: ["heroku/php", "heroku/nodejs"],
+          )
+
+          run_cmd("deploy heroku")
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/php/commands/deploy_test.rb
+++ b/test/project_types/php/commands/deploy_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "project_types/php/test_helper"
+
+module PHP
+  module Commands
+    class DeployTest < MiniTest::Test
+      def setup
+        super
+        project_context("app_types", "php")
+      end
+
+      def test_without_arguments_calls_help
+        @context.expects(:puts).with(PHP::Commands::Deploy.help)
+        run_cmd("deploy")
+      end
+    end
+  end
+end

--- a/test/project_types/php/commands/open_test.rb
+++ b/test/project_types/php/commands/open_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "project_types/php/test_helper"
-require 'benchmark'
+
 module PHP
   module Commands
     class OpenTest < MiniTest::Test

--- a/test/test_helpers/heroku.rb
+++ b/test/test_helpers/heroku.rb
@@ -44,6 +44,36 @@ module TestHelpers
         .with("git", "branch", "--list", "--format=%(refname:short)")
         .returns(["master\n", status_mock[:true]])
 
+      # heroku.get_config
+      @context.stubs(:capture2e)
+        .with do |heroku_cmd, config_cmd, _config|
+          heroku_cmd == heroku_command(full_path: full_path) && config_cmd == "config:get"
+        end
+        .returns(["", status_mock[:true]])
+
+      # heroku.set_config
+      @context.stubs(:system)
+        .with do |heroku_cmd, config_cmd, _config, _value|
+          heroku_cmd == heroku_command(full_path: full_path) && config_cmd == "config:set"
+        end
+        .returns(status_mock[:true])
+
+      # create new php app key
+      @context.stubs(:capture2e)
+        .with("php", "artisan", "key:generate", "--show")
+        .returns(["new_key", status_mock[:true]])
+
+      # heroku.add_buildpacks
+      @context.stubs(:system)
+        .with(heroku_command(full_path: full_path), "buildpacks:clear")
+        .returns(status_mock[:true])
+
+      @context.stubs(:system)
+        .with do |heroku_cmd, pack_cmd, _pack|
+          heroku_cmd == heroku_command(full_path: full_path) && pack_cmd == "buildpacks:add"
+        end
+        .returns(status_mock[:true])
+
       # deploy
       @context.stubs(:system)
         .with("git", "push", "-u", "heroku", "master:master")
@@ -170,6 +200,22 @@ module TestHelpers
       end
     end
 
+    def expects_heroku_get_config(status:, config: nil, value: nil, full_path: false)
+      if status
+        @context.expects(:capture2e)
+          .with(heroku_command(full_path: full_path), "config:get", config)
+          .returns([value, status_mock[:true]])
+      else
+        @context.expects(:capture2e)
+          .with do |called_cmd, called_heroku_cmd, called_config|
+            called_cmd == heroku_command(full_path: full_path) &&
+            called_heroku_cmd == "config:get" &&
+            (!called_config || config == called_config)
+          end
+          .returns(["", status_mock[:false]])
+      end
+    end
+
     def expects_heroku_installed(status:, full_path: false, twice: false)
       File.stubs(:exist?)
         .with(heroku_command(full_path: full_path))
@@ -192,11 +238,52 @@ module TestHelpers
         .returns(status_mock[:"#{status}"])
     end
 
+    def expects_heroku_add_buildpacks(clear_status:, add_status:, buildpacks: nil, full_path: false)
+      @context.expects(:system)
+        .with(heroku_command(full_path: full_path), "buildpacks:clear")
+        .returns(status_mock[:"#{clear_status}"])
+
+      if clear_status
+        buildpacks.each do |buildpack|
+          @context.expects(:system)
+            .with(heroku_command(full_path: full_path), "buildpacks:add", buildpack)
+            .returns(status_mock[:"#{add_status}"])
+
+          break unless add_status
+        end
+      end
+    end
+
+    def expects_heroku_set_config(status:, config: nil, value: nil, full_path: false)
+      if status
+        @context.expects(:system)
+          .with(heroku_command(full_path: full_path), "config:set", "#{config}=#{value}")
+          .returns(status_mock[:true])
+      else
+        @context.expects(:system)
+          .with do |called_cmd, called_heroku_cmd, called_config, called_value|
+            called_cmd == heroku_command(full_path: full_path) &&
+            called_heroku_cmd == "config:set" &&
+            (!called_value || value == called_value)
+            (!called_config || config == called_config)
+          end
+          .returns(status_mock[:false])
+      end
+    end
+
     def expects_heroku_whoami(status:, full_path: false)
       output = status ? "username" : nil
 
       @context.expects(:capture2e)
         .with(heroku_command(full_path: full_path), "whoami")
+        .returns([output, status_mock[:"#{status}"]])
+    end
+
+    def expects_php_key_generate(status:)
+      output = status ? "new_key" : nil
+
+      @context.expects(:capture2e)
+        .with("php", "artisan", "key:generate", "--show")
         .returns([output, status_mock[:"#{status}"]])
     end
 


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR adds a `deploy` command for PHP apps, and implements a `heroku` deploy target, which successfully deploys an app after it is modified to work around the PHP library not being public yet.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrmenting this when releasing).
