### PR TITLE
[scripts] Only print api_key during error if it exists

### DIFF
--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -16,7 +16,11 @@ module Script
         Layers::Application::PushScript.call(ctx: @ctx, force: options.flags.key?(:force))
         @ctx.puts(@ctx.message("script.push.script_pushed", api_key: api_key))
       rescue StandardError => e
-        msg = @ctx.message("script.push.error.operation_failed", api_key: api_key)
+        msg = if api_key
+          @ctx.message("script.push.error.operation_failed_with_api_key", api_key: api_key)
+        else
+          @ctx.message("script.push.error.operation_failed_no_api_key")
+        end
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: msg)
       end
 

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -161,7 +161,8 @@ module Script
           HELP
 
           error: {
-            operation_failed: "Couldn't push script to app (API key: %{api_key}).",
+            operation_failed_with_api_key: "Couldn't push script to app (API key: %{api_key}).",
+            operation_failed_no_api_key: "Couldn't push script to app.",
           },
 
           script_pushed: "{{v}} Script pushed to app (API key: %{api_key}).",

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -51,6 +51,30 @@ module Script
         assert_equal err_msg, e.message
       end
 
+      def test_push_doesnt_print_api_key_when_it_hasnt_been_selected
+        Tasks::EnsureEnv.expects(:call)
+        @script_project_repo.expects(:get).returns(nil)
+
+        UI::ErrorHandler.expects(:pretty_print_and_raise).with do |_error, args|
+          assert_equal args[:failed_op], @context.message("script.push.error.operation_failed_no_api_key")
+        end
+
+        perform_command
+      end
+
+      def test_push_prints_api_key_when_it_has_been_selected
+        Tasks::EnsureEnv.expects(:call)
+        Layers::Application::PushScript.expects(:call).raises(StandardError.new)
+
+        UI::ErrorHandler.expects(:pretty_print_and_raise).with do |_error, args|
+          assert_equal args[:failed_op], @context.message(
+            "script.push.error.operation_failed_with_api_key", api_key: @api_key
+          )
+        end
+
+        perform_command
+      end
+
       private
 
       def perform_command


### PR DESCRIPTION
### WHY are these changes introduced?

Current errors will also print the app's api key so the user is clear on what api key is being used. However, there could be an error before the user could even select an error. 

### WHAT is this pull request doing?

If the api key hasn't been set, simply do not print the `(API key: mykey)` section in the error message. 

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
