### PR TITLE
fix: release workflow needs to update bundler version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
       with:
         ruby-version: 2.6
     
+    - name: Update bundler
+      run: gem install bundler:2.1.4
+
     - name: Install dependencies
       run: bundle install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
         ruby-version: 2.6
         bundler-cache: true
 
-    - name: Install dependencies
-      run: bundle install
-
     - name: Create package
       run: bundle exec rake package
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,10 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1.1.2
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
-    
-    - name: Update bundler
-      run: gem install bundler:2.1.4
+        bundler-cache: true
 
     - name: Install dependencies
       run: bundle install


### PR DESCRIPTION
### WHY are these changes introduced?

The create_release workflow has been failing for a while. The latest round of failures come from the version of bundler having been updated to `2.1.4` but that version not being installed.

<img width="1047" alt="Screen Shot 2021-05-31 at 8 53 29 AM" src="https://user-images.githubusercontent.com/989784/120204010-f498da00-c1ed-11eb-8abd-97ee4e102143.png">

### WHAT is this pull request doing?

Adding a line to install the specific version of bundler being used.

**If there's a better way to do this, I'm open to it!**

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrmenting this when releasing).
