### PR TITLE
[Checkout extensibility] Add specification handler for checkout_ui_extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [#1287](https://github.com/Shopify/shopify-app-cli/pull/1287): Allow new Checkout Extensions to specify configuration attributes in their extension.config.yml file.
 
 Version 1.13.1
 --------------

--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module SpecificationHandlers
+      class CheckoutUiExtension < Default
+        PERMITTED_CONFIG_KEYS = [:metafields, :extension_points]
+
+        def config(context)
+          {
+            **Features::ArgoConfig.parse_yaml(context, PERMITTED_CONFIG_KEYS),
+            **argo.config(context),
+          }
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Models
+    module SpecificationHandlers
+      class CheckoutUiExtensionTest < MiniTest::Test
+        include ExtensionTestHelpers
+
+        def setup
+          super
+          YAML.stubs(:load_file).returns({})
+          ShopifyCli::ProjectType.load_type(:extension)
+          Features::Argo.any_instance.stubs(:config).returns({})
+          Features::ArgoConfig.stubs(:parse_yaml).returns({})
+
+          specifications = DummySpecifications.build(identifier: "checkout_ui_extension", surface: "checkout")
+
+          @identifier = "CHECKOUT_UI_EXTENSION"
+          @checkout_ui_extension = specifications[@identifier]
+        end
+
+        def test_create_uses_standard_argo_create_implementation
+          directory_name = "checkout_ui_extension"
+
+          Features::Argo.any_instance
+            .expects(:create)
+            .with(directory_name, @identifier, @context)
+            .once
+
+          @checkout_ui_extension.create(directory_name, @context)
+        end
+
+        def test_config_uses_standard_argo_config_implementation
+          Features::Argo.any_instance.expects(:config).with(@context).once.returns({})
+          @checkout_ui_extension.config(@context)
+        end
+
+        def test_config_merges_with_standard_argo_config_implementation
+          script_content = "alert(true)"
+          metafields = [{ key: "a-key", namespace: "a-namespace" }]
+          extension_points = ["Checkout::Feature::Render"]
+
+          initial_config = { script_content: script_content }
+          yaml_config = { "metafields": metafields, "extension_points": extension_points }
+
+          Features::Argo.any_instance.expects(:config).with(@context).once.returns(initial_config)
+          Features::ArgoConfig.stubs(:parse_yaml).returns(yaml_config)
+
+          config = @checkout_ui_extension.config(@context)
+          assert_equal(metafields, config[:metafields])
+          assert_equal(extension_points, config[:extension_points])
+          assert_equal(script_content, config[:script_content])
+        end
+
+        def test_config_passes_allowed_keys
+          Features::Argo.any_instance.stubs(:config).returns({})
+          Features::ArgoConfig
+            .expects(:parse_yaml)
+            .with(@context, [:metafields, :extension_points])
+            .once
+            .returns({})
+
+          @checkout_ui_extension.config(@context)
+        end
+
+        def test_graphql_identifier
+          assert_equal @identifier, @checkout_ui_extension.graphql_identifier
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Partially Fixes https://github.com/Shopify/argo-private/issues/1581

For Unite, we want to remove all public facing mention of "Argo" and as such, we are renaming the extension type `checkout_argo_extension` to `checkout_ui_extension`. To do so, we also need a new specification handler for this type in the CLI so it can pick up the extension configurations from their `extension.config.yml` file that will be persisted as part of the extension configuration in Core. 

### WHAT is this pull request doing?

This PR introduces this new specification handler which is exactly the same as the `checkout_argo_extension` specification handler but with a different name.

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).