### PR TITLE
fix: include name in list of args in extension serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased
 ------
 
+Version 1.13.1
+--------------
+* [1272](https://github.com/Shopify/shopify-app-cli/pull/1272): Fix minor bug with extension serve for UI extensions
+
 Version 1.13.0
 --------------
 

--- a/lib/project_types/extension/features/argo_runtime.rb
+++ b/lib/project_types/extension/features/argo_runtime.rb
@@ -7,6 +7,7 @@ module Extension
       ARGO_ADMIN_CLI_PACKAGE_NAME = "@shopify/argo-admin-cli"
 
       ARGO_RUN_0_4_0 = Models::NpmPackage.new(name: "@shopify/argo-run", version: "0.4.0")
+      ARGO_ADMIN_CLI_0_9_0 = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.9.0")
       ARGO_ADMIN_CLI_0_9_3 = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.9.3")
       ARGO_ADMIN_CLI_0_11_0 = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0")
 
@@ -62,6 +63,15 @@ module Extension
         case cli
         when admin?
           cli >= ARGO_ADMIN_CLI_0_11_0
+        else
+          false
+        end
+      end
+
+      def accepts_name?
+        case cli
+        when admin?
+          cli >= ARGO_ADMIN_CLI_0_9_0
         else
           false
         end

--- a/lib/project_types/extension/features/argo_serve_options.rb
+++ b/lib/project_types/extension/features/argo_serve_options.rb
@@ -34,6 +34,7 @@ module Extension
           options << "--argoVersion=#{renderer_package.version}" if argo_runtime.accepts_argo_version?
           options << "--uuid=#{project.registration_uuid}" if argo_runtime.accepts_uuid?
           options << "--publicUrl=#{public_url}" if argo_runtime.accepts_tunnel_url?
+          options << "--name=#{project.title}" if argo_runtime.accepts_name?
         end
       end
     end

--- a/test/project_types/extension/features/argo_runtime_test.rb
+++ b/test/project_types/extension/features/argo_runtime_test.rb
@@ -91,6 +91,22 @@ module Extension
         end
       end
 
+      def test_accepts_name
+        runtimes = {
+          checkout_runtime_0_3_8 => does_not_support_feature,
+          checkout_runtime_0_4_0 => does_not_support_feature,
+          admin_runtime_0_11_0 => supports_feature,
+          admin_runtime_0_9_3 => supports_feature,
+          admin_runtime_0_9_2 => supports_feature,
+          admin_runtime_0_9_0 => supports_feature,
+          admin_runtime_0_8_9 => does_not_support_feature,
+        }
+
+        runtimes.each do |runtime, accepts_argo_version|
+          assert_equal accepts_argo_version, runtime.accepts_name?
+        end
+      end
+
       private
 
       def checkout_runtime_0_3_8
@@ -125,6 +141,20 @@ module Extension
         ArgoRuntime.new(
           cli: Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.9.2"),
           renderer: Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.9.3")
+        )
+      end
+
+      def admin_runtime_0_9_0
+        ArgoRuntime.new(
+          cli: Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.9.0"),
+          renderer: Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.9.0")
+        )
+      end
+
+      def admin_runtime_0_8_9
+        ArgoRuntime.new(
+          cli: Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.8.9"),
+          renderer: Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.8.9")
         )
       end
 

--- a/test/project_types/extension/tasks/argo_serve_options_test.rb
+++ b/test/project_types/extension/tasks/argo_serve_options_test.rb
@@ -79,6 +79,19 @@ renderer_package: argo_admin)
         assert_includes(options.npm_serve_command, "--uuid=#{registration_uuid}")
       end
 
+      def test_serve_options_include_name_if_name_supported
+        argo_runtime = setup_argo_runtime(renderer_package: argo_admin, version: "0.9.0")
+        extension_title = "my test extension"
+        ExtensionProject.any_instance.expects(:title).returns(extension_title)
+        options = Features::ArgoServeOptions.new(
+          argo_runtime: argo_runtime, context: @context,
+          renderer_package: argo_admin
+        )
+
+        assert_includes(options.yarn_serve_command, "--name=#{extension_title}")
+        assert_includes(options.npm_serve_command, "--name=#{extension_title}")
+      end
+
       private
 
       def argo_admin(version = "0.1.2")


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/argo-private/issues/1575

### WHAT is this pull request doing?

`--name` needs to be passed along to `argo-admin-cli` when running `shopify serve` in an extension project.

BEFORE

<img width="1920" alt="Screen Shot 2021-05-31 at 5 05 16 PM" src="https://user-images.githubusercontent.com/989784/121395309-e5193f80-c917-11eb-857d-0943145b8312.png">

AFTER

<img width="1680" alt="Screen Shot 2021-06-09 at 11 31 57 AM" src="https://user-images.githubusercontent.com/989784/121395378-fbbf9680-c917-11eb-86fd-a8dbf3133827.png">


<img width="1890" alt="Screen Shot 2021-06-09 at 11 44 50 AM" src="https://user-images.githubusercontent.com/989784/121395555-2d386200-c918-11eb-9968-35c725022b8c.png">

🎩 Tophatting
* `cd` into a product subscription extension project
* run `shopify serve`
* observe `--name` is being passed as an argument to the `argo-admin-cli` command
* `cd` into a checkout extension project
* run `shopify serve`
* observe the `--name` argument is not being passed to the `argo-run` command

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
