### PR TITLE
Extensions/Serve: Remove ArgoAdminBeta Flag Protection

### DIFF
--- a/lib/project_types/extension/features/argo_runtime.rb
+++ b/lib/project_types/extension/features/argo_runtime.rb
@@ -12,7 +12,6 @@ module Extension
 
       property! :renderer, accepts: Models::NpmPackage
       property! :cli, accepts: Models::NpmPackage
-      property :beta_access, accepts: Array, default: -> { [] }
 
       def accepts_port?
         case cli
@@ -51,7 +50,6 @@ module Extension
       end
 
       def accepts_shop?
-        return false unless beta_access.include?(:argo_admin_beta)
         case cli
         when admin?
           cli >= ARGO_ADMIN_CLI_0_11_0
@@ -61,7 +59,6 @@ module Extension
       end
 
       def accepts_api_key?
-        return false unless beta_access.include?(:argo_admin_beta)
         case cli
         when admin?
           cli >= ARGO_ADMIN_CLI_0_11_0

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -8,7 +8,6 @@ module Extension
       property! :context, accepts: ShopifyCli::Context
       property! :port, accepts: Integer, default: 39351
       property  :tunnel_url, accepts: String, default: ""
-      property :beta_access, accepts: Array, default: -> { [] }
 
       def call
         validate_env!

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -61,8 +61,6 @@ module Extension
 
         return if required_fields.none?
 
-        return unless beta_access.include?(:argo_admin_beta)
-
         ShopifyCli::Tasks::EnsureEnv.call(context, required: required_fields)
         ShopifyCli::Tasks::EnsureDevStore.call(context) if required_fields.include?(:shop)
 

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -57,7 +57,6 @@ module Extension
             context: context,
             port: port,
             tunnel_url: tunnel_url,
-            beta_access: beta_access
           ).call
         end
 
@@ -69,12 +68,7 @@ module Extension
           @argo_runtime ||= Features::ArgoRuntime.new(
             renderer: renderer_package(context),
             cli: cli_package(context),
-            beta_access: beta_access
           )
-        end
-
-        def beta_access
-          []
         end
 
         def cli_package(context)

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -74,11 +74,7 @@ module Extension
         end
 
         def beta_access
-          argo_admin_beta? ? [:argo_admin_beta] : []
-        end
-
-        def argo_admin_beta?
-          ShopifyCli::Shopifolk.check && ShopifyCli::Feature.enabled?(:argo_admin_beta)
+          []
         end
 
         def cli_package(context)

--- a/test/project_types/extension/features/argo_runtime_test.rb
+++ b/test/project_types/extension/features/argo_runtime_test.rb
@@ -67,8 +67,7 @@ module Extension
         runtimes = {
           checkout_runtime_0_3_8 => does_not_support_feature,
           checkout_runtime_0_4_0 => does_not_support_feature,
-          admin_runtime_0_11_0 => does_not_support_feature,
-          admin_runtime_0_11_0_with_beta_access => supports_feature,
+          admin_runtime_0_11_0 => supports_feature,
           admin_runtime_0_9_3 => does_not_support_feature,
           admin_runtime_0_9_2 => does_not_support_feature,
         }
@@ -82,8 +81,7 @@ module Extension
         runtimes = {
           checkout_runtime_0_3_8 => does_not_support_feature,
           checkout_runtime_0_4_0 => does_not_support_feature,
-          admin_runtime_0_11_0 => does_not_support_feature,
-          admin_runtime_0_11_0_with_beta_access => supports_feature,
+          admin_runtime_0_11_0 => supports_feature,
           admin_runtime_0_9_3 => does_not_support_feature,
           admin_runtime_0_9_2 => does_not_support_feature,
         }
@@ -120,14 +118,6 @@ module Extension
         ArgoRuntime.new(
           cli: Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0"),
           renderer: Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.9.3")
-        )
-      end
-
-      def admin_runtime_0_11_0_with_beta_access
-        ArgoRuntime.new(
-          cli: Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0"),
-          renderer: Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.9.3"),
-          beta_access: [:argo_admin_beta]
         )
       end
 

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -29,28 +29,6 @@ module Extension
         argo_serve.expects(:call_js_system).returns(true).once
         argo_serve.call
       end
-
-      def test_argo_serve_defers_to_js_system_for_argo_admin_beta
-        cli = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0")
-        renderer = Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.0.1")
-        argo_runtime = Features::ArgoRuntime.new(cli: cli, renderer: renderer)
-        specification_handler = ExtensionTestHelpers.test_specifications["TEST_EXTENSION"]
-
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-
-        argo_serve = Features::ArgoServe.new(
-          context: @context,
-          argo_runtime: argo_runtime,
-          specification_handler: specification_handler,
-          beta_access: [:argo_admin_beta]
-        )
-
-        Tasks::FindNpmPackages.expects(:exactly_one_of).returns(ShopifyCli::Result.success(renderer))
-
-        argo_serve.expects(:call_js_system).returns(true).once
-        argo_serve.call
-      end
     end
   end
 end

--- a/test/project_types/extension/tasks/argo_serve_options_test.rb
+++ b/test/project_types/extension/tasks/argo_serve_options_test.rb
@@ -24,7 +24,6 @@ renderer_package: argo_admin)
         argo_runtime = setup_argo_runtime(
           renderer_package: argo_admin,
           version: "0.11.0",
-          beta_access: [:argo_admin_beta]
         )
 
         options = Features::ArgoServeOptions.new(argo_runtime: argo_runtime, context: @context,
@@ -39,7 +38,6 @@ renderer_package: argo_admin)
         argo_runtime = setup_argo_runtime(
           renderer_package: argo_admin,
           version: "0.11.0",
-          beta_access: [:argo_admin_beta]
         )
 
         options = Features::ArgoServeOptions.new(argo_runtime: argo_runtime, context: @context,
@@ -94,10 +92,10 @@ renderer_package: argo_admin)
         )
       end
 
-      def setup_argo_runtime(renderer_package:, version:, cli_package_name: "@shopify/argo-admin-cli", beta_access: [])
+      def setup_argo_runtime(renderer_package:, version:, cli_package_name: "@shopify/argo-admin-cli")
         cli = Models::NpmPackage.new(name: cli_package_name, version: version)
 
-        Features::ArgoRuntime.new(renderer: renderer_package, cli: cli, beta_access: beta_access)
+        Features::ArgoRuntime.new(renderer: renderer_package, cli: cli)
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

In preparation for GA of the new extension developer experience.

### WHAT is this pull request doing?

Removes the argo_admin_beta flag protection in ArgoServe.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrmenting this when releasing).
