### PR TITLE
[scripts] print script build error in frame

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -72,7 +72,7 @@ module Script
         class SystemCallFailureError < ScriptProjectError
           attr_reader :out, :cmd
           def initialize(out:, cmd:)
-            super()
+            super(out)
             @out = out
             @cmd = cmd
           end

--- a/test/project_types/script/layers/infrastructure/command_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/command_runner_test.rb
@@ -27,7 +27,8 @@ describe Script::Layers::Infrastructure::CommandRunner do
     describe "on failure" do
       it "raises SystemCallFailureError" do
         context.expects(:capture2e).with(cmd).returns(system_output(msg: expected_output, success: false))
-        assert_raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError) { subject }
+        e = assert_raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError) { subject }
+        assert_equal expected_output, e.message
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/3156

Some error messages within the build frame were being smothered instead of printing the relevant error.

### WHAT is this pull request doing?

Ensures that `SystemCallFailureError`s have a defined `message`. The build frame will try to print the error message, but since that class didn't have one defined, the class name was printed instead.

I double checked that other build errors did not have this problem. 

![image](https://user-images.githubusercontent.com/28009669/119990931-e8ffa600-bf96-11eb-8275-b026fdd42b85.png)
 

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrmenting this when releasing).
