### PR TITLE
[scripts] do not require a force push if the the overwrite script prompt was answered

### DIFF
--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -8,12 +8,13 @@ module Script
       end
 
       def call(_args, _name)
-        Tasks::EnsureEnv.call(@ctx)
+        fresh_env = Tasks::EnsureEnv.call(@ctx)
+        force = options.flags.key?(:force) || !!fresh_env
 
         api_key = Layers::Infrastructure::ScriptProjectRepository.new(ctx: @ctx).get.api_key
         return @ctx.puts(self.class.help) unless api_key
 
-        Layers::Application::PushScript.call(ctx: @ctx, force: options.flags.key?(:force))
+        Layers::Application::PushScript.call(ctx: @ctx, force: force)
         @ctx.puts(@ctx.message("script.push.script_pushed", api_key: api_key))
       rescue StandardError => e
         msg = if api_key

--- a/lib/project_types/script/tasks/ensure_env.rb
+++ b/lib/project_types/script/tasks/ensure_env.rb
@@ -11,7 +11,7 @@ module Script
         script_project_repo = Layers::Infrastructure::ScriptProjectRepository.new(ctx: ctx)
         script_project = script_project_repo.get
 
-        return if script_project.api_key && script_project.api_secret && script_project.uuid_defined?
+        return false if script_project.api_key && script_project.api_secret && script_project.uuid_defined?
 
         org = ask_org
         app = ask_app(org["apps"])
@@ -22,6 +22,8 @@ module Script
           secret: app["apiSecretKeys"].first["secret"],
           uuid: uuid
         )
+
+        true
       end
 
       private

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -9,8 +9,9 @@ module Script
         super
         @context = TestHelpers::FakeContext.new
         @api_key = "apikey"
+        @uuid = "uuid"
         @force = true
-        @env = ShopifyCli::Resources::EnvFile.new(api_key: @api_key, secret: "shh")
+        @env = ShopifyCli::Resources::EnvFile.new(api_key: @api_key, secret: "shh", extra: { "UUID" => @uuid })
         @script_project_repo = TestHelpers::FakeScriptProjectRepository.new
         @script_project_repo.create(
           language: "assemblyscript",
@@ -51,6 +52,19 @@ module Script
         assert_equal err_msg, e.message
       end
 
+      def test_does_not_force_push_if_user_env_already_existed
+        @force = false
+        Layers::Application::PushScript.expects(:call).with(ctx: @context, force: @force)
+        perform_command
+      end
+
+      def test_force_pushes_script_if_user_env_was_just_created
+        @force = false
+        Tasks::EnsureEnv.expects(:call).returns(true)
+        Layers::Application::PushScript.expects(:call).with(ctx: @context, force: true)
+        perform_command
+      end
+
       def test_push_doesnt_print_api_key_when_it_hasnt_been_selected
         Tasks::EnsureEnv.expects(:call)
         @script_project_repo.expects(:get).returns(nil)
@@ -78,7 +92,7 @@ module Script
       private
 
       def perform_command
-        capture_io { run_cmd("push --force") }
+        capture_io { run_cmd("push #{@force ? "--force" : ""}") }
       end
     end
   end

--- a/test/project_types/script/tasks/ensure_env_test.rb
+++ b/test/project_types/script/tasks/ensure_env_test.rb
@@ -41,7 +41,7 @@ describe Script::Tasks::EnsureEnv do
         ShopifyCli::PartnersAPI.expects(:query).never
         Script::Layers::Infrastructure::ScriptService.any_instance.expects(:get_app_scripts).never
 
-        assert_nil subject
+        refute subject
       end
     end
 
@@ -63,13 +63,16 @@ describe Script::Tasks::EnsureEnv do
       end
 
       def expect_new_env
-        assert_equal selected_api_key, subject.env.api_key
-        assert_equal selected_secret, subject.env.secret
+        assert subject
+
+        project = script_project_repository.get
+        assert_equal selected_api_key, project.env.api_key
+        assert_equal selected_secret, project.env.secret
 
         if selected_uuid.nil?
-          assert_nil subject.env.extra["UUID"]
+          assert_nil project.env.extra["UUID"]
         else
-          assert_equal selected_uuid, subject.env.extra["UUID"]
+          assert_equal selected_uuid, project.env.extra["UUID"]
         end
       end
 
@@ -118,9 +121,11 @@ describe Script::Tasks::EnsureEnv do
               context.expects(:puts).with(selected_org_msg)
               context.stubs(:puts).with(Not(equals(selected_org_msg)))
 
-              assert_equal selected_api_key, subject.env.api_key
-              assert_equal selected_secret, subject.env.secret
-              assert_nil subject.env.extra["UUID"]
+              assert subject
+              project = script_project_repository.get
+              assert_equal selected_api_key, project.env.api_key
+              assert_equal selected_secret, project.env.secret
+              assert_nil project.env.extra["UUID"]
             end
           end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/3022

When a script is being connected to an app, we check if there are existing scripts on that app and if the user wants to overwrite any of them. If they select 'YES', but the push command was run without the --force flag, then the command fails. Since the user explicitly consented to overwriting, the --force flag should not be required.

Note that this is basically a temporary solution. Once the CLI DX changes are finalized, the app connection step will occur in another command and the `push` command will always require force. 

### WHAT is this pull request doing?

- Checks if the `EnsureEnv` task created a new env, and force the script push if it did. 
   - If a valid env exists, this task will return false.
   - If no env exists yet, then the user gets prompted. If scripts exist on an app, the user either said "YES" overwrite an existing script, or "NO" do not overwrite (instead, create a new script), create a new env, and return true. In either case, forcing the push will do exactly what the user wants. So, we just need to check if `EnsureEnv` created a new env.

### Screenshot

<img width="1561" alt="jacobsteves@Jacobs-MacBook-Pro:~:src:misc:scripts:" src="https://user-images.githubusercontent.com/28009669/121688228-3567dd00-ca91-11eb-9f38-2e8f468d71b6.png">


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
