### PR TITLE
Abort if reauthentication fails

### DIFF
--- a/lib/shopify-cli/admin_api.rb
+++ b/lib/shopify-cli/admin_api.rb
@@ -85,11 +85,14 @@ module ShopifyCli
 
       private
 
-      def authenticated_req(ctx, shop)
-        yield
+      def authenticated_req(ctx, shop, &block)
+        CLI::Kit::Util
+          .begin(&block)
+          .retry_after(API::APIRequestUnauthorizedError, retries: 1) do
+            authenticate(ctx, shop)
+          end
       rescue API::APIRequestUnauthorizedError
-        authenticate(ctx, shop)
-        retry
+        ctx.abort(ctx.message("core.api.error.failed_auth"))
       end
 
       def authenticate(ctx, shop)

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -184,6 +184,7 @@ module ShopifyCli
 
         api: {
           error: {
+            failed_auth: "Failed to authenticate with Shopify. Please try again later.",
             internal_server_error: "{{red:{{x}} An unexpected error occurred on Shopify.}}",
             internal_server_error_debug: "\n{{red:Response details:}}\n%s\n\n",
             invalid_url: "Invalid URL: %s",

--- a/test/shopify-cli/admin_api_test.rb
+++ b/test/shopify-cli/admin_api_test.rb
@@ -110,5 +110,31 @@ module ShopifyCli
         @context, "query", shop: "other-test-shop.myshopify.com", api_version: "2019-04"
       )
     end
+
+    def test_query_fails_gracefully_when_unable_to_authenticate
+      ShopifyCli::DB.expects(:get).with(:admin_access_token).returns("token123").twice
+      api_stub = stub
+      AdminAPI.expects(:new).with(
+        ctx: @context,
+        auth_header: "X-Shopify-Access-Token",
+        token: "token123",
+        url: "https://shop.myshopify.com/admin/api/2019-04/graphql.json",
+      ).returns(api_stub).twice
+      api_stub.expects(:query).raises(API::APIRequestUnauthorizedError).twice
+
+      @oauth_client = mock
+      ShopifyCli::OAuth.expects(:new).returns(@oauth_client)
+      @oauth_client.expects(:authenticate).with("https://shop.myshopify.com/admin/oauth")
+
+      io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        AdminAPI.query(@context, "query", shop: "shop.myshopify.com", api_version: "2019-04")
+      end
+      assert_message_output(
+        io: io,
+        expected_content: [
+          @context.message("core.api.error.failed_auth"),
+        ]
+      )
+    end
   end
 end

--- a/test/shopify-cli/partners_api_test.rb
+++ b/test/shopify-cli/partners_api_test.rb
@@ -46,6 +46,33 @@ module ShopifyCli
       PartnersAPI.query(@context, "query")
     end
 
+    def test_query_fails_gracefully_when_unable_to_authenticate
+      Shopifolk.stubs(:check).returns(false)
+      ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns("token123").twice
+
+      api_stub = stub
+      PartnersAPI.expects(:new).with(
+        ctx: @context,
+        token: "token123",
+        url: "https://partners.shopify.com/api/cli/graphql",
+      ).returns(api_stub).twice
+      api_stub.expects(:query).raises(API::APIRequestUnauthorizedError).twice
+
+      @oauth_client = mock
+      ShopifyCli::OAuth.expects(:new).returns(@oauth_client)
+      @oauth_client.expects(:authenticate).with("https://accounts.shopify.com/oauth")
+
+      io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        PartnersAPI.query(@context, "query")
+      end
+      assert_message_output(
+        io: io,
+        expected_content: [
+          @context.message("core.api.error.failed_auth"),
+        ]
+      )
+    end
+
     def test_query_fails_gracefully_without_partners_account
       ShopifyCli::DB.expects(:get).with(:identity_exchange_token).returns("token123")
       api_stub = stub


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

Currently, if authentication fails for whatever reason then we get stuck in an authentication loop which results in the CLI hanging. This definitely is not a great experience as users have no idea whats going on.

### WHAT is this pull request doing?

Instead of retrying forever, we now will retry the authentication once. This will allow us to refresh any tokens that need to be refreshed, or login to Shopify and get a new token.

If reauthentication fails for whatever reason, we print a general message informing users that we can't login right now. 

I have locally tested: a successful token refresh, a token refresh that fails that results in a new login flow, and a login immediately after running `shopify logout` and everything works as expected.   

### Example failure 
![image](https://user-images.githubusercontent.com/28009669/120519270-6b75d480-c3a0-11eb-8058-359a9915fd9e.png)

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrmenting this when releasing).
