### PR TITLE
[Fix] Include the Scripts SDK only if required for the extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [1288](https://github.com/Shopify/shopify-app-cli/pull/1288): Fix bug where Scripts SDK was included for projects that don't require it
 
 Version 1.13.1
 --------------

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -45,27 +45,20 @@ module Script
           end
 
           def write_package_json
-            package_json = <<~HERE
-              {
-                "name": "#{script_name}",
-                "version": "1.0.0",
-                "devDependencies": {
-                  "@shopify/scripts-sdk-as": "#{extension_point.sdks.assemblyscript.sdk_version}",
-                  "@shopify/scripts-toolchain-as": "#{extension_point.sdks.assemblyscript.toolchain_version}",
-                  "#{extension_point.sdks.assemblyscript.package}": "#{extension_point_version}",
-                  "@as-pect/cli": "^6.0.0",
-                  "assemblyscript": "^0.18.13"
-                },
-                "scripts": {
-                  "test": "asp --summary --verbose",
-                  "build": "#{build_command}"
-                },
-                "engines": {
-                  "node": ">=#{MIN_NODE_VERSION}"
-                }
+            package_json = {
+              name: script_name,
+              version: "1.0.0",
+              devDependencies: dev_dependencies,
+              scripts: {
+                test: "asp --summary --verbose",
+                build: build_command,
+              },
+              engines: {
+                node: ">=#{MIN_NODE_VERSION}"
               }
-            HERE
-            ctx.write("package.json", package_json)
+            }
+
+            ctx.write("package.json", JSON.pretty_generate(package_json))
           end
 
           def bootstap_command
@@ -89,6 +82,21 @@ module Script
             else
               "#{BUILD} --domain #{domain} --ep #{type} #{ASC_ARGS}"
             end
+          end
+
+          def dev_dependencies
+            dependencies = {
+              "@as-pect/cli": "^6.0.0",
+              "assemblyscript": "^0.18.13",
+              "@shopify/scripts-toolchain-as": extension_point.sdks.assemblyscript.toolchain_version,
+              "#{extension_point.sdks.assemblyscript.package}": extension_point_version,
+            }
+
+            if extension_point.sdks.assemblyscript.sdk_version
+              dependencies["@shopify/scripts-sdk-as"] = extension_point.sdks.assemblyscript.sdk_version
+            end
+            
+            dependencies
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -54,8 +54,8 @@ module Script
                 build: build_command,
               },
               engines: {
-                node: ">=#{MIN_NODE_VERSION}"
-              }
+                node: ">=#{MIN_NODE_VERSION}",
+              },
             }
 
             ctx.write("package.json", JSON.pretty_generate(package_json))
@@ -95,7 +95,7 @@ module Script
             if extension_point.sdks.assemblyscript.sdk_version
               dependencies["@shopify/scripts-sdk-as"] = extension_point.sdks.assemblyscript.sdk_version
             end
-            
+
             dependencies
           end
         end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

If an extension point doesn't require the Scripts SDK, the CLI populates the package.json for new projects with an invalid value for the SDK dependency. Instead, the CLI should not include the SDK altogether if an extension point doesn't require it.

### WHAT is this pull request doing?

This PR conditionally includes the SDK in the built package.json file when creating a new script project.

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
