### PR TITLE
removed invalid options from help text

### DIFF
--- a/lib/project_types/node/messages/messages.rb
+++ b/lib/project_types/node/messages/messages.rb
@@ -21,7 +21,6 @@ module Node
             Usage: {{command:%s create node}}
             Options:
               {{command:--name=NAME}} App name. Any string.
-              {{command:--app-url=APPURL}} App URL. Must be a valid URL.
               {{command:--organization-id=ID}} Partner organization ID. Must be an existing organization.
               {{command:--shop-domain=MYSHOPIFYDOMAIN }} Development store URL. Must be an existing development store.
           HELP

--- a/lib/project_types/rails/messages/messages.rb
+++ b/lib/project_types/rails/messages/messages.rb
@@ -30,7 +30,6 @@ module Rails
             Usage: {{command:%s create rails}}
             Options:
               {{command:--name=NAME}} App name. Any string.
-              {{command:--app-url=APPURL}} App URL. Must be a valid URL.
               {{command:--organization-id=ID}} Partner organization ID. Must be an existing organization.
               {{command:--shop-domain=MYSHOPIFYDOMAIN }} Development store URL. Must be an existing development store.
               {{command:--db=DB}} Database type. Must be one of: mysql, postgresql, sqlite3, oracle, frontbase, ibm_db, sqlserver, jdbcmysql, jdbcsqlite3, jdbcpostgresql, jdbc.


### PR DESCRIPTION
### WHY are these changes introduced?

When running `shopify create` with the `--app-url` option, I get an error:
```
shopify-cli-1.13.1/lib/shopify-cli/options.rb:28:in `parse_flags': invalid option: --app-url (OptionParser::InvalidOption)
```

### WHAT is this pull request doing?

I don't know if the `--app-url` option is valid or not. For this pr, I assumed it was not valid and I removed it from the help text. If it is valid, I'd be happy to close this and try to fix it, or at least create an issue.


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
